### PR TITLE
Fixed performance of MALDI-TOF data import

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractScanMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractScanMSD.java
@@ -52,9 +52,9 @@ import org.eclipse.chemclipse.msd.model.xic.IExtractedIonSignal;
  * </li>
  * </ol>
  *
- * @author eselmeister
- * @author <a href="mailto:alexander.kerner@openchrom.net">Alexander Kerner</a>
- * @author janosbinder
+ * @author Philip Wenig
+ * @author Alexander Kerner
+ * @author Janos Binder
  * @see AbstractChromatogramMSD
  */
 public abstract class AbstractScanMSD extends AbstractScan implements IScanMSD {
@@ -62,7 +62,7 @@ public abstract class AbstractScanMSD extends AbstractScan implements IScanMSD {
 	/**
 	 * Renew the serialVersionUID any time you have changed some fields or methods.
 	 */
-	private static final long serialVersionUID = -5705437012632871946L;
+	private static final long serialVersionUID = -5705437012632871947L;
 	//
 	private static final Logger logger = Logger.getLogger(AbstractScanMSD.class);
 	//
@@ -127,6 +127,12 @@ public abstract class AbstractScanMSD extends AbstractScan implements IScanMSD {
 	}
 
 	@Override
+	public boolean checkIntensityCollisions() {
+
+		return true;
+	}
+
+	@Override
 	public AbstractScanMSD addIons(List<IIon> ions, boolean addIntensities) {
 
 		for(IIon ion : ions) {
@@ -154,25 +160,27 @@ public abstract class AbstractScanMSD extends AbstractScan implements IScanMSD {
 		}
 		//
 		boolean addNew = true;
-		for(IIon actualIon : ionsList) {
-			if(checkIon(ion, actualIon)) {
-				/*
-				 * Check whether the intensity should be added or only the higher intensity
-				 * should be taken.<br/> Replace the abundance only, if the abundance is higher
-				 * than the older one otherwise do nothing
-				 */
-				if(addIntensity) {
-					addIntensities(actualIon, ion);
-					addNew = false;
-					break;
-				} else {
-					if(ion.getAbundance() >= actualIon.getAbundance()) {
-						addHigherIntensity(actualIon, ion);
+		if(checkIntensityCollisions()) {
+			for(IIon actualIon : ionsList) {
+				if(checkIon(ion, actualIon)) {
+					/*
+					 * Check whether the intensity should be added or only the higher intensity
+					 * should be taken.<br/> Replace the abundance only, if the abundance is higher
+					 * than the older one otherwise do nothing
+					 */
+					if(addIntensity) {
+						addIntensities(actualIon, ion);
 						addNew = false;
 						break;
 					} else {
-						addNew = false;
-						break;
+						if(ion.getAbundance() >= actualIon.getAbundance()) {
+							addHigherIntensity(actualIon, ion);
+							addNew = false;
+							break;
+						} else {
+							addNew = false;
+							break;
+						}
 					}
 				}
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractVendorMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractVendorMassSpectrum.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -20,7 +20,7 @@ public abstract class AbstractVendorMassSpectrum extends AbstractRegularMassSpec
 	 * Renew the serialVersionUID any time you have changed some fields or
 	 * methods.
 	 */
-	private static final long serialVersionUID = 5013842421250687340L;
+	private static final long serialVersionUID = 5013842421250687341L;
 	//
 	private File file;
 
@@ -44,6 +44,12 @@ public abstract class AbstractVendorMassSpectrum extends AbstractRegularMassSpec
 			name = file.getName();
 		}
 		return name;
+	}
+
+	@Override
+	public boolean checkIntensityCollisions() {
+
+		return true;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IScanMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IScanMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 Lablicate GmbH.
+ * Copyright (c) 2008, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -55,7 +55,7 @@ import org.eclipse.chemclipse.msd.model.xic.IExtractedIonSignal;
  * [PeakSubstanceLibraryMassSpectrum]<br/>
  * [...]<br/>
  * 
- * @author eselmeister
+ * @author Philip Wenig
  * @author Alexander Kerner
  * @see AbstractChromatogramMSD
  */
@@ -360,4 +360,12 @@ public interface IScanMSD extends IScan, IMassSpectrumCloneable, IMassSpectrumNo
 	 * @return boolean
 	 */
 	boolean isHighResolutionMS();
+
+	/**
+	 * Check each ion for possible collisions with other ions before adding it.
+	 * This comes at a huge performance toll and may not be required for MALDI.
+	 * 
+	 * @return boolean
+	 */
+	boolean checkIntensityCollisions();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IVendorMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IVendorMassSpectrum.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -16,7 +16,7 @@ import java.io.File;
 /**
  * More informations about the class structure of mass spectra are stored in {@link IScanMSD}.
  * 
- * @author eselmeister
+ * @author Philip Wenig
  */
 public interface IVendorMassSpectrum extends IRegularMassSpectrum {
 
@@ -48,7 +48,7 @@ public interface IVendorMassSpectrum extends IRegularMassSpectrum {
 	 * It could be that the range of the ion values differs from manufacturer to
 	 * manufacturer.<br/>
 	 * One manufacturer for example stores maximal 2000 ion values, another 4000
-	 * ion.<br/>
+	 * ions.<br/>
 	 * Be aware of it!
 	 * 
 	 * @return int

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/ScanMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/ScanMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -25,8 +25,8 @@ import org.eclipse.chemclipse.msd.model.exceptions.IonLimitExceededException;
 /**
  * If a new mass spectrum type should be implemented, extend the abstract class {@link AbstractScanMSD} and not this class.
  * 
- * @author eselmeister
- * @author <a href="mailto:alexander.kerner@openchrom.net">Alexander Kerner</a>
+ * @author Philip Wenig
+ * @author Alexander Kerner
  */
 public class ScanMSD extends AbstractScanMSD implements IScanMSD {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/VendorMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/VendorMassSpectrum.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -28,8 +28,7 @@ public class VendorMassSpectrum extends AbstractVendorMassSpectrum implements IV
 	private static final long serialVersionUID = 6529896871219884041L;
 	private static final Logger logger = Logger.getLogger(VendorMassSpectrum.class);
 	/**
-	 * MAX_IONS The total amount of ions to be stored in the
-	 * Agilent chromatogram.<br/>
+	 * MAX_IONS The total amount of ions to be stored in the chromatogram.<br/>
 	 * It does not mean, that ion 2000 is the upper bound, but only 2000 mass
 	 * fragments can be stored in a mass spectrum.
 	 */


### PR DESCRIPTION
This removes a performance bottleneck where every ion was checked against all ions for every ion addition. It would take minutes to load a file with ~300.000 ions while other tools like http://www.mmass.org/ import them instantly.