### PR TITLE
Add back "Export Table Selection"

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/l10n/SupportMessages.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/l10n/SupportMessages.java
@@ -27,6 +27,7 @@ public class SupportMessages extends NLS {
 	public static String errorMessageEven;
 	public static String errorMessageOdd;
 	public static String errorMessageOddIncludingZero;
+	public static String exportTableSelection;
 	public static String fileName;
 	public static String filePath;
 	public static String files;

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/l10n/messages.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/l10n/messages.properties
@@ -9,6 +9,7 @@ enterIon=Enter an ion.
 errorMessageOddIncludingZero=Has to be an odd number including zero.
 errorMessageOdd=Has to be an odd number.
 errorMessageEven=Has to be an even number.
+exportTableSelection=Export Table Selection
 fileName=File Name
 filePath=File Path
 files=Files

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/menu/CopyClipboardHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/menu/CopyClipboardHandler.java
@@ -24,7 +24,7 @@ public class CopyClipboardHandler extends AbstractTableMenuEntry implements ITab
 	@Override
 	public String getCategory() {
 
-		return ""; // Must be empty to be placed on the main menu level.
+		return SupportMessages.exportTableSelection;
 	}
 
 	@Override


### PR DESCRIPTION
This fixes an unwanted change from https://github.com/eclipse/chemclipse/pull/1301.