### PR TITLE
Bump Actions due to Node 12 deprecation

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
 #
 #  Contributors:
 #  Thomas Jaeckle - initial API and implementation
@@ -20,8 +20,8 @@ jobs:
     name: Year
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: jitterbit/get-changed-files@v1
+      - uses: actions/checkout@v3
+      - uses: masesgroup/retrieve-changed-files@v2
         id: changed-files
         continue-on-error: true
       - name: Print changed files


### PR DESCRIPTION
https://github.com/eclipse/swtchart/pull/332