### PR TITLE
Cleaned up the GTK launcher versions

### DIFF
--- a/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
+++ b/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
@@ -15,10 +15,8 @@
 
    <launcherArgs>
       <programArgs>-clearPersistedState
---launcher.GTK_version 2
       </programArgs>
-      <programArgsLin>--launcher.GTK_version
-3
+      <programArgsLin>--launcher.GTK_version 3
       </programArgsLin>
       <vmArgs>-Xms512M
 -Xmx2G


### PR DESCRIPTION
This doesn't change much. With or without this change `org.eclipse.swt.internal.gtk.version=3.24.20` is set for me. My complaint about the previous setting is just that GTK version gets set on Windows and Mac where it does not make any sense. GTK 2 is deprecated and shouldn't be used. Loading ChemClipse with `--launcher.GTK_version 2 --launcher.GTK_version 3` is a rubbish configuration even though GTK 3 won in the end.