### PR TITLE
Replaced direct usage of Equinox DS bundle

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.compilation.base.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.compilation.base.feature/feature.xml
@@ -38,6 +38,10 @@ http://www.eclipse.org/legal/epl-v10.html
          id="org.eclipse.userstorage"
          version="0.0.0"/>
 
+   <includes
+         id="org.eclipse.rcp"
+         version="0.0.0"/>
+
    <plugin
          id="org.apache.httpcomponents.httpclient"
          download-size="0"

--- a/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
+++ b/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
@@ -79,7 +79,7 @@ Contributors:
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.cm" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
-      <plugin id="org.eclipse.equinox.ds" autoStart="true" startLevel="2" />
+      <plugin id="org.apache.felix.scr" autoStart="true" startLevel="1" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
       <plugin id="org.eclipse.update.configurator" autoStart="true" startLevel="4" />


### PR DESCRIPTION
This is a followup to https://github.com/eclipse/chemclipse/pull/941 that incorporates the required changes from https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Fporting%2F4.10%2Frecommended.html&cp%3D2_3_1_3&anchor=EquinoxDS_to_FelixSCR