### PR TITLE
Made empty string validation optional

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/settings/FilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/settings/FilterSettings.java
@@ -24,11 +24,11 @@ public class FilterSettings extends AbstractChromatogramFilterSettings {
 
 	@JsonProperty(value = "Ions To Remove", defaultValue = "18 28 84 207")
 	@JsonPropertyDescription(value = "List the ions to remove, separated by a white space.")
-	@StringSettingsProperty(regExp = "(^$|((\\d+[;|\\s]?)+))", description = "must be space separated digits.", isMultiLine = false)
+	@StringSettingsProperty(regExp = "(^$|((\\d+[;|\\s]?)+))", description = "must be space separated digits.", isMultiLine = false, allowEmpty = false)
 	private String ionsToRemove = "18;28;84;207";
 	@JsonProperty(value = "Ions To Preserve", defaultValue = "103 104")
 	@JsonPropertyDescription(value = "List the ions to preserve, separated by a white space.")
-	@StringSettingsProperty(regExp = "(^$|((\\d+[;|\\s]?)+))", description = "must be space separated digits.", isMultiLine = false)
+	@StringSettingsProperty(regExp = "(^$|((\\d+[;|\\s]?)+))", description = "must be space separated digits.", isMultiLine = false, allowEmpty = true)
 	private String ionsToPreserve = "103;104";
 	@JsonProperty(value = "Adjust Threshold Transitions", defaultValue = "true")
 	@JsonPropertyDescription(value = "Adjust zero threshold transitions.")

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/ionremover/settings/ChromatogramFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/ionremover/settings/ChromatogramFilterSettings.java
@@ -21,7 +21,7 @@ public class ChromatogramFilterSettings extends AbstractChromatogramFilterSettin
 
 	@JsonProperty(value = "Ions To Remove", defaultValue = "18 28 84 207")
 	@JsonPropertyDescription(value = "List the ions to remove, separated by a white space.")
-	@StringSettingsProperty(regExp = "(\\d+[;|\\s]?)+", description = "must be space separated digits.", isMultiLine = false)
+	@StringSettingsProperty(regExp = "(\\d+[;|\\s]?)+", description = "must be space separated digits.", isMultiLine = false, allowEmpty = false)
 	private String ionsToRemove = "18 28 84 207";
 
 	public String getIonsToRemove() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/ionremover/settings/MassSpectrumFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/ionremover/settings/MassSpectrumFilterSettings.java
@@ -23,7 +23,7 @@ public class MassSpectrumFilterSettings extends AbstractMassSpectrumFilterSettin
 
 	@JsonProperty(value = "Ions", defaultValue = "18 28 84 207")
 	@JsonPropertyDescription(value = "List the ions, separated by a white space.")
-	@StringSettingsProperty(regExp = "(\\d+[;|\\s]?)+", description = "must be space separated digits.", isMultiLine = false)
+	@StringSettingsProperty(regExp = "(\\d+[;|\\s]?)+", description = "must be space separated digits.", isMultiLine = false, allowEmpty = false)
 	private String ionsToRemove = "18 28 84 207";
 	@JsonProperty(value = "Mode", defaultValue = "INCLUDE")
 	@JsonPropertyDescription(value = "Gives the mode to use (include = remove all ions given in the list, exclude = remove all ions not in the list)")

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/ionremover/settings/PeakFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/ionremover/settings/PeakFilterSettings.java
@@ -21,7 +21,7 @@ public class PeakFilterSettings extends AbstractPeakFilterSettings {
 
 	@JsonProperty(value = "Ions To Remove", defaultValue = "18 28 84 207")
 	@JsonPropertyDescription(value = "List the ions to remove, separated by a white space.")
-	@StringSettingsProperty(regExp = "(\\d+[;|\\s]?)+", description = "must be space separated digits.", isMultiLine = false)
+	@StringSettingsProperty(regExp = "(\\d+[;|\\s]?)+", description = "must be space separated digits.", isMultiLine = false, allowEmpty = false)
 	private String ionsToRemove = "18 28 84 207";
 
 	public String getIonsToRemove() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.peakmax/src/org/eclipse/chemclipse/chromatogram/msd/integrator/supplier/peakmax/settings/PeakIntegrationSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.peakmax/src/org/eclipse/chemclipse/chromatogram/msd/integrator/supplier/peakmax/settings/PeakIntegrationSettings.java
@@ -30,7 +30,7 @@ public class PeakIntegrationSettings extends AbstractPeakIntegrationSettings {
 	//
 	@JsonProperty(value = "Ions to integrate", defaultValue = TIC)
 	@JsonPropertyDescription(value = "List the ions to integrate, separated by a white space. 0 = TIC")
-	@StringSettingsProperty(regExp = "(\\d+[;|\\s]?)+", description = "must be space separated digits.", isMultiLine = false)
+	@StringSettingsProperty(regExp = "(\\d+[;|\\s]?)+", description = "must be space separated digits.", isMultiLine = false, allowEmpty = false)
 	private String ionsToIntegrate = TIC;
 	/*
 	 * The selected ions are handled separately.

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.sumarea/src/org/eclipse/chemclipse/chromatogram/msd/integrator/supplier/sumarea/settings/ChromatogramIntegrationSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.sumarea/src/org/eclipse/chemclipse/chromatogram/msd/integrator/supplier/sumarea/settings/ChromatogramIntegrationSettings.java
@@ -21,7 +21,7 @@ public class ChromatogramIntegrationSettings extends AbstractChromatogramIntegra
 
 	@JsonProperty(value = "Ions To Integrate", defaultValue = "")
 	@JsonPropertyDescription(value = "List the ions to integrate, separated by a semicolon. Empty means TIC.")
-	@StringSettingsProperty(regExp = "(^$|((\\d+;?)+))", description = "must be space separated digits.", isMultiLine = false)
+	@StringSettingsProperty(regExp = "(^$|((\\d+;?)+))", description = "must be semicolon separated digits.", isMultiLine = false, allowEmpty = true)
 	private String selectedIons = "";
 
 	public String getSelectedIons() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scanremover/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scanremover/settings/FilterSettingsRemover.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scanremover/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scanremover/settings/FilterSettingsRemover.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Lablicate GmbH.
+ * Copyright (c) 2011, 2021 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -22,7 +22,7 @@ public class FilterSettingsRemover extends AbstractChromatogramFilterSettings {
 
 	@JsonProperty(value = "Scan Remover Pattern", defaultValue = PreferenceSupplier.DEF_REMOVER_PATTERN)
 	@JsonPropertyDescription(value = "The pattern, which is used to remove scans.")
-	@StringSettingsProperty(regExp = PreferenceSupplier.CHECK_REMOVER_PATTERM)
+	@StringSettingsProperty(regExp = PreferenceSupplier.CHECK_REMOVER_PATTERM, allowEmpty = false)
 	private String scanRemoverPattern = PreferenceSupplier.DEF_REMOVER_PATTERN;
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/supplier/trapezoid/settings/PeakIntegrationSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/supplier/trapezoid/settings/PeakIntegrationSettings.java
@@ -29,7 +29,7 @@ public class PeakIntegrationSettings extends AbstractPeakIntegrationSettings {
 	//
 	@JsonProperty(value = "Ions to integrate", defaultValue = TIC)
 	@JsonPropertyDescription(value = "List the ions to integrate, separated by a white space. 0 = TIC")
-	@StringSettingsProperty(regExp = "(\\d+[;|\\s]?)+", description = "must be space separated digits.", isMultiLine = false)
+	@StringSettingsProperty(regExp = "(\\d+[;|\\s]?)+", description = "must be space separated digits.", isMultiLine = false, allowEmpty = false)
 	private String ionsToIntegrate = TIC;
 	/*
 	 * The selected ions are handled separately.

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/settings/StringSettingsProperty.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/settings/StringSettingsProperty.java
@@ -32,4 +32,6 @@ public @interface StringSettingsProperty {
 	String description() default "must match the pattern.";
 
 	boolean isMultiLine() default false;
+
+	boolean allowEmpty() default true;
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/settings/parser/SettingsClassParser.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/settings/parser/SettingsClassParser.java
@@ -126,7 +126,7 @@ public class SettingsClassParser<SettingType> implements SettingsParser<SettingT
 								StringSettingsProperty settingsProperty = (StringSettingsProperty)annotation;
 								String regExp = settingsProperty.regExp();
 								if(regExp != null && !regExp.isEmpty()) {
-									inputValue.addValidator(new RegularExpressionValidator(property.getName(), Pattern.compile(regExp), settingsProperty.description(), settingsProperty.isMultiLine()));
+									inputValue.addValidator(new RegularExpressionValidator(property.getName(), Pattern.compile(regExp), settingsProperty.description(), settingsProperty.isMultiLine(), settingsProperty.allowEmpty()));
 								}
 								inputValue.setMultiLine(settingsProperty.isMultiLine());
 							} else if(annotation instanceof FileSettingProperty) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/settings/validation/RegularExpressionValidator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/settings/validation/RegularExpressionValidator.java
@@ -24,13 +24,15 @@ public class RegularExpressionValidator implements IValidator {
 	private Pattern regExp;
 	private String description;
 	private boolean multiline;
+	private boolean allowEmpty;
 
-	public RegularExpressionValidator(String fieldName, Pattern regExp, String description, boolean multiline) {
+	public RegularExpressionValidator(String fieldName, Pattern regExp, String description, boolean multiline, boolean allowEmpty) {
 
 		this.fieldName = fieldName;
 		this.regExp = regExp;
 		this.description = description;
 		this.multiline = multiline;
+		this.allowEmpty = allowEmpty;
 	}
 
 	@Override
@@ -38,7 +40,7 @@ public class RegularExpressionValidator implements IValidator {
 
 		if(value instanceof String) {
 			String string = (String)value;
-			if(!string.isEmpty()) {
+			if(!string.isEmpty() || allowEmpty) {
 				if(multiline) {
 					String[] lines = string.split("[\r\n]+");
 					int n = 1;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.model/src/org/eclipse/chemclipse/xxd/model/settings/peaks/ClassifierAssignFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.model/src/org/eclipse/chemclipse/xxd/model/settings/peaks/ClassifierAssignFilterSettings.java
@@ -32,11 +32,11 @@ public class ClassifierAssignFilterSettings {
 	private boolean matchPartly = true;
 	@JsonProperty(value = "Match Expression(s)", defaultValue = "")
 	@JsonPropertyDescription(value = "List the identification target names to search for.")
-	@StringSettingsProperty(regExp = REGULAR_EXPRESSION, isMultiLine = true)
+	@StringSettingsProperty(regExp = REGULAR_EXPRESSION, isMultiLine = true, allowEmpty = true)
 	private String matchExpressions = "";
 	@JsonProperty(value = "Match Classification(s)", defaultValue = "")
 	@JsonPropertyDescription(value = "If the identification target name is matched, set the classifier.")
-	@StringSettingsProperty(regExp = REGULAR_EXPRESSION, isMultiLine = true)
+	@StringSettingsProperty(regExp = REGULAR_EXPRESSION, isMultiLine = true, allowEmpty = true)
 	private String matchClassifications = "";
 
 	public boolean isUseRegularExpression() {


### PR DESCRIPTION
https://github.com/eclipse/chemclipse/commit/f48e0cf679503225e05866fe002129bde44c28e8 added a regression where empty strings are always not allowed, however in some cases the UI instructs you to leave it empty for no action. I decided to default back to the previous (check broken) behavior but make it configurable.