### PR TITLE
Added .zip to the Peak Identifier - Library (MS) context menu settings dialog

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/msd/identifier/supplier/file/settings/MassSpectrumIdentifierSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/msd/identifier/supplier/file/settings/MassSpectrumIdentifierSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 Lablicate GmbH.
+ * Copyright (c) 2014, 2021 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -30,7 +30,7 @@ public class MassSpectrumIdentifierSettings extends AbstractMassSpectrumIdentifi
 
 	@JsonProperty(value = "Library File", defaultValue = "")
 	@JsonPropertyDescription("Select the library file.")
-	@FileSettingProperty(dialogType = DialogType.OPEN_DIALOG, extensionNames = {"AMDIS (*.msl)", "AMDIS (*.msp)"}, validExtensions = {"*.msl", "*.msp"}, onlyDirectory = false)
+	@FileSettingProperty(dialogType = DialogType.OPEN_DIALOG, extensionNames = {"AMDIS (*.msl)", "AMDIS (*.MSL)", "NIST (*.msp)", "NIST (*.MSP)", "MassBank (.zip)", "MassBank (.ZIP)"}, validExtensions = {"*.msl", "*.MSL", "*.msp", "*.MSP", "*.zip", "*.ZIP"}, onlyDirectory = false)
 	private File libraryFile;
 	@JsonProperty(value = "Pre-Optimization", defaultValue = "false")
 	private boolean usePreOptimization = false;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/msd/identifier/supplier/file/settings/PeakIdentifierSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/msd/identifier/supplier/file/settings/PeakIdentifierSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 Lablicate GmbH.
+ * Copyright (c) 2015, 2021 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -32,7 +32,7 @@ public class PeakIdentifierSettings extends AbstractPeakIdentifierSettingsMSD im
 
 	@JsonProperty(value = "Library File", defaultValue = "")
 	@JsonPropertyDescription("Select the library file.")
-	@FileSettingProperty(dialogType = DialogType.OPEN_DIALOG, extensionNames = {"AMDIS (*.msl)", "AMDIS (*.msp)", "AMDIS (*.MSL)", "AMDIS (*.MSP)"}, validExtensions = {"*.msl", "*.msp", "*.MSL", "*.MSP"}, onlyDirectory = false)
+	@FileSettingProperty(dialogType = DialogType.OPEN_DIALOG, extensionNames = {"AMDIS (*.msl)", "AMDIS (*.MSL)", "NIST (*.msp)", "NIST (*.MSP)", "MassBank (.zip)", "MassBank (.ZIP)"}, validExtensions = {"*.msl", "*.MSL", "*.msp", "*.MSP", "*.zip", "*.ZIP"}, onlyDirectory = false)
 	private File libraryFile;
 	@JsonProperty(value = "Pre-Optimization", defaultValue = "false")
 	private boolean usePreOptimization = false;


### PR DESCRIPTION
This is a followup of https://github.com/eclipse/chemclipse/issues/147 which allows this to use in a one-time action and it is helps with discoverability.