### PR TITLE
Manually manage the dependencies

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.base.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.base.feature/feature.xml
@@ -518,13 +518,6 @@ http://www.eclipse.org/legal/epl-v10.html
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.e4.emf.xpath"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="com.fasterxml.jackson.core.jackson-annotations"
          download-size="0"
          install-size="0"

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.compilation.base.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.compilation.base.feature/feature.xml
@@ -31,29 +31,7 @@ http://www.eclipse.org/legal/epl-v10.html
          version="0.0.0"/>
 
    <includes
-         id="org.eclipse.epp.mpc"
-         version="0.0.0"/>
-
-   <includes
-         id="org.eclipse.userstorage"
-         version="0.0.0"/>
-
-   <includes
          id="org.eclipse.rcp"
          version="0.0.0"/>
-
-   <plugin
-         id="org.apache.httpcomponents.httpclient"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.httpcomponents.httpcore"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
 
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
@@ -1174,13 +1174,6 @@ http://www.eclipse.org/legal/epl-v10.html
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.equinox.cm"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.chemclipse.jaxb"
          download-size="0"
          install-size="0"

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
@@ -197,4 +197,60 @@ http://www.eclipse.org/legal/epl-v10.html
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.apache.pdfbox.fontbox"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.ui.ide"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.ui.intro"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.ui.intro.universal"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.e4.ui.ide"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.debug.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.ltk.core.refactoring"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.ltk.ui.refactoring"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
@@ -34,34 +34,6 @@ http://www.eclipse.org/legal/epl-v10.html
          unpack="false"/>
 
    <plugin
-         id="org.objectweb.asm"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.discovery"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.ui.discovery"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.commons.lang"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.apache.commons.lang3"
          download-size="0"
          install-size="0"
@@ -112,13 +84,6 @@ http://www.eclipse.org/legal/epl-v10.html
 
    <plugin
          id="com.google.guava"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.httpcomponents.httpcore"
          download-size="0"
          install-size="0"
          version="0.0.0"
@@ -185,20 +150,6 @@ http://www.eclipse.org/legal/epl-v10.html
 
    <plugin
          id="org.eclipse.help.webapp"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.http.jetty"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.pde.api.tools"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
+++ b/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="ChemClipse" uid="org.eclipse.chemclipse.rcp.compilation.community.product.id" id="org.eclipse.chemclipse.rcp.compilation.community.ui.product" application="org.eclipse.chemclipse.rcp.app.ui.org.eclipse.chemclipse.rcp.application" version="0.9.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="ChemClipse" uid="org.eclipse.chemclipse.rcp.compilation.community.product.id" id="org.eclipse.chemclipse.rcp.compilation.community.ui.product" application="org.eclipse.chemclipse.rcp.app.ui.org.eclipse.chemclipse.rcp.application" version="0.9.0.qualifier" useFeatures="true" includeLaunchers="true" autoIncludeRequirements="false">
 
    <aboutInfo>
       <image path="/org.eclipse.chemclipse.rcp.compilation.community.ui/icons/about_250x330.png"/>

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -8,7 +8,6 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
-	<unit id="org.eclipse.epp.mpc.feature.group" version="0.0.0"/>
 	<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 	<repository location="https://download.eclipse.org/releases/2022-06/"/>
 </location>


### PR DESCRIPTION
Similar to https://github.com/eclipse/chemclipse/pull/1130 I remove unused plugins and add missing ones. Since 2022-06 these are implicitly managed upon launch which removed control and slowed down the startup from within the IDE.