### PR TITLE
Removed PDE API Tools

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
@@ -198,13 +198,6 @@ http://www.eclipse.org/legal/epl-v10.html
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.pde.api.tools"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.apache.pdfbox"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
https://www.eclipse.org/pde/pde-api-tools/ is part of the Eclipse IDE, nothing that is useful here.