### PR TITLE
Fixed the chemical table data being editable

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedMoleculeUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedMoleculeUI.java
@@ -332,6 +332,7 @@ public class ExtendedMoleculeUI extends Composite implements IExtendedPartUI {
 		tabItem.setText("Content");
 		//
 		Text text = createTextMolecule(tabFolder);
+		text.setEditable(false);
 		tabItem.setControl(text);
 		//
 		return text;


### PR DESCRIPTION
This is a followup of https://github.com/eclipse/chemclipse/issues/438. It is data fetched from a database, not a molecule editor.