### PR TITLE
Fixed the HTML help

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
@@ -218,4 +218,32 @@ http://www.eclipse.org/legal/epl-v10.html
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.help.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.help.webapp"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.http.jetty"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.pde.api.tools"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/Application.e4xmi
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/Application.e4xmi
@@ -32,8 +32,10 @@
         <children xsi:type="menu:HandledMenuItem" xmi:id="_nz0_UDiVEeKDEdWQrkwLnQ" elementId="org.eclipse.chemclipse.rcp.app.ui.handledmenuitem.preferences" label="Preferences" iconURI="platform:/plugin/org.eclipse.chemclipse.rcp.ui.icons/icons/16x16/preferences.gif" command="_XevnQDiVEeKDEdWQrkwLnQ"/>
       </children>
       <children xsi:type="menu:Menu" xmi:id="_h0BcRjLzEeKMEOdllHiEaA" elementId="org.eclipse.chemclipse.rcp.app.ui.menu.help" label="Help">
-        <children xsi:type="menu:HandledMenuItem" xmi:id="_h0BcRzLzEeKMEOdllHiEaA" elementId="org.eclipse.chemclipse.rcp.app.ui.menu.item.about" label="About" iconURI="platform:/plugin/org.eclipse.jface/icons/full/message_info.png" command="_h0A1RDLzEeKMEOdllHiEaA"/>
-        <children xsi:type="menu:HandledMenuItem" xmi:id="_-y9BQCaJEeOrR5M2kqmSOQ" elementId="org.eclipse.chemclipse.rcp.app.ui.menu.item.help" label="Documentation" iconURI="platform:/plugin/org.eclipse.ui/icons/full/etool16/help_contents.png" command="_zeEzsCaJEeOrR5M2kqmSOQ"/>
+        <children xsi:type="menu:HandledMenuItem" xmi:id="_h0BcRzLzEeKMEOdllHiEaA" elementId="org.eclipse.chemclipse.rcp.app.ui.menu.item.about" label="About" iconURI="platform:/plugin/org.eclipse.jface/icons/full/message_info.png" tooltip="Show versions and licenses" command="_h0A1RDLzEeKMEOdllHiEaA"/>
+        <children xsi:type="menu:HandledMenuItem" xmi:id="_-y9BQCaJEeOrR5M2kqmSOQ" elementId="org.eclipse.chemclipse.rcp.app.ui.menu.item.help.contents" label="Contents" iconURI="platform:/plugin/org.eclipse.help.ui/icons/etool16/help.png" tooltip="Show the table of contents" command="_zeEzsCaJEeOrR5M2kqmSOQ"/>
+        <children xsi:type="menu:HandledMenuItem" xmi:id="_RIofcBQIEe2TEsI5wKibaA" elementId="org.eclipse.chemclipse.rcp.app.ui.menu.item.help.search" label="Search" iconURI="platform:/plugin/org.eclipse.help.ui/icons/etool16/helpsearch_co.png" tooltip="Search through the help" command="_WfrxwBQKEe2TEsI5wKibaA"/>
+        <children xsi:type="menu:HandledMenuItem" xmi:id="_PwyGQBQJEe2TEsI5wKibaA" elementId="org.eclipse.chemclipse.rcp.app.ui.menu.item.help.context" label="Context" iconURI="platform:/plugin/org.eclipse.help.ui/icons/view16/help_view.png" tooltip="Show context sensitive help" command="_bDq6UBQKEe2TEsI5wKibaA"/>
       </children>
     </mainMenu>
     <sharedElements xsi:type="basic:Part" xmi:id="_Sq1foEd4EeKhRMzT2OpX0g" elementId="org.eclipse.ui.console.ConsoleView" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" label="Console" iconURI="platform:/plugin/org.eclipse.ui.console/icons/full/cview16/console_view.png">
@@ -136,11 +138,13 @@
   <handlers xmi:id="_E4KTYDilEeKDEdWQrkwLnQ" elementId="org.eclipse.chemclipse.rcp.app.ui.handler.selectView" contributionURI="bundleclass://org.eclipse.chemclipse.rcp.app.ui/org.eclipse.chemclipse.rcp.app.ui.handlers.SelectViewHandler" command="_ASbeYDilEeKDEdWQrkwLnQ"/>
   <handlers xmi:id="_2GedcEaqEeKL9t3RgmYB_g" elementId="org.eclipse.chemclipse.rcp.app.ui.handler.import" contributionURI="bundleclass://org.eclipse.chemclipse.rcp.app.ui/org.eclipse.chemclipse.rcp.app.ui.handlers.ImportHandler" command="_w-HcgEaqEeKL9t3RgmYB_g"/>
   <handlers xmi:id="_53gfEEaqEeKL9t3RgmYB_g" elementId="org.eclipse.chemclipse.rcp.app.ui.handler.export" contributionURI="bundleclass://org.eclipse.chemclipse.rcp.app.ui/org.eclipse.chemclipse.rcp.app.ui.handlers.ExportHandler" command="_zmfM8EaqEeKL9t3RgmYB_g"/>
-  <handlers xmi:id="_wRrJICaJEeOrR5M2kqmSOQ" elementId="org.eclipse.chemclipse.rcp.app.ui.handler.help" contributionURI="bundleclass://org.eclipse.chemclipse.rcp.app.ui/org.eclipse.chemclipse.rcp.app.ui.handlers.HelpHandler" command="_zeEzsCaJEeOrR5M2kqmSOQ"/>
+  <handlers xmi:id="_wRrJICaJEeOrR5M2kqmSOQ" elementId="org.eclipse.chemclipse.rcp.app.ui.handler.help.contents" contributionURI="bundleclass://org.eclipse.chemclipse.rcp.app.ui/org.eclipse.chemclipse.rcp.app.ui.handlers.HelpContentsHandler" command="_zeEzsCaJEeOrR5M2kqmSOQ"/>
   <handlers xmi:id="_NeEKMIgsEemJaOKd7Cy7Ww" elementId="org.eclipse.chemclipse.rcp.app.ui.handler.opensnippet" contributionURI="bundleclass://org.eclipse.chemclipse.rcp.app.ui/org.eclipse.chemclipse.rcp.app.ui.handlers.OpenSnippetHandler" command="_-eZF4IgrEemJaOKd7Cy7Ww"/>
   <handlers xmi:id="_XLWkMLgWEemNgNx3khJk0g" elementId="org.eclipse.chemclipse.rcp.app.ui.handler.opentoolmenu" contributionURI="bundleclass://org.eclipse.chemclipse.rcp.app.ui/org.eclipse.chemclipse.rcp.app.ui.handlers.OpenMenuHandler" command="_mZc7gLgVEemNgNx3khJk0g"/>
   <handlers xmi:id="_-CiPIMzGEeqoZ6zANnMIXQ" elementId="org.eclipse.chemclipse.rcp.app.ui.handler.installassets" contributionURI="bundleclass://org.eclipse.chemclipse.rcp.app.ui/org.eclipse.chemclipse.rcp.app.ui.handlers.InstallAssetsHandler" command="_wrYAwMzGEeqoZ6zANnMIXQ"/>
   <handlers xmi:id="_b_Jt8KzhEeu9gOO-5hThuA" elementId="org.eclipse.chemclipse.rcp.app.ui.handler.resetperspective" contributionURI="bundleclass://org.eclipse.chemclipse.rcp.app.ui/org.eclipse.chemclipse.rcp.app.ui.handlers.ResetPerspectiveHandler" command="_X4T0YKzhEeu9gOO-5hThuA"/>
+  <handlers xmi:id="_havKEBQKEe2TEsI5wKibaA" elementId="org.eclipse.chemclipse.rcp.app.ui.handler.help.search" contributionURI="bundleclass://org.eclipse.chemclipse.rcp.app.ui/org.eclipse.chemclipse.rcp.app.ui.handlers.SearchHelpHandler" command="_WfrxwBQKEe2TEsI5wKibaA"/>
+  <handlers xmi:id="_l9XAsBQKEe2TEsI5wKibaA" elementId="org.eclipse.chemclipse.rcp.app.ui.handler.help.context" contributionURI="bundleclass://org.eclipse.chemclipse.rcp.app.ui/org.eclipse.chemclipse.rcp.app.ui.handlers.DynamicHelpHandler" command="_bDq6UBQKEe2TEsI5wKibaA"/>
   <bindingTables xmi:id="_h0A1PDLzEeKMEOdllHiEaA" elementId="org.eclipse.chemclipse.rcp.app.ui.bindingtable" bindingContext="_h0A1MTLzEeKMEOdllHiEaA">
     <bindings xmi:id="_h0A1PTLzEeKMEOdllHiEaA" elementId="org.eclipse.chemclipse.rcp.app.ui.keybinding.quit" keySequence="M1+Q" command="_h0A1OjLzEeKMEOdllHiEaA"/>
     <bindings xmi:id="_h0A1RjLzEeKMEOdllHiEaA" elementId="org.eclipse.chemclipse.rcp.app.ui.keybinding.about" keySequence="M1+A" command="_h0A1RDLzEeKMEOdllHiEaA"/>
@@ -159,13 +163,15 @@
   <commands xmi:id="_ASbeYDilEeKDEdWQrkwLnQ" elementId="org.eclipse.chemclipse.rcp.app.ui.command.selectView" commandName="Select View"/>
   <commands xmi:id="_w-HcgEaqEeKL9t3RgmYB_g" elementId="org.eclipse.chemclipse.rcp.app.ui.command.import" commandName="Import"/>
   <commands xmi:id="_zmfM8EaqEeKL9t3RgmYB_g" elementId="org.eclipse.chemclipse.rcp.app.ui.command.export" commandName="Export"/>
-  <commands xmi:id="_zeEzsCaJEeOrR5M2kqmSOQ" elementId="org.eclipse.chemclipse.rcp.app.ui.command.help" commandName="Help"/>
+  <commands xmi:id="_zeEzsCaJEeOrR5M2kqmSOQ" elementId="org.eclipse.chemclipse.rcp.app.ui.command.help.contents" commandName="Help Contents"/>
   <commands xmi:id="_-eZF4IgrEemJaOKd7Cy7Ww" elementId="org.eclipse.chemclipse.rcp.app.ui.command.opensnippet" commandName="Open Snippet" description="Open the given Snippet in the editor area">
     <parameters xmi:id="_-eZF4YgrEemJaOKd7Cy7Ww" elementId="org.eclipse.chemclipse.rcp.app.ui.commandparameter.opensnippet.snippetid" name="snippetid" optional="false"/>
   </commands>
   <commands xmi:id="_mZc7gLgVEemNgNx3khJk0g" elementId="chemclipse.command.opentoolmenu" commandName="Open Tool Menu" description="Open the Tool menu"/>
   <commands xmi:id="_wrYAwMzGEeqoZ6zANnMIXQ" elementId="org.eclipse.chemclipse.rcp.app.ui.command.installassets" commandName="Install Assets" description="Installs additional assets"/>
   <commands xmi:id="_X4T0YKzhEeu9gOO-5hThuA" elementId="org.eclipse.chemclipse.rcp.app.ui.command.resetperspective" commandName="Reset Perspective"/>
+  <commands xmi:id="_WfrxwBQKEe2TEsI5wKibaA" elementId="org.eclipse.chemclipse.rcp.app.ui.command.help.search" commandName="Search Help"/>
+  <commands xmi:id="_bDq6UBQKEe2TEsI5wKibaA" elementId="org.eclipse.chemclipse.rcp.app.ui.command.help.context" commandName="Help context" description="Context sensitive help"/>
   <addons xmi:id="_h0A1NDLzEeKMEOdllHiEaA" elementId="org.eclipse.e4.core.commands.service" contributionURI="bundleclass://org.eclipse.e4.core.commands/org.eclipse.e4.core.commands.CommandServiceAddon"/>
   <addons xmi:id="_h0A1NTLzEeKMEOdllHiEaA" elementId="org.eclipse.e4.ui.contexts.service" contributionURI="bundleclass://org.eclipse.e4.ui.services/org.eclipse.e4.ui.services.ContextServiceAddon"/>
   <addons xmi:id="_h0A1NjLzEeKMEOdllHiEaA" elementId="org.eclipse.e4.ui.bindings.service" contributionURI="bundleclass://org.eclipse.e4.ui.bindings/org.eclipse.e4.ui.bindings.BindingServiceAddon"/>

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/helpData.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/helpData.xml
@@ -3,8 +3,4 @@
         <tocOrder>
                 <toc id="/org.eclipse.chemclipse.rcp.app.ui/toc.xml"/>
         </tocOrder>
-        <hidden>
-                <toc id="/org.eclipse.jdt.doc.user/toc.xml"/>
-                <toc id="/org.eclipse.platform.doc.user/toc.xml"/>
-        </hidden>
 </extensions>

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/handlers/DynamicHelpHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/handlers/DynamicHelpHandler.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2013, 2022 Lablicate GmbH.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Dr. Philip Wenig - initial API and implementation
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.rcp.app.ui.handlers;
+
+import org.eclipse.core.commands.ParameterizedCommand;
+import org.eclipse.e4.core.commands.ECommandService;
+import org.eclipse.e4.core.commands.EHandlerService;
+import org.eclipse.e4.core.di.annotations.Execute;
+import org.eclipse.e4.core.services.log.Logger;
+
+@SuppressWarnings("restriction")
+public class DynamicHelpHandler {
+
+	@Execute
+	void execute(ECommandService commandService, EHandlerService handlerService, Logger logger) {
+
+		ParameterizedCommand command = commandService.createCommand("org.eclipse.ui.help.dynamicHelp", null);
+		if(handlerService.canExecute(command)) {
+			handlerService.executeHandler(command);
+		} else {
+			logger.warn("Can't handle to open the dynamic help dialog.");
+		}
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/handlers/HelpContentsHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/handlers/HelpContentsHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 Lablicate GmbH.
+ * Copyright (c) 2013, 2022 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,7 +18,7 @@ import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.core.services.log.Logger;
 
 @SuppressWarnings("restriction")
-public class HelpHandler {
+public class HelpContentsHandler {
 
 	@Execute
 	void execute(ECommandService commandService, EHandlerService handlerService, Logger logger) {
@@ -27,7 +27,7 @@ public class HelpHandler {
 		if(handlerService.canExecute(command)) {
 			handlerService.executeHandler(command);
 		} else {
-			logger.warn("Can't handle to open the help dialog.");
+			logger.warn("Can't handle to open the help contents dialog.");
 		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/handlers/SearchHelpHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/handlers/SearchHelpHandler.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2013, 2022 Lablicate GmbH.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Dr. Philip Wenig - initial API and implementation
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.rcp.app.ui.handlers;
+
+import org.eclipse.core.commands.ParameterizedCommand;
+import org.eclipse.e4.core.commands.ECommandService;
+import org.eclipse.e4.core.commands.EHandlerService;
+import org.eclipse.e4.core.di.annotations.Execute;
+import org.eclipse.e4.core.services.log.Logger;
+
+@SuppressWarnings("restriction")
+public class SearchHelpHandler {
+
+	@Execute
+	void execute(ECommandService commandService, EHandlerService handlerService, Logger logger) {
+
+		ParameterizedCommand command = commandService.createCommand("org.eclipse.ui.help.helpSearch", null);
+		if(handlerService.canExecute(command)) {
+			handlerService.executeHandler(command);
+		} else {
+			logger.warn("Can't handle to open the help search dialog.");
+		}
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/contexts.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/contexts.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?NLS TYPE="org.eclipse.help.contexts"?>
+<contexts>
+   <context id="chromatogram_overlay" title="Chromatogram Overlay">
+      <description>The chromatogram overlay can stack multiple opened chromatograms in one view.</description>
+      <topic label="Controls" href="html/controls/chromatogram_overlay.html"/>
+   </context>
+   <context id="chromatogram_editor" title="Chromatogram Editor">
+      <description>This is the main editor. Right-click on it to choose chemometric operations.</description>
+      <topic label="Controls" href="html/controls/chromatogram_editor.html"/>
+   </context>
+   <context id="peak_scan_list" title="Peak/Scan List">
+   	 <description>The peak/scan list can be used to manage the peaks or scans shown in the current selection.</description>
+  	 <topic label="Controls" href="html/controls/peak_scan_list.html"/>
+   </context>
+</contexts>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
@@ -281,5 +281,12 @@
       <toc
             file="controls.xml">
       </toc>
+   </extension>
+   <extension
+         point="org.eclipse.help.contexts">
+      <contexts
+            file="contexts.xml"
+            plugin="org.eclipse.chemclipse.ux.extension.xxd.ui">
+      </contexts>
    </extension>   
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
@@ -45,8 +45,8 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
 import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
-import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplierContext;
+import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.support.events.IChemClipseEvents;
@@ -111,7 +111,7 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 	//
 	private final IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
 	private final Shell shell;
-	private final ObjectChangedListener<Object> updateMenuListener = new ObjectChangedListener<Object>() {
+	private final ObjectChangedListener<Object> updateMenuListener = new ObjectChangedListener<>() {
 
 		@Override
 		public void objectChanged(ChangeType type, Object newObject, Object oldObject) {
@@ -272,8 +272,7 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 
 		if(objects.size() == 1) {
 			Object object = objects.get(0);
-			if(object instanceof IChromatogramSelection) {
-				IChromatogramSelection chromatogramSelection = (IChromatogramSelection)object;
+			if(object instanceof IChromatogramSelection chromatogramSelection) {
 				if(extendedChromatogramUI.isActiveChromatogramSelection(chromatogramSelection)) {
 					extendedChromatogramUI.update();
 					IChromatogram chromatogram = chromatogramSelection.getChromatogram();
@@ -353,14 +352,11 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 				/*
 				 * Already available.
 				 */
-				if(object instanceof IChromatogramMSD) {
-					IChromatogramMSD chromatogram = (IChromatogramMSD)object;
+				if(object instanceof IChromatogramMSD chromatogram) {
 					chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);
-				} else if(object instanceof IChromatogramCSD) {
-					IChromatogramCSD chromatogram = (IChromatogramCSD)object;
+				} else if(object instanceof IChromatogramCSD chromatogram) {
 					chromatogramSelection = new ChromatogramSelectionCSD(chromatogram);
-				} else if(object instanceof IChromatogramWSD) {
-					IChromatogramWSD chromatogram = (IChromatogramWSD)object;
+				} else if(object instanceof IChromatogramWSD chromatogram) {
 					chromatogramSelection = new ChromatogramSelectionWSD(chromatogram);
 				}
 				chromatogramFile = null;
@@ -406,14 +402,11 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 				monitor.subTask("Save Chromatogram");
 				//
 				IProcessingInfo processingInfo = null;
-				if(chromatogram instanceof IChromatogramMSD) {
-					IChromatogramMSD chromatogramMSD = (IChromatogramMSD)chromatogram;
+				if(chromatogram instanceof IChromatogramMSD chromatogramMSD) {
 					processingInfo = ChromatogramConverterMSD.getInstance().convert(chromatogramFile, chromatogramMSD, converterId, monitor);
-				} else if(chromatogram instanceof IChromatogramCSD) {
-					IChromatogramCSD chromatogramCSD = (IChromatogramCSD)chromatogram;
+				} else if(chromatogram instanceof IChromatogramCSD chromatogramCSD) {
 					processingInfo = ChromatogramConverterCSD.getInstance().convert(chromatogramFile, chromatogramCSD, converterId, monitor);
-				} else if(chromatogram instanceof IChromatogramWSD) {
-					IChromatogramWSD chromatogramWSD = (IChromatogramWSD)chromatogram;
+				} else if(chromatogram instanceof IChromatogramWSD chromatogramWSD) {
 					processingInfo = ChromatogramConverterWSD.getInstance().convert(chromatogramFile, chromatogramWSD, converterId, monitor);
 				}
 				//

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/help/HelpContext.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/help/HelpContext.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Lablicate GmbH.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ * 
+ *******************************************************************************/
+package org.eclipse.chemclipse.ux.extension.xxd.ui.help;
+
+public class HelpContext {
+
+	HelpContext() {
+
+		// static only
+	}
+
+	public static final String PREFIX = "org.eclipse.chemclipse.ux.extension.xxd.ui."; //$NON-NLS-1$
+	//
+	public static final String CHROMATOGRAM_EDITOR = PREFIX + "chromatogram_editor"; //$NON-NLS-1$
+	public static final String CHROMATOGRAM_OVERLAY = PREFIX + "chromatogram_overlay"; //$NON-NLS-1$
+	public static final String PEAK_SCAN_LIST = PREFIX + "peak_scan_list"; //$NON-NLS-1$
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/ChromatogramOverlayPart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/ChromatogramOverlayPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Lablicate GmbH.
+ * Copyright (c) 2017, 2022 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -43,8 +43,7 @@ public class ChromatogramOverlayPart extends AbstractPart<ExtendedChromatogramOv
 		public void execute(MPart part, MDirectToolItem toolItem) {
 
 			Object object = part.getObject();
-			if(object instanceof ChromatogramOverlayPart) {
-				ChromatogramOverlayPart overlayPart = (ChromatogramOverlayPart)object;
+			if(object instanceof ChromatogramOverlayPart overlayPart) {
 				overlayPart.getControl().setZoomLocked(toolItem.isSelected());
 			}
 		}
@@ -56,6 +55,7 @@ public class ChromatogramOverlayPart extends AbstractPart<ExtendedChromatogramOv
 		return new ExtendedChromatogramOverlayUI(parent, SWT.BORDER);
 	}
 
+	@Override
 	@Focus
 	public void setFocus() {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/PeakScanListPart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/PeakScanListPart.java
@@ -48,8 +48,7 @@ public class PeakScanListPart extends AbstractPart<ExtendedPeakScanListUI> {
 		void execute(MPart part, MDirectToolItem toolItem) {
 
 			Object object = part.getObject();
-			if(object instanceof PeakScanListPart) {
-				PeakScanListPart listPart = (PeakScanListPart)object;
+			if(object instanceof PeakScanListPart listPart) {
 				listPart.linkWithEditor = toolItem.isSelected();
 				listPart.updatePeakSelection(null);
 			}
@@ -89,21 +88,19 @@ public class PeakScanListPart extends AbstractPart<ExtendedPeakScanListUI> {
 				getControl().updateChromatogramSelection(null);
 				unloadData();
 				return false;
-			} else {
-				if(isChromatogramEvent(topic)) {
-					if(object instanceof IChromatogramSelection) {
-						IChromatogramSelection<?, ?> chromatogramSelection = (IChromatogramSelection<?, ?>)object;
-						getControl().updateChromatogramSelection(chromatogramSelection);
-						return true;
-					}
-				} else if(isUpdateEditorEvent(topic)) {
-					logger.info(object);
-					getControl().refreshTableViewer();
+			} else if(isChromatogramEvent(topic)) {
+				if(object instanceof IChromatogramSelection) {
+					IChromatogramSelection<?, ?> chromatogramSelection = (IChromatogramSelection<?, ?>)object;
+					getControl().updateChromatogramSelection(chromatogramSelection);
 					return true;
-				} else if(isIdentificationTopic(topic)) {
-					getControl().updateChromatogramSelection();
-					linkWithEditor = false; // TODO Workaround: This otherwise breaks the table selection after undo.
 				}
+			} else if(isUpdateEditorEvent(topic)) {
+				logger.info(object);
+				getControl().refreshTableViewer();
+				return true;
+			} else if(isIdentificationTopic(topic)) {
+				getControl().updateChromatogramSelection();
+				linkWithEditor = false; // TODO Workaround: This otherwise breaks the table selection after undo.
 			}
 		}
 		//

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramOverlayUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramOverlayUI.java
@@ -49,6 +49,7 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramRulerChart;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.charts.IRulerUpdateNotifier;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.charts.RulerEvent;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.help.HelpContext;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.support.OverlayChartSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferenceConstants;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageChromatogram;
@@ -104,6 +105,7 @@ import org.eclipse.swtchart.extensions.linecharts.ILineSeriesData;
 import org.eclipse.swtchart.extensions.linecharts.ILineSeriesSettings;
 import org.eclipse.swtchart.extensions.linecharts.LineSeriesData;
 import org.eclipse.swtchart.extensions.preferences.PreferencePage;
+import org.eclipse.ui.PlatformUI;
 
 public class ExtendedChromatogramOverlayUI extends Composite implements IExtendedPartUI {
 
@@ -183,6 +185,8 @@ public class ExtendedChromatogramOverlayUI extends Composite implements IExtende
 		 * This is needed to layout both combo boxes accordingly.
 		 */
 		this.layout(true);
+		//
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, HelpContext.CHROMATOGRAM_OVERLAY);
 	}
 
 	private Composite createToolbarMain(Composite parent) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramOverlayUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramOverlayUI.java
@@ -291,8 +291,7 @@ public class ExtendedChromatogramOverlayUI extends Composite implements IExtende
 			@Override
 			public String getText(Object element) {
 
-				if(element instanceof Derivative) {
-					Derivative derivative = (Derivative)element;
+				if(element instanceof Derivative derivative) {
 					return derivative.label();
 				}
 				return null;
@@ -564,12 +563,10 @@ public class ExtendedChromatogramOverlayUI extends Composite implements IExtende
 						appendXWC(availableSeriesIds, selectionSeries, lineSeriesDataList, chromatogram, displayType, chromatogramName);
 					} else if(displayType.equals(DisplayType.MPC)) {
 						appendMPC(availableSeriesIds, selectionSeries, lineSeriesDataList, chromatogram, displayType, chromatogramName);
+					} else if(displayType.equals(DisplayType.BPC) || displayType.equals(DisplayType.XIC) || displayType.equals(DisplayType.TSC)) {
+						appendXXC(availableSeriesIds, selectionSeries, lineSeriesDataList, chromatogram, displayType, chromatogramName);
 					} else {
-						if(displayType.equals(DisplayType.BPC) || displayType.equals(DisplayType.XIC) || displayType.equals(DisplayType.TSC)) {
-							appendXXC(availableSeriesIds, selectionSeries, lineSeriesDataList, chromatogram, displayType, chromatogramName);
-						} else {
-							appendTIC(availableSeriesIds, selectionSeries, lineSeriesDataList, chromatogram, displayType, chromatogramName);
-						}
+						appendTIC(availableSeriesIds, selectionSeries, lineSeriesDataList, chromatogram, displayType, chromatogramName);
 					}
 				}
 				i++;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
@@ -60,6 +60,7 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.calibration.IUpdateListener;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.dialogs.ClassifierDialog;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.dialogs.InternalStandardDialog;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.help.HelpContext;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.support.TableConfigSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.operations.DeletePeaksOperation;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.operations.DeleteScansOperation;
@@ -92,6 +93,7 @@ import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swtchart.extensions.core.IKeyboardSupport;
+import org.eclipse.ui.PlatformUI;
 
 @SuppressWarnings("rawtypes")
 public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI, ConfigurableUI<PeakScanListUIConfig> {
@@ -258,6 +260,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 		buttonMerge.setEnabled(false);
 		buttonDelete.setEnabled(false);
 		scanIdentifierUI.setEnabled(false);
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, HelpContext.PEAK_SCAN_LIST);
 	}
 
 	private void createToolbarMain(Composite parent) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -52,8 +52,8 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.core.DefaultProcessingResult;
-import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.IMessageProvider;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
 import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
@@ -310,7 +310,7 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 		if(chromatogramSelection != null && eventBroker != null) {
 			UpdateNotifierUI.update(display, chromatogramSelection);
 		}
-		return chromatogramSelection != null ? true : false;
+		return chromatogramSelection != null;
 	}
 
 	public boolean fireUpdatePeak(Display display) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -86,6 +86,7 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.calibration.RetentionIndexUI;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChartSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.editors.EditorProcessTypeSupplier;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.help.HelpContext;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.charts.TargetReferenceLabelMarker;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.handlers.DynamicHandler;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.methods.MethodCancelException;
@@ -1021,6 +1022,8 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 		PartSupport.setCompositeVisibility(toolbars.get(TOOLBAR_CHROMATOGRAM_ALIGNMENT), false);
 		PartSupport.setCompositeVisibility(toolbars.get(TOOLBAR_METHOD), preferenceStore.getBoolean(PreferenceConstants.P_CHROMATOGRAM_SHOW_METHODS_TOOLBAR));
 		PartSupport.setCompositeVisibility(toolbars.get(TOOLBAR_RETENTION_INDICES), false);
+		//
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, HelpContext.CHROMATOGRAM_EDITOR);
 		//
 		chromatogramReferencesUI.setComboVisible(preferenceStore.getBoolean(PreferenceConstants.P_CHROMATOGRAM_SHOW_REFERENCES_COMBO));
 		chromatogramReferencesUI.setUpdateListener(new IUpdateListener() {


### PR DESCRIPTION
I removed too much in https://github.com/eclipse/chemclipse/pull/1096 which results in a crash whenever you open `Help` → `Documentation`. I noticed that modern Eclipse IDEs have a lot more help options, so I added those as well.