### PR TITLE
Fixed the unit for IR spectra

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartXIR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartXIR.java
@@ -123,7 +123,7 @@ public class ChartXIR extends LineChart {
 	private void setPrimaryAxisSetProcessed(IChartSettings chartSettings) {
 
 		IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
-		primaryAxisSettingsX.setTitle("Wavelength (nm)");
+		primaryAxisSettingsX.setTitle("Wavenumber [1/cm]");
 		primaryAxisSettingsX.setDecimalFormat(new DecimalFormat(("0.0##"), new DecimalFormatSymbols(Locale.ENGLISH)));
 		primaryAxisSettingsX.setColor(DisplayUtils.getDisplay().getSystemColor(SWT.COLOR_BLACK));
 		primaryAxisSettingsX.setVisible(true);


### PR DESCRIPTION
Looking at http://www.gaml.org/Examples/Thermo%20Nicolet%20OMNIC%20FTIR/TN_OMNIC_FTIR.gaml we noticed the unit is wrong. It is wavelengths per unit distance for historical reasons.