### PR TITLE
Fixed UI not updating when a peak was deleted from the Peak/Scans list

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
@@ -500,6 +500,9 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 			 */
 			if(scansToClear.size() > 0 || peaksToDelete.size() > 0) {
 				if(chromatogramSelection != null) {
+					chromatogramSelection.setSelectedPeak(null);
+					chromatogramSelection.setSelectedScan(null);
+					chromatogramSelection.setSelectedIdentifiedScan(null);
 					chromatogramSelection.update(true);
 				}
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
@@ -508,6 +508,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 			}
 			//
 			UpdateNotifierUI.update(display, chromatogramSelection);
+			UpdateNotifierUI.update(display, IChemClipseEvents.TOPIC_IDENTIFICATION_TARGETS_UPDATE_SELECTION, "A peak or scan was deleted.");
 			updateChromatogramSelection();
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/OpenChrom/openchrom/issues/60 No. 4. This might be a regression as https://github.com/eclipse/chemclipse/issues/231 claims to have fixed this already.