### PR TITLE
Added the remaining missing HTML documentation files to the release package

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/build.properties
@@ -8,4 +8,5 @@ bin.includes = META-INF/,\
                css/,\
                schema/,\
                toc.xml,\
-               controls.xml
+               controls.xml,\
+               helpData.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/build.properties
@@ -4,19 +4,9 @@ bin.includes = META-INF/,\
                OSGI-INF/,\
                fragment.e4xmi,\
                plugin.xml,\
+               controls.xml,\
                css/,\
                icons/,\
                schema/,\
                html/
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/


### PR DESCRIPTION
This is a followup of https://github.com/eclipse/chemclipse/pull/573 as my HTML help is shown when building locally, but is not displayed when downloading released packages from https://ci.eclipse.org/chemclipse/job/chemclipse/job/develop/