### PR TITLE
Updated to Eclipse 2022-12

### DIFF
--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -9,7 +9,7 @@
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
 	<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-	<repository location="https://download.eclipse.org/releases/2022-09/"/>
+	<repository location="https://download.eclipse.org/releases/2022-12/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.eclipse.babel.nls_eclipse_de.feature.group" version="0.0.0"/>
@@ -28,7 +28,7 @@
 	<unit id="javax.activation" version="0.0.0"/>
 	<unit id="javax.annotation" version="0.0.0"/>
 	<unit id="org.apache.commons.codec" version="0.0.0"/>
-	<repository location="https://download.eclipse.org/tools/orbit/downloads/2022-09"/>
+	<repository location="https://download.eclipse.org/tools/orbit/downloads/2022-12"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>


### PR DESCRIPTION
There are no breaking changes except for [JobManager implementation changes](https://help.eclipse.org/latest/index.jsp?nav=%2F2_3_1) but that doesn't concern us.