### PR TITLE
fix #351 reinstate smooth method

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/processor/SavitzkyGolayProcessor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/processor/SavitzkyGolayProcessor.java
@@ -80,6 +80,12 @@ public class SavitzkyGolayProcessor {
 		return smoothValues(ticValues, filter, monitor);
 	}
 
+	public static double[] smooth(double[] ticValues, int derivative, int order, int width, IProgressMonitor monitor) {
+
+		SavitzkyGolayFilter filter = new SavitzkyGolayFilter(order, width, derivative);
+		return smoothValues(ticValues, filter, monitor);
+	}
+
 	public static double[] smooth(ITotalScanSignals totalScanSignals, ChromatogramFilterSettings filterSettings, IProgressMonitor monitor) {
 
 		int size = totalScanSignals.size();


### PR DESCRIPTION
smooth method with signature 'double[], int, int int, IProgressMonitor' used in external plugins
Signed-off-by: Lorenz Gerber <lorenz.gerber@lablicate.com>