### PR TITLE
Fix MANIFEST.MF last line(s) in xxd.model

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.model/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.model/META-INF/MANIFEST.MF
@@ -51,4 +51,3 @@ Service-Component: OSGI-INF/org.eclipse.chemclipse.xxd.model.filter.peaks.Remove
  OSGI-INF/org.eclipse.chemclipse.xxd.model.filter.peaks.ProcessPeaksByIntegratedAreaFilter.xml,
  OSGI-INF/org.eclipse.chemclipse.xxd.model.filter.peaks.ProcessPeaksByPercentageAreaFilter.xml,
  OSGI-INF/org.eclipse.chemclipse.xxd.model.filter.peaks.ProcessPeaksByAsymmetricalPeakShapeFilter.xml
-Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
This will resolve the error 'Header must be terminated by a line break'
that was introduced while merging #195 #196 #197.

Signed-off-by: Alexander Stark <alexander.stark@lablicate.com>