### PR TITLE
Remove unused log4j 2.15.0

### DIFF
--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -99,11 +99,6 @@
 	<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20191126223242/repository"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-	<unit id="org.apache.log4j" version="0.0.0"/>
-	<unit id="org.apache.logging.log4j" version="0.0.0"/>
-	<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20211213173813/repository"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 	<repository location="https://download.eclipse.org/swtchart/integration/develop/repository"/>
 </location>


### PR DESCRIPTION
resolves CVE-2021-45046. It is not used. Distributing this only makes it look like ChemClipse derived software is vulnerable. We don't need any of the remote configuration loading and class instantiation features of version 2. This reverts https://github.com/eclipse/chemclipse/commit/cd625cd025b288afd4d889f405dcd47939af6331