### PR TITLE
Fixed hidden editor toolbars not updating with more than one chromatogram

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/META-INF/MANIFEST.MF
@@ -32,7 +32,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.equinox.p2.core;bundle-version="2.1.0",
  org.eclipse.equinox.p2.metadata;bundle-version="2.1.0",
  org.eclipse.core.databinding;bundle-version="1.6.0",
- org.eclipse.chemclipse.rcp.ui.icons
+ org.eclipse.chemclipse.rcp.ui.icons,
+ org.eclipse.chemclipse.model
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.support.ui.activator,

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/processors/ProcessorToolbar.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/processors/ProcessorToolbar.java
@@ -18,8 +18,10 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 
+import org.eclipse.chemclipse.model.notifier.UpdateNotifier;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplier;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplierContext;
+import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.chemclipse.support.ui.preferences.ProcessorToolbarPreferencePage;
 import org.eclipse.chemclipse.support.ui.swt.EditorToolBar;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -46,9 +48,14 @@ public class ProcessorToolbar {
 
 		if(preferenceStore != null) {
 			preferencesSupport = new PreferencesSupport(preferenceStore, key, context, isVisible);
-			editorToolBar.addPreferencePages(() -> Collections.singleton(new ProcessorToolbarPreferencePage(preferencesSupport)), () -> update()); // Callback
+			editorToolBar.addPreferencePages(() -> Collections.singleton(new ProcessorToolbarPreferencePage(preferencesSupport)), () -> fireUpdateEvent()); // Callback
 			update(); // Initialize
 		}
+	}
+
+	private void fireUpdateEvent() {
+
+		UpdateNotifier.update(IChemClipseEvents.TOPIC_EDITOR_CHROMATOGRAM_TOOLBAR_UPDATE, true);
 	}
 
 	public void update() {
@@ -80,7 +87,6 @@ public class ProcessorToolbar {
 			toolBar.setVisible(true);
 			toolBar.addSeparator();
 		}
-		//
 		editorToolBar.update();
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/swt/EditorToolBar.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/swt/EditorToolBar.java
@@ -28,6 +28,8 @@ import java.util.function.Supplier;
 import org.eclipse.chemclipse.model.notifier.UpdateNotifier;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
+import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
+import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.chemclipse.support.ui.preferences.ToolbarPreferencePage;
 import org.eclipse.jface.action.AbstractGroupMarker;
 import org.eclipse.jface.action.Action;
@@ -329,11 +331,10 @@ public class EditorToolBar {
 			if(parent != null) {
 				parent.enableToolbarTextPage(preferenceStore, key);
 			} else {
-				updateShowTextByPreference(preferenceStore, key);
 				config.addPreferencePageContainer(new PreferencePageContainer(() -> {
 					return Collections.singleton(new ToolbarPreferencePage(preferenceStore, key));
 				}, () -> updateShowTextByPreference(preferenceStore, key)));
-				update();
+				fireUpdateEvent();
 			}
 		}
 	}
@@ -344,7 +345,7 @@ public class EditorToolBar {
 			parent.addPreferencePages(pageSupplier, settingsChangedRunnable);
 		} else {
 			config.addPreferencePageContainer(new PreferencePageContainer(pageSupplier, settingsChangedRunnable));
-			update();
+			fireUpdateEvent();
 		}
 	}
 
@@ -425,6 +426,11 @@ public class EditorToolBar {
 			this.supplier = supplier;
 			this.runnable = runnable;
 		}
+	}
+
+	private void fireUpdateEvent() {
+
+		UpdateNotifier.update(IChemClipseEvents.TOPIC_EDITOR_CHROMATOGRAM_TOOLBAR_UPDATE, true);
 	}
 
 	public void clear() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/swt/EditorToolBar.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/swt/EditorToolBar.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import org.eclipse.chemclipse.model.notifier.UpdateNotifier;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
 import org.eclipse.chemclipse.support.ui.preferences.ToolbarPreferencePage;
@@ -169,10 +170,10 @@ public class EditorToolBar {
 
 	public void setVisible(boolean visible) {
 
-		if(toolBarManager instanceof SubContributionManager) {
-			((SubContributionManager)toolBarManager).setVisible(visible);
-		} else if(toolBarManager instanceof ToolBarManager) {
-			Control control = ((ToolBarManager)toolBarManager).getControl();
+		if(toolBarManager instanceof SubContributionManager toolBarManager) {
+			toolBarManager.setVisible(visible);
+		} else if(toolBarManager instanceof ToolBarManager toolBarManager) {
+			Control control = toolBarManager.getControl();
 			control.setVisible(visible);
 			/*
 			 * Resize the layout.
@@ -349,10 +350,10 @@ public class EditorToolBar {
 
 	public boolean isVisible() {
 
-		if(toolBarManager instanceof SubContributionManager) {
-			return ((SubContributionManager)toolBarManager).isVisible();
-		} else if(toolBarManager instanceof ToolBarManager) {
-			return ((ToolBarManager)toolBarManager).getControl().isVisible();
+		if(toolBarManager instanceof SubContributionManager toolBarManager) {
+			return toolBarManager.isVisible();
+		} else if(toolBarManager instanceof ToolBarManager toolBarManager) {
+			return toolBarManager.getControl().isVisible();
 		} else {
 			return false;
 		}
@@ -373,7 +374,7 @@ public class EditorToolBar {
 		private void addPreferencePageContainer(PreferencePageContainer container) {
 
 			if(configAction == null) {
-				configAction = new Action("Settings", ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_CONFIGURE, IApplicationImage.SIZE_16x16)) {
+				configAction = new Action("Settings", ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_CONFIGURE, IApplicationImageProvider.SIZE_16x16)) {
 
 					@Override
 					public void runWithEvent(Event event) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/events/IChemClipseEvents.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/events/IChemClipseEvents.java
@@ -96,4 +96,6 @@ public interface IChemClipseEvents {
 	String TOPIC_EDITOR_PCR_CLOSE = "editor/pcr/close";
 	String TOPIC_EDITOR_NMR_CLOSE = "editor/nmr/close";
 	String TOPIC_EDITOR_XIR_CLOSE = "editor/xir/close";
+	//
+	String TOPIC_EDITOR_CHROMATOGRAM_TOOLBAR_UPDATE = "editor/chromatogram/toolbar/update";
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/Activator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/Activator.java
@@ -199,6 +199,8 @@ public class Activator extends AbstractActivatorUI {
 		dataUpdateSupport.subscribe(IChemClipseEvents.TOPIC_EDITOR_PCR_CLOSE, IChemClipseEvents.EVENT_BROKER_DATA);
 		dataUpdateSupport.subscribe(IChemClipseEvents.TOPIC_EDITOR_NMR_CLOSE, IChemClipseEvents.EVENT_BROKER_DATA);
 		dataUpdateSupport.subscribe(IChemClipseEvents.TOPIC_EDITOR_XIR_CLOSE, IChemClipseEvents.EVENT_BROKER_DATA);
+		//
+		dataUpdateSupport.subscribe(IChemClipseEvents.TOPIC_EDITOR_CHROMATOGRAM_TOOLBAR_UPDATE, IChemClipseEvents.EVENT_BROKER_DATA);
 	}
 
 	private void initializePreferenceStoreSubtract(IPreferenceSupplier preferenceSupplier) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
@@ -99,6 +99,7 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 	private static final String TOPIC_PEAK = IChemClipseEvents.TOPIC_PEAK_XXD_UPDATE_SELECTION;
 	private static final String TOPIC_EDITOR_UPDATE = IChemClipseEvents.TOPIC_EDITOR_CHROMATOGRAM_UPDATE;
 	private static final String TOPIC_EDITOR_ADJUST = IChemClipseEvents.TOPIC_EDITOR_CHROMATOGRAM_ADJUST;
+	private static final String TOPIC_TOOLBAR_UPDATE = IChemClipseEvents.TOPIC_EDITOR_CHROMATOGRAM_TOOLBAR_UPDATE;
 	//
 	private final DataType dataType;
 	private final MPart part;
@@ -152,6 +153,7 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 		if(shell != null) {
 			extendedChromatogramUI.fireUpdate(shell.getDisplay());
 		}
+		extendedChromatogramUI.checkUpdates();
 	}
 
 	@PostConstruct
@@ -296,6 +298,9 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 				logger.info("Adjust the chromatogram editor: " + object);
 				extendedChromatogramUI.adjustChromatogramChart();
 				return true;
+			} else if(TOPIC_TOOLBAR_UPDATE.equals(topic)) {
+				logger.info("Updating processor toolbar");
+				extendedChromatogramUI.updateToolbar();
 			}
 		}
 		//
@@ -305,7 +310,7 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 	@Override
 	protected boolean isUpdateTopic(String topic) {
 
-		return TOPIC_CHROMATOGRAM.equals(topic) || TOPIC_SCAN.equals(topic) || TOPIC_PEAK.equals(topic) || TOPIC_EDITOR_UPDATE.equals(topic) || TOPIC_EDITOR_ADJUST.equals(topic);
+		return TOPIC_CHROMATOGRAM.equals(topic) || TOPIC_SCAN.equals(topic) || TOPIC_PEAK.equals(topic) || TOPIC_EDITOR_UPDATE.equals(topic) || TOPIC_EDITOR_ADJUST.equals(topic) || TOPIC_TOOLBAR_UPDATE.equals(topic);
 	}
 
 	private void processChromatogram(IChromatogramSelection chromatogramSelection) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSubtractScanUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSubtractScanUI.java
@@ -52,7 +52,7 @@ import org.eclipse.swt.widgets.TabItem;
 
 public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI {
 
-	private static final Logger logger = Logger.getLogger(ExtendedScanChartUI.class);
+	private static final Logger logger = Logger.getLogger(ExtendedSubtractScanUI.class);
 	//
 	private TabFolder tabFolder;
 	private ScanChartUI scanChartUI;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -37,6 +37,7 @@ import org.eclipse.chemclipse.model.columns.ISeparationColumn;
 import org.eclipse.chemclipse.model.columns.SeparationColumnFactory;
 import org.eclipse.chemclipse.model.comparator.PeakRetentionTimeComparator;
 import org.eclipse.chemclipse.model.core.IChromatogram;
+import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IPeakModel;
 import org.eclipse.chemclipse.model.core.IScan;
@@ -66,6 +67,7 @@ import org.eclipse.chemclipse.processing.ui.support.ProcessingInfoPartSupport;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
 import org.eclipse.chemclipse.support.comparator.SortOrder;
+import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.chemclipse.support.settings.OperatingSystemUtils;
 import org.eclipse.chemclipse.support.text.ValueFormat;
 import org.eclipse.chemclipse.support.ui.processors.ProcessorToolbar;
@@ -93,6 +95,7 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.methods.MethodCancelException;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.methods.MethodSupportUI;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.methods.ResumeMethodSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.methods.SettingsWizard;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.part.support.DataUpdateSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.ChromatogramAxisIntensity;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.ChromatogramAxisMilliseconds;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.ChromatogramAxisMinutes;
@@ -286,6 +289,13 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 		return toolbarMain.isVisible();
 	}
 
+	public void updateToolbar() {
+
+		toolbarMain.setShowText(preferenceStore.getBoolean(PREFERENCE_SHOW_TOOLBAR_TEXT));
+		toolbarMain.update();
+		processorToolbar.update();
+	}
+
 	/**
 	 * Resets the chart ranges 1:1.
 	 */
@@ -422,6 +432,15 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 				setSeparationColumnSelection();
 				updateWavelengths();
 			}
+		}
+	}
+
+	public void checkUpdates() {
+
+		DataUpdateSupport dataUpdateSupport = Activator.getDefault().getDataUpdateSupport();
+		List<Object> updates = dataUpdateSupport.getUpdates(IChemClipseEvents.TOPIC_EDITOR_CHROMATOGRAM_TOOLBAR_UPDATE);
+		if(!updates.isEmpty()) {
+			updateToolbar();
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -826,7 +826,7 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 	private TargetReference createTargetReference(IPeak peak) {
 
 		IPeakModel peakModel = peak.getPeakModel();
-		String name = FORMAT.format(peakModel.getRetentionTimeAtPeakMaximum() / IChromatogram.MINUTE_CORRELATION_FACTOR);
+		String name = FORMAT.format(peakModel.getRetentionTimeAtPeakMaximum() / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
 		float retentionIndex = peakModel.getPeakMaximum().getRetentionIndex();
 		return new TargetReference(peak, TargetReferenceType.PEAK, name, retentionIndex);
 	}


### PR DESCRIPTION
When having more than one toolbar, changing the processor icons or the text switch will only apply to one chromatogram. However, the settings are persisted across, so it shows inconsistent preferences on the ones that didn't update. This adds an update hook via the event system to fix it.