### PR TITLE
Fixed broken segment width and window size settings

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/preferences/PreferenceSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 Lablicate GmbH.
+ * Copyright (c) 2014, 2022 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -70,9 +70,9 @@ public class PreferenceSupplier implements IPreferenceSupplier {
 	@Override
 	public Map<String, String> getDefaultValues() {
 
-		Map<String, String> defaultValues = new HashMap<String, String>();
+		Map<String, String> defaultValues = new HashMap<>();
 		defaultValues.put(P_NOISE_CALCULATOR_ID, DEF_NOISE_CALCULATOR_ID);
-		defaultValues.put(DEF_SEGMENT_WIDTH, DEF_SEGMENT_WIDTH);
+		defaultValues.put(P_SEGMENT_WIDTH, DEF_SEGMENT_WIDTH);
 		return defaultValues;
 	}
 
@@ -102,7 +102,6 @@ public class PreferenceSupplier implements IPreferenceSupplier {
 	public static int getSelectedSegmentWidth() {
 
 		IEclipsePreferences preferences = INSTANCE().getPreferences();
-		int segmentWidth = SegmentWidth.getAdjustedSetting(preferences.get(P_SEGMENT_WIDTH, DEF_SEGMENT_WIDTH));
-		return segmentWidth;
+		return SegmentWidth.getAdjustedSetting(preferences.get(P_SEGMENT_WIDTH, DEF_SEGMENT_WIDTH));
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/OSGI-INF/l10n/bundle.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/OSGI-INF/l10n/bundle.properties
@@ -21,3 +21,5 @@ demo=Demo
 ExtendedIntegerFieldEditor.errorMessageOddIncludingZero=Has to be an odd number including zero.
 ExtendedIntegerFieldEditor.errorMessageOdd=Has to be an odd number.
 ExtendedIntegerFieldEditor.errorMessageEven=Has to be an even number.
+
+SpinnerFieldEditorOddNumber.errorMessage=Value must be odd.

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/OSGI-INF/l10n/bundle.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/OSGI-INF/l10n/bundle.properties
@@ -17,3 +17,7 @@ Bundle-Name=Support UI
 Bundle-Vendor=ChemClipse
 #
 demo=Demo
+
+ExtendedIntegerFieldEditor.errorMessageOddIncludingZero=Has to be an odd number including zero.
+ExtendedIntegerFieldEditor.errorMessageOdd=Has to be an odd number.
+ExtendedIntegerFieldEditor.errorMessageEven=Has to be an even number.

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/OSGI-INF/l10n/bundle_de.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/OSGI-INF/l10n/bundle_de.properties
@@ -17,3 +17,7 @@ Bundle-Name=Support UI
 Bundle-Vendor=ChemClipse
 #
 demo=Demo
+
+ExtendedIntegerFieldEditor.errorMessageOddIncludingZero=Zahl muss ungerade sein inklusive null.
+ExtendedIntegerFieldEditor.errorMessageOdd=Zahl muss ungerade sein.
+ExtendedIntegerFieldEditor.errorMessageEven=Zahl muss gerade sein.

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/OSGI-INF/l10n/bundle_de.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/OSGI-INF/l10n/bundle_de.properties
@@ -21,3 +21,5 @@ demo=Demo
 ExtendedIntegerFieldEditor.errorMessageOddIncludingZero=Zahl muss ungerade sein inklusive null.
 ExtendedIntegerFieldEditor.errorMessageOdd=Zahl muss ungerade sein.
 ExtendedIntegerFieldEditor.errorMessageEven=Zahl muss gerade sein.
+
+SpinnerFieldEditorOddNumber.errorMessage=Wert muss ungerade sein.

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/Activator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/Activator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Lablicate GmbH.
+ * Copyright (c) 2011, 2022 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -27,6 +27,12 @@ public class Activator extends AbstractActivatorUI {
 	 * Instance
 	 */
 	private static Activator plugin;
+	private static BundleContext context;
+
+	public static BundleContext getContext() {
+
+		return context;
+	}
 
 	/*
 	 * (non-Javadoc)
@@ -35,6 +41,7 @@ public class Activator extends AbstractActivatorUI {
 	public void start(BundleContext context) throws Exception {
 
 		super.start(context);
+		Activator.context = context;
 		plugin = this;
 		initializePreferenceStore(SupportPreferences.INSTANCE());
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/messages/SupportMessages.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/messages/SupportMessages.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2022 Lablicate GmbH.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Dr. Philip Wenig - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.support.ui.messages;
+
+import org.eclipse.chemclipse.support.l10n.Messages;
+import org.eclipse.chemclipse.support.messages.ISupportMessages;
+import org.eclipse.chemclipse.support.ui.Activator;
+
+public class SupportMessages implements ISupportMessages {
+
+	private static Messages messages;
+
+	/**
+	 * Returns the messages instance to get a translation.
+	 * 
+	 * @return {@link Messages}
+	 */
+	public static Messages INSTANCE() {
+
+		if(messages == null) {
+			messages = new Messages(Activator.getContext().getBundle());
+		}
+		return messages;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/preferences/fieldeditors/ExtendedIntegerFieldEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/preferences/fieldeditors/ExtendedIntegerFieldEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Lablicate GmbH.
+ * Copyright (c) 2019, 2022 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@
 package org.eclipse.chemclipse.support.ui.preferences.fieldeditors;
 
 import org.eclipse.chemclipse.support.settings.IntSettingsProperty.Validation;
+import org.eclipse.chemclipse.support.ui.messages.SupportMessages;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Text;
 
@@ -69,18 +70,18 @@ public class ExtendedIntegerFieldEditor extends org.eclipse.jface.preference.Int
 						return true;
 					}
 					if(number % 2 == 0) {
-						showErrorMessage();
+						showErrorMessage(SupportMessages.INSTANCE().getMessage("ExtendedIntegerFieldEditor.errorMessageOddIncludingZero"));
 						return false;
 					}
 				}
 				if(validation == Validation.ODD_NUMBER) {
 					if(number % 2 == 0) {
-						showErrorMessage();
+						showErrorMessage(SupportMessages.INSTANCE().getMessage("ExtendedIntegerFieldEditor.errorMessageOdd"));
 						return false;
 					}
 				} else if(validation == Validation.EVEN_NUMBER) {
 					if(number % 2 != 0) {
-						showErrorMessage();
+						showErrorMessage(SupportMessages.INSTANCE().getMessage("ExtendedIntegerFieldEditor.errorMessageEven"));
 						return false;
 					}
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/preferences/fieldeditors/SpinnerFieldEditorOddNumber.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/preferences/fieldeditors/SpinnerFieldEditorOddNumber.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 Lablicate GmbH.
+ * Copyright (c) 2012, 2022 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,16 +11,19 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.support.ui.preferences.fieldeditors;
 
+import org.eclipse.chemclipse.support.ui.messages.SupportMessages;
 import org.eclipse.swt.widgets.Composite;
 
 public class SpinnerFieldEditorOddNumber extends SpinnerFieldEditorBounded {
 
 	public SpinnerFieldEditorOddNumber(String name, String labelText, int min, int max, Composite parent) {
+
 		super(name, labelText, min, max, parent);
 		setIncrement(2);
 	}
 
 	public SpinnerFieldEditorOddNumber(String name, String labelText, int min, int max, int strategy, Composite parent) {
+
 		super(name, labelText, min, max, strategy, parent);
 		setIncrement(2);
 	}
@@ -30,7 +33,7 @@ public class SpinnerFieldEditorOddNumber extends SpinnerFieldEditorBounded {
 
 		int value = getIntValue();
 		if(value % 2 == 0) {
-			setErrorMessage("Value must be odd");
+			setErrorMessage(SupportMessages.INSTANCE().getMessage("SpinnerFieldEditorOddNumber.errorMessage"));
 			return false;
 		}
 		return super.doCheckState();


### PR DESCRIPTION
This fixes the S/N calculator settings not being initialized and 0 being a disallowed value means that you get a nag screen just by clicking through the preferences. Also some filters like SNIP Detector/Filterm Splitter Limit IOns (SIM) and First Derivative would show an error like 7 "has to be a whole number" when Window Size actually checked against even/odd. The error message from JFace was already localized so I localized everything as well. https://github.com/OpenChrom/openchrom/issues/24