### PR TITLE
Added support for FT-IR JCAMP-DX files

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/META-INF/MANIFEST.MF
@@ -14,7 +14,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.processing;bundle-version="0.8.0",
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
- org.eclipse.chemclipse.support;bundle-version="0.8.0"
+ org.eclipse.chemclipse.support;bundle-version="0.8.0",
+ org.eclipse.chemclipse.xir.model,
+ org.eclipse.chemclipse.xir.converter
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: ChemClipse

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/plugin.xml
@@ -57,4 +57,18 @@
             isImportable="true">
       </ChromatogramSupplier>
    </extension>
+   <extension
+         point="org.eclipse.chemclipse.xir.converter.scanSupplier">
+      <ScanSupplier
+            description="Reads JCAMP-DX FT-IR (*.dx) scans."
+            fileExtension=".dx"
+            filterName="FT-IR (*.dx)"
+            id="org.eclipse.chemclipse.xir.converter.supplier.jcampdx"
+            importConverter="org.eclipse.chemclipse.xir.converter.supplier.jcampdx.converter.ScanImportConverter"
+            exportConverter="org.eclipse.chemclipse.xir.converter.supplier.jcampdx.converter.ScanExportConverter"
+            importMagicNumberMatcher="org.eclipse.chemclipse.xir.converter.supplier.jcampdx.io.MagicNumberMatcherInfraredSpectroscopy"
+            isExportable="false"
+            isImportable="true">
+      </ScanSupplier>
+   </extension>
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/xir/converter/supplier/jcampdx/converter/ScanExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/xir/converter/supplier/jcampdx/converter/ScanExportConverter.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Lablicate GmbH.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Philip Wenig - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xir.converter.supplier.jcampdx.converter;
+
+import java.io.File;
+
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.processing.core.ProcessingInfo;
+import org.eclipse.chemclipse.xir.converter.core.AbstractScanExportConverter;
+import org.eclipse.chemclipse.xir.converter.core.IScanExportConverter;
+import org.eclipse.chemclipse.xir.model.core.IScanXIR;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+@SuppressWarnings("rawtypes")
+public class ScanExportConverter extends AbstractScanExportConverter implements IScanExportConverter {
+
+	@Override
+	public IProcessingInfo<?> convert(File file, IScanXIR scan, IProgressMonitor monitor) {
+
+		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
+		processingInfo.addInfoMessage("FTIR", "Export is not available");
+		return processingInfo;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/xir/converter/supplier/jcampdx/converter/ScanImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/xir/converter/supplier/jcampdx/converter/ScanImportConverter.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Lablicate GmbH.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Philip Wenig - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xir.converter.supplier.jcampdx.converter;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.processing.core.ProcessingInfo;
+import org.eclipse.chemclipse.xir.converter.core.AbstractScanImportConverter;
+import org.eclipse.chemclipse.xir.converter.core.IScanImportConverter;
+import org.eclipse.chemclipse.xir.converter.supplier.jcampdx.io.ScanReader;
+import org.eclipse.chemclipse.xir.converter.supplier.jcampdx.model.IVendorScanXIR;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+@SuppressWarnings("rawtypes")
+public class ScanImportConverter extends AbstractScanImportConverter implements IScanImportConverter {
+
+	private static final Logger logger = Logger.getLogger(ScanImportConverter.class);
+
+	@Override
+	public IProcessingInfo<IVendorScanXIR> convert(File file, IProgressMonitor monitor) {
+
+		IProcessingInfo<IVendorScanXIR> processingInfo = new ProcessingInfo<>();
+		try {
+			ScanReader scanReader = new ScanReader();
+			IVendorScanXIR vendorScan = scanReader.read(file, monitor);
+			processingInfo.setProcessingResult(vendorScan);
+		} catch(IOException e) {
+			processingInfo.addErrorMessage("JCAMP-DX", "There was a problem to import the FT-IR file.");
+			logger.warn(e);
+		}
+		return processingInfo;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/xir/converter/supplier/jcampdx/io/MagicNumberMatcherInfraredSpectroscopy.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/xir/converter/supplier/jcampdx/io/MagicNumberMatcherInfraredSpectroscopy.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xir.converter.supplier.jcampdx.io;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+import org.eclipse.chemclipse.converter.core.AbstractMagicNumberMatcher;
+import org.eclipse.chemclipse.converter.core.IMagicNumberMatcher;
+
+public class MagicNumberMatcherInfraredSpectroscopy extends AbstractMagicNumberMatcher implements IMagicNumberMatcher {
+
+	@Override
+	public boolean checkFileFormat(File file) {
+
+		if(!checkFileExtension(file, ".dx")) {
+			return false;
+		}
+		try (BufferedReader bufferedReader = new BufferedReader(new FileReader(file))) {
+			for(int i = 0; i < 3; i++) {
+				if(bufferedReader.readLine().contains("##DATA TYPE=INFRARED SPECTRUM")) {
+					return true;
+				}
+			}
+		} catch(IOException e) {
+			return false;
+		}
+		return false;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/xir/converter/supplier/jcampdx/io/ScanReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/xir/converter/supplier/jcampdx/io/ScanReader.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Lablicate GmbH.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xir.converter.supplier.jcampdx.io;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.activation.UnsupportedDataTypeException;
+
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.xir.converter.supplier.jcampdx.model.IVendorScanXIR;
+import org.eclipse.chemclipse.xir.converter.supplier.jcampdx.model.VendorScanXIR;
+import org.eclipse.chemclipse.xir.model.core.SignalXIR;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+public class ScanReader {
+
+	private static final Logger logger = Logger.getLogger(ScanReader.class);
+	//
+	private static final String HEADER_MARKER = "##";
+	private static final String DATE = "##DATE=";
+	private static final String XUNITS = "##XUNITS=";
+	private static final String YUNITS = "##YUNITS=";
+	// private static final String RESOLUTION = "##RESOLUTION=";
+	private static final String FIRSTX = "##FIRSTX=";
+	private static final String LASTX = "##LASTX=";
+	private static final String DELTAX = "##DELTAX=";
+	// private static final String MAXY = "##MAXY=";
+	// private static final String MINY = "##MINY=";
+	private static final String XFACTOR = "##XFACTOR=";
+	private static final String YFACTOR = "##YFACTOR=";
+	// private static final String NPOINTS = "##NPOINTS=";
+	private static final String FIRSTY = "##FIRSTY=";
+	private static final String XYDATA = "##XYDATA=";
+	//
+	private static final Pattern rawYpattern = Pattern.compile("\\+(\\d*)");
+
+	public IVendorScanXIR read(File file, IProgressMonitor monitor) throws IOException {
+
+		IVendorScanXIR vendorScan = new VendorScanXIR();
+		FileReader fileReader = new FileReader(file);
+		BufferedReader bufferedReader = new BufferedReader(fileReader);
+		String line;
+		float firstX = 0;
+		float firstY = 0;
+		float lastX = 0;
+		float deltaX = 0;
+		double xFactor = 0;
+		double yFactor = 0;
+		float rawX = 0;
+		boolean firstValue = true;
+		boolean transmission = false;
+		boolean absorbance = false;
+		while((line = bufferedReader.readLine()) != null) {
+			if(line.startsWith(DATE)) {
+				String date = line.trim().replace(DATE, "");
+				SimpleDateFormat format = new SimpleDateFormat("dd/MM/yyyy");
+				try {
+					Date parsedDate = format.parse(date);
+					vendorScan.setDate(parsedDate);
+				} catch(ParseException e) {
+					logger.warn(e);
+				}
+			}
+			if(line.startsWith(XYDATA)) {
+				if(!line.contains("(X++(Y..Y))")) {
+					bufferedReader.close();
+					fileReader.close();
+					throw new UnsupportedDataTypeException("Unknown line compression type: " + line);
+				}
+			}
+			if(line.startsWith(FIRSTX)) {
+				firstX = Float.parseFloat(line.trim().replace(FIRSTX, ""));
+				rawX = firstX;
+			}
+			if(line.startsWith(FIRSTY)) {
+				firstY = Float.parseFloat(line.trim().replace(FIRSTY, ""));
+			}
+			if(line.startsWith(LASTX)) {
+				lastX = Float.parseFloat(line.trim().replace(LASTX, ""));
+			}
+			if(line.startsWith(DELTAX)) {
+				deltaX = Float.parseFloat(line.trim().replace(DELTAX, ""));
+			}
+			if(line.startsWith(XFACTOR)) {
+				xFactor = Double.valueOf(line.trim().replace(XFACTOR, ""));
+			}
+			if(line.startsWith(YFACTOR)) {
+				yFactor = Double.valueOf(line.trim().replace(YFACTOR, ""));
+			}
+			if(line.startsWith(XUNITS)) {
+				String xUnit = line.trim().replace(XUNITS, "");
+				if(!xUnit.equals("1/CM")) {
+					bufferedReader.close();
+					fileReader.close();
+					throw new UnsupportedDataTypeException("Unsupported X unit: " + xUnit);
+				}
+			}
+			if(line.startsWith(YUNITS)) {
+				String yUnit = line.trim().replace(YUNITS, "");
+				if(yUnit.equals("TRANSMITTANCE")) {
+					transmission = true;
+				} else if(yUnit.equals("ABSORBANCE")) {
+					absorbance = true;
+				} else {
+					bufferedReader.close();
+					fileReader.close();
+					throw new UnsupportedDataTypeException("Unsupported Y unit: " + yUnit);
+				}
+			}
+			if(!line.startsWith(HEADER_MARKER)) {
+				Matcher rawYs = rawYpattern.matcher(line.trim());
+				while(rawYs.find()) {
+					if(!firstValue) {
+						rawX += deltaX;
+					}
+					double x = rawX * xFactor;
+					//
+					int rawY = Integer.parseInt(rawYs.group(1));
+					double y = rawY * yFactor;
+					if(firstValue) {
+						if(firstY != y) { // TODO approximate here
+							logger.warn("Expected first Y to be " + firstY + " but calculated " + y);
+						}
+					}
+					if(absorbance) {
+						vendorScan.getProcessedSignals().add(new SignalXIR(x, y, 0));
+					} else if(transmission) {
+						vendorScan.getProcessedSignals().add(new SignalXIR(x, 0, y));
+					}
+					firstValue = false;
+				}
+			}
+		}
+		if(lastX != rawX * xFactor) {
+			logger.warn("Expected last X to be " + lastX + " but calculated " + rawX * xFactor);
+		}
+		bufferedReader.close();
+		fileReader.close();
+		return vendorScan;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/xir/converter/supplier/jcampdx/io/ScanWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/xir/converter/supplier/jcampdx/io/ScanWriter.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Lablicate GmbH.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Dr. Philip Wenig - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xir.converter.supplier.jcampdx.io;
+
+public class ScanWriter {
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/xir/converter/supplier/jcampdx/model/IVendorScanXIR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/xir/converter/supplier/jcampdx/model/IVendorScanXIR.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Lablicate GmbH.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Dr. Philip Wenig - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xir.converter.supplier.jcampdx.model;
+
+import org.eclipse.chemclipse.xir.model.core.IScanXIR;
+
+public interface IVendorScanXIR extends IScanXIR {
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/xir/converter/supplier/jcampdx/model/VendorScanXIR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/xir/converter/supplier/jcampdx/model/VendorScanXIR.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Lablicate GmbH.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Dr. Philip Wenig - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xir.converter.supplier.jcampdx.model;
+
+import org.eclipse.chemclipse.xir.model.core.ScanXIR;
+
+public class VendorScanXIR extends ScanXIR implements IVendorScanXIR {
+
+	private static final long serialVersionUID = 802091858998726463L;
+}


### PR DESCRIPTION
Closes https://github.com/eclipse/chemclipse/issues/842

I used this dataset https://zenodo.org/record/3986032 as a reference as it contains both `.spc` and `.dx` files.