### PR TITLE
Removed InputEntriesWizardPage force closing

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/wizards/InputEntriesWizardPage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/wizards/InputEntriesWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Lablicate GmbH.
+ * Copyright (c) 2011, 2022 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -14,7 +14,6 @@
 package org.eclipse.chemclipse.ux.extension.xxd.ui.wizards;
 
 import java.io.File;
-import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -24,9 +23,8 @@ import org.eclipse.chemclipse.processing.converter.ISupplierFileIdentifier;
 import org.eclipse.chemclipse.ux.extension.ui.swt.DataExplorerTreeRoot;
 import org.eclipse.chemclipse.ux.extension.ui.swt.DataExplorerTreeUI;
 import org.eclipse.chemclipse.ux.extension.ui.swt.MultiDataExplorerTreeUI;
-import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.jface.wizard.IWizardContainer;
+import org.eclipse.jface.wizard.IWizard;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.widgets.Composite;
 
@@ -69,19 +67,9 @@ public class InputEntriesWizardPage extends WizardPage {
 		@Override
 		protected void handleDoubleClick(File file, DataExplorerTreeUI treeUI) {
 
-			IWizardContainer container = page.getContainer();
-			try {
-				Method method = container.getClass().getDeclaredMethod("buttonPressed", int.class);
-				boolean accessible = method.isAccessible();
-				try {
-					method.setAccessible(true);
-					method.invoke(container, IDialogConstants.FINISH_ID);
-				} finally {
-					method.setAccessible(accessible);
-				}
-			} catch(Exception e) {
-				// trigger not possible then
-				e.printStackTrace();
+			IWizard wizard = page.getWizard();
+			if(wizard.canFinish()) {
+				wizard.performFinish();
 			}
 		}
 	}


### PR DESCRIPTION
The previous code was non-compliant with https://wiki.sei.cmu.edu/confluence/display/java/SEC05-J.+Do+not+use+reflection+to+increase+accessibility+of+classes%2C+methods%2C+or+fields due to its use of unsafe reflection magic. I also didn't like the force finishing because with the `.cal` wizard you are then left with an empty calibration run.