### PR TITLE
Fixed disposing a cached font crashing the chromatogram editor

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChromatogramChart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChromatogramChart.java
@@ -36,7 +36,6 @@ public class ChromatogramChart extends LineChart {
 	private String titleSeconds = "";
 	private String titleMinutes = "";
 	private String titleRelativeIntensity = "";
-	private Font titleFont;
 
 	public ChromatogramChart() {
 
@@ -249,7 +248,7 @@ public class ChromatogramChart extends LineChart {
 		String name = preferenceStore.getString(PreferenceConstants.P_FONT_NAME_X_AXIS_MINUTES);
 		int height = preferenceStore.getInt(PreferenceConstants.P_FONT_SIZE_X_AXIS_MINUTES);
 		int style = preferenceStore.getInt(PreferenceConstants.P_FONT_STYLE_X_AXIS_MINUTES);
-		titleFont = Fonts.getCachedFont(getBaseChart().getDisplay(), name, height, style);
+		Font titleFont = Fonts.getCachedFont(getBaseChart().getDisplay(), name, height, style);
 		boolean drawAxisLine = ChartSupport.getBoolean(PreferenceConstants.P_SHOW_X_AXIS_LINE_MINUTES);
 		boolean drawPositionMarker = ChartSupport.getBoolean(PreferenceConstants.P_SHOW_X_AXIS_POSITION_MARKER_MINUTES);
 		//
@@ -285,12 +284,5 @@ public class ChromatogramChart extends LineChart {
 		 * Update the title to retrieve the correct axis.
 		 */
 		titleMinutes = title;
-	}
-
-	@Override
-	public void dispose() {
-
-		titleFont.dispose();
-		super.dispose();
 	}
 }


### PR DESCRIPTION
Closes https://github.com/eclipse/chemclipse/issues/1020. Undos parts of https://github.com/eclipse/chemclipse/pull/996.