### PR TITLE
Fixed saving files silently failing on Gtk/Linux

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/IConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/IConverterSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -41,7 +41,7 @@ public interface IConverterSupport {
 	 */
 	default String[] getFilterExtensions(Predicate<? super ISupplier> filter) {
 
-		List<String> extensions = new ArrayList<String>();
+		List<String> extensions = new ArrayList<>();
 		for(ISupplier supplier : getSupplier(filter)) {
 			if(supplier.getDirectoryExtension().equals("")) {
 				FileExtensionCompiler fileExtensionCompiler = new FileExtensionCompiler(supplier.getFileExtension(), true);

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/support/FileExtensionCompiler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/support/FileExtensionCompiler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 Lablicate GmbH.
+ * Copyright (c) 2008, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -29,13 +29,14 @@ public class FileExtensionCompiler {
 	 * @param extension
 	 */
 	public FileExtensionCompiler(String extension, boolean useLowerAndUpperCase) {
+
 		/*
 		 * Avoid null pointer exceptions.
 		 */
 		if(extension == null) {
 			extension = "";
 		}
-		extensions = new ArrayList<String>();
+		extensions = new ArrayList<>();
 		/*
 		 * Add ".ionXML"
 		 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/META-INF/MANIFEST.MF
@@ -101,7 +101,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.chemclipse.tsd.converter;bundle-version="0.9.0",
  org.eclipse.ui.workbench;bundle-version="3.111.0",
  org.eclipse.core.commands;bundle-version="3.9.100",
- org.eclipse.chemclipse.rcp.app;bundle-version="0.9.0"
+ org.eclipse.chemclipse.rcp.app;bundle-version="0.9.0",
+ org.apache.commons.io;bundle-version="2.8.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Import-Package: javax.annotation;version="[1.0.0,2.0.0)",

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/editors/ChromatogramFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/editors/ChromatogramFileSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Lablicate GmbH.
+ * Copyright (c) 2018, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -18,7 +18,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
+import org.apache.commons.io.FilenameUtils;
 import org.eclipse.chemclipse.converter.chromatogram.IChromatogramConverterSupport;
 import org.eclipse.chemclipse.converter.exceptions.NoConverterAvailableException;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
@@ -75,12 +77,19 @@ public class ChromatogramFileSupport {
 			Map<Integer, ISupplier> exportSupplierMap = setExportConverter(chromatogramConverterSupport, fileDialog);
 			String filename = fileDialog.open();
 			if(filename != null) {
+				String filePath = fileDialog.getFilterPath() + File.separator + fileDialog.getFileName();
+				boolean overwrite = fileDialog.getOverwrite();
 				int key = fileDialog.getFilterIndex();
 				if(exportSupplierMap.containsKey(key)) {
 					ISupplier selectedSupplier = exportSupplierMap.get(key);
-					String filePath = fileDialog.getFilterPath() + File.separator + fileDialog.getFileName();
-					boolean overwrite = fileDialog.getOverwrite();
 					validateAndExportFile(shell, chromatogram, dataType, filePath, overwrite, selectedSupplier);
+					return true;
+				} else {
+					String extension = FilenameUtils.getExtension(fileDialog.getFileName());
+					Optional<ISupplier> guessedSupplier = chromatogramConverterSupport.getSupplier().stream().filter(s -> s.getFileExtension().contains(extension)).findFirst();
+					if(guessedSupplier.isEmpty())
+						return false;
+					validateAndExportFile(shell, chromatogram, dataType, filePath, overwrite, guessedSupplier.get());
 					return true;
 				}
 			}


### PR DESCRIPTION
For some reason, I always hit this part of [FileDialog](https://github.com/eclipse-platform/eclipse.platform.swt/blob/master/bundles/org.eclipse.swt/Eclipse%20SWT/gtk/org/eclipse/swt/widgets/FileDialog.java#L230-L235) where the `fileIndex` is not set despite the types of files being shown in the combo box. The variables which are set give enough information on what to do.