### PR TITLE
Fixed msd.filter.supplier.subtract.ui/toc_filter.xml being excluded from HTML help

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.ui/toc_filter.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.ui/toc_filter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?NLS TYPE="org.eclipse.help.toc"?>
 
-<toc label="MS Subtract Filter" link_to="../org.eclipse.chemclipse.rcp.app.ui/toc.xml#filter">
+<toc label="MS Subtract Filter" link_to="../org.eclipse.chemclipse.rcp.app.ui/toc.xml#functionality">
 	<topic label="MS Substract Filter"  href="html/plugin/main.html"/>
 </toc>


### PR DESCRIPTION
Resolves

> !MESSAGE Error reading help table of contents file /"org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.ui/toc_filter.xml" (skipping file)
