### PR TITLE
Added back white background to charts

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/ChromatogramFilterReset.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/ChromatogramFilterReset.java
@@ -27,6 +27,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 @SuppressWarnings("rawtypes")
 public class ChromatogramFilterReset extends AbstractChromatogramFilter implements IChromatogramFilter {
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/ui/editors/BatchJobEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/ui/editors/BatchJobEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -17,7 +17,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import javax.xml.stream.XMLStreamException;
@@ -98,8 +97,7 @@ public class BatchJobEditor extends EditorPart implements IRunnableWithProgress 
 		fileName = fileName.substring(0, fileName.length() - 4);
 		setPartName(fileName);
 		//
-		if(batchProcessJob == null && input instanceof IFileEditorInput) {
-			IFileEditorInput fileEditorInput = (IFileEditorInput)input;
+		if(batchProcessJob == null && input instanceof IFileEditorInput fileEditorInput) {
 			file = fileEditorInput.getFile().getLocation().toFile();
 			//
 			ImportRunnable runnable = new ImportRunnable(file);
@@ -110,7 +108,7 @@ public class BatchJobEditor extends EditorPart implements IRunnableWithProgress 
 			} catch(InvocationTargetException e) {
 				throw new PartInitException("The file could't be loaded.", e.getTargetException());
 			} catch(InterruptedException e) {
-				return;
+				Thread.currentThread().interrupt();
 			}
 		} else {
 			throw new PartInitException("The file could't be loaded.");
@@ -148,11 +146,7 @@ public class BatchJobEditor extends EditorPart implements IRunnableWithProgress 
 		batchJobUI = new BatchJobUI(parent, supplierContext, Activator.getDefault().getPreferenceStore(), PreferenceSupplier.P_FILTER_PATH_IMPORT_RECORDS, dataTypes, this);
 		batchJobUI.setModificationHandler(this::updateDirtyStatus);
 		//
-		if(batchProcessJob != null) {
-			batchJobUI.doLoad(getBatchJobFiles(), new ProcessMethod(batchProcessJob.getProcessMethod()));
-		} else {
-			batchJobUI.doLoad(Collections.emptyList(), new ProcessMethod(ProcessMethod.CHROMATOGRAPHY));
-		}
+		batchJobUI.doLoad(getBatchJobFiles(), new ProcessMethod(batchProcessJob.getProcessMethod()));
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.compilation.community.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.compilation.community.ui/plugin.xml
@@ -30,6 +30,10 @@
                name="Version"
                value="0.9.0">
          </property>
+         <property
+               name="applicationCSS"
+               value="platform:/plugin/org.eclipse.chemclipse.rcp.app.ui/css/chemclipse.css">
+         </property>
       </product>
    </extension>
    <extension

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
@@ -89,7 +89,7 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 
 		deleteSeries();
 		if(massSpectrum != null) {
-			List<IBarSeriesData> barSeriesDataList = new ArrayList<IBarSeriesData>();
+			List<IBarSeriesData> barSeriesDataList = new ArrayList<>();
 			ISeriesData seriesData = getMassSpectrum(massSpectrum);
 			IBarSeriesData barSeriesData = new BarSeriesData(seriesData);
 			barSeriesDataList.add(barSeriesData);
@@ -102,7 +102,7 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 		numberOfHighestIntensitiesToLabel = 5;
 		barSeriesIonComparator = new BarSeriesIonComparator();
 		labelOption = LabelOption.EXACT;
-		customLabels = new HashMap<Double, String>();
+		customLabels = new HashMap<>();
 		//
 		IChartSettings chartSettings = getChartSettings();
 		chartSettings.setOrientation(SWT.HORIZONTAL);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -109,6 +109,10 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 		chartSettings.setHorizontalSliderVisible(true);
 		chartSettings.setVerticalSliderVisible(true);
 		chartSettings.setCreateMenu(true);
+		//
+		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 		//
 		chartSettings.addMenuEntry(new UpdateMenuEntry());
 		//

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
@@ -101,6 +101,10 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 		chartSettings.setVerticalSliderVisible(true);
 		chartSettings.setCreateMenu(true);
 		//
+		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		//
 		chartSettings.addMenuEntry(new UpdateMenuEntry());
 		addMassSpectrumFilter(chartSettings);
 		addMassSpectrumIdentifier(chartSettings);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartNMR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartNMR.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -150,6 +150,10 @@ public class ChartNMR extends LineChart {
 	private void initialize() {
 
 		modifyProcessed();
+		IChartSettings chartSettings = getChartSettings();
+		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 	}
 
 	private void modifyRaw() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartPCR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartPCR.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -75,6 +75,10 @@ public class ChartPCR extends LineChart {
 	private void initialize() {
 
 		modify();
+		IChartSettings chartSettings = getChartSettings();
+		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 	}
 
 	private void modify() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartXIR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartXIR.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -51,6 +51,10 @@ public class ChartXIR extends LineChart {
 
 	private void initialize(boolean isAbsorbance) {
 
+		IChartSettings chartSettings = getChartSettings();
+		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 		modifyProcessed(isAbsorbance);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChromatogramChart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChromatogramChart.java
@@ -93,6 +93,10 @@ public class ChromatogramChart extends LineChart {
 		rangeRestriction.setRestrictZoomX(false);
 		rangeRestriction.setRestrictZoomY(true);
 		//
+		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		//
 		modifyAxes(true);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ChromatogramHeatmapUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ChromatogramHeatmapUI.java
@@ -415,7 +415,7 @@ public class ChromatogramHeatmapUI extends Composite implements IExtendedPartUI 
 
 		Canvas canvas = new Canvas(parent, SWT.FILL | SWT.BORDER);
 		canvas.setLayoutData(new GridData(GridData.FILL_BOTH));
-		canvas.setBackground(getDisplay().getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
+		canvas.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 		//
 		lightweightSystem = createLightweightSystem(canvas);
 		//
@@ -425,7 +425,7 @@ public class ChromatogramHeatmapUI extends Composite implements IExtendedPartUI 
 	private LightweightSystem createLightweightSystem(Canvas canvas) {
 
 		LightweightSystem lightweightSystem = new LightweightSystem(canvas);
-		lightweightSystem.getRootFigure().setBackgroundColor(getDisplay().getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
+		lightweightSystem.getRootFigure().setBackgroundColor(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 		//
 		return lightweightSystem;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedCombinedScanUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedCombinedScanUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.chemclipse.converter.exceptions.NoConverterAvailableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogram;
+import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.types.DataType;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -92,6 +93,7 @@ public class ExtendedCombinedScanUI extends Composite implements IExtendedPartUI
 		createControl();
 	}
 
+	@Override
 	public boolean setFocus() {
 
 		updateScan();
@@ -109,8 +111,7 @@ public class ExtendedCombinedScanUI extends Composite implements IExtendedPartUI
 			chromatogramSelection = null;
 			combinedMassSpectrum = null;
 			//
-			if(object instanceof IChromatogramSelectionMSD) {
-				IChromatogramSelectionMSD chromatogramSelectionMSD = (IChromatogramSelectionMSD)object;
+			if(object instanceof IChromatogramSelectionMSD chromatogramSelectionMSD) {
 				this.chromatogramSelection = chromatogramSelectionMSD;
 				boolean useNormalize = PreferenceSupplier.isUseNormalizedScan();
 				CalculationType calculationType = PreferenceSupplier.getCalculationType();
@@ -176,7 +177,7 @@ public class ExtendedCombinedScanUI extends Composite implements IExtendedPartUI
 		composite.setLayout(new GridLayout(1, true));
 		//
 		tabFolder = new TabFolder(composite, SWT.BOTTOM);
-		tabFolder.setBackground(getDisplay().getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
+		tabFolder.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 		tabFolder.setLayoutData(new GridData(GridData.FILL_BOTH));
 		tabFolder.addSelectionListener(new SelectionAdapter() {
 
@@ -249,11 +250,10 @@ public class ExtendedCombinedScanUI extends Composite implements IExtendedPartUI
 			if(index >= 0) {
 				TableItem tableItem = table.getItem(index);
 				Object object = tableItem.getData();
-				if(object instanceof IIdentificationTarget) {
+				if(object instanceof IIdentificationTarget identificationTarget) {
 					/*
 					 * First update the mass spectrum.
 					 */
-					IIdentificationTarget identificationTarget = (IIdentificationTarget)object;
 					if(combinedMassSpectrum != null) {
 						UpdateNotifierUI.update(display, combinedMassSpectrum, identificationTarget);
 					}
@@ -292,7 +292,7 @@ public class ExtendedCombinedScanUI extends Composite implements IExtendedPartUI
 
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Lock the combined scan.");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -308,7 +308,7 @@ public class ExtendedCombinedScanUI extends Composite implements IExtendedPartUI
 	private void updateStatus() {
 
 		buttonLocked.setToolTipText(locked ? "Edit modus: on" : "Edit modus: off");
-		buttonLocked.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT, IApplicationImage.SIZE_16x16, locked));
+		buttonLocked.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT, IApplicationImageProvider.SIZE_16x16, locked));
 		updateLabel(labelEdit, locked ? "Edit On" : "");
 		updateButtons();
 	}
@@ -451,8 +451,7 @@ public class ExtendedCombinedScanUI extends Composite implements IExtendedPartUI
 		Object[] scanIdentifierServices = Activator.getDefault().getScanIdentifierServices();
 		if(scanIdentifierServices != null) {
 			for(Object object : scanIdentifierServices) {
-				if(object instanceof IScanIdentifierService) {
-					IScanIdentifierService scanIdentifierService = (IScanIdentifierService)object;
+				if(object instanceof IScanIdentifierService scanIdentifierService) {
 					DataType dataType = scanIdentifierService.getDataType();
 					if(DataType.MSD.equals(dataType)) {
 						Class<? extends IWorkbenchPreferencePage> preferencePage = scanIdentifierService.getPreferencePage();
@@ -499,8 +498,7 @@ public class ExtendedCombinedScanUI extends Composite implements IExtendedPartUI
 	private String getCombinedRangeInfo(Object object) {
 
 		StringBuilder builder = new StringBuilder();
-		if(object instanceof IChromatogramSelectionMSD) {
-			IChromatogramSelectionMSD chromatogramSelectionMSD = (IChromatogramSelectionMSD)object;
+		if(object instanceof IChromatogramSelectionMSD chromatogramSelectionMSD) {
 			int startRetentionTime = chromatogramSelectionMSD.getStartRetentionTime();
 			int stopRetentionTime = chromatogramSelectionMSD.getStopRetentionTime();
 			IChromatogram<?> chromatogram = chromatogramSelectionMSD.getChromatogram();
@@ -509,9 +507,9 @@ public class ExtendedCombinedScanUI extends Composite implements IExtendedPartUI
 			builder.append("–");
 			builder.append(chromatogram.getScanNumber(stopRetentionTime));
 			builder.append(" | RT range: ");
-			builder.append(decimalFormat.format((double)startRetentionTime / IChromatogram.MINUTE_CORRELATION_FACTOR));
+			builder.append(decimalFormat.format(startRetentionTime / IChromatogramOverview.MINUTE_CORRELATION_FACTOR));
 			builder.append("–");
-			builder.append(decimalFormat.format((double)stopRetentionTime / IChromatogram.MINUTE_CORRELATION_FACTOR));
+			builder.append(decimalFormat.format(stopRetentionTime / IChromatogramOverview.MINUTE_CORRELATION_FACTOR));
 			builder.append(" | Calculation Type: ");
 			builder.append(PreferenceSupplier.getCalculationType().toString());
 		} else {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakChartUI.java
@@ -24,6 +24,7 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferenceConstant
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.PeakChartSupport;
 import org.eclipse.chemclipse.wsd.model.core.IPeakWSD;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swtchart.ILineSeries;
@@ -55,6 +56,7 @@ public class PeakChartUI extends ScrollableChart {
 		super();
 		modifyChart();
 		setChartType(ChartType.LINE);
+		initialize();
 	}
 
 	public PeakChartUI(Composite parent, int style) {
@@ -62,6 +64,7 @@ public class PeakChartUI extends ScrollableChart {
 		super(parent, style);
 		modifyChart();
 		setChartType(ChartType.LINE);
+		initialize();
 	}
 
 	public void setInput(IPeak peak) {
@@ -81,7 +84,7 @@ public class PeakChartUI extends ScrollableChart {
 		if(peak1 != null) {
 			//
 			modifyChart(peak1);
-			List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
+			List<ILineSeriesData> lineSeriesDataList = new ArrayList<>();
 			lineSeriesDataList.addAll(getPeakSeriesData(peak1, false, "Peak1"));
 			lineSeriesDataList.addAll(getPeakSeriesData(peak2, false, "Peak2"));
 			addLineSeriesData(lineSeriesDataList);
@@ -93,7 +96,7 @@ public class PeakChartUI extends ScrollableChart {
 		prepareChart();
 		if(peaks != null && !peaks.isEmpty()) {
 			modifyChart(peaks.get(0));
-			List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
+			List<ILineSeriesData> lineSeriesDataList = new ArrayList<>();
 			for(int i = 0; i < peaks.size(); i++) {
 				IPeak peak = peaks.get(i);
 				if(peak != null) {
@@ -118,9 +121,17 @@ public class PeakChartUI extends ScrollableChart {
 		ChartSupport.addSecondaryAxisY(chartSettings, titleY1);
 	}
 
+	private void initialize() {
+
+		IChartSettings chartSettings = getChartSettings();
+		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+	}
+
 	private List<ILineSeriesData> getPeakSeriesData(IPeak peak, boolean mirrored, String postfix) {
 
-		List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
+		List<ILineSeriesData> lineSeriesDataList = new ArrayList<>();
 		IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
 		boolean includeBackground = preferenceStore.getBoolean(PreferenceConstants.P_SHOW_PEAK_BACKGROUND);
 		/*
@@ -221,7 +232,7 @@ public class PeakChartUI extends ScrollableChart {
 		/*
 		 * Suspend the update when adding new data to improve the performance.
 		 */
-		if(lineSeriesDataList != null && lineSeriesDataList.size() > 0) {
+		if(lineSeriesDataList != null && !lineSeriesDataList.isEmpty()) {
 			BaseChart baseChart = getBaseChart();
 			baseChart.suspendUpdate(true);
 			for(ILineSeriesData lineSeriesData : lineSeriesDataList) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakChartUI.java
@@ -124,6 +124,7 @@ public class PeakChartUI extends ScrollableChart {
 	private void initialize() {
 
 		IChartSettings chartSettings = getChartSettings();
+		chartSettings.setTitleVisible(false);
 		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakTracesUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakTracesUI.java
@@ -134,6 +134,7 @@ public class PeakTracesUI extends ScrollableChart {
 	private void initialize() {
 
 		IChartSettings chartSettings = getChartSettings();
+		chartSettings.setTitleVisible(false);
 		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakTracesUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakTracesUI.java
@@ -47,6 +47,7 @@ import org.eclipse.chemclipse.wsd.model.core.IScanWSD;
 import org.eclipse.chemclipse.wsd.model.core.support.IMarkedWavelengths;
 import org.eclipse.chemclipse.wsd.model.core.support.MarkedWavelengths;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swtchart.ILineSeries;
 import org.eclipse.swtchart.IPlotArea;
@@ -79,6 +80,7 @@ public class PeakTracesUI extends ScrollableChart {
 		super();
 		modifyChart();
 		setChartType(ChartType.LINE);
+		initialize();
 	}
 
 	public PeakTracesUI(Composite parent, int style) {
@@ -86,6 +88,7 @@ public class PeakTracesUI extends ScrollableChart {
 		super(parent, style);
 		modifyChart();
 		setChartType(ChartType.LINE);
+		initialize();
 	}
 
 	public List<Integer> getTraces() {
@@ -126,6 +129,14 @@ public class PeakTracesUI extends ScrollableChart {
 		}
 		//
 		addLineSeriesData(lineSeriesDataList);
+	}
+
+	private void initialize() {
+
+		IChartSettings chartSettings = getChartSettings();
+		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 	}
 
 	private List<ILineSeriesData> extractSIC(IChromatogramPeakMSD chromatogramPeak) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
@@ -40,6 +40,7 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.ScanDataSupport
 import org.eclipse.chemclipse.wsd.model.core.IScanWSD;
 import org.eclipse.chemclipse.xir.model.core.IScanISD;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
@@ -348,6 +349,10 @@ public class ScanChartUI extends ScrollableChart {
 		dataType = DataType.AUTO_DETECT;
 		signalType = SignalType.AUTO_DETECT;
 		modifyChart(DataType.MSD_NOMINAL, signalType);
+		IChartSettings chartSettings = getChartSettings();
+		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 	}
 
 	private DataType determineDataType(IScan scan) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
@@ -48,7 +48,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swtchart.IBarSeries;
 import org.eclipse.swtchart.IBarSeries.BarWidthStyle;
 import org.eclipse.swtchart.ICustomPaintListener;
-import org.eclipse.swtchart.ILineSeries;
 import org.eclipse.swtchart.IPlotArea;
 import org.eclipse.swtchart.ISeries;
 import org.eclipse.swtchart.extensions.barcharts.IBarSeriesData;
@@ -89,7 +88,7 @@ public class ScanChartUI extends ScrollableChart {
 	private DecimalFormat decimalFormatNormalIntensity = ValueFormat.getDecimalFormatEnglish("0");
 	private DecimalFormat decimalFormatLowIntensity = ValueFormat.getDecimalFormatEnglish("0.0000");
 	private ScanChartSupport scanChartSupport = new ScanChartSupport();
-	private Font font = DisplayUtils.getDisplay().getSystemFont();
+	private Font systemFont = DisplayUtils.getDisplay().getSystemFont();
 	//
 	private ScanDataSupport scanDataSupport = new ScanDataSupport();
 
@@ -130,11 +129,9 @@ public class ScanChartUI extends ScrollableChart {
 					BarSeriesValue barSeriesValue = barSeriesValues.get(i);
 					printLabel(barSeriesValue, useX, e);
 				} else {
-					if(addModuloLabels) {
-						if(i % modulo == 0) {
-							BarSeriesValue barSeriesValue = barSeriesValues.get(i);
-							printLabel(barSeriesValue, useX, e);
-						}
+					if(addModuloLabels && i % modulo == 0) {
+						BarSeriesValue barSeriesValue = barSeriesValues.get(i);
+						printLabel(barSeriesValue, useX, e);
 					}
 				}
 			}
@@ -277,7 +274,7 @@ public class ScanChartUI extends ScrollableChart {
 	@Override
 	public void dispose() {
 
-		font.dispose();
+		systemFont.dispose();
 		super.dispose();
 	}
 
@@ -472,7 +469,7 @@ public class ScanChartUI extends ScrollableChart {
 		String name = preferenceStore.getString(PreferenceConstants.P_SCAN_LABEL_FONT_NAME);
 		int height = preferenceStore.getInt(PreferenceConstants.P_SCAN_LABEL_FONT_SIZE);
 		int style = preferenceStore.getInt(PreferenceConstants.P_SCAN_LABEL_FONT_STYLE);
-		font = Fonts.getCachedFont(getBaseChart().getDisplay(), name, height, style);
+		systemFont = Fonts.getCachedFont(getBaseChart().getDisplay(), name, height, style);
 		//
 		labelHighestIntensities = preferenceStore.getInt(PreferenceConstants.P_SCAN_LABEL_HIGHEST_INTENSITIES);
 		addModuloLabels = preferenceStore.getBoolean(PreferenceConstants.P_SCAN_LABEL_MODULO_INTENSITIES);
@@ -585,7 +582,6 @@ public class ScanChartUI extends ScrollableChart {
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void addLineSeriesData(List<ILineSeriesData> lineSeriesDataList) {
 
 		/*
@@ -603,7 +599,7 @@ public class ScanChartUI extends ScrollableChart {
 					ISeriesData optimizedSeriesData = calculateSeries(seriesData, COMPRESS_TO_LENGTH);
 					ILineSeriesSettings lineSeriesSettings = lineSeriesData.getSettings();
 					lineSeriesSettings.getSeriesSettingsHighlight(); // Initialize
-					ILineSeries lineSeries = (ILineSeries)createSeries(optimizedSeriesData, lineSeriesSettings);
+					ISeries<?> lineSeries = createSeries(optimizedSeriesData, lineSeriesSettings);
 					baseChart.applySeriesSettings(lineSeries, lineSeriesSettings);
 				} catch(SeriesException e) {
 					//
@@ -634,7 +630,7 @@ public class ScanChartUI extends ScrollableChart {
 	private void printLabel(BarSeriesValue barSeriesValue, boolean useX, PaintEvent e) {
 
 		Font currentFont = e.gc.getFont();
-		e.gc.setFont(font);
+		e.gc.setFont(systemFont);
 		//
 		Point point = barSeriesValue.getPoint();
 		String label = (useX) ? getLabel(barSeriesValue.getX()) : getLabel(barSeriesValue.getY());
@@ -677,14 +673,13 @@ public class ScanChartUI extends ScrollableChart {
 		return label;
 	}
 
-	@SuppressWarnings({"rawtypes"})
 	private List<BarSeriesValue> getBarSeriesValuesList() {
 
 		List<BarSeriesValue> barSeriesIons = new ArrayList<>();
 		//
 		int widthPlotArea = getBaseChart().getPlotArea().getSize().x;
-		ISeries[] series = getBaseChart().getSeriesSet().getSeries();
-		for(ISeries barSeries : series) {
+		ISeries<?>[] series = getBaseChart().getSeriesSet().getSeries();
+		for(ISeries<?> barSeries : series) {
 			if(barSeries != null) {
 				//
 				double[] xSeries = barSeries.getXSeries();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanTableUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanTableUI.java
@@ -12,9 +12,8 @@
 package org.eclipse.chemclipse.ux.extension.xxd.ui.swt;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
-import java.util.Map;
 
 import org.eclipse.chemclipse.csd.model.core.IScanCSD;
 import org.eclipse.chemclipse.logging.core.Logger;
@@ -40,7 +39,6 @@ import org.eclipse.jface.viewers.IContentProvider;
 import org.eclipse.jface.viewers.ITableLabelProvider;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.jface.viewers.ViewerComparator;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 
@@ -48,9 +46,9 @@ public class ScanTableUI extends ExtendedTableViewer {
 
 	private static final Logger logger = Logger.getLogger(ScanTableUI.class);
 	//
-	private Map<DataType, ITableLabelProvider> labelProviderMap;
-	private Map<DataType, ViewerComparator> viewerComparatorMap;
-	private Map<DataType, IContentProvider> contentProviderMap;
+	private EnumMap<DataType, ITableLabelProvider> labelProviderMap;
+	private EnumMap<DataType, ViewerComparator> viewerComparatorMap;
+	private EnumMap<DataType, IContentProvider> contentProviderMap;
 	//
 	private ScanSignalListFilter scanSignalListFilter;
 	private IScan scan = null;
@@ -60,9 +58,9 @@ public class ScanTableUI extends ExtendedTableViewer {
 	public ScanTableUI(Composite parent, int style) {
 
 		super(parent, style);
-		labelProviderMap = new HashMap<DataType, ITableLabelProvider>();
-		viewerComparatorMap = new HashMap<DataType, ViewerComparator>();
-		contentProviderMap = new HashMap<DataType, IContentProvider>();
+		labelProviderMap = new EnumMap<>(DataType.class);
+		viewerComparatorMap = new EnumMap<>(DataType.class);
+		contentProviderMap = new EnumMap<>(DataType.class);
 		setLabelAndContentProviders(DataType.MSD_NOMINAL);
 	}
 
@@ -203,7 +201,7 @@ public class ScanTableUI extends ExtendedTableViewer {
 		}
 		//
 		scanSignalListFilter = new ScanSignalListFilter();
-		setFilters(new ViewerFilter[]{scanSignalListFilter});
+		setFilters(scanSignalListFilter);
 		setEditingSupport();
 	}
 

--- a/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
+++ b/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
@@ -88,6 +88,7 @@ Contributors:
    </preferencesInfo>
 
    <cssInfo>
+      <file path="/org.eclipse.chemclipse.rcp.app.ui/css/chemclipse.css"/>
    </cssInfo>
 
 </product>


### PR DESCRIPTION
https://github.com/eclipse/swtchart/pull/341 gives them a grayish look which might be good for uninitialized graphs, but I didn't want to change the existing proven color scheme where chromatograms get the same color as lists which is white in bright mode.