### PR TITLE
Fixed saving settings not working for localized plugins.

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/settings/parser/InputValue.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/settings/parser/InputValue.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -32,10 +32,11 @@ public class InputValue {
 	private FileSettingProperty fileSettingProperty;
 	private final List<IValidator<Object>> validators = new ArrayList<>();
 	private ComboSupplier<?> comboSupplier;
+	private String contributorURI = "";
 
 	public boolean hasRegexConstraint() {
 
-		return (regularExpression != null && !"".equals(regularExpression));
+		return (!"".equals(regularExpression));
 	}
 
 	public Class<?> getRawType() {
@@ -119,5 +120,15 @@ public class InputValue {
 	public ComboSupplier<?> getComboSupplier() {
 
 		return comboSupplier;
+	}
+
+	public String getContributorURI() {
+
+		return contributorURI;
+	}
+
+	public void setContributorURI(String contributorURI) {
+
+		this.contributorURI = contributorURI;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/settings/parser/SettingsClassParser.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/settings/parser/SettingsClassParser.java
@@ -88,18 +88,18 @@ public class SettingsClassParser<SettingType> implements SettingsParser<SettingT
 				JavaType javaType = objectMapper.getSerializationConfig().constructType(clazz);
 				BeanDescription beanDescription = objectMapper.getSerializationConfig().introspect(javaType);
 				List<BeanPropertyDefinition> properties = beanDescription.findProperties();
-				String contributorURI = "platform:/plugin/" + FrameworkUtil.getBundle(clazz).getSymbolicName();
-				TranslationService translationService = TranslationSupport.getTranslationService();
 				//
 				for(BeanPropertyDefinition property : properties) {
 					AnnotatedField annotatedField = property.getField();
 					if(annotatedField != null) {
 						//
 						InputValue inputValue = new InputValue();
+						String contributorURI = "platform:/plugin/" + FrameworkUtil.getBundle(clazz).getSymbolicName();
+						inputValue.setContributorURI(contributorURI);
 						inputValue.setRawType(annotatedField.getRawType());
-						inputValue.setName((property.getName() == null) ? "" : translationService.translate(property.getName(), contributorURI));
+						inputValue.setName((property.getName() == null) ? "" : property.getName());
 						PropertyMetadata propertyMetadata = property.getMetadata();
-						inputValue.setDescription((propertyMetadata.getDescription() == null) ? "" : translationService.translate(propertyMetadata.getDescription(), contributorURI));
+						inputValue.setDescription((propertyMetadata.getDescription() == null) ? "" : propertyMetadata.getDescription());
 						Object defaultValue = propertyMetadata.getDefaultValue();
 						if(defaultValue == null) {
 							if(defaultInstance == null) {
@@ -131,9 +131,10 @@ public class SettingsClassParser<SettingType> implements SettingsParser<SettingT
 								inputValue.addValidator(new MinMaxValidator<>(property.getName(), settingsProperty.minValue(), settingsProperty.maxValue(), Double.class));
 							} else if(annotation instanceof StringSettingsProperty settingsProperty) {
 								String regExp = settingsProperty.regExp();
-								String description = translationService.translate(settingsProperty.description(), contributorURI);
-								String name = translationService.translate(property.getName(), contributorURI);
 								if(regExp != null && !regExp.isEmpty()) {
+									TranslationService translationService = TranslationSupport.getTranslationService();
+									String description = translationService.translate(settingsProperty.description(), contributorURI);
+									String name = translationService.translate(property.getName(), contributorURI);
 									inputValue.addValidator(new RegularExpressionValidator(name, Pattern.compile(regExp), description, settingsProperty.isMultiLine(), settingsProperty.allowEmpty()));
 								}
 								inputValue.setMultiLine(settingsProperty.isMultiLine());

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/settings/validation/RegularExpressionValidator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/settings/validation/RegularExpressionValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Lablicate GmbH.
+ * Copyright (c) 2019, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -38,8 +38,7 @@ public class RegularExpressionValidator implements IValidator<Object> {
 	@Override
 	public IStatus validate(Object value) {
 
-		if(value instanceof String) {
-			String string = (String)value;
+		if(value instanceof String string) {
 			if(!string.isEmpty() || allowEmpty) {
 				if(multiline) {
 					String[] lines = string.split("[\r\n]+");

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/MethodListLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/MethodListLabelProvider.java
@@ -24,6 +24,7 @@ import org.eclipse.chemclipse.processing.supplier.IProcessSupplierContext;
 import org.eclipse.chemclipse.processing.supplier.IProcessorPreferences;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
+import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.support.ui.provider.AbstractChemClipseLabelProvider;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.core.databinding.validation.ValidationStatus;
@@ -63,29 +64,28 @@ public class MethodListLabelProvider extends AbstractChemClipseLabelProvider {
 	public Image getColumnImage(Object element, int columnIndex) {
 
 		if(columnIndex == 0) {
-			if(element instanceof IProcessEntry) {
+			if(element instanceof IProcessEntry processEntry) {
 				/*
 				 * Validate
 				 */
-				IProcessEntry processEntry = (IProcessEntry)element;
 				IStatus status = validate(processEntry);
 				//
 				if(status.matches(IStatus.ERROR)) {
-					return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_STATUS_ERROR, IApplicationImage.SIZE_16x16);
+					return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_STATUS_ERROR, IApplicationImageProvider.SIZE_16x16);
 				}
 				if(status.matches(IStatus.WARNING)) {
-					return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_STATUS_WARN, IApplicationImage.SIZE_16x16);
+					return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_STATUS_WARN, IApplicationImageProvider.SIZE_16x16);
 				}
 				if(status.matches(IStatus.INFO)) {
-					return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_STATUS_EMPTY, IApplicationImage.SIZE_16x16);
+					return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_STATUS_EMPTY, IApplicationImageProvider.SIZE_16x16);
 				}
 				if(status.isOK()) {
-					return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_STATUS_OK, IApplicationImage.SIZE_16x16);
+					return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_STATUS_OK, IApplicationImageProvider.SIZE_16x16);
 				}
 			} else if(element instanceof IProcessMethod) {
-				return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_METHOD, IApplicationImage.SIZE_16x16);
+				return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_METHOD, IApplicationImageProvider.SIZE_16x16);
 			} else if(element instanceof ProcessEntryContainer) {
-				return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_FOLDER_OPENED, IApplicationImage.SIZE_16x16);
+				return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_FOLDER_OPENED, IApplicationImageProvider.SIZE_16x16);
 			}
 		}
 		return null;
@@ -94,8 +94,8 @@ public class MethodListLabelProvider extends AbstractChemClipseLabelProvider {
 	@Override
 	public String getToolTipText(Object element) {
 
-		if(element instanceof IProcessEntry) {
-			IStatus status = validate((IProcessEntry)element);
+		if(element instanceof IProcessEntry processEntry) {
+			IStatus status = validate(processEntry);
 			if(!status.isOK()) {
 				return status.getMessage();
 			}
@@ -110,10 +110,10 @@ public class MethodListLabelProvider extends AbstractChemClipseLabelProvider {
 			return "";
 		}
 		//
-		if(element instanceof IProcessEntry) {
-			IProcessEntry processEntry = (IProcessEntry)element;
+		if(element instanceof IProcessEntry processEntry) {
 			IProcessSupplierContext supplierContext = IProcessEntry.getContext(processEntry, processTypeSupport);
 			IProcessSupplier<?> processSupplier = supplierContext.getSupplier(processEntry.getProcessorId());
+			//
 			switch(columnIndex) {
 				case 1:
 					return processEntry.getName();
@@ -149,8 +149,7 @@ public class MethodListLabelProvider extends AbstractChemClipseLabelProvider {
 				default:
 					break;
 			}
-		} else if(element instanceof ProcessEntryContainer) {
-			ProcessEntryContainer method = (ProcessEntryContainer)element;
+		} else if(element instanceof ProcessEntryContainer method) {
 			switch(columnIndex) {
 				case 1:
 					return method.getName();
@@ -167,7 +166,7 @@ public class MethodListLabelProvider extends AbstractChemClipseLabelProvider {
 	@Override
 	public Image getImage(Object element) {
 
-		return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_PROCESS_CONTROL, IApplicationImage.SIZE_16x16);
+		return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_PROCESS_CONTROL, IApplicationImageProvider.SIZE_16x16);
 	}
 
 	private IStatus validate(IProcessEntry processEntry) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/methods/SettingsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/methods/SettingsUI.java
@@ -23,12 +23,14 @@ import java.util.Map.Entry;
 
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.processing.supplier.IProcessorPreferences;
+import org.eclipse.chemclipse.support.l10n.TranslationSupport;
 import org.eclipse.chemclipse.support.settings.parser.InputValue;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.methods.SettingsUIProvider.SettingsUIControl;
 import org.eclipse.core.databinding.validation.ValidationStatus;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.e4.core.services.translation.TranslationService;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
@@ -144,8 +146,10 @@ public class SettingsUI<T> extends Composite {
 
 			for(WidgetItem widgetItem : widgetItems) {
 				Label label = new Label(parent, SWT.NONE);
-				label.setText(widgetItem.getInputValue().getName());
-				label.setToolTipText(widgetItem.getInputValue().getDescription());
+				String contributorURI = widgetItem.getInputValue().getContributorURI();
+				TranslationService translationService = TranslationSupport.getTranslationService();
+				label.setText(translationService.translate(widgetItem.getInputValue().getName(), contributorURI));
+				label.setToolTipText(translationService.translate(widgetItem.getInputValue().getDescription(), contributorURI));
 				GridData data = new GridData(SWT.LEFT, SWT.TOP, false, false);
 				data.verticalIndent = 5;
 				data.horizontalIndent = 5;


### PR DESCRIPTION
https://github.com/eclipse/chemclipse/pull/1259 and https://github.com/eclipse/chemclipse/pull/1276 added a regression because it annotates the JSON with an untranslated string and stores the translated version so the matching fails when loading settings. This moves the translation further towards the UI code.