### PR TITLE
Downgrade Apache Commons CSV to 1.8 again

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.workflows/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.workflows/META-INF/MANIFEST.MF
@@ -24,8 +24,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.chromatogram.xxd.integrator;bundle-version="0.8.0",
  org.eclipse.chemclipse.chromatogram.xxd.calculator;bundle-version="0.8.0",
  org.apache.commons.math3;bundle-version="3.5.0",
- org.apache.pdfbox,
- org.apache.commons.commons-csv;bundle-version="1.10.0"
+ org.apache.pdfbox;bundle-version="2.0.26",
+ org.apache.commons.commons-csv;bundle-version="1.8.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.chromatogram.xxd.process.supplier.workflows.converter,

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.csv/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.csv/META-INF/MANIFEST.MF
@@ -20,7 +20,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.csd.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.csd.converter;bundle-version="0.8.0",
  com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.9.9",
- org.apache.commons.commons-csv;bundle-version="1.10.0"
+ org.apache.commons.commons-csv;bundle-version="1.8.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Import-Package: org.osgi.service.component.annotations;version="1.2.0"

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/META-INF/MANIFEST.MF
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.numeric;bundle-version="0.8.0",
  org.eclipse.chemclipse.pcr.report.supplier.tabular;bundle-version="0.9.0",
  org.apache.commons.lang3;bundle-version="3.12.0",
- org.apache.commons.commons-csv;bundle-version="1.10.0",
+ org.apache.commons.commons-csv;bundle-version="1.8.0",
  org.apache.commons.commons-io;bundle-version="2.11.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle: org.eclipse.core.runtime,
  wrapped.org.apache.poi.ooxml-schemas;bundle-version="1.4.0",
  wrapped.org.apache.poi.poi;bundle-version="4.1.1",
  wrapped.org.apache.poi.poi-ooxml;bundle-version="4.1.1",
- org.apache.commons.commons-csv;bundle-version="1.10.0"
+ org.apache.commons.commons-csv;bundle-version="1.8.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.xxd.process.supplier.pca.core,

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -44,7 +44,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-csv</artifactId>
-				<version>1.10.0</version>
+				<version>1.8</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
In https://github.com/eclipse/chemclipse/pull/1333 I updated to 1.10 because the version number increase seemed low. However, this causes a lot of disruption due to API and behavior changes that need to be addressed somewhat later.