### PR TITLE
Improved Mass Spectra performance

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/calculator/SubtractCalculator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/calculator/SubtractCalculator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 Lablicate GmbH.
+ * Copyright (c) 2013, 2022 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -136,7 +136,7 @@ public class SubtractCalculator {
 		/*
 		 * Test if null.
 		 */
-		if(massSpectra == null || massSpectra.size() == 0 || massSpectrumFilterSettings == null) {
+		if(massSpectra == null || massSpectra.isEmpty() || massSpectrumFilterSettings == null) {
 			return;
 		}
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/library/LibraryService.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/library/LibraryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Lablicate GmbH.
+ * Copyright (c) 2016, 2022 Lablicate GmbH.
  *
  * All rights reserved. This
  * program and the accompanying materials are made available under the terms of
@@ -78,7 +78,7 @@ public class LibraryService {
 					 */
 					processingInfo = libraryService.identify(identificationTarget, monitor);
 					massSpectra = processingInfo.getProcessingResult();
-					if(massSpectra != null && massSpectra.size() > 0) {
+					if(massSpectra != null && !massSpectra.isEmpty()) {
 						break exitloop;
 					}
 				}
@@ -86,7 +86,7 @@ public class LibraryService {
 			/*
 			 * Post check.
 			 */
-			if(massSpectra == null || massSpectra.size() == 0) {
+			if(massSpectra == null || massSpectra.isEmpty()) {
 				processingInfo = getNoIdentifierAvailableProcessingInfo();
 			}
 		} catch(NoIdentifierAvailableException e) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterCleaner.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterCleaner.java
@@ -77,25 +77,25 @@ public class FilterCleaner extends AbstractChromatogramFilter {
 		 */
 		for(int scan = startScan; scan <= stopScan; scan++) {
 			IScan chromatogramScan = chromatogram.getScan(scan);
-			if(chromatogramScan instanceof IScanMSD) {
+			if(chromatogramScan instanceof IScanMSD scanMSD) {
 				/*
 				 * MSD
 				 */
-				if(((IScanMSD)chromatogramScan).getNumberOfIons() == 0) {
+				if(scanMSD.isEmpty()) {
 					scansToRemove.add(scan);
 				}
-			} else if(chromatogramScan instanceof IScanCSD) {
+			} else if(chromatogramScan instanceof IScanCSD scanCSD) {
 				/*
 				 * CSD
 				 */
-				if(((IScanCSD)chromatogramScan).getTotalSignal() == 0) {
+				if(scanCSD.getTotalSignal() == 0) {
 					scansToRemove.add(scan);
 				}
-			} else if(chromatogramScan instanceof IScanWSD) {
+			} else if(chromatogramScan instanceof IScanWSD scanWSD) {
 				/*
 				 * WSD
 				 */
-				if(((IScanWSD)chromatogramScan).getScanSignals().isEmpty()) {
+				if(scanWSD.getScanSignals().isEmpty()) {
 					scansToRemove.add(scan);
 				}
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/fin/DatabaseImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/fin/DatabaseImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Lablicate GmbH.
+ * Copyright (c) 2020, 2022 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -34,7 +34,7 @@ public class DatabaseImportConverter extends AbstractDatabaseImportConverter {
 			try {
 				IMassSpectraReader massSpectraReader = new FINReader();
 				IMassSpectra massSpectra = massSpectraReader.read(file, monitor);
-				if(massSpectra != null && massSpectra.size() > 0) {
+				if(massSpectra != null && !massSpectra.isEmpty()) {
 					processingInfo.setProcessingResult(massSpectra);
 				} else {
 					processingInfo.addErrorMessage(DESCRIPTION, "No mass spectra were extracted." + file.getAbsolutePath());

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLDatabaseImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLDatabaseImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 Lablicate GmbH.
+ * Copyright (c) 2008, 2022 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -41,7 +41,7 @@ public class MSLDatabaseImportConverter extends AbstractDatabaseImportConverter 
 				file = SpecificationValidatorMSL.validateSpecification(file);
 				IMassSpectraReader massSpectraReader = new MSLReader();
 				IMassSpectra massSpectra = massSpectraReader.read(file, monitor);
-				if(massSpectra != null && massSpectra.size() > 0) {
+				if(massSpectra != null && !massSpectra.isEmpty()) {
 					processingInfo.setProcessingResult(massSpectra);
 				} else {
 					processingInfo.addErrorMessage(DESCRIPTION, "No mass spectra are stored." + file.getAbsolutePath());

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLPeakExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLPeakExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Lablicate GmbH.
+ * Copyright (c) 2012, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -16,7 +16,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IPeaks;
 import org.eclipse.chemclipse.msd.converter.peak.AbstractPeakExportConverter;
@@ -55,17 +54,14 @@ public class MSLPeakExportConverter extends AbstractPeakExportConverter {
 				 * Convert the mass spectra.
 				 */
 				PeakWriterMSL peakWriter = new PeakWriterMSL();
-				peakWriter.write(file, peaks, append, monitor);
+				peakWriter.write(file, peaks, append);
 				processingInfo.setProcessingResult(file);
 			} catch(FileNotFoundException e) {
 				logger.warn(e);
 				processingInfo.addErrorMessage(DESCRIPTION, "The file couldn't be found: " + file.getAbsolutePath());
-			} catch(FileIsNotWriteableException e) {
-				logger.warn(e);
-				processingInfo.addErrorMessage(DESCRIPTION, "The file is not writeable: " + file.getAbsolutePath());
 			} catch(IOException e) {
 				logger.warn(e);
-				processingInfo.addErrorMessage(DESCRIPTION, "Something has gone completely wrong: " + file.getAbsolutePath());
+				processingInfo.addErrorMessage(DESCRIPTION, "The file is not writeable: " + file.getAbsolutePath());
 			}
 		}
 		return processingInfo;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLPeakImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLPeakImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Lablicate GmbH.
+ * Copyright (c) 2012, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -24,7 +24,7 @@ public class MSLPeakImportConverter extends AbstractPeakImportConverter {
 	@Override
 	public IProcessingInfo<IPeaks<?>> convert(File file, IProgressMonitor monitor) {
 
-		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<IPeaks<?>>();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		processingInfo.addErrorMessage("AMDIS MSL Peak Import", "The converter supports no *.msl file import.");
 		return processingInfo;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/ChromatogramPeakExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/ChromatogramPeakExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Lablicate GmbH.
+ * Copyright (c) 2012, 2022 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -35,8 +35,7 @@ public class ChromatogramPeakExportConverter extends AbstractChromatogramExportC
 
 		file = SpecificationValidatorMSP.validateSpecification(file);
 		IProcessingInfo<File> processingInfo = super.validate(file);
-		if(!processingInfo.hasErrorMessages() && chromatogram instanceof IChromatogramMSD) {
-			IChromatogramMSD chromatogramMSD = (IChromatogramMSD)chromatogram;
+		if(!processingInfo.hasErrorMessages() && chromatogram instanceof IChromatogramMSD chromatogramMSD) {
 			IChromatogramMSDWriter writer = new ChromatogramWriterMSP();
 			try {
 				writer.writeChromatogram(file, chromatogramMSD, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPDatabaseImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPDatabaseImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Lablicate GmbH.
+ * Copyright (c) 2016, 2022 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -41,7 +41,7 @@ public class MSPDatabaseImportConverter extends AbstractDatabaseImportConverter 
 				file = SpecificationValidatorMSP.validateSpecification(file);
 				IMassSpectraReader massSpectraReader = new MSPReader();
 				IMassSpectra massSpectra = massSpectraReader.read(file, monitor);
-				if(massSpectra != null && massSpectra.size() > 0) {
+				if(massSpectra != null && !massSpectra.isEmpty()) {
 					processingInfo.setProcessingResult(massSpectra);
 				} else {
 					processingInfo.addErrorMessage(DESCRIPTION, "No mass spectra are stored." + file.getAbsolutePath());

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPPeakExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPPeakExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Lablicate GmbH.
+ * Copyright (c) 2012, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -16,7 +16,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IPeaks;
 import org.eclipse.chemclipse.msd.converter.peak.AbstractPeakExportConverter;
@@ -55,17 +54,14 @@ public class MSPPeakExportConverter extends AbstractPeakExportConverter {
 				 * Convert the mass spectra.
 				 */
 				PeakWriterMSP peakWriter = new PeakWriterMSP();
-				peakWriter.write(file, peaks, append, monitor);
+				peakWriter.write(file, peaks, append);
 				processingInfo.setProcessingResult(file);
 			} catch(FileNotFoundException e) {
 				logger.warn(e);
 				processingInfo.addErrorMessage(DESCRIPTION, "The file couldn't be found: " + file.getAbsolutePath());
-			} catch(FileIsNotWriteableException e) {
-				logger.warn(e);
-				processingInfo.addErrorMessage(DESCRIPTION, "The file is not writeable: " + file.getAbsolutePath());
 			} catch(IOException e) {
 				logger.warn(e);
-				processingInfo.addErrorMessage(DESCRIPTION, "Something has gone completely wrong: " + file.getAbsolutePath());
+				processingInfo.addErrorMessage(DESCRIPTION, "The file is not writeable: " + file.getAbsolutePath());
 			}
 		}
 		return processingInfo;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/AbstractMassSpectraWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/AbstractMassSpectraWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Lablicate GmbH.
+ * Copyright (c) 2016, 2022 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -110,7 +110,7 @@ public abstract class AbstractMassSpectraWriter extends AbstractWriter implement
 			/*
 			 * There must be at least one ion.
 			 */
-			if(massSpectrum != null && massSpectrum.getNumberOfIons() > 0) {
+			if(massSpectrum != null && !massSpectrum.isEmpty()) {
 				writeMassSpectrum(fileWriter, massSpectrum, monitor);
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/AbstractMassSpectraWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/AbstractMassSpectraWriter.java
@@ -12,7 +12,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.amdis.io;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -31,7 +30,7 @@ public abstract class AbstractMassSpectraWriter extends AbstractWriter implement
 	private static final int MAX_SPECTRA_CHUNK = 65535;
 
 	@Override
-	public void write(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotWriteableException, IOException {
+	public void write(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
 		FileWriter fileWriter = new FileWriter(file, append);
 		writeMassSpectrum(fileWriter, massSpectrum, monitor);
@@ -39,7 +38,7 @@ public abstract class AbstractMassSpectraWriter extends AbstractWriter implement
 	}
 
 	@Override
-	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotWriteableException, IOException {
+	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
 		if(massSpectra.size() > 65535 && PreferenceSupplier.isSplitLibrary()) {
 			/*
@@ -70,7 +69,7 @@ public abstract class AbstractMassSpectraWriter extends AbstractWriter implement
 	private List<IMassSpectra> getSplittedMassSpectra(IMassSpectra massSpectra) {
 
 		IMassSpectra massSpectraChunk;
-		List<IMassSpectra> splittedMassSpectra = new ArrayList<IMassSpectra>();
+		List<IMassSpectra> splittedMassSpectra = new ArrayList<>();
 		//
 		massSpectraChunk = new MassSpectra();
 		int counter = 1;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/AbstractWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/AbstractWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 Lablicate GmbH.
+ * Copyright (c) 2012, 2022 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -95,7 +95,7 @@ public abstract class AbstractWriter {
 	 */
 	protected void removeIonsWithAnTooLowAbundance(IScanMSD normalizedMassSpectrum, float minimumAbundance) {
 
-		List<IIon> ionsToRemove = new ArrayList<IIon>();
+		List<IIon> ionsToRemove = new ArrayList<>();
 		for(IIon ion : normalizedMassSpectrum.getIons()) {
 			if(ion.getAbundance() < minimumAbundance) {
 				ionsToRemove.add(ion);
@@ -110,10 +110,9 @@ public abstract class AbstractWriter {
 	protected String getSynonyms(IScanMSD massSpectrum) {
 
 		StringBuilder builder = new StringBuilder();
-		if(massSpectrum instanceof ILibraryMassSpectrum) {
-			ILibraryMassSpectrum libraryMassSpectrum = (ILibraryMassSpectrum)massSpectrum;
+		if(massSpectrum instanceof ILibraryMassSpectrum libraryMassSpectrum) {
 			Set<String> synonyms = libraryMassSpectrum.getLibraryInformation().getSynonyms();
-			if(synonyms.size() > 0) {
+			if(!synonyms.isEmpty()) {
 				for(String synonym : synonyms) {
 					/*
 					 * Set the synonym.
@@ -171,11 +170,10 @@ public abstract class AbstractWriter {
 	protected IIdentificationTarget getIdentificationTarget(IScanMSD massSpectrum) {
 
 		IIdentificationTarget identificationTarget = null;
-		if(massSpectrum instanceof IRegularLibraryMassSpectrum) {
+		if(massSpectrum instanceof IRegularLibraryMassSpectrum libraryMassSpectrum) {
 			/*
 			 * Library MS
 			 */
-			IRegularLibraryMassSpectrum libraryMassSpectrum = (IRegularLibraryMassSpectrum)massSpectrum;
 			try {
 				identificationTarget = new IdentificationTarget(libraryMassSpectrum.getLibraryInformation(), ComparisonResult.createNoMatchComparisonResult());
 			} catch(ReferenceMustNotBeNullException e) {
@@ -189,7 +187,7 @@ public abstract class AbstractWriter {
 			float retentionIndex = massSpectrum.getRetentionIndex();
 			IdentificationTargetComparator identificationTargetComparator = new IdentificationTargetComparator(SortOrder.DESC, retentionIndex);
 			Collections.sort(targets, identificationTargetComparator);
-			if(targets.size() >= 1) {
+			if(!targets.isEmpty()) {
 				identificationTarget = targets.get(0);
 			}
 		}
@@ -203,7 +201,7 @@ public abstract class AbstractWriter {
 		float retentionIndex = peak.getPeakModel().getPeakMaximum().getRetentionIndex();
 		IdentificationTargetComparator identificationTargetComparator = new IdentificationTargetComparator(SortOrder.DESC, retentionIndex);
 		Collections.sort(targets, identificationTargetComparator);
-		if(targets.size() >= 1) {
+		if(!targets.isEmpty()) {
 			identificationTarget = targets.get(0);
 		}
 		return identificationTarget;
@@ -248,8 +246,7 @@ public abstract class AbstractWriter {
 	protected String getCommentsField(IScanMSD massSpectrum) {
 
 		String field = COMMENTS;
-		if(massSpectrum instanceof IRegularLibraryMassSpectrum) {
-			IRegularLibraryMassSpectrum regularMassSpectrum = (IRegularLibraryMassSpectrum)massSpectrum;
+		if(massSpectrum instanceof IRegularLibraryMassSpectrum regularMassSpectrum) {
 			field += regularMassSpectrum.getLibraryInformation().getComments();
 		}
 		return field;
@@ -264,8 +261,7 @@ public abstract class AbstractWriter {
 	protected String getSourceField(IScanMSD massSpectrum, IIdentificationTarget identificationTarget) {
 
 		String field = SOURCE;
-		if(massSpectrum instanceof IVendorLibraryMassSpectrum) {
-			IVendorLibraryMassSpectrum amdisMassSpectrum = (IVendorLibraryMassSpectrum)massSpectrum;
+		if(massSpectrum instanceof IVendorLibraryMassSpectrum amdisMassSpectrum) {
 			field += amdisMassSpectrum.getSource();
 		} else {
 			if(identificationTarget != null) {
@@ -284,8 +280,7 @@ public abstract class AbstractWriter {
 	protected String getRetentionTimeField(IScanMSD massSpectrum) {
 
 		String field = RT;
-		if(massSpectrum instanceof IRegularMassSpectrum) {
-			IRegularMassSpectrum regularMassSpectrum = (IRegularMassSpectrum)massSpectrum;
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
 			field += decimalFormat.format(regularMassSpectrum.getRetentionTime() / (1000.0d * 60.0d)); // RT in minutes
 		} else {
 			field += decimalFormat.format(0.0d);
@@ -302,8 +297,7 @@ public abstract class AbstractWriter {
 	protected String getRelativeRetentionTimeField(IScanMSD massSpectrum) {
 
 		String field = RRT;
-		if(massSpectrum instanceof IRegularMassSpectrum) {
-			IRegularMassSpectrum regularMassSpectrum = (IRegularMassSpectrum)massSpectrum;
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
 			field += decimalFormat.format(regularMassSpectrum.getRelativeRetentionTime() / (1000.0d * 60.0d)); // RRT in minutes
 		} else {
 			field += decimalFormat.format(0.0d);
@@ -320,8 +314,7 @@ public abstract class AbstractWriter {
 	protected String getRetentionIndexField(IScanMSD massSpectrum) {
 
 		String field = RI;
-		if(massSpectrum instanceof IRegularMassSpectrum) {
-			IRegularMassSpectrum regularMassSpectrum = (IRegularMassSpectrum)massSpectrum;
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
 			field += decimalFormat.format(regularMassSpectrum.getRetentionIndex());
 		} else {
 			field += decimalFormat.format(0.0d);
@@ -351,8 +344,7 @@ public abstract class AbstractWriter {
 	protected String getFormulaField(IScanMSD massSpectrum) {
 
 		String field = FORMULA;
-		if(massSpectrum instanceof IRegularLibraryMassSpectrum) {
-			IRegularLibraryMassSpectrum regularMassSpectrum = (IRegularLibraryMassSpectrum)massSpectrum;
+		if(massSpectrum instanceof IRegularLibraryMassSpectrum regularMassSpectrum) {
 			field += regularMassSpectrum.getLibraryInformation().getFormula();
 		}
 		return field;
@@ -367,8 +359,7 @@ public abstract class AbstractWriter {
 	protected String getMWField(IScanMSD massSpectrum) {
 
 		String field = MW;
-		if(massSpectrum instanceof IRegularLibraryMassSpectrum) {
-			IRegularLibraryMassSpectrum regularMassSpectrum = (IRegularLibraryMassSpectrum)massSpectrum;
+		if(massSpectrum instanceof IRegularLibraryMassSpectrum regularMassSpectrum) {
 			field += regularMassSpectrum.getLibraryInformation().getMolWeight();
 		}
 		return field;
@@ -443,11 +434,10 @@ public abstract class AbstractWriter {
 		massSpectrumCopy.setRetentionIndex(massSpectrum.getRetentionIndex());
 		//
 		massSpectrumCopy.getTargets().addAll(massSpectrum.getTargets());
-		if(massSpectrum instanceof IRegularLibraryMassSpectrum) {
+		if(massSpectrum instanceof IRegularLibraryMassSpectrum regularMassSpectrum) {
 			/*
 			 * Transfer the library information.
 			 */
-			IRegularLibraryMassSpectrum regularMassSpectrum = (IRegularLibraryMassSpectrum)massSpectrum;
 			massSpectrumCopy.setLibraryInformation(regularMassSpectrum.getLibraryInformation());
 		} else {
 			/*
@@ -555,7 +545,7 @@ public abstract class AbstractWriter {
 
 		StringBuilder builder = new StringBuilder();
 		List<IInternalStandard> internalStandards = peak.getInternalStandards();
-		if(internalStandards.size() > 0) {
+		if(!internalStandards.isEmpty()) {
 			for(IInternalStandard internalStandard : internalStandards) {
 				/*
 				 * Set the synonym.
@@ -579,7 +569,7 @@ public abstract class AbstractWriter {
 
 		StringBuilder builder = new StringBuilder();
 		List<IQuantitationEntry> quanitationEntries = peak.getQuantitationEntries();
-		if(quanitationEntries.size() > 0) {
+		if(!quanitationEntries.isEmpty()) {
 			for(IQuantitationEntry quantitationEntry : quanitationEntries) {
 				/*
 				 * Set the synonym.

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/FINReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/FINReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Lablicate GmbH.
+ * Copyright (c) 2020, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -14,13 +14,10 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.io;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.model.IVendorLibraryMassSpectrum;
@@ -38,16 +35,16 @@ public class FINReader extends AbstractMassSpectraReader implements IMassSpectra
 	private static final String UNKNOWN = "Unknown";
 
 	@Override
-	public IMassSpectra read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
 		IMassSpectra massSpectra = new MassSpectra();
 		massSpectra.setConverterId("");
 		massSpectra.setName(file.getName());
-		parse(massSpectra, file, monitor);
+		parse(massSpectra, file);
 		return massSpectra;
 	}
 
-	private void parse(IMassSpectra massSpectra, File file, IProgressMonitor monitor) throws FileNotFoundException, IOException {
+	private void parse(IMassSpectra massSpectra, File file) throws IOException {
 
 		/*
 		 * ...

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSLReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSLReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -240,7 +240,7 @@ public class MSLReader extends AbstractMassSpectraReader implements IMassSpectra
 		 * fragment.
 		 */
 		IVendorLibraryMassSpectrum massSpectrum = extractMassSpectrum(massSpectrumData, referenceIdentifierMarker, referenceIdentifierPrefix);
-		if(massSpectrum.getNumberOfIons() > 0) {
+		if(!massSpectrum.isEmpty()) {
 			massSpectra.addMassSpectrum(massSpectrum);
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSLReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSLReader.java
@@ -14,7 +14,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.io;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
@@ -24,10 +23,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.model.core.AbstractChromatogram;
+import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.model.exceptions.AbundanceLimitExceededException;
 import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
@@ -68,7 +65,7 @@ public class MSLReader extends AbstractMassSpectraReader implements IMassSpectra
 	private static final String LINE_DELIMITER = "\r\n";
 
 	@Override
-	public IMassSpectra read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
 		List<String> massSpectraData = getMassSpectraData(file);
 		//
@@ -160,7 +157,7 @@ public class MSLReader extends AbstractMassSpectraReader implements IMassSpectra
 	private List<String> getMassSpectraData(File file) throws IOException {
 
 		Charset charset = PreferenceSupplier.getCharsetImportMSL();
-		List<String> massSpectraData = new ArrayList<String>();
+		List<String> massSpectraData = new ArrayList<>();
 		//
 		try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(new FileInputStream(file), charset))) {
 			StringBuilder builder = new StringBuilder();
@@ -317,7 +314,7 @@ public class MSLReader extends AbstractMassSpectraReader implements IMassSpectra
 		try {
 			Matcher matcher = pattern.matcher(massSpectrumData);
 			if(matcher.find()) {
-				content = (int)(Double.parseDouble(matcher.group(group).trim()) * AbstractChromatogram.MINUTE_CORRELATION_FACTOR);
+				content = (int)(Double.parseDouble(matcher.group(group).trim()) * IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
 			}
 		} catch(Exception e) {
 			logger.warn(e);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSLWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSLWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -26,9 +26,7 @@ public class MSLWriter extends AbstractMassSpectraWriter implements IMassSpectra
 
 		IScanMSD optimizedMassSpectrum = getOptimizedMassSpectrum(massSpectrum);
 		IIdentificationTarget identificationTarget = getIdentificationTarget(optimizedMassSpectrum);
-		if(identificationTarget == null) {
-			identificationTarget = getIdentificationTarget(massSpectrum);
-		} else if("".equals(identificationTarget.getLibraryInformation().getName())) {
+		if(identificationTarget == null || "".equals(identificationTarget.getLibraryInformation().getName())) {
 			identificationTarget = getIdentificationTarget(massSpectrum);
 		}
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader.java
@@ -14,7 +14,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.io;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
@@ -26,10 +25,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.model.core.AbstractChromatogram;
+import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.model.exceptions.AbundanceLimitExceededException;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
@@ -75,7 +72,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 	private static final String RETENTION_INDICES_DELIMITER = ", ";
 
 	@Override
-	public IMassSpectra read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
 		List<String> massSpectraData = getMassSpectraData(file);
 		//
@@ -114,7 +111,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 	private List<String> getMassSpectraData(File file) throws IOException {
 
 		Charset charset = PreferenceSupplier.getCharsetImportMSP();
-		List<String> massSpectraData = new ArrayList<String>();
+		List<String> massSpectraData = new ArrayList<>();
 		//
 		try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(new FileInputStream(file), charset))) {
 			StringBuilder builder = new StringBuilder();
@@ -324,7 +321,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 	 */
 	private Set<String> extractSynonyms(String massSpectrumData, Pattern pattern) {
 
-		Set<String> synonyms = new HashSet<String>();
+		Set<String> synonyms = new HashSet<>();
 		Matcher matcher = pattern.matcher(massSpectrumData);
 		while(matcher.find()) {
 			String synonym = matcher.group(2).trim();
@@ -346,7 +343,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 		try {
 			Matcher matcher = pattern.matcher(massSpectrumData);
 			if(matcher.find()) {
-				content = (int)(Double.parseDouble(matcher.group(group).trim()) * AbstractChromatogram.MINUTE_CORRELATION_FACTOR);
+				content = (int)(Double.parseDouble(matcher.group(group).trim()) * IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
 			}
 		} catch(Exception e) {
 			logger.warn(e);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -251,7 +251,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 		 * Store the mass spectrum in mass spectra if there is at least 1 mass
 		 * fragment.
 		 */
-		if(massSpectrum.getNumberOfIons() > 0) {
+		if(!massSpectrum.isEmpty()) {
 			massSpectra.addMassSpectrum(massSpectrum);
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -26,9 +26,7 @@ public class MSPWriter extends AbstractMassSpectraWriter implements IMassSpectra
 
 		IScanMSD optimizedMassSpectrum = getOptimizedMassSpectrum(massSpectrum);
 		IIdentificationTarget identificationTarget = getIdentificationTarget(optimizedMassSpectrum);
-		if(identificationTarget == null) {
-			identificationTarget = getIdentificationTarget(massSpectrum);
-		} else if("".equals(identificationTarget.getLibraryInformation().getName())) {
+		if(identificationTarget == null || "".equals(identificationTarget.getLibraryInformation().getName())) {
 			identificationTarget = getIdentificationTarget(massSpectrum);
 		}
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/PeakWriterMSL.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/PeakWriterMSL.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Lablicate GmbH.
+ * Copyright (c) 2016, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,27 +15,26 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IPeaks;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.eclipse.core.runtime.IProgressMonitor;
 
 public class PeakWriterMSL extends AbstractWriter {
 
-	public void write(File file, IPeaks<?> peaks, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
+	public void write(File file, IPeaks<?> peaks, boolean append) throws IOException {
 
-		FileWriter fileWriter = new FileWriter(file, append);
-		for(IPeak peak : peaks.getPeaks()) {
-			if(peak instanceof IPeakMSD) {
-				writePeak(fileWriter, (IPeakMSD)peak);
+		try (FileWriter fileWriter = new FileWriter(file, append)) {
+			for(IPeak peak : peaks.getPeaks()) {
+				if(peak instanceof IPeakMSD peakMSD) {
+					writePeak(fileWriter, peakMSD);
+				}
 			}
 		}
 	}
 
-	public void write(File file, IPeakMSD peak, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
+	public void write(File file, IPeakMSD peak, boolean append) throws IOException {
 
 		FileWriter fileWriter = new FileWriter(file, append);
 		writePeak(fileWriter, peak);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/PeakWriterMSP.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/PeakWriterMSP.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Lablicate GmbH.
+ * Copyright (c) 2016, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,27 +15,26 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IPeaks;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.eclipse.core.runtime.IProgressMonitor;
 
 public class PeakWriterMSP extends AbstractWriter {
 
-	public void write(File file, IPeaks<?> peaks, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
+	public void write(File file, IPeaks<?> peaks, boolean append) throws IOException {
 
-		FileWriter fileWriter = new FileWriter(file, append);
-		for(IPeak peak : peaks.getPeaks()) {
-			if(peak instanceof IPeakMSD) {
-				writePeak(fileWriter, (IPeakMSD)peak);
+		try (FileWriter fileWriter = new FileWriter(file, append)) {
+			for(IPeak peak : peaks.getPeaks()) {
+				if(peak instanceof IPeakMSD peakMSD) {
+					writePeak(fileWriter, peakMSD);
+				}
 			}
 		}
 	}
 
-	public void write(File file, IPeakMSD peak, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
+	public void write(File file, IPeakMSD peak, boolean append) throws IOException {
 
 		FileWriter fileWriter = new FileWriter(file, append);
 		writePeak(fileWriter, peak);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank/src/org/eclipse/chemclipse/msd/converter/supplier/massbank/converter/MassBankImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank/src/org/eclipse/chemclipse/msd/converter/supplier/massbank/converter/MassBankImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 Lablicate GmbH.
+ * Copyright (c) 2014, 2022 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -35,7 +35,7 @@ public class MassBankImportConverter implements IDatabaseImportConverter, IMassS
 		try {
 			IMassSpectraReader massSpectraReader = new MassBankReader();
 			IMassSpectra massSpectra = massSpectraReader.read(file, monitor);
-			if(massSpectra != null && massSpectra.size() > 0) {
+			if(massSpectra != null && !massSpectra.isEmpty()) {
 				processingInfo.setProcessingResult(massSpectra);
 			} else {
 				processingInfo.addErrorMessage(DESCRIPTION, "No mass spectra are stored in" + file.getAbsolutePath());

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank/src/org/eclipse/chemclipse/msd/converter/supplier/massbank/io/MassBankReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank/src/org/eclipse/chemclipse/msd/converter/supplier/massbank/io/MassBankReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 Lablicate GmbH.
+ * Copyright (c) 2014, 2022 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -73,9 +73,9 @@ public class MassBankReader extends AbstractMassSpectraReader implements IMassSp
 						continue;
 					}
 					if(entry.getName().toLowerCase().endsWith(".txt")) {
-						IScanMSD spectrum = readMassSpectrum(zipFile.getInputStream(entry), null);
-						if(spectrum.getNumberOfIons() > 0) {
-							massSpectra.addMassSpectrum(spectrum);
+						IScanMSD massSpectrum = readMassSpectrum(zipFile.getInputStream(entry), null);
+						if(!massSpectrum.isEmpty()) {
+							massSpectra.addMassSpectrum(massSpectrum);
 						}
 					}
 				}
@@ -84,9 +84,9 @@ public class MassBankReader extends AbstractMassSpectraReader implements IMassSp
 		} else {
 			IMassSpectra massSpectra = new MassSpectra();
 			try (FileInputStream inputStream = new FileInputStream(file)) {
-				IScanMSD spectrum = readMassSpectrum(inputStream, monitor);
-				if(spectrum.getNumberOfIons() > 0) {
-					massSpectra.addMassSpectrum(spectrum);
+				IScanMSD massSpectrum = readMassSpectrum(inputStream, monitor);
+				if(!massSpectrum.isEmpty()) {
+					massSpectra.addMassSpectrum(massSpectrum);
 				}
 			}
 			return massSpectra;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/converter/MassSpectrumImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/converter/MassSpectrumImportConverter.java
@@ -38,7 +38,7 @@ public class MassSpectrumImportConverter extends AbstractMassSpectrumImportConve
 			try {
 				IMassSpectraReader massSpectraReader = new MassSpectrumReader();
 				IMassSpectra massSpectra = massSpectraReader.read(file, monitor);
-				if(massSpectra != null && massSpectra.size() > 0) {
+				if(massSpectra != null && !massSpectra.isEmpty()) {
 					processingInfo.setProcessingResult(massSpectra);
 				} else {
 					processingInfo.addErrorMessage(DESCRIPTION, "No mass spectra are stored." + file.getAbsolutePath());

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/MassSpectrumImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/MassSpectrumImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -42,7 +42,7 @@ public class MassSpectrumImportConverter extends AbstractMassSpectrumImportConve
 				file = SpecificationValidator.validateSpecification(file);
 				IMassSpectraReader massSpectraReader = new MassSpectrumReader();
 				IMassSpectra massSpectra = massSpectraReader.read(file, monitor);
-				if(massSpectra != null && massSpectra.size() > 0) {
+				if(massSpectra != null && !massSpectra.isEmpty()) {
 					processingInfo.setProcessingResult(massSpectra);
 				} else {
 					processingInfo.addErrorMessage(DESCRIPTION, "No mass spectra are stored." + file.getAbsolutePath());

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Lablicate GmbH.
+ * Copyright (c) 2021, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -40,7 +40,7 @@ public class MassSpectrumImportConverter extends AbstractMassSpectrumImportConve
 				file = SpecificationValidator.validateSpecification(file);
 				IMassSpectraReader massSpectraReader = new MassSpectrumReader();
 				IMassSpectra massSpectra = massSpectraReader.read(file, monitor);
-				if(massSpectra != null && massSpectra.size() > 0) {
+				if(massSpectra != null && !massSpectra.isEmpty()) {
 					processingInfo.setProcessingResult(massSpectra);
 				} else {
 					processingInfo.addErrorMessage(DESCRIPTION, "No mass spectra are stored." + file.getAbsolutePath());

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -42,7 +42,7 @@ public class MassSpectrumImportConverter extends AbstractMassSpectrumImportConve
 				file = SpecificationValidator.validateSpecification(file);
 				IMassSpectraReader massSpectraReader = new MassSpectrumReader();
 				IMassSpectra massSpectra = massSpectraReader.read(file, monitor);
-				if(massSpectra != null && massSpectra.size() > 0) {
+				if(massSpectra != null && !massSpectra.isEmpty()) {
 					processingInfo.setProcessingResult(massSpectra);
 				} else {
 					processingInfo.addErrorMessage(DESCRIPTION, "No mass spectra are stored." + file.getAbsolutePath());

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/src/org/eclipse/chemclipse/msd/converter/supplier/sirius/converter/SiriusImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/src/org/eclipse/chemclipse/msd/converter/supplier/sirius/converter/SiriusImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Lablicate GmbH.
+ * Copyright (c) 2021, 2022 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -35,7 +35,7 @@ public class SiriusImportConverter implements IDatabaseImportConverter, IMassSpe
 		try {
 			IMassSpectraReader massSpectraReader = new SiriusReader();
 			IMassSpectra massSpectra = massSpectraReader.read(file, monitor);
-			if(massSpectra != null && massSpectra.size() > 0) {
+			if(massSpectra != null && !massSpectra.isEmpty()) {
 				processingInfo.setProcessingResult(massSpectra);
 			} else {
 				processingInfo.addErrorMessage(DESCRIPTION, "No mass spectra are stored in" + file.getAbsolutePath());

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/src/org/eclipse/chemclipse/msd/converter/supplier/sirius/io/SiriusReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/src/org/eclipse/chemclipse/msd/converter/supplier/sirius/io/SiriusReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Lablicate GmbH.
+ * Copyright (c) 2021, 2022 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -73,9 +73,9 @@ public class SiriusReader extends AbstractMassSpectraReader implements IMassSpec
 						continue;
 					}
 					if(entry.getName().toLowerCase().endsWith(".ms")) {
-						IScanMSD spectrum = readMassSpectrum(zipFile.getInputStream(entry), null);
-						if(spectrum.getNumberOfIons() > 0) {
-							massSpectra.addMassSpectrum(spectrum);
+						IScanMSD massSpectrum = readMassSpectrum(zipFile.getInputStream(entry), null);
+						if(!massSpectrum.isEmpty()) {
+							massSpectra.addMassSpectrum(massSpectrum);
 						}
 					}
 				}
@@ -84,9 +84,9 @@ public class SiriusReader extends AbstractMassSpectraReader implements IMassSpec
 		} else {
 			IMassSpectra massSpectra = new MassSpectra();
 			try (FileInputStream inputStream = new FileInputStream(file)) {
-				IScanMSD spectrum = readMassSpectrum(inputStream, monitor);
-				if(spectrum.getNumberOfIons() > 0) {
-					massSpectra.addMassSpectrum(spectrum);
+				IScanMSD massSpectrum = readMassSpectrum(inputStream, monitor);
+				if(!massSpectrum.isEmpty()) {
+					massSpectra.addMassSpectrum(massSpectrum);
 				}
 			}
 			return massSpectra;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/core/support/Identifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/core/support/Identifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2022 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -131,7 +131,7 @@ public class Identifier {
 				logger.info("Get the mass spectra.");
 				boolean isUseOptimizedMassSpectrum = searchSettings.isUseOptimizedMassSpectrum();
 				massSpectra = getMassSpectra(massSpectrumList, isUseOptimizedMassSpectrum);
-				if(massSpectra.size() > 0) {
+				if(!massSpectra.isEmpty()) {
 					int numberOfUnknownEntriesToProcess = massSpectra.size();
 					logger.info("Process: " + numberOfUnknownEntriesToProcess);
 					runtimeSupport.getNistSupport().setNumberOfUnknownEntriesToProcess(numberOfUnknownEntriesToProcess);
@@ -210,7 +210,7 @@ public class Identifier {
 				 */
 				boolean isUseOptimizedMassSpectrum = searchSettings.isUseOptimizedMassSpectrum();
 				IMassSpectra massSpectra = getMassSpectraFromPeakList(peaks, isUseOptimizedMassSpectrum);
-				if(massSpectra.size() > 0) {
+				if(!massSpectra.isEmpty()) {
 					int numberOfUnknownEntriesToProcess = massSpectra.size();
 					runtimeSupport.getNistSupport().setNumberOfUnknownEntriesToProcess(numberOfUnknownEntriesToProcess);
 					prepareFiles(runtimeSupport, massSpectra, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/core/support/Identifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/core/support/Identifier.java
@@ -142,7 +142,7 @@ public class Identifier {
 					logger.info("Run Identification");
 					Compounds compounds = runNistApplication(runtimeSupport, maxProcessTime, waitTime, monitor);
 					logger.info("Assign Compounds");
-					identificationResults = assignMassSpectrumCompounds(compounds.getCompounds(), massSpectrumList, identificationResults, searchSettings, identifierTable, monitor);
+					assignMassSpectrumCompounds(compounds.getCompounds(), massSpectrumList, identificationResults, searchSettings, identifierTable, monitor);
 				}
 			} catch(FileIsNotWriteableException e) {
 				logger.warn(e);
@@ -740,8 +740,8 @@ public class Identifier {
 
 	private String getName(String name) {
 
-		name = name.replaceAll("à", ".alpha.");
-		name = name.replaceAll("á", ".beta.");
+		name = name.replace("à", ".alpha.");
+		name = name.replace("á", ".beta.");
 		return name;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractMassSpectra.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractMassSpectra.java
@@ -85,6 +85,12 @@ public abstract class AbstractMassSpectra implements IMassSpectra {
 	}
 
 	@Override
+	public boolean isEmpty() {
+
+		return massSpectra.isEmpty();
+	}
+
+	@Override
 	public List<IScanMSD> getList() {
 
 		return massSpectra;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractScanMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractScanMSD.java
@@ -481,6 +481,12 @@ public abstract class AbstractScanMSD extends AbstractScan implements IScanMSD {
 	}
 
 	@Override
+	public boolean isEmpty() {
+
+		return ionsList.isEmpty();
+	}
+
+	@Override
 	public IIon getIon(int ion) throws AbundanceLimitExceededException, IonLimitExceededException {
 
 		if(hasIons()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IIonProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IIonProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Lablicate GmbH.
+ * Copyright (c) 2015, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -29,4 +29,9 @@ public interface IIonProvider {
 	 * @return int
 	 */
 	int getNumberOfIons();
+
+	/**
+	 * Returns true when there are no ions.
+	 */
+	boolean isEmpty();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IMassSpectra.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IMassSpectra.java
@@ -60,6 +60,13 @@ public interface IMassSpectra extends IUpdateListener {
 	List<IScanMSD> getList();
 
 	/**
+	 * Returns true if the list is empty.
+	 * 
+	 * @return boolean
+	 */
+	boolean isEmpty();
+
+	/**
 	 * Returns the number of stored mass spectra.
 	 * 
 	 * @return int

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/ExtractedIonSignalExtractor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/ExtractedIonSignalExtractor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 Lablicate GmbH.
+ * Copyright (c) 2012, 2022 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -28,6 +28,7 @@ public class ExtractedIonSignalExtractor implements IExtractedIonSignalExtractor
 	 * @throws ChromatogramIsNullException
 	 */
 	public ExtractedIonSignalExtractor(IChromatogramMSD chromatogram) throws ChromatogramIsNullException {
+
 		if(chromatogram == null) {
 			throw new ChromatogramIsNullException();
 		}
@@ -94,7 +95,7 @@ public class ExtractedIonSignalExtractor implements IExtractedIonSignalExtractor
 		 */
 		exitloop:
 		for(int scan = start; scan <= stop; scan++) {
-			if(chromatogram.getSupplierScan(scan).getNumberOfIons() > 0) {
+			if(!chromatogram.getSupplierScan(scan).isEmpty()) {
 				startScan = scan;
 				break exitloop;
 			}
@@ -103,7 +104,7 @@ public class ExtractedIonSignalExtractor implements IExtractedIonSignalExtractor
 		 * Get the stop without empty scans.
 		 */
 		for(int scan = stop; scan > startScan; scan--) {
-			if(chromatogram.getSupplierScan(scan).getNumberOfIons() == 0) {
+			if(chromatogram.getSupplierScan(scan).isEmpty()) {
 				stopScan = scan - 1;
 			}
 		}
@@ -120,7 +121,7 @@ public class ExtractedIonSignalExtractor implements IExtractedIonSignalExtractor
 
 	private boolean extractSignals(IExtractedIonSignals extractedIonSignals, IScanMSD scanMSD, float startIon, float stopIon) {
 
-		if(scanMSD.getNumberOfIons() > 0) {
+		if(!scanMSD.isEmpty()) {
 			if(startIon == 0 && stopIon == 0) {
 				extractedIonSignals.add(scanMSD.getExtractedIonSignal());
 			} else {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/support/DatabaseFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/support/DatabaseFileSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 Lablicate GmbH.
+ * Copyright (c) 2015, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -187,7 +187,7 @@ public class DatabaseFileSupport {
 		/*
 		 * If the mass spectra is null, exit.
 		 */
-		if(massSpectra == null || massSpectra.size() == 0) {
+		if(massSpectra == null || massSpectra.isEmpty()) {
 			return;
 		}
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/support/MassSpectrumFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/support/MassSpectrumFileSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 Lablicate GmbH.
+ * Copyright (c) 2013, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -59,7 +59,7 @@ public class MassSpectrumFileSupport {
 		/*
 		 * If the chromatogram is null, exit.
 		 */
-		if(massSpectra == null || massSpectra.size() == 0) {
+		if(massSpectra == null || massSpectra.isEmpty()) {
 			return;
 		}
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/runnables/LibraryServiceRunnable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/runnables/LibraryServiceRunnable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Lablicate GmbH.
+ * Copyright (c) 2017, 2022 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -84,7 +84,7 @@ public class LibraryServiceRunnable implements IRunnableWithProgress {
 			try {
 				IProcessingInfo<IMassSpectra> processingInfo = libraryService.identify(identificationTarget, subMonitor.split(100));
 				IMassSpectra massSpectra = processingInfo.getProcessingResult();
-				if(massSpectra != null && massSpectra.size() > 0) {
+				if(massSpectra != null && !massSpectra.isEmpty()) {
 					libraryMassSpectrumConsumer.accept(massSpectra.getMassSpectrum(1));
 					return;
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
@@ -925,7 +925,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 							}
 						}
 						//
-						if(massSpectra.size() > 0) {
+						if(!massSpectra.isEmpty()) {
 							DatabaseFileSupport.saveMassSpectra(e.display.getActiveShell(), massSpectra, chromatogram.getName());
 						}
 					}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ascii/src/org/eclipse/chemclipse/msd/converter/supplier/ascii/core/MassSpectrumImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ascii/src/org/eclipse/chemclipse/msd/converter/supplier/ascii/core/MassSpectrumImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Lablicate GmbH.
+ * Copyright (c) 2016, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -41,7 +41,7 @@ public class MassSpectrumImportConverter extends AbstractMassSpectrumImportConve
 				file = SpecificationValidator.validateSpecification(file, "ascii");
 				IMassSpectraReader massSpectraReader = new MassSpectraReader();
 				IMassSpectra massSpectra = massSpectraReader.read(file, monitor);
-				if(massSpectra != null && massSpectra.size() > 0) {
+				if(massSpectra != null && !massSpectra.isEmpty()) {
 					processingInfo.setProcessingResult(massSpectra);
 				} else {
 					processingInfo.addErrorMessage(DESCRIPTION, "No mass spectra are stored." + file.getAbsolutePath());

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/converter/DatabaseImportConverterJDL.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/converter/DatabaseImportConverterJDL.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Lablicate GmbH.
+ * Copyright (c) 2017, 2022 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -47,7 +47,7 @@ public class DatabaseImportConverterJDL extends AbstractDatabaseImportConverter 
 				file = SpecificationValidator.validateSpecification(file, "JDL");
 				IMassSpectraReader massSpectraReader = new MassSpectraReader();
 				IMassSpectra massSpectra = massSpectraReader.read(file, monitor);
-				if(massSpectra != null && massSpectra.size() > 0) {
+				if(massSpectra != null && !massSpectra.isEmpty()) {
 					processingInfo.setProcessingResult(massSpectra);
 				} else {
 					processingInfo.addErrorMessage(DESCRIPTION, "No mass spectra are stored." + file.getAbsolutePath());

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/converter/DatabaseImportConverterJDX.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/converter/DatabaseImportConverterJDX.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 Lablicate GmbH.
+ * Copyright (c) 2015, 2022 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -47,7 +47,7 @@ public class DatabaseImportConverterJDX extends AbstractDatabaseImportConverter 
 				file = SpecificationValidator.validateSpecification(file, "JDX");
 				IMassSpectraReader massSpectraReader = new MassSpectraReader();
 				IMassSpectra massSpectra = massSpectraReader.read(file, monitor);
-				if(massSpectra != null && massSpectra.size() > 0) {
+				if(massSpectra != null && !massSpectra.isEmpty()) {
 					processingInfo.setProcessingResult(massSpectra);
 				} else {
 					processingInfo.addErrorMessage(DESCRIPTION, "No mass spectra are stored." + file.getAbsolutePath());


### PR DESCRIPTION
This is https://rules.sonarsource.com/java/RSPEC-1155 hidden behind custom interfaces that just seems to wrap a `List`. In the case of `IMassSpectra`, I assume it will be bad, as those databases can contain many entries. It should be even worse for `IIonProvider` because scans take up most of the RAM usage and item count when profiling OpenChrom.