### PR TITLE
Added basic metadata for MALDI-TOF MS spectra

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractVendorStandaloneMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractVendorStandaloneMassSpectrum.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Lablicate GmbH.
+ * 
+ * All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.model.core;
+
+import java.util.Date;
+
+public abstract class AbstractVendorStandaloneMassSpectrum extends AbstractVendorMassSpectrum implements IVendorStandaloneMassSpectrum {
+
+	/**
+	 * Renew the serialVersionUID any time you have changed some fields or
+	 * methods.
+	 */
+	private static final long serialVersionUID = 7180911179209208597L;
+	//
+	private String sample;
+	private String description;
+	private String operator;
+	private Date acquisitionDate;
+	private String instrument;
+
+	@Override
+	public String getSampleName() {
+
+		return sample;
+	}
+
+	@Override
+	public void setSampleName(String name) {
+
+		this.sample = name;
+	}
+
+	@Override
+	public String getOperator() {
+
+		return operator;
+	}
+
+	@Override
+	public void setOperator(String operator) {
+
+		this.operator = operator;
+	}
+
+	@Override
+	public Date getDate() {
+
+		return acquisitionDate;
+	}
+
+	@Override
+	public void setDate(Date acquisitionDate) {
+
+		this.acquisitionDate = acquisitionDate;
+	}
+
+	@Override
+	public String getInstrument() {
+
+		return instrument;
+	}
+
+	@Override
+	public void setInstrument(String instrument) {
+
+		this.instrument = instrument;
+	}
+
+	@Override
+	public String getDescription() {
+
+		return description;
+	}
+
+	@Override
+	public void setDescription(String description) {
+
+		this.description = description;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IVendorStandaloneMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IVendorStandaloneMassSpectrum.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Lablicate GmbH.
+ * 
+ * All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.model.core;
+
+import java.util.Date;
+
+/**
+ * An interface for single MALDI-TOF MS spectra which contain additional metadata.
+ * 
+ * @author Matthias Mailänder
+ */
+public interface IVendorStandaloneMassSpectrum extends IVendorMassSpectrum {
+
+	String getSampleName();
+
+	void setSampleName(String name);
+
+	String getDescription();
+
+	void setDescription(String description);
+
+	String getOperator();
+
+	void setOperator(String operator);
+
+	Date getDate();
+
+	void setDate(Date date);
+
+	String getInstrument();
+
+	void setInstrument(String instrument);
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/VendorStandaloneMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/VendorStandaloneMassSpectrum.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2022 Lablicate GmbH.
+ * 
+ * All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Dr. Philip Wenig - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.model.implementation;
+
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.model.exceptions.AbundanceLimitExceededException;
+import org.eclipse.chemclipse.msd.model.core.AbstractVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IScanIon;
+import org.eclipse.chemclipse.msd.model.core.IVendorMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.exceptions.IonLimitExceededException;
+
+public class VendorStandaloneMassSpectrum extends AbstractVendorStandaloneMassSpectrum implements IVendorStandaloneMassSpectrum {
+
+	/**
+	 * Renew the serialVersionUID any time you have changed some fields or
+	 * methods.
+	 */
+	private static final long serialVersionUID = 7540947309609765366L;
+	private static final Logger logger = Logger.getLogger(VendorStandaloneMassSpectrum.class);
+	public static final int MAX_IONS = Integer.MAX_VALUE;
+
+	@Override
+	public int getMaxPossibleIons() {
+
+		return MAX_IONS;
+	}
+
+	@Override
+	public int getMaxPossibleRetentionTime() {
+
+		return 0; // TODO: this should move away
+	}
+
+	@Override
+	public int getMinPossibleRetentionTime() {
+
+		return 0; // TODO: this should move away
+	}
+
+	/**
+	 * Keep in mind, it is a covariant return.<br/>
+	 * IMassSpectrum is needed. ISupplierMassSpectrum is a subtype of
+	 * IMassSpectrum.
+	 */
+	@Override
+	public IVendorMassSpectrum makeDeepCopy() throws CloneNotSupportedException {
+
+		/*
+		 * The method super.clone() is not used here to avoid removing the mass
+		 * fragments from the mass spectrum and to add freshly created ones
+		 * again.
+		 */
+		IVendorMassSpectrum massSpectrum = (IVendorMassSpectrum)super.clone();
+		IScanIon defaultIon;
+		/*
+		 * The instance variables have been copied by super.clone();.<br/> The
+		 * ions in the ion list need not to be removed via
+		 * removeAllIons as the method super.clone() has created a new
+		 * list.<br/> It is necessary to fill the list again, as the abstract
+		 * super class does not know each available type of ion.<br/>
+		 * Make a deep copy of all ions.
+		 */
+		for(IIon ion : getIons()) {
+			try {
+				defaultIon = new ScanIon(ion.getIon(), ion.getAbundance());
+				massSpectrum.addIon(defaultIon);
+			} catch(AbundanceLimitExceededException e) {
+				logger.warn(e);
+			} catch(IonLimitExceededException e) {
+				logger.warn(e);
+			}
+		}
+		return massSpectrum;
+	}
+
+	@Override
+	protected Object clone() throws CloneNotSupportedException {
+
+		return makeDeepCopy();
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ExtendedMassSpectrumHeaderUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ExtendedMassSpectrumHeaderUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Lablicate GmbH.
+ * Copyright (c) 2020, 2022 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,6 +12,8 @@
 package org.eclipse.chemclipse.ux.extension.xxd.ui;
 
 import org.eclipse.chemclipse.msd.model.core.IVendorMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.support.text.ValueFormat;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -32,10 +34,19 @@ public class ExtendedMassSpectrumHeaderUI extends Composite {
 		StringBuilder builder = new StringBuilder();
 		if(massSpectrum != null) {
 			addHeaderLine(builder, "Name", massSpectrum.getName());
-			addHeaderLine(builder, "Type Description", massSpectrum.getMassSpectrumTypeDescription());
+			addHeaderLine(builder, "Data", massSpectrum.getMassSpectrumTypeDescription());
 			addHeaderLine(builder, "File", massSpectrum.getFile().getName());
-			addHeaderLine(builder, "Mass Spectrometer", "MS" + massSpectrum.getMassSpectrometer());
+			addHeaderLine(builder, "Technique", "MS" + massSpectrum.getMassSpectrometer());
 			addHeaderLine(builder, "Ions", Integer.toString(massSpectrum.getNumberOfIons()));
+			if(massSpectrum instanceof IVendorStandaloneMassSpectrum) {
+				IVendorStandaloneMassSpectrum standaloneMassSpectrum = (IVendorStandaloneMassSpectrum)massSpectrum;
+				addHeaderLine(builder, "Sample", standaloneMassSpectrum.getSampleName());
+				addHeaderLine(builder, "Instrument", standaloneMassSpectrum.getInstrument());
+				addHeaderLine(builder, "Operator", standaloneMassSpectrum.getOperator());
+				if(standaloneMassSpectrum.getDate() != null) {
+					addHeaderLine(builder, "Date", ValueFormat.getDateFormatEnglish().format(standaloneMassSpectrum.getDate()));
+				}
+			}
 		}
 		//
 		text.setText(builder.toString());


### PR DESCRIPTION
This is a followup to https://github.com/eclipse/chemclipse/pull/911 which adds some metadata fields commonly found in data files.