### PR TITLE
Renamed Mass Spectrum Peak List to Mass Spectrum Scan List

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/fragment.e4xmi
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/fragment.e4xmi
@@ -91,7 +91,7 @@
             </children>
           </children>
           <children xsi:type="basic:PartStack" xmi:id="_F-avMJRlEeW3h-K0O5zQFg" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.perspective.maldi.partstack.1" containerData="2500">
-            <children xsi:type="basic:Part" xmi:id="_OTuAUOMCEeeFk6MNh27L1g" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.part.MassSpectrumPeakList" contributionURI="bundleclass://org.eclipse.chemclipse.ux.extension.xxd.ui/org.eclipse.chemclipse.ux.extension.xxd.ui.parts.MassSpectrumPeakListPart" label="Mass Spectrum Peak List" iconURI="platform:/plugin/org.eclipse.chemclipse.support.ui/icons/16x16/file.gif"/>
+            <children xsi:type="basic:Part" xmi:id="_OTuAUOMCEeeFk6MNh27L1g" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.part.MassSpectrumScanList" contributionURI="bundleclass://org.eclipse.chemclipse.ux.extension.xxd.ui/org.eclipse.chemclipse.ux.extension.xxd.ui.parts.MassSpectrumScanListPart" label="Mass Spectrum Scan List" iconURI="platform:/plugin/org.eclipse.chemclipse.rcp.ui.icons/icons/16x16/selectedScansDefault.gif"/>
           </children>
         </children>
       </children>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/MassSpectrumScanListPart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/MassSpectrumScanListPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 Lablicate GmbH.
+ * Copyright (c) 2014, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -22,12 +22,12 @@ import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 
-public class MassSpectrumPeakListPart extends AbstractPart<ExtendedMassSpectrumIonsListUI> {
+public class MassSpectrumScanListPart extends AbstractPart<ExtendedMassSpectrumIonsListUI> {
 
 	private static final String TOPIC = IChemClipseEvents.TOPIC_SCAN_XXD_UPDATE_SELECTION;
 
 	@Inject
-	public MassSpectrumPeakListPart(Composite parent) {
+	public MassSpectrumScanListPart(Composite parent) {
 
 		super(parent, TOPIC);
 	}
@@ -43,8 +43,8 @@ public class MassSpectrumPeakListPart extends AbstractPart<ExtendedMassSpectrumI
 
 		if(objects.size() == 1) {
 			Object object = objects.get(0);
-			if(object instanceof IScanMSD) {
-				getControl().update((IScanMSD)object);
+			if(object instanceof IScanMSD scanMSD) {
+				getControl().update(scanMSD);
 				return true;
 			}
 		}


### PR DESCRIPTION
because there is no concept of peaks yet for MALDI. This just shows all the ions and is mislabeled.