### PR TITLE
Speedup the .msl .msp .xlsx .jdx .jdl detection

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MagicNumberMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MagicNumberMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Lablicate GmbH.
+ * Copyright (c) 2016, 2021 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,17 +15,12 @@ import java.io.File;
 
 import org.eclipse.chemclipse.converter.core.AbstractMagicNumberMatcher;
 import org.eclipse.chemclipse.converter.core.IMagicNumberMatcher;
-import org.eclipse.chemclipse.msd.converter.supplier.amdis.internal.converter.SpecificationValidatorMSL;
 
 public class MagicNumberMatcher extends AbstractMagicNumberMatcher implements IMagicNumberMatcher {
 
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		file = SpecificationValidatorMSL.validateSpecification(file);
-		if(file.exists()) {
-			return true;
-		}
-		return false;
+		return checkFileExtension(file, ".MSL");
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MagicNumberMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MagicNumberMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Lablicate GmbH.
+ * Copyright (c) 2016, 2021 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,17 +15,12 @@ import java.io.File;
 
 import org.eclipse.chemclipse.converter.core.AbstractMagicNumberMatcher;
 import org.eclipse.chemclipse.converter.core.IMagicNumberMatcher;
-import org.eclipse.chemclipse.msd.converter.supplier.amdis.internal.converter.SpecificationValidatorMSP;
 
 public class MagicNumberMatcher extends AbstractMagicNumberMatcher implements IMagicNumberMatcher {
 
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		file = SpecificationValidatorMSP.validateSpecification(file);
-		if(file.exists()) {
-			return true;
-		}
-		return false;
+		return checkFileExtension(file, ".MSP");
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.excel/src/org/eclipse/chemclipse/msd/converter/supplier/excel/converter/MagicNumberMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.excel/src/org/eclipse/chemclipse/msd/converter/supplier/excel/converter/MagicNumberMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Lablicate GmbH.
+ * Copyright (c) 2016, 2021 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,22 +15,12 @@ import java.io.File;
 
 import org.eclipse.chemclipse.converter.core.AbstractMagicNumberMatcher;
 import org.eclipse.chemclipse.converter.core.IMagicNumberMatcher;
-import org.eclipse.chemclipse.msd.converter.supplier.excel.internal.converter.SpecificationValidator;
 
 public class MagicNumberMatcher extends AbstractMagicNumberMatcher implements IMagicNumberMatcher {
 
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		boolean isValidFormat = false;
-		try {
-			file = SpecificationValidator.validateSpecification(file);
-			if(file.exists()) {
-				isValidFormat = true;
-			}
-		} catch(Exception e) {
-			// Print no exception.
-		}
-		return isValidFormat;
+		return checkFileExtension(file, ".XLSX");
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/io/MagicNumberMatcherChromatogram.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/io/MagicNumberMatcherChromatogram.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Lablicate GmbH.
+ * Copyright (c) 2016, 2021 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,27 +15,12 @@ import java.io.File;
 
 import org.eclipse.chemclipse.converter.core.AbstractMagicNumberMatcher;
 import org.eclipse.chemclipse.converter.core.IMagicNumberMatcher;
-import org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.internal.converter.SpecificationValidator;
 
 public class MagicNumberMatcherChromatogram extends AbstractMagicNumberMatcher implements IMagicNumberMatcher {
 
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		boolean isValidFormat = false;
-		try {
-			file = SpecificationValidator.validateSpecification(file, "JDX");
-			if(file.exists()) {
-				return true;
-			} else {
-				file = SpecificationValidator.validateSpecification(file, "JDL");
-				if(file.exists()) {
-					return true;
-				}
-			}
-		} catch(Exception e) {
-			// Print no exception.
-		}
-		return isValidFormat;
+		return checkFileExtension(file, ".JDX") || checkFileExtension(file, ".JDL");
 	}
 }


### PR DESCRIPTION
This is a followup of https://github.com/eclipse/chemclipse/pull/655. It saves 1 ms per file per converter on my machine.