### PR TITLE
Fix mzXML with namespaces not being shown in Data Explorer

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramMagicNumberMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramMagicNumberMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Lablicate GmbH.
+ * Copyright (c) 2016, 2022 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -39,9 +39,10 @@ public class ChromatogramMagicNumberMatcher extends AbstractMagicNumberMatcher i
 				return isValidFormat;
 			}
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+			documentBuilderFactory.setNamespaceAware(true);
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);
-			NodeList root = document.getElementsByTagName(IConstants.NODE_MZXML);
+			NodeList root = document.getElementsByTagNameNS("*", IConstants.NODE_MZXML);
 			if(root.getLength() != 1) {
 				return isValidFormat;
 			}


### PR DESCRIPTION
A file with a namespace prefix like

```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<ns2:mzXML xmlns:ns2="http://sashimi.sourceforge.net/schema_revision/mzXML_3.2">
```

will currently not get detected as the checks are too strict.