### PR TITLE
Removed the Eclipse Java Development Tools

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
@@ -71,10 +71,6 @@ http://www.eclipse.org/legal/epl-v10.html
          version="0.0.0"/>
 
    <includes
-         id="org.eclipse.jdt"
-         version="0.0.0"/>
-
-   <includes
          id="org.eclipse.ecf.filetransfer.feature"
          version="0.0.0"/>
 


### PR DESCRIPTION
Depends on https://github.com/eclipse/chemclipse/pull/516. Fixes the first point of https://github.com/OpenChrom/openchrom/issues/76.