### PR TITLE
Improved performance around the Targets part

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedComparisonScanUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedComparisonScanUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -118,33 +118,26 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 		List<Object> objects = dataUpdateSupport.getUpdates(topic);
 		if(!objects.isEmpty()) {
 			Object last = objects.get(0);
-			if(last instanceof IScanMSD) {
-				IScanMSD scan = (IScanMSD)last;
+			if(last instanceof IScanMSD scan) {
 				float retentionIndex = scan.getRetentionIndex();
 				IdentificationTargetComparator identificationTargetComparator = new IdentificationTargetComparator(retentionIndex);
 				IIdentificationTarget identificationTarget = IIdentificationTarget.getBestIdentificationTarget(scan.getTargets(), identificationTargetComparator);
 				update(scan, identificationTarget);
-			} else if(last instanceof IPeakMSD) {
-				IPeakMSD peakMSD = (IPeakMSD)last;
+			} else if(last instanceof IPeakMSD peakMSD) {
 				IPeakMassSpectrum scan = peakMSD.getExtractedMassSpectrum();
 				float retentionIndex = scan.getRetentionIndex();
 				IdentificationTargetComparator identificationTargetComparator = new IdentificationTargetComparator(retentionIndex);
 				IIdentificationTarget identificationTarget = IIdentificationTarget.getBestIdentificationTarget(peakMSD.getTargets(), identificationTargetComparator);
 				update(scan, identificationTarget);
-			} else if(last instanceof Object[]) {
-				Object[] values = (Object[])last;
+			} else if(last instanceof Object[] values) {
 				Object first = values[0];
 				Object second = values[1];
 				if(IChemClipseEvents.TOPIC_SCAN_TARGET_UPDATE_COMPARISON.equals(topic)) {
-					if(first instanceof IScanMSD && second instanceof IIdentificationTarget) {
-						IScanMSD unknownMassSpectrum = (IScanMSD)first;
-						IIdentificationTarget identificationTarget = (IIdentificationTarget)second;
+					if(first instanceof IScanMSD unknownMassSpectrum && second instanceof IIdentificationTarget identificationTarget) {
 						update(unknownMassSpectrum, identificationTarget);
 					}
 				} else if(IChemClipseEvents.TOPIC_SCAN_REFERENCE_UPDATE_COMPARISON.equals(topic)) {
-					if(first instanceof IScanMSD && second instanceof IScanMSD) {
-						IScanMSD unknownMassSpectrum = (IScanMSD)first;
-						IScanMSD referenceMassSpectrum = (IScanMSD)second;
+					if(first instanceof IScanMSD unknownMassSpectrum && second instanceof IScanMSD referenceMassSpectrum) {
 						update(unknownMassSpectrum, referenceMassSpectrum);
 					}
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -676,11 +676,10 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 				 * Only one object.
 				 */
 				Object object = list.size() == 1 ? list.get(0) : null;
-				if(object instanceof IPeak) {
+				if(object instanceof IPeak peak) {
 					/*
 					 * Fire updates
 					 */
-					IPeak peak = (IPeak)object;
 					IdentificationTargetComparator identificationTargetComparator = new IdentificationTargetComparator(SortOrder.DESC, peak.getPeakModel().getPeakMaximum().getRetentionIndex());
 					IIdentificationTarget identificationTarget = IIdentificationTarget.getBestIdentificationTarget(peak.getTargets(), identificationTargetComparator);
 					if(moveRetentionTimeOnPeakSelection) {
@@ -696,15 +695,13 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 					//
 					UpdateNotifierUI.update(display, peak);
 					UpdateNotifierUI.update(display, identificationTarget);
-					if(peak instanceof IPeakMSD) {
-						IPeakMSD peakMSD = (IPeakMSD)peak;
+					if(peak instanceof IPeakMSD peakMSD) {
 						UpdateNotifierUI.update(display, peakMSD.getPeakModel().getPeakMassSpectrum(), identificationTarget);
 					}
-				} else if(object instanceof IScan) {
+				} else if(object instanceof IScan scan) {
 					/*
 					 * Fire updates
 					 */
-					IScan scan = (IScan)object;
 					IdentificationTargetComparator identificationTargetComparator = new IdentificationTargetComparator(SortOrder.DESC, scan.getRetentionIndex());
 					IIdentificationTarget identificationTarget = IIdentificationTarget.getBestIdentificationTarget(scan.getTargets(), identificationTargetComparator);
 					//
@@ -715,8 +712,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 					//
 					UpdateNotifierUI.update(display, scan);
 					UpdateNotifierUI.update(display, identificationTarget);
-					if(scan instanceof IScanMSD) {
-						IScanMSD scanMSD = (IScanMSD)scan;
+					if(scan instanceof IScanMSD scanMSD) {
 						UpdateNotifierUI.update(display, scanMSD, identificationTarget);
 					}
 				}
@@ -769,7 +765,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 
 				List<IChromatogramPeakMSD> peaksToMerge = getSelectedPeaksMSD();
 				if(peaksToMerge.size() >= 2) {
-					if(chromatogramSelection instanceof IChromatogramSelectionMSD) {
+					if(chromatogramSelection instanceof IChromatogramSelectionMSD chromatogramSelectionMSD) {
 						/*
 						 * Merge Peaks
 						 */
@@ -779,7 +775,6 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 						/*
 						 * Modify the chromatogram
 						 */
-						IChromatogramSelectionMSD chromatogramSelectionMSD = (IChromatogramSelectionMSD)chromatogramSelection;
 						IChromatogramMSD chromatogramMSD = chromatogramSelectionMSD.getChromatogram();
 						IChromatogramPeakMSD chromatogramPeakMSD = new ChromatogramPeakMSD(peakMSD.getPeakModel(), chromatogramMSD);
 						/*
@@ -857,11 +852,10 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 
 		IScanMSD massSpectrum;
 		//
-		if(object instanceof IPeakMSD) {
-			IPeakMSD peak = (IPeakMSD)object;
+		if(object instanceof IPeakMSD peak) {
 			massSpectrum = peak.getPeakModel().getPeakMassSpectrum();
-		} else if(object instanceof IScanMSD) {
-			massSpectrum = (IScanMSD)object;
+		} else if(object instanceof IScanMSD scanMSD) {
+			massSpectrum = scanMSD;
 		} else {
 			massSpectrum = null;
 		}
@@ -991,8 +985,8 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 		List<IPeak> peakList = new ArrayList<>();
 		for(TableItem tableItem : table.getItems()) {
 			Object object = tableItem.getData();
-			if(object instanceof IPeak) {
-				peakList.add((IPeak)object);
+			if(object instanceof IPeak peak) {
+				peakList.add(peak);
 			}
 		}
 		return peakList;
@@ -1004,8 +998,8 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 		for(int index : indices) {
 			TableItem tableItem = table.getItem(index);
 			Object object = tableItem.getData();
-			if(object instanceof IPeak) {
-				peakList.add((IPeak)object);
+			if(object instanceof IPeak peak) {
+				peakList.add(peak);
 			}
 		}
 		return peakList;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedTargetsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedTargetsUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -782,6 +782,7 @@ public class ExtendedTargetsUI extends Composite implements IExtendedPartUI {
 		return isChromatogramActive() ? targetListChromatogram : targetListOther;
 	}
 
+	@SuppressWarnings("rawtypes")
 	private void updateOnFocus() {
 
 		DataUpdateSupport dataUpdateSupport = Activator.getDefault().getDataUpdateSupport();
@@ -789,8 +790,7 @@ public class ExtendedTargetsUI extends Composite implements IExtendedPartUI {
 		//
 		if(!objects.isEmpty()) {
 			Object object = objects.get(0);
-			if(object instanceof IChromatogramSelection) {
-				IChromatogramSelection<?, ?> chromatogramSelection = (IChromatogramSelection<?, ?>)object;
+			if(object instanceof IChromatogramSelection chromatogramSelection) {
 				updateChromatogram(chromatogramSelection);
 			} else {
 				updateOther(object);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakTracesUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakTracesUI.java
@@ -61,7 +61,7 @@ import org.eclipse.swtchart.extensions.linecharts.ILineSeriesSettings;
 
 public class PeakTracesUI extends ScrollableChart {
 
-	private final int NO_TRACE_SELECTION = 0;
+	private static final int NO_TRACE_SELECTION = 0;
 	//
 	private final ChromatogramChartSupport chromatogramChartSupport = new ChromatogramChartSupport();
 	private final PeakChartSupport peakChartSupport = new PeakChartSupport();
@@ -114,10 +114,10 @@ public class PeakTracesUI extends ScrollableChart {
 		//
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<>();
 		//
-		if(peak instanceof IChromatogramPeakMSD) {
-			lineSeriesDataList.addAll(extractSIC((IChromatogramPeakMSD)peak));
-		} else if(peak instanceof IChromatogramPeakWSD) {
-			lineSeriesDataList.addAll(extractSWC((IChromatogramPeakWSD)peak));
+		if(peak instanceof IChromatogramPeakMSD chromatogramPeakMSD) {
+			lineSeriesDataList.addAll(extractSIC(chromatogramPeakMSD));
+		} else if(peak instanceof IChromatogramPeakWSD chromatogramPeakWSD) {
+			lineSeriesDataList.addAll(extractSWC(chromatogramPeakWSD));
 		} else if(peak != null) {
 			lineSeriesDataList.add(extractTIC(peak));
 		}
@@ -170,8 +170,7 @@ public class PeakTracesUI extends ScrollableChart {
 		int startRetentionTime = peakModel.getStartRetentionTime() - offsetRetentionTime;
 		int stopRetentionTime = peakModel.getStopRetentionTime() + offsetRetentionTime;
 		IScan peakMaximum = peakModel.getPeakMaximum();
-		if(peakMaximum instanceof IScanWSD) {
-			IScanWSD scanWSD = (IScanWSD)peakMaximum;
+		if(peakMaximum instanceof IScanWSD scanWSD) {
 			IChromatogramSelection<?, ?> chromatogramSelection = new ChromatogramSelection<>(chromatogram);
 			chromatogramSelection.setRangeRetentionTime(startRetentionTime, stopRetentionTime, false);
 			//
@@ -294,7 +293,7 @@ public class PeakTracesUI extends ScrollableChart {
 		/*
 		 * Suspend the update when adding new data to improve the performance.
 		 */
-		if(lineSeriesDataList != null && lineSeriesDataList.size() > 0) {
+		if(lineSeriesDataList != null && !lineSeriesDataList.isEmpty()) {
 			BaseChart baseChart = getBaseChart();
 			baseChart.suspendUpdate(true);
 			for(ILineSeriesData lineSeriesData : lineSeriesDataList) {


### PR DESCRIPTION
I noticed that
> Targets have been modified (deleted/updated).

gets logged a lot and it triggers the `TOPIC_EDITOR_CHROMATOGRAM_UPDATE` which many parts listen to not just the editor, but also the Peak/Scan List which might then trigger another update.

Every selection in the Targets list would trigger it, even when no targets are actually chosen or renamed/deleted. This removes this update to reduce the load on the overall update mechanisms. It also does not seem to be required to update the automatic library search in the Scan Comparison part.