### PR TITLE
Update SLF4J and add Logback to diagnose thirdparty library problems

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
@@ -1013,13 +1013,6 @@ http://www.eclipse.org/legal/epl-v10.html
          unpack="false"/>
 
    <plugin
-         id="org.slf4j.api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.w3c.dom.events"
          download-size="0"
          install-size="0"
@@ -1187,4 +1180,26 @@ http://www.eclipse.org/legal/epl-v10.html
          version="0.0.0"
          fragment="true"
          unpack="false"/>
+
+   <plugin
+         id="ch.qos.logback.classic"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="ch.qos.logback.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="slf4j.api"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
@@ -1173,4 +1173,18 @@ http://www.eclipse.org/legal/epl-v10.html
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.ui.monitoring"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.ui.monitoring.nl_de"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
@@ -476,19 +476,4 @@ http://www.eclipse.org/legal/epl-v10.html
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="org.eclipse.ui.monitoring"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.ui.monitoring.nl_de"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         fragment="true"
-         unpack="false"/>
-
 </feature>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/META-INF/MANIFEST.MF
@@ -23,5 +23,7 @@ Require-Bundle: org.eclipse.core.runtime,
  wrapped.org.apache.httpcomponents.httpclient;bundle-version="4.5.14",
  wrapped.org.apache.httpcomponents.httpcore;bundle-version="4.4.16",
  slf4j.api;bundle-version="1.7.36",
+ com.github.jsonld-java;bundle-version="0.13.4",
+ wrapped.org.apache.httpcomponents.httpclient-cache;bundle-version="4.5.14"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/META-INF/MANIFEST.MF
@@ -22,6 +22,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.apache.commons.commons-compress;bundle-version="1.22.0",
  wrapped.org.apache.httpcomponents.httpclient;bundle-version="4.5.14",
  wrapped.org.apache.httpcomponents.httpcore;bundle-version="4.4.16",
- org.slf4j.api;bundle-version="1.7.30"
+ slf4j.api;bundle-version="1.7.36",
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -249,6 +249,12 @@
 		<dependencies>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpclient-cache</artifactId>
+				<version>4.5.14</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpclient</artifactId>
 				<version>4.5.14</version>
 				<type>jar</type>
@@ -299,12 +305,22 @@
 			</dependency>
 		</dependencies>
 	</location>
-	<location includeDependencyDepth="none" includeSource="true" missingManifest="generate" type="Maven">
+	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
 		<dependencies>
 			<dependency>
 				<groupId>org.apache.xmlbeans</groupId>
 				<artifactId>xmlbeans</artifactId>
 				<version>3.1.0</version>
+				<type>jar</type>
+			</dependency>
+		</dependencies>
+	</location>
+	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
+		<dependencies>
+			<dependency>
+				<groupId>com.github.jsonld-java</groupId>
+				<artifactId>jsonld-java</artifactId>
+				<version>0.13.4</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -11,6 +11,8 @@
 	<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 	<unit id="javax.activation" version="0.0.0"/>
 	<unit id="javax.annotation" version="0.0.0"/>
+	<unit id="ch.qos.logback.classic" version="0.0.0"/>
+	<unit id="ch.qos.logback.core" version="0.0.0"/>
 	<repository location="https://download.eclipse.org/releases/2023-03/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -33,6 +35,12 @@
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
 				<version>1.15</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>2.11.0</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Update SLF4J according to https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/588 and setup [SLF4J in eclipse applications](https://www.vogella.com/tutorials/EclipseLogging/article.html#slf4j-in-eclipse-applications) which revealed a dependency problem that was hidden by our previous no-operation logging.