### PR TITLE
Removed separation column enum internal name

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/columns/SeparationColumnFactory.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/columns/SeparationColumnFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Lablicate GmbH.
+ * Copyright (c) 2018, 2022 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,21 +21,17 @@ public class SeparationColumnFactory {
 
 	private static final Logger logger = Logger.getLogger(SeparationColumnType.class);
 
-	public static String getColumnLabel(ISeparationColumn separationColumn, int nameLength) {
+	public static String getColumnLabel(ISeparationColumn separationColumn, int labelLength) {
 
-		StringBuilder builder = new StringBuilder();
 		if(separationColumn != null) {
-			String name = separationColumn.getName();
-			if(name.length() > nameLength) {
-				name = name.substring(0, nameLength) + "...";
+			String label = separationColumn.getSeparationColumnType().label();
+			if(label.length() > labelLength) {
+				label = label.substring(0, labelLength) + "...";
 			}
-			builder.append(name);
-			builder.append(" (");
-			builder.append(separationColumn.getSeparationColumnType().label());
-			builder.append(")");
+			return label;
 		}
 		//
-		return builder.toString().trim();
+		return "";
 	}
 
 	public static List<ISeparationColumn> getSeparationColumns() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -1062,7 +1062,7 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 		//
 		editorToolBar.addAction(createLabelsAction());
 		editorToolBar.addAction(createToggleToolbarAction("Info", "the info toolbar.", IApplicationImage.IMAGE_INFO, TOOLBAR_INFO));
-		editorToolBar.createCombo(this::initComboViewerSeparationColumn, true, 250);
+		editorToolBar.createCombo(this::initComboViewerSeparationColumn, true, 100);
 		chromatogramReferencesUI = new ChromatogramReferencesUI(editorToolBar, this::setChromatogramSelectionInternal);
 		editorToolBar.addAction(createToggleToolbarAction("Edit", "the edit toolbar.", IApplicationImage.IMAGE_EDIT, TOOLBAR_EDIT));
 		editorToolBar.addAction(createToggleToolbarAction("Alignment", "the chromatogram alignment toolbar.", IApplicationImage.IMAGE_ALIGN_CHROMATOGRAMS, TOOLBAR_CHROMATOGRAM_ALIGNMENT));
@@ -1166,7 +1166,7 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 			public String getText(Object element) {
 
 				if(element instanceof ISeparationColumn separationColumn) {
-					return SeparationColumnFactory.getColumnLabel(separationColumn, 25);
+					return SeparationColumnFactory.getColumnLabel(separationColumn, 10);
 				}
 				return null;
 			}


### PR DESCRIPTION
to save some horizontal space in the toolbar.