### PR TITLE
Fixed compressed .mzML crashing when (optional) EncodedLength isn't read

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/io/MassSpectrumReaderVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/io/MassSpectrumReaderVersion110.java
@@ -126,8 +126,6 @@ public class MassSpectrumReaderVersion110 extends AbstractMassSpectraReader impl
 			logger.warn(e);
 		} catch(DataFormatException e) {
 			logger.warn(e);
-		} catch(NullPointerException e) {
-			logger.warn(e, e.fillInStackTrace());
 		}
 		//
 		IVendorMassSpectra massSpectra = new VendorMassSpectra();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/converter/BinaryReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/converter/BinaryReader.java
@@ -66,9 +66,10 @@ public class BinaryReader {
 		}
 		if(compressed) {
 			Inflater inflater = new Inflater();
-			inflater.setInput(binary);
-			byte[] byteArray = new byte[binaryDataArrayType.getEncodedLength().intValue()];
-			byteBuffer = ByteBuffer.wrap(byteArray, 0, inflater.inflate(byteArray));
+			inflater.setInput(byteBuffer.array());
+			byte[] byteArray = new byte[byteBuffer.capacity() * 10];
+			int decodedLength = inflater.inflate(byteArray);
+			byteBuffer = ByteBuffer.wrap(byteArray, 0, decodedLength);
 		}
 		byteBuffer.order(ByteOrder.LITTLE_ENDIAN); // this is always the case
 		if(doublePrecision) {


### PR DESCRIPTION
Closes https://github.com/eclipse/chemclipse/issues/649