### PR TITLE
Reduced the info level warnings

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/columns/SeparationColumnIndices.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/columns/SeparationColumnIndices.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Lablicate GmbH.
+ * Copyright (c) 2018, 2021 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -53,13 +53,16 @@ public class SeparationColumnIndices extends TreeMap<Integer, IRetentionIndexEnt
 	@Override
 	public boolean equals(Object obj) {
 
-		if(this == obj)
+		if(this == obj) {
 			return true;
-		if(obj == null)
+		}
+		if(obj == null) {
 			return false;
-		if(getClass() != obj.getClass())
+		}
+		if(getClass() != obj.getClass()) {
 			return false;
-		ISeparationColumn other = (ISeparationColumn)obj;
+		}
+		ISeparationColumnIndices other = (ISeparationColumnIndices)obj;
 		if(!other.equals(this)) {
 			return false;
 		}

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparisonSupplier_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparisonSupplier_3_Test.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.massspectrum;
 
+import static org.junit.Assert.assertNotEquals;
+
 import junit.framework.TestCase;
 
 public class MassSpectrumComparisonSupplier_3_Test extends TestCase {
@@ -42,22 +44,22 @@ public class MassSpectrumComparisonSupplier_3_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertTrue("equals", supplier1.equals(supplier2));
+		assertEquals("equals", supplier1, supplier2);
 	}
 
 	public void testEquals_2() {
 
-		assertTrue("equals", supplier2.equals(supplier1));
+		assertEquals("equals", supplier2, supplier1);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("equals", supplier1.equals(null));
+		assertNotNull("equals", supplier1);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("equals", supplier1.equals("Test"));
+		assertNotEquals("equals", supplier1, new Object());
 	}
 
 	public void testHashCode_1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparisonSupplier_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparisonSupplier_4_Test.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.massspectrum;
 
+import static org.junit.Assert.assertNotEquals;
+
 import junit.framework.TestCase;
 
 public class MassSpectrumComparisonSupplier_4_Test extends TestCase {
@@ -42,26 +44,26 @@ public class MassSpectrumComparisonSupplier_4_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertFalse("equals", supplier1.equals(supplier2));
+		assertNotEquals("equals", supplier1, supplier2);
 	}
 
 	public void testEquals_2() {
 
-		assertFalse("equals", supplier2.equals(supplier1));
+		assertNotEquals("equals", supplier2, supplier1);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("equals", supplier1.equals(null));
+		assertNotNull("equals", supplier1);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("equals", supplier1.equals("Test"));
+		assertNotEquals("equals", supplier1, new Object());
 	}
 
 	public void testHashCode_1() {
 
-		assertFalse("hashCode", supplier1.hashCode() == supplier2.hashCode());
+		assertNotEquals("hashCode", supplier1.hashCode(), supplier2.hashCode());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/support/RawPeak_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/support/RawPeak_2_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.peak.support;
 
+import static org.junit.Assert.assertNotEquals;
+
 import org.eclipse.chemclipse.chromatogram.peak.detector.support.IRawPeak;
 import org.eclipse.chemclipse.chromatogram.peak.detector.support.RawPeak;
 
@@ -19,7 +21,7 @@ import junit.framework.TestCase;
 /**
  * Tests the raw peak.
  * 
- * @author eselmeister
+ * @author Philip Wenig
  */
 public class RawPeak_2_Test extends TestCase {
 
@@ -48,22 +50,22 @@ public class RawPeak_2_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertTrue("equals", rawPeak1.equals(rawPeak2));
+		assertEquals("equals", rawPeak1, rawPeak2);
 	}
 
 	public void testEquals_2() {
 
-		assertTrue("equals", rawPeak2.equals(rawPeak1));
+		assertEquals("equals", rawPeak2, rawPeak1);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("equals", rawPeak1.equals(null));
+		assertNotNull("equals", rawPeak1);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("equals", rawPeak1.equals("test"));
+		assertNotEquals("equals", rawPeak1, new Object());
 	}
 
 	public void testHashCode_1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/support/RawPeak_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/support/RawPeak_3_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.peak.support;
 
+import static org.junit.Assert.assertNotEquals;
+
 import org.eclipse.chemclipse.chromatogram.peak.detector.support.IRawPeak;
 import org.eclipse.chemclipse.chromatogram.peak.detector.support.RawPeak;
 
@@ -19,7 +21,7 @@ import junit.framework.TestCase;
 /**
  * Tests the raw peak.
  * 
- * @author eselmeister
+ * @author Philip Wenig
  */
 public class RawPeak_3_Test extends TestCase {
 
@@ -48,21 +50,21 @@ public class RawPeak_3_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertFalse("equals", rawPeak1.equals(rawPeak2));
+		assertNotEquals("equals", rawPeak1, rawPeak2);
 	}
 
 	public void testEquals_2() {
 
-		assertFalse("equals", rawPeak2.equals(rawPeak1));
+		assertNotEquals("equals", rawPeak2, rawPeak1);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("equals", rawPeak1.equals(null));
+		assertNotNull("equals", rawPeak1);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("equals", rawPeak1.equals("test"));
+		assertNotEquals("equals", rawPeak1, new Object());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/support/RawPeak_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/support/RawPeak_4_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.peak.support;
 
+import static org.junit.Assert.assertNotEquals;
+
 import org.eclipse.chemclipse.chromatogram.peak.detector.support.IRawPeak;
 import org.eclipse.chemclipse.chromatogram.peak.detector.support.RawPeak;
 
@@ -19,7 +21,7 @@ import junit.framework.TestCase;
 /**
  * Tests the raw peak.
  * 
- * @author eselmeister
+ * @author Philip Wenig
  */
 public class RawPeak_4_Test extends TestCase {
 
@@ -48,21 +50,21 @@ public class RawPeak_4_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertFalse("equals", rawPeak1.equals(rawPeak2));
+		assertNotEquals("equals", rawPeak1, rawPeak2);
 	}
 
 	public void testEquals_2() {
 
-		assertFalse("equals", rawPeak2.equals(rawPeak1));
+		assertNotEquals("equals", rawPeak2, rawPeak1);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("equals", rawPeak1.equals(null));
+		assertNotNull("equals", rawPeak1);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("equals", rawPeak1.equals("test"));
+		assertNotEquals("equals", rawPeak1, new Object());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/support/RawPeak_5_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/support/RawPeak_5_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.peak.support;
 
+import static org.junit.Assert.assertNotEquals;
+
 import org.eclipse.chemclipse.chromatogram.peak.detector.support.IRawPeak;
 import org.eclipse.chemclipse.chromatogram.peak.detector.support.RawPeak;
 
@@ -19,7 +21,7 @@ import junit.framework.TestCase;
 /**
  * Tests the raw peak.
  * 
- * @author eselmeister
+ * @author Philip Wenig
  */
 public class RawPeak_5_Test extends TestCase {
 
@@ -48,21 +50,21 @@ public class RawPeak_5_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertFalse("equals", rawPeak1.equals(rawPeak2));
+		assertNotEquals("equals", rawPeak1, rawPeak2);
 	}
 
 	public void testEquals_2() {
 
-		assertFalse("equals", rawPeak2.equals(rawPeak1));
+		assertNotEquals("equals", rawPeak2, rawPeak1);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("equals", rawPeak1.equals(null));
+		assertNotNull("equals", rawPeak1);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("equals", rawPeak1.equals("test"));
+		assertNotEquals("equals", rawPeak1, new Object());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.quantitation.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/quantitation/core/PeakQuantifierSupplier_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.quantitation.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/quantitation/core/PeakQuantifierSupplier_3_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 Lablicate GmbH.
+ * Copyright (c) 2013, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -10,6 +10,8 @@
  * Dr. Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.quantitation.core;
+
+import static org.junit.Assert.assertNotEquals;
 
 import junit.framework.TestCase;
 
@@ -42,22 +44,22 @@ public class PeakQuantifierSupplier_3_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertTrue("equals", supplier1.equals(supplier2));
+		assertEquals("equals", supplier1, supplier2);
 	}
 
 	public void testEquals_2() {
 
-		assertTrue("equals", supplier2.equals(supplier1));
+		assertEquals("equals", supplier2, supplier1);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("equals", supplier1.equals(null));
+		assertNotNull("equals", supplier1);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("equals", supplier1.equals("Test"));
+		assertNotEquals("equals", supplier1, new Object());
 	}
 
 	public void testHashCode_1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.quantitation.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/quantitation/core/PeakQuantifierSupplier_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.quantitation.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/quantitation/core/PeakQuantifierSupplier_4_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 Lablicate GmbH.
+ * Copyright (c) 2013, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -10,6 +10,8 @@
  * Dr. Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.quantitation.core;
+
+import static org.junit.Assert.assertNotEquals;
 
 import junit.framework.TestCase;
 
@@ -42,26 +44,26 @@ public class PeakQuantifierSupplier_4_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertFalse("equals", supplier1.equals(supplier2));
+		assertNotEquals("equals", supplier1, supplier2);
 	}
 
 	public void testEquals_2() {
 
-		assertFalse("equals", supplier2.equals(supplier1));
+		assertNotEquals("equals", supplier2, supplier1);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("equals", supplier1.equals(null));
+		assertNotNull("equals", supplier1);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("equals", supplier1.equals("Test"));
+		assertNotEquals("equals", supplier1, new Object());
 	}
 
 	public void testHashCode_1() {
 
-		assertFalse("hashCode", supplier1.hashCode() == supplier2.hashCode());
+		assertNotEquals("hashCode", supplier1.hashCode(), supplier2.hashCode());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorSupplier_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorSupplier_3_Test.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.core;
 
+import static org.junit.Assert.assertNotEquals;
+
 import junit.framework.TestCase;
 
 public class BaselineDetectorSupplier_3_Test extends TestCase {
@@ -42,22 +44,22 @@ public class BaselineDetectorSupplier_3_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertTrue("equals", supplier1.equals(supplier2));
+		assertEquals("equals", supplier1, supplier2);
 	}
 
 	public void testEquals_2() {
 
-		assertTrue("equals", supplier2.equals(supplier1));
+		assertEquals("equals", supplier2, supplier1);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("equals", supplier1.equals(null));
+		assertNotNull("equals", supplier1);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("equals", supplier1.equals("Test"));
+		assertNotEquals("equals", supplier1, new Object());
 	}
 
 	public void testHashCode_1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorSupplier_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorSupplier_4_Test.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.core;
 
+import static org.junit.Assert.assertNotEquals;
+
 import junit.framework.TestCase;
 
 public class BaselineDetectorSupplier_4_Test extends TestCase {
@@ -42,22 +44,22 @@ public class BaselineDetectorSupplier_4_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertFalse("equals", supplier1.equals(supplier2));
+		assertNotEquals("equals", supplier1, supplier2);
 	}
 
 	public void testEquals_2() {
 
-		assertFalse("equals", supplier2.equals(supplier1));
+		assertNotEquals("equals", supplier2, supplier1);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("equals", supplier1.equals(null));
+		assertNotNull("equals", supplier1);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("equals", supplier1.equals("Test"));
+		assertNotEquals("equals", supplier1, new Object());
 	}
 
 	public void testHashCode_1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/PeakIntegrationResult_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/PeakIntegrationResult_1_Test.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.integrator.result;
 
+import static org.junit.Assert.assertNotEquals;
+
 import junit.framework.TestCase;
 
 public class PeakIntegrationResult_1_Test extends TestCase {
@@ -34,26 +36,26 @@ public class PeakIntegrationResult_1_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertEquals("equals", true, result1.equals(result2));
+		assertEquals("equals", result1, result2);
 	}
 
 	public void testEquals_2() {
 
-		assertEquals("equals", true, result2.equals(result1));
+		assertEquals("equals", result2, result1);
 	}
 
 	public void testEquals_3() {
 
-		assertEquals("equals", true, result1.equals(result1));
+		assertEquals("equals", result1, result1);
 	}
 
 	public void testEquals_4() {
 
-		assertEquals("equals", false, result1.equals(null));
+		assertNotNull("equals", result1);
 	}
 
 	public void testEquals_5() {
 
-		assertEquals("equals", false, result2.equals(new String("other object")));
+		assertNotEquals("equals", result2, new Object());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/PeakIntegrationResult_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/PeakIntegrationResult_2_Test.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.integrator.result;
 
+import static org.junit.Assert.assertNotEquals;
+
 import junit.framework.TestCase;
 
 public class PeakIntegrationResult_2_Test extends TestCase {
@@ -38,26 +40,26 @@ public class PeakIntegrationResult_2_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertEquals("equals", false, result1.equals(result2));
+		assertNotEquals("equals", result1, result2);
 	}
 
 	public void testEquals_2() {
 
-		assertEquals("equals", false, result2.equals(result1));
+		assertNotEquals("equals", result2, result1);
 	}
 
 	public void testEquals_3() {
 
-		assertEquals("equals", true, result1.equals(result1));
+		assertEquals("equals", result1, result1);
 	}
 
 	public void testEquals_4() {
 
-		assertEquals("equals", false, result1.equals(null));
+		assertNotNull("equals", result1);
 	}
 
 	public void testEquals_5() {
 
-		assertEquals("equals", false, result2.equals(new String("other object")));
+		assertNotEquals("equals", result2, new Object());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/baseline/BaselineSegment_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/baseline/BaselineSegment_4_Test.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.model.baseline;
 
+import static org.junit.Assert.assertNotEquals;
+
 import junit.framework.TestCase;
 
 public class BaselineSegment_4_Test extends TestCase {
@@ -48,32 +50,32 @@ public class BaselineSegment_4_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertTrue("Equals", segmentI.equals(segmentII));
+		assertEquals("Equals", segmentI, segmentII);
 	}
 
 	public void testEquals_2() {
 
-		assertTrue("Equals", segmentII.equals(segmentI));
+		assertEquals("Equals", segmentII, segmentI);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("Equals", segmentI.equals(null));
+		assertNotNull("Equals", segmentI);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("Equals", segmentII.equals(null));
+		assertNotNull("Equals", segmentII);
 	}
 
 	public void testEquals_5() {
 
-		assertFalse("Equals", segmentI.equals(new String("Test")));
+		assertNotEquals("Equals", segmentI, new Object());
 	}
 
 	public void testEquals_6() {
 
-		assertFalse("Equals", segmentII.equals(new String("Test")));
+		assertNotEquals("Equals", segmentII, new Object());
 	}
 
 	public void testHashCode_1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/baseline/BaselineSegment_5_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/baseline/BaselineSegment_5_Test.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.model.baseline;
 
+import static org.junit.Assert.assertNotEquals;
+
 import junit.framework.TestCase;
 
 public class BaselineSegment_5_Test extends TestCase {
@@ -48,31 +50,31 @@ public class BaselineSegment_5_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertFalse("Equals", segmentI.equals(segmentII));
+		assertNotEquals("Equals", segmentI, segmentII);
 	}
 
 	public void testEquals_2() {
 
-		assertFalse("Equals", segmentII.equals(segmentI));
+		assertNotEquals("Equals", segmentII, segmentI);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("Equals", segmentI.equals(null));
+		assertNotNull("Equals", segmentI);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("Equals", segmentII.equals(null));
+		assertNotNull("Equals", segmentII);
 	}
 
 	public void testEquals_5() {
 
-		assertFalse("Equals", segmentI.equals(new String("Test")));
+		assertNotEquals("Equals", segmentI, new Object());
 	}
 
 	public void testEquals_6() {
 
-		assertFalse("Equals", segmentII.equals(new String("Test")));
+		assertNotEquals("Equals", segmentII, new Object());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/src/org/eclipse/chemclipse/msd/converter/massspectrum/MassSpectrumSupplier_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/src/org/eclipse/chemclipse/msd/converter/massspectrum/MassSpectrumSupplier_2_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -10,6 +10,8 @@
  * Dr. Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.converter.massspectrum;
+
+import static org.junit.Assert.assertNotEquals;
 
 import org.eclipse.chemclipse.converter.chromatogram.ChromatogramSupplier;
 
@@ -47,88 +49,88 @@ public class MassSpectrumSupplier_2_Test extends TestCase {
 	public void testEquals_1() {
 
 		MassSpectrumSupplier anotherSupplier = new MassSpectrumSupplier();
-		assertEquals("equals", true, supplier.equals(anotherSupplier));
+		assertEquals("equals", supplier, anotherSupplier);
 	}
 
 	public void testEquals_2() {
 
 		MassSpectrumSupplier anotherSupplier = new MassSpectrumSupplier();
 		anotherSupplier.setId("chemclipse");
-		assertEquals("equals", false, supplier.equals(anotherSupplier));
+		assertNotEquals("equals", supplier, anotherSupplier);
 		anotherSupplier.setId("");
-		assertEquals("equals", true, supplier.equals(anotherSupplier));
+		assertEquals("equals", supplier, anotherSupplier);
 		anotherSupplier.setDescription("chemclipse");
-		assertEquals("equals", false, supplier.equals(anotherSupplier));
+		assertNotEquals("equals", supplier, anotherSupplier);
 		anotherSupplier.setDescription("");
-		assertEquals("equals", true, supplier.equals(anotherSupplier));
+		assertEquals("equals", supplier, anotherSupplier);
 		anotherSupplier.setFilterName("chemclipse");
-		assertEquals("equals", false, supplier.equals(anotherSupplier));
+		assertNotEquals("equals", supplier, anotherSupplier);
 		anotherSupplier.setFilterName("");
-		assertEquals("equals", true, supplier.equals(anotherSupplier));
+		assertEquals("equals", supplier, anotherSupplier);
 		anotherSupplier.setFileExtension("chemclipse");
-		assertEquals("equals", false, supplier.equals(anotherSupplier));
+		assertNotEquals("equals", supplier, anotherSupplier);
 		anotherSupplier.setFileExtension("");
-		assertEquals("equals", true, supplier.equals(anotherSupplier));
+		assertEquals("equals", supplier, anotherSupplier);
 		anotherSupplier.setFileName("chemclipse");
-		assertEquals("equals", false, supplier.equals(anotherSupplier));
+		assertNotEquals("equals", supplier, anotherSupplier);
 		anotherSupplier.setFileName("");
-		assertEquals("equals", true, supplier.equals(anotherSupplier));
+		assertEquals("equals", supplier, anotherSupplier);
 		anotherSupplier.setDirectoryExtension("chemclipse");
-		assertEquals("equals", false, supplier.equals(anotherSupplier));
+		assertNotEquals("equals", supplier, anotherSupplier);
 		anotherSupplier.setDirectoryExtension("");
-		assertEquals("equals", true, supplier.equals(anotherSupplier));
+		assertEquals("equals", supplier, anotherSupplier);
 	}
 
 	public void testEquals_3() {
 
 		MassSpectrumSupplier anotherSupplier = new MassSpectrumSupplier();
 		anotherSupplier.setId("chemclipse");
-		assertEquals("equals", false, anotherSupplier.equals(supplier));
+		assertNotEquals("equals", anotherSupplier, supplier);
 		anotherSupplier.setId("");
-		assertEquals("equals", true, anotherSupplier.equals(supplier));
+		assertEquals("equals", anotherSupplier, supplier);
 		anotherSupplier.setDescription("chemclipse");
-		assertEquals("equals", false, anotherSupplier.equals(supplier));
+		assertNotEquals("equals", anotherSupplier, supplier);
 		anotherSupplier.setDescription("");
-		assertEquals("equals", true, anotherSupplier.equals(supplier));
+		assertEquals("equals", anotherSupplier, supplier);
 		anotherSupplier.setFilterName("chemclipse");
-		assertEquals("equals", false, anotherSupplier.equals(supplier));
+		assertNotEquals("equals", anotherSupplier, supplier);
 		anotherSupplier.setFilterName("");
-		assertEquals("equals", true, anotherSupplier.equals(supplier));
+		assertEquals("equals", anotherSupplier, supplier);
 		anotherSupplier.setFileExtension("chemclipse");
-		assertEquals("equals", false, anotherSupplier.equals(supplier));
+		assertNotEquals("equals", anotherSupplier, supplier);
 		anotherSupplier.setFileExtension("");
-		assertEquals("equals", true, anotherSupplier.equals(supplier));
+		assertEquals("equals", anotherSupplier, supplier);
 		anotherSupplier.setFileName("chemclipse");
-		assertEquals("equals", false, anotherSupplier.equals(supplier));
+		assertNotEquals("equals", anotherSupplier, supplier);
 		anotherSupplier.setFileName("");
-		assertEquals("equals", true, anotherSupplier.equals(supplier));
+		assertEquals("equals", anotherSupplier, supplier);
 		anotherSupplier.setDirectoryExtension("chemclipse");
-		assertEquals("equals", false, anotherSupplier.equals(supplier));
+		assertNotEquals("equals", anotherSupplier, supplier);
 		anotherSupplier.setDirectoryExtension("");
-		assertEquals("equals", true, anotherSupplier.equals(supplier));
+		assertEquals("equals", anotherSupplier, supplier);
 	}
 
 	public void testEquals_4() {
 
 		MassSpectrumSupplier anotherSupplier = supplier;
-		assertEquals("equals", true, anotherSupplier.equals(supplier));
+		assertEquals("equals", anotherSupplier, supplier);
 	}
 
 	public void testEquals_5() {
 
-		assertEquals("equals", true, supplier.equals(supplier));
+		assertEquals("equals", supplier, supplier);
 	}
 
 	public void testEquals_6() {
 
 		ChromatogramSupplier anotherSupplier = null;
-		assertEquals("equals", false, supplier.equals(anotherSupplier));
+		assertNotEquals("equals", supplier, anotherSupplier);
 	}
 
 	public void testEquals_7() {
 
 		Object anotherSupplier = new Object();
-		assertEquals("equals", false, supplier.equals(anotherSupplier));
+		assertNotEquals("equals", supplier, anotherSupplier);
 	}
 
 	public void testHashCode_1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/Chromatogram_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/Chromatogram_1_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,12 +11,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.implementation;
 
+import static org.junit.Assert.assertNotEquals;
+
 import junit.framework.TestCase;
 
 /**
  * Tests the methods equals and hashCode.
  * 
- * @author eselmeister
+ * @author Philip Wenig
  */
 public class Chromatogram_1_Test extends TestCase {
 
@@ -41,32 +43,32 @@ public class Chromatogram_1_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertTrue(chromatogram1.equals(chromatogram2));
+		assertEquals(chromatogram1, chromatogram2);
 	}
 
 	public void testEquals_2() {
 
-		assertTrue(chromatogram2.equals(chromatogram1));
+		assertEquals(chromatogram2, chromatogram1);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse(chromatogram1.equals(null));
+		assertNotNull(chromatogram1);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse(chromatogram2.equals(null));
+		assertNotNull(chromatogram2);
 	}
 
 	public void testEquals_5() {
 
-		assertFalse(chromatogram1.equals(new String("")));
+		assertNotEquals(chromatogram1, new Object());
 	}
 
 	public void testEquals_6() {
 
-		assertFalse(chromatogram2.equals(new String("")));
+		assertNotEquals(chromatogram2, new Object());
 	}
 
 	public void testHashCode_1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/Ion_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/Ion_3_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,12 +11,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.implementation;
 
+import static org.junit.Assert.assertNotEquals;
+
 import junit.framework.TestCase;
 
 /**
  * Equals test.
  * 
- * @author eselmeister
+ * @author Philip Wenig
  */
 public class Ion_3_Test extends TestCase {
 
@@ -41,27 +43,27 @@ public class Ion_3_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertEquals("equals", true, ion1.equals(ion2));
+		assertEquals("equals", ion1, ion2);
 	}
 
 	public void testEquals_2() {
 
-		assertEquals("equals", true, ion2.equals(ion1));
+		assertEquals("equals", ion2, ion1);
 	}
 
 	public void testEquals_3() {
 
-		assertEquals("equals", true, ion1.equals(ion1));
+		assertEquals("equals", ion1, ion1);
 	}
 
 	public void testEquals_4() {
 
-		assertEquals("equals", false, ion1.equals(null));
+		assertNotNull("equals", ion1);
 	}
 
 	public void testEquals_5() {
 
-		assertEquals("equals", false, ion2.equals(new String("other object")));
+		assertNotEquals("equals", ion2, new Object());
 	}
 
 	public void testCompareTo_1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/Ion_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/Ion_4_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,12 +11,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.implementation;
 
+import static org.junit.Assert.assertNotEquals;
+
 import junit.framework.TestCase;
 
 /**
  * Equals test.
  * 
- * @author eselmeister
+ * @author Philip Wenig
  */
 public class Ion_4_Test extends TestCase {
 
@@ -41,27 +43,27 @@ public class Ion_4_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertEquals("equals", false, ion1.equals(ion2));
+		assertNotEquals("equals", ion1, ion2);
 	}
 
 	public void testEquals_2() {
 
-		assertEquals("equals", false, ion2.equals(ion1));
+		assertNotEquals("equals", ion2, ion1);
 	}
 
 	public void testEquals_3() {
 
-		assertEquals("equals", true, ion1.equals(ion1));
+		assertEquals("equals", ion1, ion1);
 	}
 
 	public void testEquals_4() {
 
-		assertEquals("equals", false, ion1.equals(null));
+		assertNotNull("equals", ion1);
 	}
 
 	public void testEquals_5() {
 
-		assertEquals("equals", false, ion2.equals(new String("other object")));
+		assertNotEquals("equals", ion2, new Object());
 	}
 
 	public void testCompareTo_1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/Ion_5_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/Ion_5_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,12 +11,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.implementation;
 
+import static org.junit.Assert.assertNotEquals;
+
 import junit.framework.TestCase;
 
 /**
  * Equals test.
  * 
- * @author eselmeister
+ * @author Philip Wenig
  */
 public class Ion_5_Test extends TestCase {
 
@@ -41,27 +43,27 @@ public class Ion_5_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertEquals("equals", false, ion1.equals(ion2));
+		assertNotEquals("equals", ion1, ion2);
 	}
 
 	public void testEquals_2() {
 
-		assertEquals("equals", false, ion2.equals(ion1));
+		assertNotEquals("equals", ion2, ion1);
 	}
 
 	public void testEquals_3() {
 
-		assertEquals("equals", true, ion1.equals(ion1));
+		assertEquals("equals", ion1, ion1);
 	}
 
 	public void testEquals_4() {
 
-		assertEquals("equals", false, ion1.equals(null));
+		assertNotNull("equals", ion1);
 	}
 
 	public void testEquals_5() {
 
-		assertEquals("equals", false, ion2.equals(new String("other object")));
+		assertNotEquals("equals", ion2, new Object());
 	}
 
 	public void testCompareTo_1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/SupplierIon_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/SupplierIon_3_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -10,6 +10,8 @@
  * Dr. Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.implementation;
+
+import static org.junit.Assert.assertNotEquals;
 
 import junit.framework.TestCase;
 
@@ -43,22 +45,22 @@ public class SupplierIon_3_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertEquals("equals", true, ion1.equals(ion2));
+		assertEquals("equals", ion1, ion2);
 	}
 
 	public void testEquals_2() {
 
-		assertEquals("equals", true, ion2.equals(ion1));
+		assertEquals("equals", ion2, ion1);
 	}
 
 	public void testEquals_3() {
 
-		assertEquals("equals", false, ion1.equals(ionX));
+		assertNotEquals("equals", ion1, ionX);
 	}
 
 	public void testEquals_4() {
 
-		assertEquals("equals", false, ion2.equals(ionX));
+		assertNotEquals("equals", ion2, ionX);
 	}
 
 	public void testHashCode_1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/SupplierIon_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/SupplierIon_4_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,12 +11,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.implementation;
 
+import static org.junit.Assert.assertNotEquals;
+
 import junit.framework.TestCase;
 
 /**
  * Equals and hashCode test.
  * 
- * @author eselmeister
+ * @author Philip Wenig
  */
 public class SupplierIon_4_Test extends TestCase {
 
@@ -43,41 +45,41 @@ public class SupplierIon_4_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertEquals("equals", false, ion1.equals(ion2));
+		assertNotEquals("equals", ion1, ion2);
 	}
 
 	public void testEquals_2() {
 
-		assertEquals("equals", false, ion2.equals(ion1));
+		assertNotEquals("equals", ion2, ion1);
 	}
 
 	public void testEquals_3() {
 
-		assertEquals("equals", false, ion1.equals(ionX));
+		assertNotEquals("equals", ion1, ionX);
 	}
 
 	public void testEquals_4() {
 
-		assertEquals("equals", false, ion2.equals(ionX));
+		assertNotEquals("equals", ion2, ionX);
 	}
 
 	public void testHashCode_1() {
 
-		assertTrue("hashCode", ion1.hashCode() != ion2.hashCode());
+		assertNotEquals("hashCode", ion1.hashCode(), ion2.hashCode());
 	}
 
 	public void testHashCode_2() {
 
-		assertTrue("hashCode", ion2.hashCode() != ion1.hashCode());
+		assertNotEquals("hashCode", ion2.hashCode(), ion1.hashCode());
 	}
 
 	public void testHashCode_3() {
 
-		assertTrue("hashCode", ion1.hashCode() != ionX.hashCode());
+		assertNotEquals("hashCode", ion1.hashCode(), ionX.hashCode());
 	}
 
 	public void testHashCode_4() {
 
-		assertTrue("hashCode", ion2.hashCode() != ionX.hashCode());
+		assertNotEquals("hashCode", ion2.hashCode(), ionX.hashCode());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/xic/ExtractedIonSignal_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/xic/ExtractedIonSignal_3_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,13 +11,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.xic;
 
+import static org.junit.Assert.assertNotEquals;
+
 import junit.framework.TestCase;
 
 /**
  * HashCode and equals test. extractedIonSignal1 = new ExtractedIonSignal(1,
  * 15); extractedIonSignal2 = new ExtractedIonSignal(1, 20);
  * 
- * @author eselmeister
+ * @author Philip Wenig
  */
 public class ExtractedIonSignal_3_Test extends TestCase {
 
@@ -42,51 +44,51 @@ public class ExtractedIonSignal_3_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertFalse("equals", extractedIonSignal1.equals(extractedIonSignal2));
+		assertNotEquals("equals", extractedIonSignal1, extractedIonSignal2);
 	}
 
 	public void testEquals_2() {
 
-		assertFalse("equals", extractedIonSignal2.equals(extractedIonSignal1));
+		assertNotEquals("equals", extractedIonSignal2, extractedIonSignal1);
 	}
 
 	public void testEquals_3() {
 
-		assertTrue("equals", extractedIonSignal1.equals(extractedIonSignal1));
+		assertEquals("equals", extractedIonSignal1, extractedIonSignal1);
 	}
 
 	public void testEquals_4() {
 
-		assertTrue("equals", extractedIonSignal2.equals(extractedIonSignal2));
+		assertEquals("equals", extractedIonSignal2, extractedIonSignal2);
 	}
 
 	public void testEquals_5() {
 
-		assertFalse("equals", extractedIonSignal1.equals(null));
+		assertNotNull("equals", extractedIonSignal1);
 	}
 
 	public void testEquals_6() {
 
-		assertFalse("equals", extractedIonSignal2.equals(null));
+		assertNotNull("equals", extractedIonSignal2);
 	}
 
 	public void testEquals_7() {
 
-		assertFalse("equals", extractedIonSignal1.equals(new String("Test")));
+		assertNotEquals("equals", extractedIonSignal1, new Object());
 	}
 
 	public void testEquals_8() {
 
-		assertFalse("equals", extractedIonSignal2.equals(new String("Test")));
+		assertNotEquals("equals", extractedIonSignal2, new Object());
 	}
 
 	public void testHashCode_1() {
 
-		assertTrue("hashCode", extractedIonSignal1.hashCode() != extractedIonSignal2.hashCode());
+		assertNotEquals("hashCode", extractedIonSignal1.hashCode(), extractedIonSignal2.hashCode());
 	}
 
 	public void testHashCode_2() {
 
-		assertTrue("hashCode", extractedIonSignal2.hashCode() != extractedIonSignal1.hashCode());
+		assertNotEquals("hashCode", extractedIonSignal2.hashCode(), extractedIonSignal1.hashCode());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/xic/TotalIonSignal_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/xic/TotalIonSignal_4_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.xic;
 
+import static org.junit.Assert.assertNotEquals;
+
 import org.eclipse.chemclipse.model.signals.ITotalScanSignal;
 import org.eclipse.chemclipse.model.signals.TotalScanSignal;
 
@@ -21,7 +23,7 @@ import junit.framework.TestCase;
  * TotalIonSignal(5720,1245.5f,25476.45f); totalIonSignal2 = new
  * TotalIonSignal(5720,1245.5f,25476.45f);
  * 
- * @author eselmeister
+ * @author Philip Wenig
  */
 public class TotalIonSignal_4_Test extends TestCase {
 
@@ -56,41 +58,41 @@ public class TotalIonSignal_4_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertTrue("equals", totalIonSignal1.equals(totalIonSignal2));
+		assertEquals("equals", totalIonSignal1, totalIonSignal2);
 	}
 
 	public void testEquals_2() {
 
-		assertTrue("equals", totalIonSignal2.equals(totalIonSignal1));
+		assertEquals("equals", totalIonSignal2, totalIonSignal1);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("equals", totalIonSignal1.equals(null));
+		assertNotNull("equals", totalIonSignal1);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("equals", totalIonSignal2.equals(null));
+		assertNotNull("equals", totalIonSignal2);
 	}
 
 	public void testEquals_5() {
 
-		assertTrue("equals", totalIonSignal1.equals(totalIonSignal1));
+		assertEquals("equals", totalIonSignal1, totalIonSignal1);
 	}
 
 	public void testEquals_6() {
 
-		assertTrue("equals", totalIonSignal2.equals(totalIonSignal2));
+		assertEquals("equals", totalIonSignal2, totalIonSignal2);
 	}
 
 	public void testEquals_7() {
 
-		assertFalse("equals", totalIonSignal1.equals(new String("Test")));
+		assertNotEquals("equals", totalIonSignal1, new Object());
 	}
 
 	public void testEquals_8() {
 
-		assertFalse("equals", totalIonSignal2.equals(new String("Test")));
+		assertNotEquals("equals", totalIonSignal2, new Object());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/xic/TotalIonSignal_5_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/xic/TotalIonSignal_5_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.xic;
 
+import static org.junit.Assert.assertNotEquals;
+
 import org.eclipse.chemclipse.model.signals.ITotalScanSignal;
 import org.eclipse.chemclipse.model.signals.TotalScanSignal;
 
@@ -21,7 +23,7 @@ import junit.framework.TestCase;
  * TotalIonSignal(5720,1245.5f,25476.45f); totalIonSignal2 = new
  * TotalIonSignal(5725,1245.5f,25476.45f);
  * 
- * @author eselmeister
+ * @author Philip Wenig
  */
 public class TotalIonSignal_5_Test extends TestCase {
 
@@ -46,51 +48,51 @@ public class TotalIonSignal_5_Test extends TestCase {
 
 	public void testHashCode_1() {
 
-		assertTrue("hashCode", totalIonSignal1.hashCode() != totalIonSignal2.hashCode());
+		assertNotEquals("hashCode", totalIonSignal1.hashCode(), totalIonSignal2.hashCode());
 	}
 
 	public void testHashCode_2() {
 
-		assertTrue("hashCode", totalIonSignal2.hashCode() != totalIonSignal1.hashCode());
+		assertNotEquals("hashCode", totalIonSignal2.hashCode(), totalIonSignal1.hashCode());
 	}
 
 	public void testEquals_1() {
 
-		assertFalse("equals", totalIonSignal1.equals(totalIonSignal2));
+		assertNotEquals("equals", totalIonSignal1, totalIonSignal2);
 	}
 
 	public void testEquals_2() {
 
-		assertFalse("equals", totalIonSignal2.equals(totalIonSignal1));
+		assertNotEquals("equals", totalIonSignal2, totalIonSignal1);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("equals", totalIonSignal1.equals(null));
+		assertNotNull("equals", totalIonSignal1);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("equals", totalIonSignal2.equals(null));
+		assertNotNull("equals", totalIonSignal2);
 	}
 
 	public void testEquals_5() {
 
-		assertTrue("equals", totalIonSignal1.equals(totalIonSignal1));
+		assertEquals("equals", totalIonSignal1, totalIonSignal1);
 	}
 
 	public void testEquals_6() {
 
-		assertTrue("equals", totalIonSignal2.equals(totalIonSignal2));
+		assertEquals("equals", totalIonSignal2, totalIonSignal2);
 	}
 
 	public void testEquals_7() {
 
-		assertFalse("equals", totalIonSignal1.equals(new String("Test")));
+		assertNotEquals("equals", totalIonSignal1, new Object());
 	}
 
 	public void testEquals_8() {
 
-		assertFalse("equals", totalIonSignal2.equals(new String("Test")));
+		assertNotEquals("equals", totalIonSignal2, new Object());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.numeric.fragment.test/src/org/eclipse/chemclipse/numeric/equations/LinearEquations_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.numeric.fragment.test/src/org/eclipse/chemclipse/numeric/equations/LinearEquations_2_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,8 +11,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.numeric.equations;
 
+import static org.junit.Assert.assertNotEquals;
+
 import org.eclipse.chemclipse.numeric.core.IPoint;
 import org.eclipse.chemclipse.numeric.core.Point;
+
 import junit.framework.TestCase;
 
 public class LinearEquations_2_Test extends TestCase {
@@ -38,22 +41,22 @@ public class LinearEquations_2_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertTrue("equals", eq1.equals(eq2));
+		assertEquals("equals", eq1, eq2);
 	}
 
 	public void testEquals_2() {
 
-		assertTrue("equals", eq2.equals(eq1));
+		assertEquals("equals", eq2, eq1);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("equals", eq1.equals(null));
+		assertNotNull("equals", eq1);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("equals", eq1.equals(""));
+		assertNotEquals("equals", eq1, new Object());
 	}
 
 	public void testHashCode_1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.numeric.fragment.test/src/org/eclipse/chemclipse/numeric/equations/LinearEquations_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.numeric.fragment.test/src/org/eclipse/chemclipse/numeric/equations/LinearEquations_3_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,8 +11,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.numeric.equations;
 
+import static org.junit.Assert.assertNotEquals;
+
 import org.eclipse.chemclipse.numeric.core.IPoint;
 import org.eclipse.chemclipse.numeric.core.Point;
+
 import junit.framework.TestCase;
 
 public class LinearEquations_3_Test extends TestCase {
@@ -40,21 +43,21 @@ public class LinearEquations_3_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertFalse("equals", eq1.equals(eq2));
+		assertNotEquals("equals", eq1, eq2);
 	}
 
 	public void testEquals_2() {
 
-		assertFalse("equals", eq2.equals(eq1));
+		assertNotEquals("equals", eq2, eq1);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("equals", eq1.equals(null));
+		assertNotNull("equals", eq1);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("equals", eq1.equals(""));
+		assertNotEquals("equals", eq1, new Object());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.numeric.fragment.test/src/org/eclipse/chemclipse/numeric/geometry/Slope_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.numeric.fragment.test/src/org/eclipse/chemclipse/numeric/geometry/Slope_2_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,8 +11,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.numeric.geometry;
 
+import static org.junit.Assert.assertNotEquals;
+
 import org.eclipse.chemclipse.numeric.core.IPoint;
 import org.eclipse.chemclipse.numeric.core.Point;
+
 import junit.framework.TestCase;
 
 public class Slope_2_Test extends TestCase {
@@ -42,22 +45,22 @@ public class Slope_2_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertTrue("equals", slope1.equals(slope2));
+		assertEquals("equals", slope1, slope2);
 	}
 
 	public void testEquals_2() {
 
-		assertTrue("equals", slope2.equals(slope1));
+		assertEquals("equals", slope2, slope1);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("equals", slope1.equals(null));
+		assertNotNull("equals", slope1);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("equals", slope1.equals("test"));
+		assertNotEquals("equals", slope1, new Object());
 	}
 
 	public void hashCode_1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.numeric.fragment.test/src/org/eclipse/chemclipse/numeric/geometry/Slope_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.numeric.fragment.test/src/org/eclipse/chemclipse/numeric/geometry/Slope_3_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,8 +11,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.numeric.geometry;
 
+import static org.junit.Assert.assertNotEquals;
+
 import org.eclipse.chemclipse.numeric.core.IPoint;
 import org.eclipse.chemclipse.numeric.core.Point;
+
 import junit.framework.TestCase;
 
 public class Slope_3_Test extends TestCase {
@@ -44,21 +47,21 @@ public class Slope_3_Test extends TestCase {
 
 	public void testEquals_1() {
 
-		assertFalse("equals", slope1.equals(slope2));
+		assertNotEquals("equals", slope1, slope2);
 	}
 
 	public void testEquals_2() {
 
-		assertFalse("equals", slope2.equals(slope1));
+		assertNotEquals("equals", slope2, slope1);
 	}
 
 	public void testEquals_3() {
 
-		assertFalse("equals", slope1.equals(null));
+		assertNotNull("equals", slope1);
 	}
 
 	public void testEquals_4() {
 
-		assertFalse("equals", slope1.equals("test"));
+		assertNotEquals("equals", slope1, new Object());
 	}
 }


### PR DESCRIPTION
It seems that JUnit improved, since a lot of those unit tests were written. Some were using comparisons that were impossible due to Java's built-in type safety which issued warnings in the IDE, others used double negation and most of them only exposed a boolean value to the logs when actually objects were compared which limits the error messages they give. In the end, nothing really changes. Getting rid of those warnings revealed one real problem.