### PR TITLE
Fixed NumberFormatExceptions in TableSupport

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/swt/TableSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/swt/TableSupport.java
@@ -87,6 +87,8 @@ public class TableSupport {
 
 	private static int[] convertColumnInfo(String columnInfo) {
 
+		if(columnInfo.isEmpty())
+			return new int[0];
 		String[] values = columnInfo.split(VALUE_DELIMITER);
 		int size = values.length;
 		int[] columns = new int[size];


### PR DESCRIPTION
This is the same as https://github.com/eclipse/swtchart/pull/277/ avoid logging warnings that are irrelevant. Exception handling is also a performance drain.