### PR TITLE
Removed notes directed at developers from end user logs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# File formats are sensitive due to compatibility constraints so changes require approval from the project founder.
+chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/ @eselmeister

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/csd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/csd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1400.java
@@ -203,6 +203,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 				dataOutputStream.writeInt(scanCSD.getRetentionTimeColumn2());
 				dataOutputStream.writeFloat(scanCSD.getRetentionIndex()); // Retention Index
 				dataOutputStream.writeBoolean(scanCSD.hasAdditionalRetentionIndices());
+				// TODO: Check (Scan) - are additional RI values stored? RetentionIndexType.POLAR, ...
 				if(scanCSD.hasAdditionalRetentionIndices()) {
 					Map<RetentionIndexType, Float> retentionIndicesTyped = scanCSD.getRetentionIndicesTyped();
 					dataOutputStream.writeInt(retentionIndicesTyped.size());
@@ -380,6 +381,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 			writeString(dataOutputStream, quantitationEntry.getCalibrationMethod()); // Calibration Method
 			dataOutputStream.writeBoolean(quantitationEntry.getUsedCrossZero()); // Used Cross Zero
 			writeString(dataOutputStream, quantitationEntry.getDescription()); // Description
+			// TODO: QuantitationEntry - Quantitation Flag
 			/*
 			 * Legacy support
 			 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/xxd/converter/supplier/chemclipse/Activator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/xxd/converter/supplier/chemclipse/Activator.java
@@ -11,13 +11,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.converter.supplier.chemclipse;
 
-import org.eclipse.chemclipse.logging.core.Logger;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
 public class Activator implements BundleActivator {
 
-	private static final Logger logger = Logger.getLogger(Activator.class);
 	private static BundleContext context;
 
 	public static BundleContext getContext() {
@@ -29,30 +27,17 @@ public class Activator implements BundleActivator {
 	 * (non-Javadoc)
 	 * @see org.osgi.framework.BundleActivator#start(org.osgi.framework.BundleContext)
 	 */
+	@Override
 	public void start(BundleContext bundleContext) throws Exception {
 
 		Activator.context = bundleContext;
-		//
-		System.out.println("TODOS next version: v1401");
-		System.out.println("\tCheck (Scan) - are additional RI values stored? RetentionIndexType.POLAR, ...");
-		System.out.println("\tIQuantitationEntry - Quantitation Flag");
-		//
-		logger.info("-------------------------------------------------");
-		logger.info("Ensure backward and forward compatibility!");
-		logger.info("-------------------------------------------------");
-		logger.info("*.ocb - measurement data container");
-		logger.info("*.ocm - process method container");
-		logger.info("*.ocq - quanititation table container");
-		logger.info("*.ocs - sequence data container");
-		logger.info("-------------------------------------------------");
-		logger.info("--- CHANGES MUST BE APPROVED BY PHILIP WENIG ---");
-		logger.info("-------------------------------------------------");
 	}
 
 	/*
 	 * (non-Javadoc)
 	 * @see org.osgi.framework.BundleActivator#stop(org.osgi.framework.BundleContext)
 	 */
+	@Override
 	public void stop(BundleContext bundleContext) throws Exception {
 
 		Activator.context = null;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/xxd/converter/supplier/chemclipse/internal/support/IFormat.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/xxd/converter/supplier/chemclipse/internal/support/IFormat.java
@@ -16,6 +16,9 @@ import java.util.zip.ZipOutputStream;
 
 public interface IFormat {
 
+	/*
+	 * CHANGES MUST BE APPROVED BY PHILIP WENIG!
+	 */
 	String CONVERTER_ID_CHROMATOGRAM = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
 	String CONVERTER_ID_METHOD = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse.processMethodSupplier";
 	/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/xxd/converter/supplier/chemclipse/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/xxd/converter/supplier/chemclipse/preferences/PreferenceSupplier.java
@@ -31,7 +31,7 @@ public class PreferenceSupplier implements IPreferenceSupplier {
 	public static final int MIN_COMPRESSION_LEVEL = 0;
 	public static final int MAX_COMPRESSION_LEVEL = 9;
 	/*
-	 * *.ocb
+	 * *.ocb (measurement data container)
 	 */
 	public static final String P_CHROMATOGRAM_VERSION_SAVE = "chromatogramVersionSave";
 	public static final String DEF_CHROMATOGRAM_VERSION_SAVE = IFormat.CHROMATOGRAM_VERSION_LATEST;
@@ -48,14 +48,14 @@ public class PreferenceSupplier implements IPreferenceSupplier {
 	public static final String P_MIN_BYTES_TO_LOAD_IN_BACKGROUND = "minBytesToLoadInBackground"; // TODO REMOVE
 	public static final int DEF_MIN_BYTES_TO_LOAD_IN_BACKGROUND = 2000000; // 2 MB
 	/*
-	 * *.ocm
+	 * *.ocm (process method container)
 	 */
 	public static final String P_METHOD_VERSION_SAVE = "methodVersionSave";
 	public static final String DEF_METHOD_VERSION_SAVE = IFormat.METHOD_VERSION_LATEST;
 	public static final String P_METHOD_COMPRESSION_LEVEL = "methodCompressionLevel";
 	public static final int DEF_METHOD_COMPRESSION_LEVEL = IFormat.METHOD_COMPRESSION_LEVEL;
 	/*
-	 * *.ocq
+	 * *.ocq (quanititation table container)
 	 */
 	public static final String P_QUANTITATION_DB_VERSION_SAVE = "quantitationDatabaseVersionSave";
 	public static final String DEF_QUANTITATION_DB_VERSION_SAVE = IFormat.QUANTDB_VERSION_LATEST;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/xxd/converter/supplier/chemclipse/versions/ChromatogramVersion.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/xxd/converter/supplier/chemclipse/versions/ChromatogramVersion.java
@@ -13,6 +13,9 @@ package org.eclipse.chemclipse.xxd.converter.supplier.chemclipse.versions;
 
 import org.eclipse.chemclipse.xxd.converter.supplier.chemclipse.internal.support.IFormat;
 
+/*
+ * Ensure backward and forward compatibility!
+ */
 public enum ChromatogramVersion implements IFormatVersion {
 	V_0701(IFormat.CHROMATOGRAM_VERSION_0701, "Nernst"), //
 	V_0803(IFormat.CHROMATOGRAM_VERSION_0803, "Dempster"), //


### PR DESCRIPTION
https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners is a better solution to enforce this policy. The log is already quite crowded, which makes it hard to find actual problems in it.