### PR TITLE
Fixed peak/scan set focus update regressions

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/part/support/DataUpdateSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/part/support/DataUpdateSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Lablicate GmbH.
+ * Copyright (c) 2019, 2022 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -39,6 +39,7 @@ public class DataUpdateSupport {
 	private Map<String, List<Object>> objectMap = new HashMap<>();
 	//
 	private List<IDataUpdateListener> updateListeners = new ArrayList<>();
+	private List<String> topicList = new ArrayList<>();
 
 	public DataUpdateSupport(IEventBroker eventBroker) throws IllegalArgumentException {
 
@@ -81,9 +82,15 @@ public class DataUpdateSupport {
 		return objectMap.getOrDefault(topic, Collections.emptyList());
 	}
 
+	public List<String> getTopics() {
+
+		return topicList;
+	}
+
 	public void clearObjects() {
 
 		objectMap.clear();
+		topicList.clear();
 	}
 
 	public void subscribe(String topic, String property) {
@@ -128,6 +135,7 @@ public class DataUpdateSupport {
 		handlerMap.clear();
 		propertiesMap.clear();
 		objectMap.clear();
+		topicList.clear();
 		//
 		logger.info("Subscriptions have been completely removed.");
 	}
@@ -185,8 +193,9 @@ public class DataUpdateSupport {
 		 * Create a new topic entry on demand.
 		 */
 		String topic = event.getTopic();
+		topicList.add(topic);
 		if(!objectMap.containsKey(topic)) {
-			objectMap.put(topic, new ArrayList<Object>());
+			objectMap.put(topic, new ArrayList<>());
 		}
 		//
 		List<Object> objects = objectMap.get(topic);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanChartUI.java
@@ -13,6 +13,7 @@
 package org.eclipse.chemclipse.ux.extension.xxd.ui.swt;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -126,6 +127,20 @@ public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 		this.eventBroker = eventBroker;
 	}
 
+	private String getLastTopic(List<String> topics) {
+
+		Collections.reverse(topics);
+		for(String topic : topics) {
+			if(topic.equals(IChemClipseEvents.TOPIC_PEAK_XXD_UPDATE_SELECTION)) {
+				return topic;
+			}
+			if(topic.equals(IChemClipseEvents.TOPIC_SCAN_XXD_UPDATE_SELECTION)) {
+				return topic;
+			}
+		}
+		return "";
+	}
+
 	@Override
 	@Focus
 	public boolean setFocus() {
@@ -135,17 +150,12 @@ public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 			return focus;
 		}
 		DataUpdateSupport dataUpdateSupport = Activator.getDefault().getDataUpdateSupport();
-		List<Object> scans = dataUpdateSupport.getUpdates(IChemClipseEvents.TOPIC_SCAN_XXD_UPDATE_SELECTION);
-		if(!scans.isEmpty()) {
-			Object last = scans.get(0);
+		List<Object> objects = dataUpdateSupport.getUpdates(getLastTopic(dataUpdateSupport.getTopics()));
+		if(!objects.isEmpty()) {
+			Object last = objects.get(0);
 			if(last instanceof IScan) {
 				update((IScan)last);
-			}
-		}
-		List<Object> peaks = dataUpdateSupport.getUpdates(IChemClipseEvents.TOPIC_PEAK_XXD_UPDATE_SELECTION);
-		if(!peaks.isEmpty()) {
-			Object last = peaks.get(0);
-			if(last instanceof IPeak) {
+			} else if(last instanceof IPeak) {
 				update(((IPeak)last).getPeakModel().getPeakMaximum());
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanChartUI.java
@@ -131,6 +131,9 @@ public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 	public boolean setFocus() {
 
 		boolean focus = super.setFocus();
+		if(editModus || subtractModus) {
+			return focus;
+		}
 		DataUpdateSupport dataUpdateSupport = Activator.getDefault().getDataUpdateSupport();
 		List<Object> scans = dataUpdateSupport.getUpdates(IChemClipseEvents.TOPIC_SCAN_XXD_UPDATE_SELECTION);
 		if(!scans.isEmpty()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanTableUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanTableUI.java
@@ -12,6 +12,7 @@
 package org.eclipse.chemclipse.ux.extension.xxd.ui.swt;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -160,27 +161,31 @@ public class ExtendedScanTableUI extends Composite implements IExtendedPartUI {
 		createControl();
 	}
 
+	private String getLastTopic(List<String> topics) {
+
+		Collections.reverse(topics);
+		for(String topic : topics) {
+			if(topic.equals(IChemClipseEvents.TOPIC_PEAK_XXD_UPDATE_SELECTION)) {
+				return topic;
+			}
+			if(topic.equals(IChemClipseEvents.TOPIC_SCAN_XXD_UPDATE_SELECTION)) {
+				return topic;
+			}
+		}
+		return "";
+	}
+
 	@Override
 	@Focus
 	public boolean setFocus() {
 
 		boolean focus = super.setFocus();
 		DataUpdateSupport dataUpdateSupport = Activator.getDefault().getDataUpdateSupport();
-		List<Object> scans = dataUpdateSupport.getUpdates(IChemClipseEvents.TOPIC_SCAN_XXD_UPDATE_SELECTION);
-		if(!scans.isEmpty()) {
-			Object last = scans.get(0);
-			if(last instanceof IScan) {
-				object = last;
-			}
+		List<Object> objects = dataUpdateSupport.getUpdates(getLastTopic(dataUpdateSupport.getTopics()));
+		if(!objects.isEmpty()) {
+			object = objects.get(0);
+			updateObject();
 		}
-		List<Object> peaks = dataUpdateSupport.getUpdates(IChemClipseEvents.TOPIC_PEAK_XXD_UPDATE_SELECTION);
-		if(!peaks.isEmpty()) {
-			Object last = peaks.get(0);
-			if(last instanceof IPeak) {
-				object = last;
-			}
-		}
-		updateObject();
 		return focus;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedTargetsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedTargetsUI.java
@@ -27,6 +27,7 @@ import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.core.ITargetSupplier;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
+import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.model.targets.ITarget;
 import org.eclipse.chemclipse.model.updates.ITargetUpdateListener;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
@@ -118,30 +119,38 @@ public class ExtendedTargetsUI extends Composite implements IExtendedPartUI {
 		createControl();
 	}
 
+	private String getLastTopic(List<String> topics) {
+
+		Collections.reverse(topics);
+		for(String topic : topics) {
+			if(topic.equals(IChemClipseEvents.TOPIC_PEAK_XXD_UPDATE_SELECTION)) {
+				return topic;
+			}
+			if(topic.equals(IChemClipseEvents.TOPIC_SCAN_XXD_UPDATE_SELECTION)) {
+				return topic;
+			}
+			if(topic.equals(IChemClipseEvents.TOPIC_CHROMATOGRAM_XXD_UPDATE_SELECTION)) {
+				return topic;
+			}
+			if(topic.equals(IChemClipseEvents.TOPIC_IDENTIFICATION_TARGETS_UPDATE_SELECTION)) {
+				return topic;
+			}
+		}
+		return "";
+	}
+
 	@Override
 	public boolean setFocus() {
 
 		DataUpdateSupport dataUpdateSupport = Activator.getDefault().getDataUpdateSupport();
-		List<Object> peaks = dataUpdateSupport.getUpdates(IChemClipseEvents.TOPIC_PEAK_XXD_UPDATE_SELECTION);
-		if(!peaks.isEmpty()) {
-			Object last = peaks.get(0);
-			if(last instanceof IPeak) {
-				update(last);
+		List<Object> objects = dataUpdateSupport.getUpdates(getLastTopic(dataUpdateSupport.getTopics()));
+		if(!objects.isEmpty()) {
+			Object last = objects.get(0);
+			if(last instanceof IChromatogramSelection) {
+				IChromatogramSelection<?, ?> chromatogramSelection = (IChromatogramSelection<?, ?>)last;
+				last = chromatogramSelection.getChromatogram();
 			}
-		}
-		List<Object> scans = dataUpdateSupport.getUpdates(IChemClipseEvents.TOPIC_SCAN_XXD_UPDATE_SELECTION);
-		if(!scans.isEmpty()) {
-			Object last = scans.get(0);
-			if(last instanceof IScan) {
-				update(last);
-			}
-		}
-		List<Object> targets = dataUpdateSupport.getUpdates(IChemClipseEvents.TOPIC_IDENTIFICATION_TARGETS_UPDATE_SELECTION);
-		if(!targets.isEmpty()) {
-			Object last = targets.get(0);
-			if(last instanceof ITarget) {
-				update(last);
-			}
+			update(last);
 		}
 		updateTargets(getDisplay());
 		return true;


### PR DESCRIPTION
This is a followup of https://github.com/eclipse/chemclipse/pull/926 https://github.com/eclipse/chemclipse/pull/929 https://github.com/eclipse/chemclipse/pull/927 which deals with regressions like the Scan Chart edit mode losing focus and scans overwriting selected peaks in the Targets part or the Targets emptying occassionally.