### PR TITLE
fixed segment extraction

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/results/AnalysisSegmentMeasurementResult.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/results/AnalysisSegmentMeasurementResult.java
@@ -48,11 +48,11 @@ public abstract class AnalysisSegmentMeasurementResult<T extends IAnalysisSegmen
 
 		List<T> list = new ArrayList<>();
 		for(T item : getResult()) {
-			if(item.containsScan(range.getStartScan())) {
-				if(item.containsScan(range.getStopScan()) || includeBorders) {
+			if(range.getStartScan() < item.getStartScan()) {
+				if(range.getStopScan() > item.getStopScan() || includeBorders) {
 					list.add(item);
 				}
-			} else if(item.containsScan(range.getStopScan()) && includeBorders) {
+			} else if(range.getStopScan() > item.getStopScan() && includeBorders) {
 				list.add(item);
 			}
 		}


### PR DESCRIPTION
Segment Extraction seems wrong. `range` is the containing object (chromatogram selection) and `item` is the contained object (noise segment) that should be included in the containing objects' range.