### PR TITLE
Fixed the PCA Files tile label

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/pca/ui/quickstart/FileTileDefinition.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/pca/ui/quickstart/FileTileDefinition.java
@@ -22,7 +22,7 @@ public class FileTileDefinition extends WizardTile {
 	@Override
 	public String getTitle() {
 
-		return "Files (Text/Binary)";
+		return "Files";
 	}
 
 	@Override


### PR DESCRIPTION
as it is clearly broken and text/binary does not add meaningful information.

![image](https://user-images.githubusercontent.com/756669/191231801-031ecab4-d379-4cbf-acf6-9042ba0e7696.png)
