### PR TITLE
Fixed a NullReferenceException when system settings are saved

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/io/JobWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/io/JobWriter.java
@@ -239,7 +239,9 @@ public class JobWriter {
 		eventWriter.add(eventFactory.createAttribute(JobTags.PROCESSOR_ID, processEntry.getProcessorId()));
 		eventWriter.add(eventFactory.createAttribute(JobTags.PROCESSOR_NAME, processEntry.getName()));
 		eventWriter.add(eventFactory.createAttribute(JobTags.PROCESSOR_DESCRIPTION, processEntry.getDescription()));
-		eventWriter.add(eventFactory.createAttribute(JobTags.PROCESSOR_JSON_SETTINGS, processEntry.getSettings()));
+		if(processEntry.getSettings() != null) {
+			eventWriter.add(eventFactory.createAttribute(JobTags.PROCESSOR_JSON_SETTINGS, processEntry.getSettings()));
+		}
 		// not used, only for backward compat
 		eventWriter.add(eventFactory.createAttribute(JobTags.PROCESSOR_SYMBOLIC_NAME, ""));
 		eventWriter.add(eventFactory.createAttribute(JobTags.PROCESSOR_CLASS_NAME, ""));


### PR DESCRIPTION
To reproduce create a new batch method, put in a file and method using system settings. Try to save.