### PR TITLE
Fixed undoable filters resetting the chart range

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/DenoiseOperation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/DenoiseOperation.java
@@ -98,7 +98,7 @@ public class DenoiseOperation extends AbstractOperation {
 
 	private void updateChromatogramSelection() {
 
-		chromatogramSelection.reset(true);
+		chromatogramSelection.update(true);
 		chromatogramSelection.getChromatogram().setDirty(true);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/selection/ChromatogramSelectionCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/selection/ChromatogramSelectionCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 Lablicate GmbH.
+ * Copyright (c) 2013, 2022 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -96,7 +96,7 @@ public class ChromatogramSelectionCSD extends AbstractChromatogramSelection<IChr
 		 */
 		if(chromatogram instanceof IChromatogramCSD) {
 			List<IChromatogramPeakCSD> peaks = ((IChromatogramCSD)chromatogram).getPeaks();
-			if(peaks != null && peaks.size() >= 1) {
+			if(peaks != null && !peaks.isEmpty()) {
 				setSelectedPeak(peaks.get(0));
 			} else {
 				setSelectedPeak(null);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelectionMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelectionMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2022 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -155,7 +155,7 @@ public class ChromatogramSelectionMSD extends AbstractChromatogramSelection<IChr
 		 */
 		if(chromatogram instanceof IChromatogramMSD) {
 			List<IChromatogramPeakMSD> peaks = ((IChromatogramMSD)chromatogram).getPeaks();
-			if(peaks != null && peaks.size() >= 1) {
+			if(peaks != null && !peaks.isEmpty()) {
 				setSelectedPeak(peaks.get(0));
 			} else {
 				setSelectedPeak(null);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/handlers/CreateSnapshotHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/handlers/CreateSnapshotHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Lablicate GmbH.
+ * Copyright (c) 2011, 2022 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -31,6 +31,7 @@ public class CreateSnapshotHandler {
 	private Clipboard clipboard;
 
 	public CreateSnapshotHandler() {
+
 		clipboard = new Clipboard(DisplayUtils.getDisplay());
 	}
 
@@ -90,9 +91,7 @@ public class CreateSnapshotHandler {
 				image = new Image(DisplayUtils.getDisplay(), compositeParent.getBounds());
 				gc.copyArea(image, 0, 0);
 			} finally {
-				if(gc != null) {
-					gc.dispose();
-				}
+				gc.dispose();
 			}
 		}
 		return image;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ChromatogramEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ChromatogramEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Lablicate GmbH.
+ * Copyright (c) 2018, 2022 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -29,6 +29,7 @@ public class ChromatogramEditor extends AbstractChromatogramEditor {
 		this.parent = parent;
 	}
 
+	@Override
 	public void setFocus() {
 
 		parent.setFocus();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakChartUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Lablicate GmbH.
+ * Copyright (c) 2018, 2022 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -88,8 +88,7 @@ public class PeakChartUI extends ScrollableChart {
 	public void setInput(List<IPeak> peaks) {
 
 		prepareChart();
-		if(peaks != null && peaks.size() >= 1) {
-			//
+		if(peaks != null && !peaks.isEmpty()) {
 			modifyChart(peaks.get(0));
 			List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
 			for(int i = 0; i < peaks.size(); i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.model/src/org/eclipse/chemclipse/xxd/model/operations/DeletePeaksOperation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.model/src/org/eclipse/chemclipse/xxd/model/operations/DeletePeaksOperation.java
@@ -73,7 +73,7 @@ public class DeletePeaksOperation extends AbstractOperation {
 	private void updateChromatogramSelection() {
 
 		chromatogramSelection.setSelectedPeak(null);
-		chromatogramSelection.reset(true);
+		chromatogramSelection.update(true);
 		chromatogramSelection.getChromatogram().setDirty(true);
 	}
 


### PR DESCRIPTION
This is a follow of https://github.com/eclipse/chemclipse/pull/892 and https://github.com/eclipse/chemclipse/pull/903.