### PR TITLE
Avoid Orbit to speed up target platform resolution

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
@@ -935,35 +935,21 @@ http://www.eclipse.org/legal/epl-v10.html
          unpack="false"/>
 
    <plugin
-         id="org.apache.poi"
+         id="wrapped.org.apache.poi.poi"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
    <plugin
-         id="org.apache.poi.ooxml"
+         id="wrapped.org.apache.poi.poi-ooxml"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
    <plugin
-         id="org.apache.poi.ooxml.schemas"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.commons.collections4"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.commons.io"
+         id="wrapped.org.apache.poi.ooxml-schemas"
          download-size="0"
          install-size="0"
          version="0.0.0"
@@ -1153,13 +1139,6 @@ http://www.eclipse.org/legal/epl-v10.html
          unpack="false"/>
 
    <plugin
-         id="org.apache.commons.csv"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.equinox.cm"
          download-size="0"
          install-size="0"
@@ -1231,6 +1210,20 @@ http://www.eclipse.org/legal/epl-v10.html
 
    <plugin
          id="com.sun.xml.bind.jaxb-impl"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.commons.commons-csv"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.commons.commons-io"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
@@ -62,20 +62,6 @@ http://www.eclipse.org/legal/epl-v10.html
          unpack="false"/>
 
    <plugin
-         id="org.apache.commons.csv"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.commons.io"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.apache.commons.logging"
          download-size="0"
          install-size="0"
@@ -345,20 +331,6 @@ http://www.eclipse.org/legal/epl-v10.html
          unpack="false"/>
 
    <plugin
-         id="org.apache.httpcomponents.httpclient"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.httpcomponents.httpcore"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.apache.commons.commons-compress"
          download-size="0"
          install-size="0"
@@ -377,5 +349,33 @@ http://www.eclipse.org/legal/epl-v10.html
          download-size="0"
          install-size="0"
          version="0.0.0"/>
+
+   <plugin
+         id="wrapped.org.apache.httpcomponents.httpclient"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="wrapped.org.apache.httpcomponents.httpcore"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.commons.commons-io"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="com.google.guava.failureaccess"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
 </feature>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis/META-INF/MANIFEST.MF
@@ -16,12 +16,12 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.24.100",
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.msd.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.chromatogram.peak.detector;bundle-version="0.8.0",
- org.apache.commons.io;bundle-version="2.2.0",
  com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.7.1",
  org.eclipse.chemclipse.chromatogram.msd.comparison;bundle-version="0.9.0",
  org.eclipse.core.commands;bundle-version="3.10.100",
  org.eclipse.chemclipse.rcp.app;bundle-version="0.9.0",
- org.eclipse.chemclipse.xxd.filter;bundle-version="0.9.0"
+ org.eclipse.chemclipse.xxd.filter;bundle-version="0.9.0",
+ org.apache.commons.commons-io;bundle-version="2.11.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: ChemClipse

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/META-INF/MANIFEST.MF
@@ -11,8 +11,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.processing;bundle-version="0.8.0",
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
- org.apache.commons.io;bundle-version="2.2.0",
- org.eclipse.chemclipse.chromatogram.msd.classifier
+ org.eclipse.chemclipse.chromatogram.msd.classifier,
+ org.apache.commons.commons-io;bundle-version="2.11.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.chromatogram.xxd.calculator.core.chromatogram,

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.workflows/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.workflows/META-INF/MANIFEST.MF
@@ -16,7 +16,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
  org.eclipse.chemclipse.xxd.process;bundle-version="0.8.0",
  org.eclipse.chemclipse.chromatogram.msd.identifier;bundle-version="0.8.0",
- org.apache.commons.csv;bundle-version="1.4.0",
  org.eclipse.chemclipse.chromatogram.filter;bundle-version="0.8.0",
  org.eclipse.chemclipse.chromatogram.msd.filter;bundle-version="0.8.0",
  org.eclipse.chemclipse.chromatogram.xxd.baseline.detector;bundle-version="0.8.0",
@@ -25,7 +24,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.chromatogram.xxd.integrator;bundle-version="0.8.0",
  org.eclipse.chemclipse.chromatogram.xxd.calculator;bundle-version="0.8.0",
  org.apache.commons.math3;bundle-version="3.5.0",
- org.apache.pdfbox
+ org.apache.pdfbox,
+ org.apache.commons.commons-csv;bundle-version="1.10.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.chromatogram.xxd.process.supplier.workflows.converter,

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/META-INF/MANIFEST.MF
@@ -12,11 +12,11 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.numeric;bundle-version="0.8.0",
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
  org.eclipse.chemclipse.processing;bundle-version="0.8.0",
- com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.7.1",
  org.eclipse.core.databinding;bundle-version="1.6.200",
  org.eclipse.e4.core.services;bundle-version="2.1.100",
  org.eclipse.e4.core.contexts;bundle-version="1.7.0",
- org.apache.commons.io
+ org.apache.commons.commons-io;bundle-version="2.11.0",
+ com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.7.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.model.baseline,

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/META-INF/MANIFEST.MF
@@ -13,10 +13,10 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.processing;bundle-version="0.8.0",
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
- org.apache.commons.io;bundle-version="2.2.0",
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
  org.eclipse.chemclipse.numeric;bundle-version="0.8.0",
- com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.9.9"
+ com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.9.9",
+ org.apache.commons.commons-io;bundle-version="2.11.0"
 Bundle-ActivationPolicy: lazy
 Import-Package: org.osgi.service.component.annotations;version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.csv/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.csv/META-INF/MANIFEST.MF
@@ -15,12 +15,12 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
- org.apache.commons.csv;bundle-version="1.4.0",
  org.eclipse.chemclipse.wsd.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.wsd.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.csd.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.csd.converter;bundle-version="0.8.0",
- com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.9.9"
+ com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.9.9",
+ org.apache.commons.commons-csv;bundle-version="1.10.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Import-Package: org.osgi.service.component.annotations;version="1.2.0"

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.excel/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.excel/META-INF/MANIFEST.MF
@@ -15,9 +15,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.processing;bundle-version="0.8.0",
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
- org.apache.poi;bundle-version="4.1.1",
- org.apache.poi.ooxml;bundle-version="4.1.1",
- org.apache.poi.ooxml.schemas;bundle-version="4.1.1"
+ wrapped.org.apache.poi.ooxml-schemas;bundle-version="1.4.0",
+ wrapped.org.apache.poi.poi;bundle-version="4.1.1",
+ wrapped.org.apache.poi.poi-ooxml;bundle-version="4.1.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.msd.converter.supplier.excel.converter,

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.processing;bundle-version="0.8.0",
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
- org.apache.commons.io;bundle-version="2.2.0"
+ org.apache.commons.commons-io;bundle-version="2.11.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.msd.converter.supplier.massbank.converter,

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.processing;bundle-version="0.8.0",
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
- org.apache.commons.io;bundle-version="2.2.0"
+ org.apache.commons.commons-io;bundle-version="2.11.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.msd.converter.supplier.sirius.converter,

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/META-INF/MANIFEST.MF
@@ -14,11 +14,11 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.logging;bundle-version="0.8.0",
  org.eclipse.chemclipse.processing;bundle-version="0.8.0",
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
- org.apache.commons.io;bundle-version="2.2.0",
  org.eclipse.chemclipse.numeric;bundle-version="0.8.0",
  org.eclipse.chemclipse.pcr.report.supplier.tabular;bundle-version="0.9.0",
- org.apache.commons.csv;bundle-version="1.8.0",
- org.apache.commons.lang3;bundle-version="3.12.0"
+ org.apache.commons.lang3;bundle-version="3.12.0",
+ org.apache.commons.commons-csv;bundle-version="1.10.0",
+ org.apache.commons.commons-io;bundle-version="2.11.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.preferences

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/META-INF/MANIFEST.MF
@@ -14,12 +14,12 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.logging;bundle-version="0.8.0",
  org.eclipse.chemclipse.processing;bundle-version="0.8.0",
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
- org.apache.commons.io;bundle-version="2.2.0",
  org.eclipse.chemclipse.numeric;bundle-version="0.8.0",
- org.apache.poi;bundle-version="3.9.0",
- org.apache.poi.ooxml;bundle-version="3.9.0",
  org.eclipse.chemclipse.pcr.report.supplier.tabular,
- org.apache.commons.lang3
+ org.apache.commons.lang3,
+ wrapped.org.apache.poi.poi;bundle-version="4.1.1",
+ wrapped.org.apache.poi.poi-ooxml;bundle-version="4.1.1",
+ org.apache.commons.commons-io;bundle-version="2.11.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.chemclipse.pcr.report.supplier.tabular

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.txt/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.txt/META-INF/MANIFEST.MF
@@ -14,8 +14,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.logging;bundle-version="0.8.0",
  org.eclipse.chemclipse.processing;bundle-version="0.8.0",
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
- org.apache.commons.io;bundle-version="2.2.0",
- org.eclipse.chemclipse.numeric;bundle-version="0.8.0"
+ org.eclipse.chemclipse.numeric;bundle-version="0.8.0",
+ org.apache.commons.commons-io;bundle-version="2.11.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.pcr.report.supplier.txt.preferences

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.connector.supplier.microsoft.office.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.connector.supplier.microsoft.office.ui/META-INF/MANIFEST.MF
@@ -13,13 +13,13 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.forms;bundle-version="3.5.2",
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
  org.eclipse.chemclipse.rcp.ui.icons;bundle-version="0.8.0",
- org.apache.poi;bundle-version="4.1.1",
- org.apache.poi.ooxml;bundle-version="4.1.1",
- org.apache.poi.ooxml.schemas;bundle-version="4.1.1",
  org.eclipse.ui.editors;bundle-version="3.8.200",
  org.eclipse.jface.text;bundle-version="3.9.2",
  org.eclipse.ui.ide;bundle-version="3.10.2",
  org.eclipse.core.resources;bundle-version="3.9.1",
- org.eclipse.chemclipse.swt.win32;bundle-version="0.9.0"
+ org.eclipse.chemclipse.swt.win32;bundle-version="0.9.0",
+ wrapped.org.apache.poi.ooxml-schemas;bundle-version="1.4.0",
+ wrapped.org.apache.poi.poi;bundle-version="4.1.1",
+ wrapped.org.apache.poi.poi-ooxml;bundle-version="4.1.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/META-INF/MANIFEST.MF
@@ -104,9 +104,9 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.workbench;bundle-version="3.111.0",
  org.eclipse.core.commands;bundle-version="3.9.100",
  org.eclipse.chemclipse.rcp.app;bundle-version="0.9.0",
- org.apache.commons.io;bundle-version="2.8.0",
  org.eclipse.chemclipse.chromatogram.xxd.identifier;bundle-version="0.9.0",
- com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.13.2"
+ com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.13.2",
+ org.apache.commons.commons-io;bundle-version="2.11.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Import-Package: javax.annotation;version="[1.0.0,2.0.0)",

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
  javax.activation;bundle-version="1.1.0",
  org.eclipse.chemclipse.xir.model;bundle-version="0.9.0",
- org.eclipse.chemclipse.xir.converter;bundle-version="0.9.0"
+ org.eclipse.chemclipse.xir.converter;bundle-version="0.9.0",
+ jakarta.activation-api;bundle-version="2.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: ChemClipse

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.pubchem/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.pubchem/META-INF/MANIFEST.MF
@@ -14,8 +14,8 @@ Require-Bundle: org.eclipse.core.runtime,
  com.google.guava;bundle-version="30.1.0",
  org.eclipse.chemclipse.msd.model;bundle-version="0.9.0",
  org.eclipse.chemclipse.processing;bundle-version="0.9.0",
- org.apache.commons.io;bundle-version="2.8.0",
  org.eclipse.chemclipse.logging;bundle-version="0.9.0",
- org.eclipse.chemclipse.chromatogram.xxd.identifier
+ org.eclipse.chemclipse.chromatogram.xxd.identifier,
+ org.apache.commons.commons-io;bundle-version="2.11.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/META-INF/MANIFEST.MF
@@ -19,8 +19,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.apache.commons.logging;bundle-version="1.2.0",
  org.apache.commons.lang3;bundle-version="3.12.0",
  org.apache.thrift;bundle-version="0.12.0",
- org.apache.httpcomponents.httpclient;bundle-version="4.5.13",
- org.apache.httpcomponents.httpcore;bundle-version="4.4.15",
- org.apache.commons.commons-compress;bundle-version="1.22.0"
+ org.apache.commons.commons-compress;bundle-version="1.22.0",
+ wrapped.org.apache.httpcomponents.httpclient;bundle-version="4.5.14",
+ wrapped.org.apache.httpcomponents.httpcore;bundle-version="4.4.16"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/META-INF/MANIFEST.MF
@@ -51,11 +51,11 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.databinding.beans;bundle-version="1.3.100",
  org.eclipse.core.databinding.property;bundle-version="1.6.0",
  org.eclipse.jface.databinding;bundle-version="1.8.1",
- org.apache.commons.io;bundle-version="2.2.0",
  org.eclipse.chemclipse.ux.extension.xxd.ui;bundle-version="0.8.0",
  org.eclipse.chemclipse.xxd.process;bundle-version="0.8.0",
  org.eclipse.e4.core.contexts;bundle-version="1.5.1",
- org.eclipse.e4.core.commands
+ org.eclipse.e4.core.commands,
+ org.apache.commons.commons-io;bundle-version="2.11.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: javax.annotation;version="1.0.0";resolution:=optional,
  javax.inject;version="1.0.0",

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/META-INF/MANIFEST.MF
@@ -15,15 +15,15 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.numeric;bundle-version="0.8.0",
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
- org.apache.poi;bundle-version="4.1.1",
- org.apache.poi.ooxml;bundle-version="4.1.1",
- org.apache.poi.ooxml.schemas;bundle-version="4.1.1",
  org.apache.commons.math3;bundle-version="3.5.0",
  org.eclipse.chemclipse.csd.converter;bundle-version="0.9.0",
  org.eclipse.chemclipse.csd.model;bundle-version="0.9.0",
- org.apache.commons.csv;bundle-version="1.4.0",
  wrapped.org.ejml.ejml-core;bundle-version="0.41.0",
- wrapped.org.ejml.ejml-ddense;bundle-version="0.41.0"
+ wrapped.org.ejml.ejml-ddense;bundle-version="0.41.0",
+ wrapped.org.apache.poi.ooxml-schemas;bundle-version="1.4.0",
+ wrapped.org.apache.poi.poi;bundle-version="4.1.1",
+ wrapped.org.apache.poi.poi-ooxml;bundle-version="4.1.1",
+ org.apache.commons.commons-csv;bundle-version="1.10.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.xxd.process.supplier.pca.core,

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/META-INF/MANIFEST.MF
@@ -13,7 +13,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.converter,
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
  com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.9.9",
- org.apache.commons.io;bundle-version="2.6.0",
  org.eclipse.chemclipse.msd.converter;bundle-version="0.9.0",
  org.eclipse.chemclipse.csd.converter;bundle-version="0.9.0",
  org.eclipse.chemclipse.nmr.converter;bundle-version="0.9.0",
@@ -22,7 +21,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.xir.converter;bundle-version="0.9.0",
  org.eclipse.chemclipse.msd.model;bundle-version="0.9.0",
  org.eclipse.chemclipse.csd.model;bundle-version="0.9.0",
- org.eclipse.chemclipse.wsd.model;bundle-version="0.9.0"
+ org.eclipse.chemclipse.wsd.model;bundle-version="0.9.0",
+ org.apache.commons.commons-io;bundle-version="2.11.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.xxd.process.comparators,

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -9,6 +9,8 @@
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
 	<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
+	<unit id="javax.activation" version="0.0.0"/>
+	<unit id="javax.annotation" version="0.0.0"/>
 	<repository location="https://download.eclipse.org/releases/2022-12/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -16,32 +18,45 @@
 	<repository location="https://download.eclipse.org/technology/babel/update-site/R0.20.0/2022-12/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-	<unit id="org.apache.commons.csv" version="0.0.0"/>
-	<unit id="com.google.guava" version="0.0.0"/>
-	<unit id="org.apache.commons.math3" version="0.0.0"/>
-	<unit id="org.apache.commons.io" version="0.0.0"/>
-	<unit id="org.apache.commons.cli" version="0.0.0"/>
-	<unit id="org.apache.poi" version="0.0.0"/>
-	<unit id="org.apache.poi.ooxml.schemas" version="0.0.0"/>
-	<unit id="org.apache.poi.ooxml" version="0.0.0"/>
-	<unit id="com.fasterxml.jackson.core.jackson-databind" version="0.0.0"/>
-	<unit id="javax.activation" version="0.0.0"/>
-	<unit id="javax.annotation" version="0.0.0"/>
-	<unit id="org.apache.commons.codec" version="0.0.0"/>
-	<unit id="org.apache.httpcomponents.httpclient" version="0.0.0"/>
-	<unit id="org.apache.httpcomponents.httpcore" version="0.0.0"/>
-	<repository location="https://download.eclipse.org/tools/orbit/downloads/2022-12"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 	<repository location="https://download.eclipse.org/swtchart/integration/develop/repository"/>
 </location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
+	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="org.apache.commons" missingManifest="generate" type="Maven">
 		<dependencies>
+			<dependency>
+				<groupId>commons-cli</groupId>
+				<artifactId>commons-cli</artifactId>
+				<version>1.5.0</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>commons-codec</groupId>
+				<artifactId>commons-codec</artifactId>
+				<version>1.15</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-compress</artifactId>
+				<version>1.22</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-csv</artifactId>
+				<version>1.10.0</version>
+				<type>jar</type>
+			</dependency>
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
 				<version>3.12.0</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-math3</artifactId>
+				<version>3.6.1</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -194,12 +209,78 @@
 			</dependency>
 		</dependencies>
 	</location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
+	<location includeDependencyDepth="none" includeDependencyScopes="compile" label="org.apache.poi" missingManifest="generate" type="Maven">
 		<dependencies>
 			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-compress</artifactId>
-				<version>1.22</version>
+				<groupId>org.apache.poi</groupId>
+				<artifactId>ooxml-schemas</artifactId>
+				<version>1.4</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.poi</groupId>
+				<artifactId>poi-ooxml</artifactId>
+				<version>4.1.1</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.poi</groupId>
+				<artifactId>poi</artifactId>
+				<version>4.1.1</version>
+				<type>jar</type>
+			</dependency>
+		</dependencies>
+	</location>
+	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="org.apache.httpcomponents" missingManifest="generate" type="Maven">
+		<dependencies>
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpclient</artifactId>
+				<version>4.5.14</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpcore</artifactId>
+				<version>4.4.16</version>
+				<type>jar</type>
+			</dependency>
+		</dependencies>
+	</location>
+	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="com.google.guava" missingManifest="generate" type="Maven">
+		<dependencies>
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>failureaccess</artifactId>
+				<version>1.0.1</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>31.1-jre</version>
+				<type>jar</type>
+			</dependency>
+		</dependencies>
+	</location>
+	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="com.fasterxml.jackson.core" missingManifest="generate" type="Maven">
+		<dependencies>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-annotations</artifactId>
+				<version>2.13.5</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-core</artifactId>
+				<version>2.13.5</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>2.13.5</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -13,7 +13,7 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.eclipse.babel.nls_eclipse_de.feature.group" version="0.0.0"/>
-	<repository location="https://download.eclipse.org/technology/babel/update-site/R0.19.2/2021-12/"/>
+	<repository location="https://download.eclipse.org/technology/babel/update-site/R0.20.0/2022-12/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.apache.commons.csv" version="0.0.0"/>


### PR DESCRIPTION
This is a desperate attempt at speeding up the build as some pull request now time out after 6 hours with @eclipse-tycho. I noticed that for [tools/orbit](https://download.eclipse.org/oomph/archive/mirror.php?location=tools/orbit) all the mirrors are broken. The main download site is slow because they try to limit the traffic to a fixed amount to keep costs under control. Most of the Orbit dependencies are available via the regular Eclipse release. However, I decided to only fetch Eclipse projects from the slow official p2 update sites. All approved third-party downloads are now fetched via Maven. This also allows for individual version updates.