### PR TITLE
Fixed some .mzML encoding mistakes

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/converter/BinaryReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/converter/BinaryReader.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.converter.supplier.mzml.internal.converter;
 
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.DoubleBuffer;
@@ -27,13 +28,19 @@ public class BinaryReader {
 
 	public static Pair<String, double[]> parseBinaryData(BinaryDataArrayType binaryDataArrayType) throws DataFormatException {
 
+		double[] values = new double[0];
+		String content = "";
+		if(binaryDataArrayType.getArrayLength() == BigInteger.ZERO) {
+			return new ImmutablePair<>(content, values);
+		}
 		byte[] binary = binaryDataArrayType.getBinary();
+		if(binary == null) {
+			return new ImmutablePair<>(content, values);
+		}
 		ByteBuffer byteBuffer = ByteBuffer.wrap(binary);
-		double[] values = null;
 		boolean compressed = false;
 		boolean doublePrecision = false;
 		int multiplicator = 1;
-		String content = "";
 		for(CVParamType cvParam : binaryDataArrayType.getCvParam()) {
 			if(cvParam.getAccession().equals("MS:1000574")) {
 				if(cvParam.getName().equals("zlib compression")) {
@@ -83,6 +90,6 @@ public class BinaryReader {
 				values[index] = new Double(floatBuffer.get(index)) * multiplicator;
 			}
 		}
-		return new ImmutablePair<String, double[]>(content, values);
+		return new ImmutablePair<>(content, values);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/converter/BinaryReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/converter/BinaryReader.java
@@ -40,12 +40,10 @@ public class BinaryReader {
 					compressed = true;
 				}
 			}
-			if(cvParam.getAccession().equals("MS:1000523")) {
-				if(cvParam.getName().equals("32-bit float")) {
-					doublePrecision = false;
-				} else if(cvParam.getName().equals("64-bit float")) {
-					doublePrecision = true;
-				}
+			if(cvParam.getAccession().equals("MS:1000521") && cvParam.getName().equals("32-bit float")) {
+				doublePrecision = false;
+			} else if(cvParam.getAccession().equals("MS:1000523") && cvParam.getName().equals("64-bit float")) {
+				doublePrecision = true;
 			}
 			if(cvParam.getAccession().equals("MS:1000514")) {
 				if(cvParam.getName().equals("m/z array")) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/converter/BinaryWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/converter/BinaryWriter.java
@@ -36,7 +36,7 @@ public class BinaryWriter {
 		BinaryDataArrayType binaryDataArrayType = createBinaryDataArray(byteBuffer);
 		binaryDataArrayType.setArrayLength(BigInteger.valueOf(values.length));
 		CVParamType cvParamDataType = new CVParamType();
-		cvParamDataType.setAccession("MS:1000523");
+		cvParamDataType.setAccession("MS:1000521");
 		cvParamDataType.setName("32-bit float");
 		binaryDataArrayType.getCvParam().add(cvParamDataType);
 		return binaryDataArrayType;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/io/ChromatogramReaderVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/io/ChromatogramReaderVersion110.java
@@ -12,7 +12,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mzml.internal.io;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.zip.DataFormatException;
 
@@ -20,8 +19,6 @@ import javax.xml.bind.JAXBException;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.converter.io.AbstractChromatogramReader;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
@@ -66,7 +63,7 @@ public class ChromatogramReaderVersion110 extends AbstractChromatogramReader imp
 	}
 
 	@Override
-	public IChromatogramOverview readOverview(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IChromatogramOverview readOverview(File file, IProgressMonitor monitor) throws IOException {
 
 		IVendorChromatogram chromatogram = null;
 		double[] retentionTimes = null;
@@ -120,7 +117,7 @@ public class ChromatogramReaderVersion110 extends AbstractChromatogramReader imp
 	}
 
 	@Override
-	public IChromatogramMSD read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IChromatogramMSD read(File file, IProgressMonitor monitor) throws IOException {
 
 		IVendorChromatogram chromatogram = null;
 		double[] intensities = null;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/io/ChromatogramWriterVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/io/ChromatogramWriterVersion110.java
@@ -12,7 +12,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mzml.internal.io;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Date;
@@ -54,7 +53,7 @@ public class ChromatogramWriterVersion110 extends AbstractChromatogramWriter imp
 	private static final Logger logger = Logger.getLogger(ChromatogramWriterVersion110.class);
 
 	@Override
-	public void writeChromatogram(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotWriteableException, IOException {
+	public void writeChromatogram(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
 		try {
 			JAXBContext jaxbContext = JAXBContext.newInstance(org.eclipse.chemclipse.msd.converter.supplier.mzml.internal.v110.model.MzML.class);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/io/ChromatogramWriterVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/io/ChromatogramWriterVersion110.java
@@ -60,6 +60,7 @@ public class ChromatogramWriterVersion110 extends AbstractChromatogramWriter imp
 			Marshaller marshaller = jaxbContext.createMarshaller();
 			//
 			RunType run = new RunType();
+			run.setId(chromatogram.getIdentifier());
 			SpectrumListType spectrumList = new SpectrumListType();
 			ChromatogramListType chromatogramList = new ChromatogramListType();
 			chromatogramList.setCount(BigInteger.valueOf(1));
@@ -112,6 +113,8 @@ public class ChromatogramWriterVersion110 extends AbstractChromatogramWriter imp
 				scanList.getScan().add(scanType);
 				//
 				SpectrumType spectrum = new SpectrumType();
+				spectrum.setId("scan=" + scan.getScanNumber());
+				spectrum.setIndex(BigInteger.valueOf(scan.getScanNumber()));
 				spectrum.setScanList(scanList);
 				spectrum.setBinaryDataArrayList(binaryDataArrayList);
 				IVendorMassSpectrum massSpectrum = (IVendorMassSpectrum)scanMSD;


### PR DESCRIPTION
As discussed in https://github.com/OpenChrom/openchrom/issues/175 this corrects some mistakes regarding identifiers to be compliant with http://www.peptideatlas.org/tmp/mzML1.1.0.html and @proteowizard pipeline tools.