### PR TITLE
Remove unused parameters and adjust dependent methods.

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/impl/ChromatogramFilterZeroValueRemoval.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/impl/ChromatogramFilterZeroValueRemoval.java
@@ -42,8 +42,8 @@ public class ChromatogramFilterZeroValueRemoval extends AbstractChromatogramFilt
 					IChromatogramSelectionMSD chromatogramSelectionMSD = chromatogramSelection;
 					ExtractedMatrix extract = new ExtractedMatrix(chromatogramSelectionMSD);
 					float[][] matrix = extract.getMatrix();
-					int numberIons = extract.getNumberOfIons();
-					int numberScans = extract.getNumberOfScans();
+					int numberIons = matrix[0].length;
+					int numberScans = matrix.length;
 					for(int ionIndex = 0; ionIndex < numberIons; ionIndex++) {
 						int startIndex = 0;
 						// pre-loop to prevent iteration from first scan
@@ -66,7 +66,7 @@ public class ChromatogramFilterZeroValueRemoval extends AbstractChromatogramFilt
 							}
 						}
 					}
-					extract.updateSignal(matrix);
+					extract.updateSignal();
 				}
 				//
 				processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, "Chromatogram Filter Adjust applied"));

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/impl/ChromatogramFilterZeroValueRemoval.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/impl/ChromatogramFilterZeroValueRemoval.java
@@ -66,7 +66,7 @@ public class ChromatogramFilterZeroValueRemoval extends AbstractChromatogramFilt
 							}
 						}
 					}
-					extract.updateSignal(matrix, numberScans, numberIons);
+					extract.updateSignal(matrix);
 				}
 				//
 				processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, "Chromatogram Filter Adjust applied"));

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/matrix/ExtractedMatrix.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/matrix/ExtractedMatrix.java
@@ -24,7 +24,7 @@ import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD
 import org.eclipse.chemclipse.msd.model.implementation.Ion;
 
 public class ExtractedMatrix {
-	
+
 	private IChromatogramSelectionMSD selection;
 	private List<IScanMSD> scans;
 	private int numberOfScans;
@@ -32,12 +32,13 @@ public class ExtractedMatrix {
 	private int startIon;
 	private int stopIon;
 	private float[][] signal;
-	
+
 	public ExtractedMatrix(IChromatogramSelectionMSD chromatogramSelection) {
+
 		this.selection = chromatogramSelection;
 		this.numberOfScans = selection.getStopScan() - selection.getStartScan() + 1;
 		this.scans = extractScans();
-		if(checkHighRes( 10)) {
+		if(checkHighRes(10)) {
 			throw new IllegalArgumentException("HighRes MSD is currently not suported");
 		} else {
 			int[] minMaxMz = getMinMaxMz();
@@ -48,28 +49,27 @@ public class ExtractedMatrix {
 			List<IIon> currentIons;
 			for(int scanIndex = 0; scanIndex < numberOfScans; scanIndex++) {
 				currentIons = scans.get(scanIndex).getIons();
-				for(IIon ion: currentIons) {
-					signal[ scanIndex ] [((int) Math.round(ion.getIon() - this.startIon))] =  ion.getAbundance();
+				for(IIon ion : currentIons) {
+					signal[scanIndex][((int)Math.round(ion.getIon() - this.startIon))] = ion.getAbundance();
 				}
 			}
 		}
 	}
-	
-	private Boolean checkHighRes( int limit ) {
+
+	private Boolean checkHighRes(int limit) {
+
 		IIonBounds bounds;
 		double rangeAbs;
-		
-		for(IScanMSD scan: scans) {
+		for(IScanMSD scan : scans) {
 			bounds = scan.getIonBounds();
 			rangeAbs = bounds.getHighestIon().getIon() - bounds.getLowestIon().getIon();
 			if(rangeAbs + limit < scan.getIons().size()) {
 				return (true);
 			}
 		}
-		
 		return false;
 	}
-	
+
 	private List<IScanMSD> extractScans() {
 
 		List<IScanMSD> scans;
@@ -87,62 +87,63 @@ public class ExtractedMatrix {
 				.collect(Collectors.toList()); //
 		return (scans);
 	}
-	
-	private int[] getMinMaxMz() {
-		
-		int[] minMaxMz = new int[2];
 
+	private int[] getMinMaxMz() {
+
+		int[] minMaxMz = new int[2];
 		Stream<Double> s = scans.stream() //
 				.flatMap(scan -> scan.getIons().stream()) //
-				.map(x -> (Double) x.getIon());
+				.map(x -> (Double)x.getIon());
 		DoubleSummaryStatistics d = s.collect(Collectors.summarizingDouble(value -> value));
-		
 		minMaxMz[0] = AbstractIon.getIon(d.getMin());
 		minMaxMz[1] = AbstractIon.getIon(d.getMax());
-		return (minMaxMz); 
+		return (minMaxMz);
 	}
 
 	public float[][] getMatrix() {
+
 		return this.signal;
 	}
 
 	public int getNumberOfScans() {
+
 		return this.numberOfScans;
 	}
 
 	public int getNumberOfIons() {
+
 		return this.numberOfIons;
 	}
 
-	public void updateSignal(float[][] signal, int numberOfScans, int nubmerOfIons ) {
-		
+	public void updateSignal(float[][] signal) {
+
 		IScanMSD currentScan;
 		IIon currentIon;
-		
 		try {
 			for(int i = 1; i <= numberOfScans; i++) {
-				currentScan = (IScanMSD) selection.getChromatogram().getScan(i);
+				currentScan = (IScanMSD)selection.getChromatogram().getScan(i);
 				currentScan.removeAllIons();
 				for(int j = startIon; j < stopIon; j++) {
-					if(signal[i-1][j-startIon] != 0.0) {
-						currentIon = new Ion(j, signal[i - 1][j - startIon] ); 
+					if(signal[i - 1][j - startIon] != 0.0) {
+						currentIon = new Ion(j, signal[i - 1][j - startIon]);
 						currentScan.addIon(currentIon);
-					}		
+					}
 				}
 			}
-		} catch (Exception e) {
+		} catch(Exception e) {
 			throw new RuntimeException("Updating the Signal failed:", e);
-		}			
+		}
 	}
 
 	public int[] getScanNumbers() {
+
 		int[] scanNumbers = scans.stream().mapToInt(scan -> scan.getScanNumber()).toArray();
 		return scanNumbers;
 	}
 
 	public int[] getRetentionTimes() {
+
 		int[] retentionTimes = scans.stream().mapToInt(scan -> scan.getRetentionTime()).toArray();
 		return retentionTimes;
 	}
-
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/matrix/ExtractedMatrix.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/matrix/ExtractedMatrix.java
@@ -27,8 +27,6 @@ public class ExtractedMatrix {
 
 	private IChromatogramSelectionMSD selection;
 	private List<IScanMSD> scans;
-	private int numberOfScans;
-	private int numberOfIons;
 	private int startIon;
 	private int stopIon;
 	private float[][] signal;
@@ -36,7 +34,6 @@ public class ExtractedMatrix {
 	public ExtractedMatrix(IChromatogramSelectionMSD chromatogramSelection) {
 
 		this.selection = chromatogramSelection;
-		this.numberOfScans = selection.getStopScan() - selection.getStartScan() + 1;
 		this.scans = extractScans();
 		if(checkHighRes(10)) {
 			throw new IllegalArgumentException("HighRes MSD is currently not suported");
@@ -44,8 +41,9 @@ public class ExtractedMatrix {
 			int[] minMaxMz = getMinMaxMz();
 			this.startIon = minMaxMz[0];
 			this.stopIon = minMaxMz[1];
-			this.numberOfIons = this.stopIon - this.startIon + 1;
-			signal = new float[numberOfScans][this.numberOfIons];
+			int numberOfScans = selection.getStopScan() - selection.getStartScan() + 1;
+			int numberOfIons = this.stopIon - this.startIon + 1;
+			signal = new float[numberOfScans][numberOfIons];
 			List<IIon> currentIons;
 			for(int scanIndex = 0; scanIndex < numberOfScans; scanIndex++) {
 				currentIons = scans.get(scanIndex).getIons();
@@ -100,27 +98,23 @@ public class ExtractedMatrix {
 		return (minMaxMz);
 	}
 
+	/**
+	 * Returns the scans/ions array
+	 * Scans along rows, ions along columns
+	 * 
+	 * @return data array scans x ions.
+	 */
 	public float[][] getMatrix() {
 
 		return this.signal;
 	}
 
-	public int getNumberOfScans() {
-
-		return this.numberOfScans;
-	}
-
-	public int getNumberOfIons() {
-
-		return this.numberOfIons;
-	}
-
-	public void updateSignal(float[][] signal) {
+	public void updateSignal() {
 
 		IScanMSD currentScan;
 		IIon currentIon;
 		try {
-			for(int i = 1; i <= numberOfScans; i++) {
+			for(int i = 1; i <= signal.length; i++) {
 				currentScan = (IScanMSD)selection.getChromatogram().getScan(i);
 				currentScan.removeAllIons();
 				for(int j = startIon; j < stopIon; j++) {

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/matrix/ExtractedMatrix_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/matrix/ExtractedMatrix_2_Test.java
@@ -81,7 +81,7 @@ public class ExtractedMatrix_2_Test extends TestCase {
 		try {
 			ChromatogramSelectionMSD selection = new ChromatogramSelectionMSD(chromatogram);
 			ExtractedMatrix extracted = new ExtractedMatrix(selection);
-			extracted.updateSignal(signalMatrix);
+			extracted.updateSignal();
 		} catch(Exception e) {
 			e.printStackTrace();
 		}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/matrix/ExtractedMatrix_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/matrix/ExtractedMatrix_2_Test.java
@@ -81,7 +81,7 @@ public class ExtractedMatrix_2_Test extends TestCase {
 		try {
 			ChromatogramSelectionMSD selection = new ChromatogramSelectionMSD(chromatogram);
 			ExtractedMatrix extracted = new ExtractedMatrix(selection);
-			extracted.updateSignal(signalMatrix, 10, 6);
+			extracted.updateSignal(signalMatrix);
 		} catch(Exception e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
In the current implementation of ExtractedMatrix, it is not possible to change the size of the matrix/number of scans, hence the numberOfIons, numberOfScans parameters are not used.