### PR TITLE
Code cleanup

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/ChromatogramFilter.java
@@ -140,15 +140,14 @@ public class ChromatogramFilter {
 	 * Returns a {@link IChromatogramFilter} instance given by the filterId or
 	 * null, if none is available.
 	 */
-	@SuppressWarnings("rawtypes")
-	private static IChromatogramFilter getChromatogramFilter(final String filterId) {
+	private static IChromatogramFilter<?, ?, ?> getChromatogramFilter(final String filterId) {
 
 		IConfigurationElement element;
 		element = getConfigurationElement(filterId);
-		IChromatogramFilter instance = null;
+		IChromatogramFilter<?, ?, ?> instance = null;
 		if(element != null) {
 			try {
-				instance = (IChromatogramFilter)element.createExecutableExtension(FILTER);
+				instance = (IChromatogramFilter<?, ?, ?>)element.createExecutableExtension(FILTER);
 			} catch(CoreException e) {
 				logger.warn(e);
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.peakmax/src/org/eclipse/chemclipse/chromatogram/msd/integrator/supplier/peakmax/core/PeakIntegrator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.peakmax/src/org/eclipse/chemclipse/chromatogram/msd/integrator/supplier/peakmax/core/PeakIntegrator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 Lablicate GmbH.
+ * Copyright (c) 2012, 2023 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -22,7 +22,6 @@ import org.eclipse.chemclipse.chromatogram.xxd.integrator.core.settings.peaks.IP
 import org.eclipse.chemclipse.chromatogram.xxd.integrator.result.IPeakIntegrationResult;
 import org.eclipse.chemclipse.chromatogram.xxd.integrator.result.IPeakIntegrationResults;
 import org.eclipse.chemclipse.chromatogram.xxd.integrator.result.PeakIntegrationResults;
-import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -30,16 +29,12 @@ import org.eclipse.core.runtime.IProgressMonitor;
 
 public class PeakIntegrator extends AbstractPeakIntegrator<IPeakIntegrationResults> {
 
-	@SuppressWarnings("unused")
-	private static final Logger logger = Logger.getLogger(PeakIntegrator.class);
-
 	@Override
 	public IProcessingInfo<IPeakIntegrationResults> integrate(IPeak peak, IPeakIntegrationSettings peakIntegrationSettings, IProgressMonitor monitor) {
 
 		IProcessingInfo<IPeakIntegrationResults> processingInfo = super.validate(peak, peakIntegrationSettings);
 		if(!processingInfo.hasErrorMessages()) {
 			if(peakIntegrationSettings instanceof PeakIntegrationSettings) {
-
 				PeakIntegratorSupport peakIntegratorSupport = new PeakIntegratorSupport();
 				IPeakIntegrationResult peakIntegrationResult = peakIntegratorSupport.calculatePeakIntegrationResult(peak, peakIntegrationSettings, monitor);
 				IPeakIntegrationResults peakIntegrationResults = new PeakIntegrationResults();
@@ -63,11 +58,9 @@ public class PeakIntegrator extends AbstractPeakIntegrator<IPeakIntegrationResul
 		IProcessingInfo<IPeakIntegrationResults> processingInfo = super.validate(peaks, peakIntegrationSettings);
 		if(!processingInfo.hasErrorMessages()) {
 			if(peakIntegrationSettings instanceof PeakIntegrationSettings) {
-
 				PeakIntegratorSupport peakIntegratorSupport = new PeakIntegratorSupport();
 				IPeakIntegrationResults peakIntegrationResults = peakIntegratorSupport.calculatePeakIntegrationResults(peaks, peakIntegrationSettings, monitor);
 				processingInfo.setProcessingResult(peakIntegrationResults);
-
 			}
 		}
 		return processingInfo;
@@ -79,7 +72,6 @@ public class PeakIntegrator extends AbstractPeakIntegrator<IPeakIntegrationResul
 		PeakIntegrationSettings peakIntegrationSettings = PreferenceSupplier.getPeakIntegrationSettings();
 		return integrate(peaks, peakIntegrationSettings, monitor);
 	}
-
 
 	@Override
 	public IProcessingInfo<IPeakIntegrationResults> integrate(IChromatogramSelection<?, ?> chromatogramSelection, IPeakIntegrationSettings peakIntegrationSettings, IProgressMonitor monitor) {
@@ -94,7 +86,6 @@ public class PeakIntegrator extends AbstractPeakIntegrator<IPeakIntegrationResul
 		}
 		return processingInfo;
 	}
-
 
 	@Override
 	public IProcessingInfo<IPeakIntegrationResults> integrate(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/AbstractBaselineDetector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/AbstractBaselineDetector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -25,10 +25,9 @@ public abstract class AbstractBaselineDetector implements IBaselineDetector {
 	private static final String ERROR_DESCRIPTION = "Baseline Detector";
 
 	@Override
-	@SuppressWarnings("rawtypes")
-	public IProcessingInfo validate(IChromatogramSelection chromatogramSelection, IBaselineDetectorSettings baselineDetectorSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<?> validate(IChromatogramSelection<?, ?> chromatogramSelection, IBaselineDetectorSettings baselineDetectorSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo<?> processingInfo = new ProcessingInfo<Object>();
+		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
 		if(chromatogramSelection == null) {
 			IProcessingMessage processingMessage = new ProcessingMessage(MessageType.ERROR, ERROR_DESCRIPTION, "The chromatogram selection is invalid.");
 			processingInfo.addMessage(processingMessage);
@@ -49,10 +48,9 @@ public abstract class AbstractBaselineDetector implements IBaselineDetector {
 	}
 
 	@Override
-	@SuppressWarnings("rawtypes")
-	public IProcessingInfo validate(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<?> validate(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
-		IProcessingInfo<?> processingInfo = new ProcessingInfo<Object>();
+		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
 		if(chromatogramSelection == null) {
 			IProcessingMessage processingMessage = new ProcessingMessage(MessageType.ERROR, ERROR_DESCRIPTION, "The chromatogram selection is invalid.");
 			processingInfo.addMessage(processingMessage);
@@ -68,7 +66,7 @@ public abstract class AbstractBaselineDetector implements IBaselineDetector {
 	@Override
 	public IProcessingInfo<?> validate(IBaselineDetectorSettings baselineDetectorSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo<?> processingInfo = new ProcessingInfo<Object>();
+		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
 		/*
 		 * Settings
 		 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/IBaselineDetector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/IBaselineDetector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -33,8 +33,7 @@ public interface IBaselineDetector {
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	@SuppressWarnings("rawtypes")
-	IProcessingInfo setBaseline(IChromatogramSelection chromatogramSelection, IBaselineDetectorSettings baselineDetectorSettings, IProgressMonitor monitor);
+	IProcessingInfo<?> setBaseline(IChromatogramSelection<?, ?> chromatogramSelection, IBaselineDetectorSettings baselineDetectorSettings, IProgressMonitor monitor);
 
 	/**
 	 * This class does the same as the other setBaseline method but does not require settings.<br/>
@@ -43,8 +42,7 @@ public interface IBaselineDetector {
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	@SuppressWarnings("rawtypes")
-	IProcessingInfo setBaseline(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor);
+	IProcessingInfo<?> setBaseline(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor);
 
 	/**
 	 * Validates the parameters.
@@ -54,8 +52,7 @@ public interface IBaselineDetector {
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	@SuppressWarnings("rawtypes")
-	IProcessingInfo validate(IChromatogramSelection chromatogramSelection, IBaselineDetectorSettings baselineDetectorSettings, IProgressMonitor monitor);
+	IProcessingInfo<?> validate(IChromatogramSelection<?, ?> chromatogramSelection, IBaselineDetectorSettings baselineDetectorSettings, IProgressMonitor monitor);
 
 	/**
 	 * Validates the parameters.
@@ -73,6 +70,5 @@ public interface IBaselineDetector {
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	@SuppressWarnings("rawtypes")
-	IProcessingInfo validate(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor);
+	IProcessingInfo<?> validate(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/impl/BaselineDelete.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/impl/BaselineDelete.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Lablicate GmbH.
+ * Copyright (c) 2020, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -19,18 +19,16 @@ import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class BaselineDelete extends AbstractBaselineDetector {
 
 	@Override
-	public IProcessingInfo setBaseline(IChromatogramSelection chromatogramSelection, IBaselineDetectorSettings baselineDetectorSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<?> setBaseline(IChromatogramSelection<?, ?> chromatogramSelection, IBaselineDetectorSettings baselineDetectorSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = super.validate(chromatogramSelection, baselineDetectorSettings, monitor);
+		IProcessingInfo<?> processingInfo = super.validate(chromatogramSelection, baselineDetectorSettings, monitor);
 		if(!processingInfo.hasErrorMessages()) {
-			if(baselineDetectorSettings instanceof DeleteSettings) {
-				IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+			if(baselineDetectorSettings instanceof DeleteSettings deleteSettings) {
+				IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 				IBaselineModel baselineModel = chromatogram.getBaselineModel();
-				DeleteSettings deleteSettings = (DeleteSettings)baselineDetectorSettings;
 				if(deleteSettings.isDeleteCompletely()) {
 					baselineModel.removeBaseline();
 				} else {
@@ -44,7 +42,7 @@ public class BaselineDelete extends AbstractBaselineDetector {
 	}
 
 	@Override
-	public IProcessingInfo setBaseline(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<?> setBaseline(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		DetectorSettings settings = new DetectorSettings();
 		return setBaseline(chromatogramSelection, settings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/impl/BaselineDetector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/impl/BaselineDetector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Lablicate GmbH.
+ * Copyright (c) 2020, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -20,18 +20,17 @@ import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class BaselineDetector extends AbstractBaselineDetector {
 
 	@Override
-	public IProcessingInfo setBaseline(IChromatogramSelection chromatogramSelection, IBaselineDetectorSettings baselineDetectorSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<?> setBaseline(IChromatogramSelection<?, ?> chromatogramSelection, IBaselineDetectorSettings baselineDetectorSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = super.validate(chromatogramSelection, baselineDetectorSettings, monitor);
+		IProcessingInfo<?> processingInfo = super.validate(chromatogramSelection, baselineDetectorSettings, monitor);
 		if(!processingInfo.hasErrorMessages()) {
 			if(baselineDetectorSettings instanceof DetectorSettings) {
 				float intensity = extractLowestIntensity(chromatogramSelection);
 				if(intensity != 0) {
-					IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+					IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 					IBaselineModel baselineModel = chromatogram.getBaselineModel();
 					int startRetentionTime = chromatogramSelection.getStartRetentionTime();
 					int stopRetentionTime = chromatogramSelection.getStopRetentionTime();
@@ -45,15 +44,15 @@ public class BaselineDetector extends AbstractBaselineDetector {
 	}
 
 	@Override
-	public IProcessingInfo setBaseline(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<?> setBaseline(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		DetectorSettings settings = new DetectorSettings();
 		return setBaseline(chromatogramSelection, settings, monitor);
 	}
 
-	private float extractLowestIntensity(IChromatogramSelection chromatogramSelection) {
+	private float extractLowestIntensity(IChromatogramSelection<?, ?> chromatogramSelection) {
 
-		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+		IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 		int scanStart = chromatogramSelection.getStartScan();
 		int scanStop = chromatogramSelection.getStopScan();
 		//

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/src/org/eclipse/chemclipse/chromatogram/xxd/edit/supplier/snip/core/BaselineDetector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/src/org/eclipse/chemclipse/chromatogram/xxd/edit/supplier/snip/core/BaselineDetector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -34,22 +34,20 @@ import org.eclipse.core.runtime.SubMonitor;
 
 public class BaselineDetector extends AbstractBaselineDetector {
 
-	@SuppressWarnings("rawtypes")
 	@Override
-	public IProcessingInfo setBaseline(IChromatogramSelection chromatogramSelection, IBaselineDetectorSettings baselineDetectorSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<?> setBaseline(IChromatogramSelection<?, ?> chromatogramSelection, IBaselineDetectorSettings baselineDetectorSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = super.validate(chromatogramSelection, baselineDetectorSettings, monitor);
+		IProcessingInfo<?> processingInfo = super.validate(chromatogramSelection, baselineDetectorSettings, monitor);
 		if(!processingInfo.hasErrorMessages()) {
-			if(baselineDetectorSettings instanceof BaselineDetectorSettings) {
-				calculateBaseline(chromatogramSelection, (BaselineDetectorSettings)baselineDetectorSettings, monitor);
+			if(baselineDetectorSettings instanceof BaselineDetectorSettings settings) {
+				calculateBaseline(chromatogramSelection, settings, monitor);
 			}
 		}
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
-	public IProcessingInfo setBaseline(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<?> setBaseline(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		BaselineDetectorSettings baselineDetectorSettings = PreferenceSupplier.getBaselineDetectorSettings();
 		return setBaseline(chromatogramSelection, baselineDetectorSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/src/org/eclipse/chemclipse/chromatogram/xxd/edit/supplier/snip/core/MassSpectrumFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/src/org/eclipse/chemclipse/chromatogram/xxd/edit/supplier/snip/core/MassSpectrumFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -40,8 +40,7 @@ public class MassSpectrumFilter extends AbstractMassSpectrumFilter {
 		}
 		IProcessingInfo<IMassSpectrumFilterResult> processingInfo = validate(massSpectra, filterSettings);
 		if(!processingInfo.hasErrorMessages()) {
-			if(filterSettings instanceof MassSpectrumFilterSettings) {
-				MassSpectrumFilterSettings massSpectrumFilterSettings = (MassSpectrumFilterSettings)filterSettings;
+			if(filterSettings instanceof MassSpectrumFilterSettings massSpectrumFilterSettings) {
 				FilterSupplier filterSupplier = new FilterSupplier();
 				int iterations = massSpectrumFilterSettings.getIterations();
 				int transitions = massSpectrumFilterSettings.getTransitions();

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/src/org/eclipse/chemclipse/chromatogram/xxd/edit/supplier/snip/core/PeakFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/src/org/eclipse/chemclipse/chromatogram/xxd/edit/supplier/snip/core/PeakFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -39,13 +39,13 @@ public class PeakFilter extends AbstractPeakFilter {
 	public IProcessingInfo<IPeakFilterResult> applyFilter(List<IPeakMSD> peaks, IPeakFilterSettings filterSettings, IProgressMonitor monitor) {
 
 		PeakFilterSettings peakFilterSettings;
-		if(filterSettings instanceof PeakFilterSettings) {
-			peakFilterSettings = (PeakFilterSettings)filterSettings;
+		if(filterSettings instanceof PeakFilterSettings settings) {
+			peakFilterSettings = settings;
 		} else {
 			peakFilterSettings = PreferenceSupplier.getPeakFilterSettings();
 		}
 		FilterSupplier filterSupplier = new FilterSupplier();
-		List<IScanMSD> massSpectra = new ArrayList<IScanMSD>();
+		List<IScanMSD> massSpectra = new ArrayList<>();
 		for(IPeakMSD peakMSD : peaks) {
 			massSpectra.add(peakMSD.getPeakModel().getPeakMassSpectrum());
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/chromatogram/IChromatogramIntegrator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/chromatogram/IChromatogramIntegrator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Lablicate GmbH.
+ * Copyright (c) 2011, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,7 +20,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 public interface IChromatogramIntegrator<R> {
 
 	IProcessingInfo<R> integrate(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramIntegrationSettings chromatogramIntegrationSettings, IProgressMonitor monitor);
-
 
 	IProcessingInfo<R> integrate(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/combined/CombinedIntegrator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/combined/CombinedIntegrator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,6 +12,7 @@
 package org.eclipse.chemclipse.chromatogram.xxd.integrator.core.combined;
 
 import org.eclipse.chemclipse.chromatogram.xxd.integrator.core.settings.combined.ICombinedIntegrationSettings;
+import org.eclipse.chemclipse.chromatogram.xxd.integrator.result.ICombinedIntegrationResult;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -47,10 +48,9 @@ public class CombinedIntegrator {
 
 	}
 
-	@SuppressWarnings("rawtypes")
-	public static IProcessingInfo integrate(IChromatogramSelection chromatogramSelection, ICombinedIntegrationSettings combinedIntegrationSettings, String integratorId, IProgressMonitor monitor) {
+	public static IProcessingInfo<ICombinedIntegrationResult> integrate(IChromatogramSelection<?, ?> chromatogramSelection, ICombinedIntegrationSettings combinedIntegrationSettings, String integratorId, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo;
+		IProcessingInfo<ICombinedIntegrationResult> processingInfo;
 		ICombinedIntegrator integrator = getCombinedIntegrator(integratorId);
 		if(integrator != null) {
 			processingInfo = integrator.integrate(chromatogramSelection, combinedIntegrationSettings, monitor);
@@ -60,16 +60,14 @@ public class CombinedIntegrator {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	public static IProcessingInfo integrate(IChromatogramSelection chromatogramSelection, String integratorId, IProgressMonitor monitor) {
+	public static IProcessingInfo<ICombinedIntegrationResult> integrate(IChromatogramSelection<?, ?> chromatogramSelection, String integratorId, IProgressMonitor monitor) {
 
 		return integrate(chromatogramSelection, getCombinedIntegrator(integratorId), monitor);
 	}
 
-	@SuppressWarnings("rawtypes")
-	public static IProcessingInfo integrate(IChromatogramSelection chromatogramSelection, ICombinedIntegrator integrator, IProgressMonitor monitor) {
+	public static IProcessingInfo<ICombinedIntegrationResult> integrate(IChromatogramSelection<?, ?> chromatogramSelection, ICombinedIntegrator integrator, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo;
+		IProcessingInfo<ICombinedIntegrationResult> processingInfo;
 		if(integrator != null) {
 			processingInfo = integrator.integrate(chromatogramSelection, monitor);
 		} else {
@@ -144,9 +142,9 @@ public class CombinedIntegrator {
 		return null;
 	}
 
-	private static IProcessingInfo<?> getNoIntegratorAvailableProcessingInfo() {
+	private static IProcessingInfo<ICombinedIntegrationResult> getNoIntegratorAvailableProcessingInfo() {
 
-		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<ICombinedIntegrationResult> processingInfo = new ProcessingInfo<>();
 		IProcessingMessage processingMessage = new ProcessingMessage(MessageType.ERROR, "Combined Integrator", NO_INTEGRATOR_AVAILABLE);
 		processingInfo.addMessage(processingMessage);
 		return processingInfo;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse/src/org/eclipse/chemclipse/chromatogram/xxd/quantitation/supplier/chemclipse/io/DatabaseSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse/src/org/eclipse/chemclipse/chromatogram/xxd/quantitation/supplier/chemclipse/io/DatabaseSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Lablicate GmbH.
+ * Copyright (c) 2019, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,15 +16,11 @@ import java.io.File;
 
 import org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.converter.quantitation.QuantDBConverter;
-import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationDatabase;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 
 public class DatabaseSupport {
-
-	@SuppressWarnings("unused")
-	private static final Logger logger = Logger.getLogger(DatabaseSupport.class);
 
 	/**
 	 * Tries to load the quantitation database from the given file.

--- a/chemclipse/plugins/org.eclipse.chemclipse.logging/src/org/eclipse/chemclipse/logging/core/Category.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.logging/src/org/eclipse/chemclipse/logging/core/Category.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -18,8 +18,7 @@ public class Category {
 
 	private final ILog logger;
 
-	@SuppressWarnings("rawtypes")
-	public Category(final Class clazz) {
+	public Category(final Class<?> clazz) {
 
 		logger = Platform.getLog(clazz);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.logging/src/org/eclipse/chemclipse/logging/core/Logger.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.logging/src/org/eclipse/chemclipse/logging/core/Logger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -16,8 +16,8 @@ public class Logger extends Category {
 	/**
 	 * @param clazz
 	 */
-	@SuppressWarnings("rawtypes")
-	protected Logger(Class clazz) {
+	protected Logger(Class<?> clazz) {
+
 		super(clazz);
 	}
 
@@ -27,8 +27,7 @@ public class Logger extends Category {
 	 * @param clazz
 	 * @return Logger
 	 */
-	@SuppressWarnings("rawtypes")
-	public static Logger getLogger(Class clazz) {
+	public static Logger getLogger(Class<?> clazz) {
 
 		return new Logger(clazz);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/statistics/AbstractSample.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/statistics/AbstractSample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -121,12 +121,15 @@ public abstract class AbstractSample<D extends ISampleData> implements ISample {
 	@Override
 	public boolean equals(Object obj) {
 
-		if(this == obj)
+		if(this == obj) {
 			return true;
-		if(obj == null)
+		}
+		if(obj == null) {
 			return false;
-		if(getClass() != obj.getClass())
+		}
+		if(getClass() != obj.getClass()) {
 			return false;
+		}
 		AbstractSample other = (AbstractSample)obj;
 		return Objects.equals(sampleName, other.sampleName);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelectionMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelectionMSD.java
@@ -132,8 +132,7 @@ public class ChromatogramSelectionMSD extends AbstractChromatogramSelection<IChr
 	public void reset(boolean fireUpdate) {
 
 		super.reset(fireUpdate);
-		@SuppressWarnings("rawtypes")
-		IChromatogram chromatogram = getChromatogram();
+		IChromatogram<?> chromatogram = getChromatogram();
 		/*
 		 * Scan
 		 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/support/DatabaseExportRunnable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/support/DatabaseExportRunnable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2019 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.msd.swt.ui.internal.support;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 
-import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.msd.converter.database.DatabaseConverter;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.processing.converter.ISupplier;
@@ -25,8 +24,6 @@ import org.eclipse.jface.operation.IRunnableWithProgress;
 
 public class DatabaseExportRunnable implements IRunnableWithProgress {
 
-	@SuppressWarnings("unused")
-	private static final Logger logger = Logger.getLogger(DatabaseExportRunnable.class);
 	private File data;
 	private File file;
 	private IMassSpectra massSpectra;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/support/MassSpectrumExportRunnable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/support/MassSpectrumExportRunnable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 Lablicate GmbH.
+ * Copyright (c) 2015, 2023 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.msd.swt.ui.internal.support;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 
-import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.msd.converter.massspectrum.MassSpectrumConverter;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.processing.converter.ISupplier;
@@ -25,8 +24,6 @@ import org.eclipse.jface.operation.IRunnableWithProgress;
 
 public class MassSpectrumExportRunnable implements IRunnableWithProgress {
 
-	@SuppressWarnings("unused")
-	private static final Logger logger = Logger.getLogger(MassSpectrumExportRunnable.class);
 	private File data;
 	private File file;
 	private IMassSpectra massSpectra;

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.test/src/org/eclipse/chemclipse/rcp/app/test/TestAssembler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.test/src/org/eclipse/chemclipse/rcp/app/test/TestAssembler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -18,6 +18,8 @@ import java.util.Enumeration;
 import java.util.List;
 
 import org.osgi.framework.Bundle;
+
+import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
 public class TestAssembler {
@@ -26,27 +28,27 @@ public class TestAssembler {
 	private Bundle[] bundles;
 
 	public TestAssembler(Bundle[] bundles) {
+
 		this.bundles = bundles;
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	public void assembleTests(TestSuite testSuite, String bundleName, String packageName, String filter) {
 
 		for(Bundle bundle : bundles) {
 			if(!isFragment(bundle) && bundle.getSymbolicName().startsWith(bundleName)) {
-				List<Class> testClasses = getTestClasses(bundle, packageName, filter);
-				for(Class clazz : testClasses) {
+				List<Class<? extends TestCase>> testClasses = getTestClasses(bundle, packageName, filter);
+				for(Class<? extends TestCase> clazz : testClasses) {
 					testSuite.addTestSuite(clazz);
 				}
 			}
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
-	private List<Class> getTestClasses(Bundle bundle, String packageName, String filter) {
+	@SuppressWarnings("unchecked")
+	private List<Class<? extends TestCase>> getTestClasses(Bundle bundle, String packageName, String filter) {
 
-		List<Class> testClasses = new ArrayList<Class>();
-		Enumeration testClassNames = bundle.findEntries("/", filter + ".class", true);
+		List<Class<? extends TestCase>> testClasses = new ArrayList<>();
+		Enumeration<?> testClassNames = bundle.findEntries("/", filter + ".class", true);
 		if(testClassNames != null) {
 			while(testClassNames.hasMoreElements()) {
 				String testClassPath = ((URL)testClassNames.nextElement()).getPath();
@@ -66,9 +68,9 @@ public class TestAssembler {
 				/*
 				 * Try to load the bundles class loader.
 				 */
-				Class testClass = null;
+				Class<? extends TestCase> testClass = null;
 				try {
-					testClass = bundle.loadClass(testClassName);
+					testClass = (Class<? extends TestCase>)bundle.loadClass(testClassName);
 				} catch(ClassNotFoundException e) {
 					throw new RuntimeException("Class was not loadable: " + testClassName, e);
 				}
@@ -89,10 +91,9 @@ public class TestAssembler {
 	 * @param bundle
 	 * @return boolean
 	 */
-	@SuppressWarnings("rawtypes")
 	private boolean isFragment(Bundle bundle) {
 
-		Enumeration headerKeys = bundle.getHeaders().keys();
+		Enumeration<?> headerKeys = bundle.getHeaders().keys();
 		/*
 		 * Search in all elements the String Fragment-Host.
 		 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.csd.ui/src/org/eclipse/chemclipse/ux/extension/csd/ui/internal/support/ChromatogramExportRunnable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.csd.ui/src/org/eclipse/chemclipse/ux/extension/csd/ui/internal/support/ChromatogramExportRunnable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2019 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -17,7 +17,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
-import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.processing.converter.ISupplier;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -25,8 +24,6 @@ import org.eclipse.jface.operation.IRunnableWithProgress;
 
 public class ChromatogramExportRunnable implements IRunnableWithProgress {
 
-	@SuppressWarnings("unused")
-	private static final Logger logger = Logger.getLogger(ChromatogramExportRunnable.class);
 	private File data;
 	private File file;
 	private IChromatogramCSD chromatogram;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/internal/support/ChromatogramExportRunnable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/internal/support/ChromatogramExportRunnable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.ux.extension.msd.ui.internal.support;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 
-import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.converter.ISupplier;
@@ -25,8 +24,6 @@ import org.eclipse.jface.operation.IRunnableWithProgress;
 
 public class ChromatogramExportRunnable implements IRunnableWithProgress {
 
-	@SuppressWarnings("unused")
-	private static final Logger logger = Logger.getLogger(ChromatogramExportRunnable.class);
 	private File data;
 	private File file;
 	private IChromatogramMSD chromatogram;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/MultiDataExplorerTreeUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/MultiDataExplorerTreeUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Lablicate GmbH.
+ * Copyright (c) 2019, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -144,7 +144,7 @@ public class MultiDataExplorerTreeUI {
 		return supplierFileIdentifierCache;
 	}
 
-	protected void handleDoubleClick(File file, DataExplorerTreeUI treeUI) {
+	protected void handleDoubleClick(File file) {
 
 		openEditor(file);
 	}
@@ -223,7 +223,7 @@ public class MultiDataExplorerTreeUI {
 			public void doubleClick(DoubleClickEvent event) {
 
 				File file = (File)((IStructuredSelection)event.getSelection()).getFirstElement();
-				handleDoubleClick(file, dataExplorerTreeUI);
+				handleDoubleClick(file);
 			}
 		});
 		//
@@ -339,7 +339,7 @@ public class MultiDataExplorerTreeUI {
 						public String getToolTipText() {
 
 							return activeFileSupplier.getDescription();
-						};
+						}
 					});
 				}
 				//
@@ -389,12 +389,11 @@ public class MultiDataExplorerTreeUI {
 		button.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		button.addSelectionListener(new SelectionAdapter() {
 
-			@SuppressWarnings("rawtypes")
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 
 				IStructuredSelection structuredSelection = treeUI.getTreeViewer().getStructuredSelection();
-				Iterator iterator = structuredSelection.iterator();
+				Iterator<?> iterator = structuredSelection.iterator();
 				while(iterator.hasNext()) {
 					Object object = iterator.next();
 					if(object instanceof File file) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.wsd.ui/src/org/eclipse/chemclipse/ux/extension/wsd/ui/internal/support/ChromatogramExportRunnable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.wsd.ui/src/org/eclipse/chemclipse/ux/extension/wsd/ui/internal/support/ChromatogramExportRunnable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.ux.extension.wsd.ui.internal.support;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 
-import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.processing.converter.ISupplier;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.chromatogram.ChromatogramConverterWSD;
@@ -25,8 +24,6 @@ import org.eclipse.jface.operation.IRunnableWithProgress;
 
 public class ChromatogramExportRunnable implements IRunnableWithProgress {
 
-	@SuppressWarnings("unused")
-	private static final Logger logger = Logger.getLogger(ChromatogramExportRunnable.class);
 	private File data;
 	private File file;
 	private IChromatogramWSD chromatogram;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ChromatogramReferencesUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ChromatogramReferencesUI.java
@@ -14,6 +14,7 @@
 package org.eclipse.chemclipse.ux.extension.xxd.ui.swt;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -36,6 +37,7 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
+import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.support.settings.OperatingSystemUtils;
 import org.eclipse.chemclipse.support.ui.swt.EditorToolBar;
 import org.eclipse.chemclipse.ux.extension.ui.provider.ISupplierEditorSupport;
@@ -177,21 +179,21 @@ public class ChromatogramReferencesUI {
 
 		if(checked) {
 			action.setToolTipText("Collapse the references items");
-			action.setImageDescriptor(ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_COLLAPSE_ALL, IApplicationImage.SIZE_16x16));
+			action.setImageDescriptor(ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_COLLAPSE_ALL, IApplicationImageProvider.SIZE_16x16));
 		} else {
 			action.setToolTipText("Expand the references items");
-			action.setImageDescriptor(ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_EXPAND_ALL, IApplicationImage.SIZE_16x16));
+			action.setImageDescriptor(ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_EXPAND_ALL, IApplicationImageProvider.SIZE_16x16));
 		}
 	}
 
 	private IChromatogramSelection<?, ?> createChromatogramSelection(IChromatogram<?> referencedChromatogram) {
 
-		if(referencedChromatogram instanceof IChromatogramCSD) {
-			return new ChromatogramSelectionCSD((IChromatogramCSD)referencedChromatogram);
-		} else if(referencedChromatogram instanceof IChromatogramMSD) {
-			return new ChromatogramSelectionMSD((IChromatogramMSD)referencedChromatogram);
-		} else if(referencedChromatogram instanceof IChromatogramWSD) {
-			return new ChromatogramSelectionWSD((IChromatogramWSD)referencedChromatogram);
+		if(referencedChromatogram instanceof IChromatogramCSD chromatogramCSD) {
+			return new ChromatogramSelectionCSD(chromatogramCSD);
+		} else if(referencedChromatogram instanceof IChromatogramMSD chromatogramMSD) {
+			return new ChromatogramSelectionMSD(chromatogramMSD);
+		} else if(referencedChromatogram instanceof IChromatogramWSD chromatogramWSD) {
+			return new ChromatogramSelectionWSD(chromatogramWSD);
 		} else {
 			return null;
 		}
@@ -223,7 +225,7 @@ public class ChromatogramReferencesUI {
 
 	private Action createButtonSelectPreviousChromatogram(EditorToolBar toolBar) {
 
-		Action action = new Action("Previous", ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_ARROW_BACKWARD, IApplicationImage.SIZE_16x16)) {
+		Action action = new Action("Previous", ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_ARROW_BACKWARD, IApplicationImageProvider.SIZE_16x16)) {
 
 			{
 				setToolTipText("Select previous chromatogram.");
@@ -277,8 +279,7 @@ public class ChromatogramReferencesUI {
 				@Override
 				public String getText(Object element) {
 
-					if(element instanceof IChromatogramSelection<?, ?>) {
-						IChromatogramSelection<?, ?> selection = (IChromatogramSelection<?, ?>)element;
+					if(element instanceof IChromatogramSelection<?, ?> selection) {
 						int index = comboChromatograms.indexOf(selection);
 						if(index > -1) {
 							/*
@@ -297,7 +298,7 @@ public class ChromatogramReferencesUI {
 
 	private Action createButtonSelectNextChromatogram(EditorToolBar toolBar) {
 
-		Action action = new Action("Next", ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_ARROW_FORWARD, IApplicationImage.SIZE_16x16)) {
+		Action action = new Action("Next", ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_ARROW_FORWARD, IApplicationImageProvider.SIZE_16x16)) {
 
 			{
 				setToolTipText("Select next chromatogram.");
@@ -317,7 +318,7 @@ public class ChromatogramReferencesUI {
 
 	private Action createButtonRemoveReference(EditorToolBar toolBar) {
 
-		Action action = new Action("Delete", ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_DELETE, IApplicationImage.SIZE_16x16)) {
+		Action action = new Action("Delete", ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_DELETE, IApplicationImageProvider.SIZE_16x16)) {
 
 			{
 				setToolTipText("Remove the reference chromatogram.");
@@ -345,7 +346,7 @@ public class ChromatogramReferencesUI {
 
 	private Action createButtonRemoveReferenceAll(EditorToolBar toolBar) {
 
-		Action action = new Action("Delete All", ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_DELETE_ALL, IApplicationImage.SIZE_16x16)) {
+		Action action = new Action("Delete All", ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_DELETE_ALL, IApplicationImageProvider.SIZE_16x16)) {
 
 			{
 				setToolTipText("Remove all reference chromatogram(s).");
@@ -375,7 +376,7 @@ public class ChromatogramReferencesUI {
 
 	private Action createButtonAddReference(EditorToolBar toolBar) {
 
-		Action action = new Action("Add", ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_ADD, IApplicationImage.SIZE_16x16)) {
+		Action action = new Action("Add", ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_ADD, IApplicationImageProvider.SIZE_16x16)) {
 
 			{
 				setToolTipText("Add a reference chromatogram.");
@@ -412,7 +413,7 @@ public class ChromatogramReferencesUI {
 
 	private Action createButtonImportReferences(EditorToolBar toolBar) {
 
-		Action action = new Action("Import", ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_IMPORT, IApplicationImage.SIZE_16x16)) {
+		Action action = new Action("Import", ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_IMPORT, IApplicationImageProvider.SIZE_16x16)) {
 
 			{
 				setToolTipText("Import reference chromatograms.");
@@ -443,8 +444,11 @@ public class ChromatogramReferencesUI {
 								addReferences(masterSelection, references);
 								comboChromatograms.refreshUI();
 								updateButtons();
-							} catch(Exception e) {
+							} catch(InterruptedException e) {
 								logger.error(e);
+								Thread.currentThread().interrupt();
+							} catch(InvocationTargetException e) {
+								logger.error(e.getCause());
 							}
 						}
 					}
@@ -487,7 +491,7 @@ public class ChromatogramReferencesUI {
 
 	private Action createButtonOpenReference(EditorToolBar toolBar) {
 
-		Action action = new Action("Open", ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_EXECUTE, IApplicationImage.SIZE_16x16)) {
+		Action action = new Action("Open", ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_EXECUTE, IApplicationImageProvider.SIZE_16x16)) {
 
 			{
 				setToolTipText("Open the chromatogram in a separate editor.");
@@ -614,10 +618,10 @@ public class ChromatogramReferencesUI {
 			this.data = data;
 			ComboViewer viewer = viewerReference.get();
 			if(viewer != null) {
-				viewer.setInput(data != null ? data : Collections.EMPTY_LIST);
+				viewer.setInput(data != null ? data : Collections.emptyList());
 				Control control = viewer.getControl();
 				if(!control.isDisposed()) {
-					control.setEnabled(data.size() > 1);
+					control.setEnabled(data != null && data.size() > 1);
 				}
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/wizards/InputEntriesWizardPage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/wizards/InputEntriesWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Lablicate GmbH.
+ * Copyright (c) 2011, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -65,7 +65,7 @@ public class InputEntriesWizardPage extends WizardPage {
 		}
 
 		@Override
-		protected void handleDoubleClick(File file, DataExplorerTreeUI treeUI) {
+		protected void handleDoubleClick(File file) {
 
 			IWizard wizard = page.getWizard();
 			if(wizard.canFinish()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/AbstractChromatogramWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/AbstractChromatogramWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -87,8 +87,8 @@ public abstract class AbstractChromatogramWSD extends AbstractChromatogram<IChro
 		int position = scan;
 		if(position > 0 && position <= getScans().size()) {
 			IScan storedScan = getScans().get(--position);
-			if(storedScan instanceof IScanWSD) {
-				return (IScanWSD)storedScan;
+			if(storedScan instanceof IScanWSD scanWSD) {
+				return scanWSD;
 			}
 		}
 		return null;
@@ -101,8 +101,8 @@ public abstract class AbstractChromatogramWSD extends AbstractChromatogram<IChro
 		/*
 		 * Fire an update to inform all listeners.
 		 */
-		if(chromatogramSelection instanceof ChromatogramSelectionWSD) {
-			((ChromatogramSelectionWSD)chromatogramSelection).update(true);
+		if(chromatogramSelection instanceof ChromatogramSelectionWSD chromatogramSelectionWSD) {
+			chromatogramSelectionWSD.update(true);
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/selection/ChromatogramSelectionWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/selection/ChromatogramSelectionWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.wsd.model.core.selection;
 
+import java.util.Optional;
+
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.exceptions.ChromatogramIsNullException;
@@ -25,7 +27,6 @@ import org.eclipse.chemclipse.wsd.model.core.IScanWSD;
 import org.eclipse.chemclipse.wsd.model.core.support.IMarkedWavelengths;
 import org.eclipse.chemclipse.wsd.model.core.support.MarkedWavelengths;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramSelectionWSD extends AbstractChromatogramSelection<IChromatogramPeakWSD, IChromatogramWSD> implements IChromatogramSelectionWSD {
 
 	private IScanWSD selectedScan;
@@ -51,10 +52,12 @@ public class ChromatogramSelectionWSD extends AbstractChromatogramSelection<IChr
 	@Override
 	public void populateWavelengths(IChromatogramWSD chromatogram) {
 
-		IScanWSD scan = (IScanWSD)chromatogram.getScans().stream().findFirst().get();
-		selectedWavelengths = new MarkedWavelengths();
-		for(IScanSignalWSD signal : scan.getScanSignals()) {
-			selectedWavelengths.add(signal.getWavelength());
+		Optional<IScan> scan = chromatogram.getScans().stream().findFirst();
+		if(!scan.isEmpty() && scan.get() instanceof IScanWSD scanWSD) {
+			selectedWavelengths = new MarkedWavelengths();
+			for(IScanSignalWSD signal : scanWSD.getScanSignals()) {
+				selectedWavelengths.add(signal.getWavelength());
+			}
 		}
 	}
 
@@ -66,11 +69,12 @@ public class ChromatogramSelectionWSD extends AbstractChromatogramSelection<IChr
 	}
 
 	@Override
+	@Deprecated
 	public IChromatogramWSD getChromatogramWSD() {
 
-		IChromatogram chromatogram = getChromatogram();
-		if(chromatogram instanceof IChromatogramWSD) {
-			return (IChromatogramWSD)chromatogram;
+		IChromatogram<?> chromatogram = getChromatogram();
+		if(chromatogram instanceof IChromatogramWSD chromatogramWSD) {
+			return chromatogramWSD;
 		}
 		return null;
 	}
@@ -91,7 +95,7 @@ public class ChromatogramSelectionWSD extends AbstractChromatogramSelection<IChr
 	public void reset(boolean fireUpdate) {
 
 		super.reset(fireUpdate);
-		IChromatogram chromatogram = getChromatogram();
+		IChromatogram<?> chromatogram = getChromatogram();
 		/*
 		 * Scan
 		 */
@@ -99,8 +103,8 @@ public class ChromatogramSelectionWSD extends AbstractChromatogramSelection<IChr
 			/*
 			 * Chromatogram WSD
 			 */
-			if(chromatogram instanceof IChromatogramWSD) {
-				selectedScan = ((IChromatogramWSD)chromatogram).getSupplierScan(1);
+			if(chromatogram instanceof IChromatogramWSD chromatogramWSD) {
+				selectedScan = chromatogramWSD.getSupplierScan(1);
 			}
 		} else {
 			selectedScan = null;
@@ -116,16 +120,16 @@ public class ChromatogramSelectionWSD extends AbstractChromatogramSelection<IChr
 	@Override
 	public void setSelectedScan(IScan selectedScan) {
 
-		if(selectedScan instanceof IScanWSD) {
-			setSelectedScan((IScanWSD)selectedScan);
+		if(selectedScan instanceof IScanWSD scanWSD) {
+			setSelectedScan(scanWSD);
 		}
 	}
 
 	@Override
 	public void setSelectedScan(IScan selectedScan, boolean update) {
 
-		if(selectedScan instanceof IScanWSD) {
-			setSelectedScan((IScanWSD)selectedScan, update);
+		if(selectedScan instanceof IScanWSD scanWSD) {
+			setSelectedScan(scanWSD, update);
 		}
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/chemclipse/io/PeakReaderMSDTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/chemclipse/io/PeakReaderMSDTestCase.java
@@ -26,8 +26,7 @@ import junit.framework.TestCase;
 @Ignore
 public class PeakReaderMSDTestCase extends TestCase {
 
-	@SuppressWarnings("rawtypes")
-	protected IPeaks peaks;
+	protected IPeaks<?> peaks;
 	protected String pathImport;
 	protected File fileImport;
 	private static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse.peaks";


### PR DESCRIPTION
including some easier to solve cases of the messy generics transition. Unused loggers are never a good idea, as instantiating them is not free.