### PR TITLE
Updated to Eclipse RCP 2022-09 and Nebula 2.7.2

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
@@ -107,7 +107,7 @@ http://www.eclipse.org/legal/epl-v10.html
          unpack="false"/>
 
    <plugin
-         id="javax.servlet.jsp"
+         id="javax.servlet.jsp-api"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -4,13 +4,13 @@
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.eclipse.nebula.feature.feature.group" version="0.0.0"/>
-	<repository location="https://download.eclipse.org/nebula/releases/2.6.0"/>
+	<repository location="https://download.eclipse.org/nebula/releases/2.7.2/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
 	<unit id="org.eclipse.epp.mpc.feature.group" version="0.0.0"/>
 	<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-	<repository location="https://download.eclipse.org/releases/2022-06/"/>
+	<repository location="https://download.eclipse.org/releases/2022-09/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.eclipse.babel.nls_eclipse_de.feature.group" version="0.0.0"/>


### PR DESCRIPTION
https://help.eclipse.org/latest/index.jsp?nav=%2F2_3_1 states there are breaking changes. Some dependencies are now resolved Maven Central rather than Eclipse Orbit and changed names.