### PR TITLE
Fixed the labels of the MassBank database importer

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank/plugin.xml
@@ -29,11 +29,11 @@
    <extension
          point="org.eclipse.chemclipse.msd.converter.databaseSupplier">
       <DatabaseSupplier
-            description="Reads MassBank mass spectra"
+            description="Reads MassBank reference spectra databases"
             exportConverter="org.eclipse.chemclipse.msd.converter.supplier.massbank.converter.MassBankExportConverter"
             fileExtension=".zip"
-            filterName="Compressed MassBank Mass Spectrum (*.zip)"
-            id="org.eclipse.chemclipse.msd.converter.supplier.massbank.DatabaseSupplier1"
+            filterName="Compressed MassBank Database (*.zip)"
+            id="org.eclipse.chemclipse.msd.converter.supplier.massbank.DatabaseSupplier"
             importConverter="org.eclipse.chemclipse.msd.converter.supplier.massbank.converter.MassBankImportConverter"
             importMagicNumberMatcher="org.eclipse.chemclipse.msd.converter.supplier.massbank.converter.MagicNumberMatcher"
             isExportable="false"


### PR DESCRIPTION
This is a followup of https://github.com/eclipse/chemclipse/issues/147 which fixes an annoyance in the `Open With` menu of the database explorer. `Compressed MassBank Mass Spectrum (*.zip)` is shown twice and you have to guess the correct one.