### PR TITLE
Fixed theme problems on Windows

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/classic.css
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/classic.css
@@ -36,6 +36,22 @@ Composite#org-eclipse-chemclipse-ux-extension-ui-views-welcomeview-background {
 	visibility:visible;
 }
 
+BaseChart {
+	background-color: #FFFFFF;
+}
+
+ChromatogramChart {
+	background-color: #FFFFFF;
+}
+
+CLabel {
+  background-color: #FFFFFF;
+}
+
+CTabFolder:selected {
+	background-color: #FFFFFF;
+}
+
 #SearchField {
 	visibility:visible; /* hidden */
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/dark.css
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/dark.css
@@ -36,6 +36,10 @@ Composite#org-eclipse-chemclipse-ux-extension-ui-views-welcomeview-background {
 	visibility:visible;
 }
 
+ToolItem {
+  color: #FFFFFF;
+}
+
 #SearchField {
 	visibility:visible; /* hidden */
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/default.css
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/default.css
@@ -36,6 +36,22 @@ Composite#org-eclipse-chemclipse-ux-extension-ui-views-welcomeview-background {
 	visibility:visible;
 }
 
+BaseChart {
+	background-color: #FFFFFF;
+}
+
+ChromatogramChart {
+	background-color: #FFFFFF;
+}
+
+CLabel {
+  background-color: #FFFFFF;
+}
+
+CTabFolder:selected {
+	background-color: #FFFFFF;
+}
+
 #SearchField {
 	visibility:visible; /* hidden */
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
@@ -110,10 +110,6 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 		chartSettings.setVerticalSliderVisible(true);
 		chartSettings.setCreateMenu(true);
 		//
-		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		//
 		chartSettings.addMenuEntry(new UpdateMenuEntry());
 		//
 		RangeRestriction rangeRestriction = chartSettings.getRangeRestriction();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
@@ -101,10 +101,6 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 		chartSettings.setVerticalSliderVisible(true);
 		chartSettings.setCreateMenu(true);
 		//
-		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		//
 		chartSettings.addMenuEntry(new UpdateMenuEntry());
 		addMassSpectrumFilter(chartSettings);
 		addMassSpectrumIdentifier(chartSettings);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartNMR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartNMR.java
@@ -150,10 +150,6 @@ public class ChartNMR extends LineChart {
 	private void initialize() {
 
 		modifyProcessed();
-		IChartSettings chartSettings = getChartSettings();
-		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 	}
 
 	private void modifyRaw() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartPCR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartPCR.java
@@ -76,6 +76,7 @@ public class ChartPCR extends LineChart {
 
 		modify();
 		IChartSettings chartSettings = getChartSettings();
+		chartSettings.setTitleVisible(false);
 	}
 
 	private void modify() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartPCR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartPCR.java
@@ -76,9 +76,6 @@ public class ChartPCR extends LineChart {
 
 		modify();
 		IChartSettings chartSettings = getChartSettings();
-		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 	}
 
 	private void modify() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartXIR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartXIR.java
@@ -51,10 +51,6 @@ public class ChartXIR extends LineChart {
 
 	private void initialize(boolean isAbsorbance) {
 
-		IChartSettings chartSettings = getChartSettings();
-		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 		modifyProcessed(isAbsorbance);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChromatogramChart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChromatogramChart.java
@@ -93,10 +93,6 @@ public class ChromatogramChart extends LineChart {
 		rangeRestriction.setRestrictZoomX(false);
 		rangeRestriction.setRestrictZoomY(true);
 		//
-		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		//
 		modifyAxes(true);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakChartUI.java
@@ -24,7 +24,6 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferenceConstant
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.PeakChartSupport;
 import org.eclipse.chemclipse.wsd.model.core.IPeakWSD;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swtchart.ILineSeries;
@@ -125,9 +124,6 @@ public class PeakChartUI extends ScrollableChart {
 
 		IChartSettings chartSettings = getChartSettings();
 		chartSettings.setTitleVisible(false);
-		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 	}
 
 	private List<ILineSeriesData> getPeakSeriesData(IPeak peak, boolean mirrored, String postfix) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakTracesUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakTracesUI.java
@@ -47,7 +47,6 @@ import org.eclipse.chemclipse.wsd.model.core.IScanWSD;
 import org.eclipse.chemclipse.wsd.model.core.support.IMarkedWavelengths;
 import org.eclipse.chemclipse.wsd.model.core.support.MarkedWavelengths;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swtchart.ILineSeries;
 import org.eclipse.swtchart.IPlotArea;
@@ -135,9 +134,6 @@ public class PeakTracesUI extends ScrollableChart {
 
 		IChartSettings chartSettings = getChartSettings();
 		chartSettings.setTitleVisible(false);
-		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 	}
 
 	private List<ILineSeriesData> extractSIC(IChromatogramPeakMSD chromatogramPeak) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
@@ -40,7 +40,6 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.ScanDataSupport
 import org.eclipse.chemclipse.wsd.model.core.IScanWSD;
 import org.eclipse.chemclipse.xir.model.core.IScanISD;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
@@ -349,10 +348,6 @@ public class ScanChartUI extends ScrollableChart {
 		dataType = DataType.AUTO_DETECT;
 		signalType = SignalType.AUTO_DETECT;
 		modifyChart(DataType.MSD_NOMINAL, signalType);
-		IChartSettings chartSettings = getChartSettings();
-		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
-		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 	}
 
 	private DataType determineDataType(IScan scan) {


### PR DESCRIPTION
On Windows, setting the default SWT colors causes flickering and inconsistencies between the backgrounds, so I try to fix this with CSS instead, which also allows per OS workarounds.