### PR TITLE
Style charts and tables instead of tabs

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/classic.css
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/classic.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -29,29 +29,18 @@
 	padding:0px 5px 7px;
 }
 
-Composite#org-eclipse-chemclipse-ux-extension-ui-views-welcomeview-background {
-	background-color:gradient linear #909090 #FFFFFF 70%;
-	background-image:none;
-	text-transform:none;
-	visibility:visible;
-}
-
-BaseChart {
+.ScrollableChart {
 	background-color: #FFFFFF;
 }
 
-ChromatogramChart {
-	background-color: #FFFFFF;
-}
-
-CLabel {
-  background-color: #FFFFFF;
-}
-
-CTabFolder:selected {
+.BaseChart {
 	background-color: #FFFFFF;
 }
 
 #SearchField {
 	visibility:visible; /* hidden */
+}
+
+Table {
+  background-color: #FFFFFF;
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/dark.css
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/dark.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -29,17 +29,22 @@
 	padding:0px 5px 7px;
 }
 
-Composite#org-eclipse-chemclipse-ux-extension-ui-views-welcomeview-background {
-	background-color:gradient linear #909090 #FFFFFF 70%;
-	background-image:none;
-	text-transform:none;
-	visibility:visible;
+.ScrollableChart {
+	background-color: #2f2f2f;
 }
 
-ToolItem {
-	color: #FFFFFF;
+.BaseChart {
+	background-color: #2f2f2f;
 }
 
 #SearchField {
 	visibility:visible; /* hidden */
+}
+
+Table {
+  background-color: #2f2f2f;
+}
+
+ToolItem {
+	color: #FFFFFF;
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/default.css
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/default.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -29,33 +29,18 @@
 	padding:0px 5px 7px;
 }
 
-Composite#org-eclipse-chemclipse-ux-extension-ui-views-welcomeview-background {
-	background-color:gradient linear #909090 #FFFFFF 70%;
-	background-image:none;
-	text-transform:none;
-	visibility:visible;
-}
-
-BaseChart {
+.ScrollableChart {
 	background-color: #FFFFFF;
 }
 
-ChromatogramChart {
-	background-color: #FFFFFF;
-}
-
-CLabel {
-  background-color: #FFFFFF;
-}
-
-CTabFolder {
-	background-color: #FFFFFF;
-}
-
-CTabItem {
+.BaseChart {
 	background-color: #FFFFFF;
 }
 
 #SearchField {
 	visibility:visible; /* hidden */
+}
+
+Table {
+  background-color: #FFFFFF;
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/editors/AbstractExtendedEditorPage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/editors/AbstractExtendedEditorPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,7 +18,6 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.forms.widgets.FormToolkit;
@@ -48,12 +47,12 @@ public abstract class AbstractExtendedEditorPage implements IExtendedEditorPage 
 	 * @param fillBody
 	 */
 	public AbstractExtendedEditorPage(String pageName, Composite container, boolean fillBody) {
+
 		/*
 		 * Create the parent composite.
 		 */
 		control = new Composite(container, SWT.NONE);
 		control.setLayout(new FillLayout());
-		control.setBackground(Display.getCurrent().getSystemColor(SWT.COLOR_WHITE));
 		/*
 		 * Forms API
 		 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChromatogramChart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChromatogramChart.java
@@ -84,6 +84,10 @@ public class ChromatogramChart extends LineChart {
 		chartSettings.setOrientation(SWT.HORIZONTAL);
 		chartSettings.setHorizontalSliderVisible(true);
 		chartSettings.setVerticalSliderVisible(false);
+		// Use background from StyleSheet.
+		chartSettings.setBackground(null);
+		chartSettings.setBackgroundChart(null);
+		chartSettings.setBackgroundPlotArea(null);
 		//
 		RangeRestriction rangeRestriction = chartSettings.getRangeRestriction();
 		rangeRestriction.setZeroX(true);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
@@ -154,12 +154,10 @@ public class ScanChartUI extends ScrollableChart {
 						printLabel(barSeriesValue, useX, e);
 					}
 				} else {
-					if(addModuloLabels) {
-						if(i % modulo == 0) {
-							BarSeriesValue barSeriesValue = barSeriesValues.get(i);
-							if(barSeriesValue.getY() < 0) {
-								printLabel(barSeriesValue, useX, e);
-							}
+					if(addModuloLabels && i % modulo == 0) {
+						BarSeriesValue barSeriesValue = barSeriesValues.get(i);
+						if(barSeriesValue.getY() < 0) {
+							printLabel(barSeriesValue, useX, e);
 						}
 					}
 				}
@@ -177,12 +175,14 @@ public class ScanChartUI extends ScrollableChart {
 
 		super();
 		setDefaultDataAndSignalType();
+		useBackgroundFromStyleSheet();
 	}
 
 	public ScanChartUI(Composite parent, int style) {
 
 		super(parent, style);
 		setDefaultDataAndSignalType();
+		useBackgroundFromStyleSheet();
 	}
 
 	public void setInput(IScan scan) {
@@ -351,6 +351,14 @@ public class ScanChartUI extends ScrollableChart {
 		dataType = DataType.AUTO_DETECT;
 		signalType = SignalType.AUTO_DETECT;
 		modifyChart(DataType.MSD_NOMINAL, signalType);
+	}
+
+	private void useBackgroundFromStyleSheet() {
+
+		IChartSettings chartSettings = getChartSettings();
+		chartSettings.setBackground(null);
+		chartSettings.setBackgroundChart(null);
+		chartSettings.setBackgroundPlotArea(null);
 	}
 
 	private DataType determineDataType(IScan scan) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/chart2d/AbtractPlotPCA.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/chart2d/AbtractPlotPCA.java
@@ -109,6 +109,9 @@ public abstract class AbtractPlotPCA extends ScatterChart {
 		} else {
 			chartSettings.setTitleColor(DisplayUtils.getDisplay().getSystemColor(SWT.COLOR_BLACK));
 		}
+		chartSettings.setBackground(null);
+		chartSettings.setBackgroundChart(null);
+		chartSettings.setBackgroundPlotArea(null);
 		chartSettings.setOrientation(SWT.HORIZONTAL);
 		chartSettings.setHorizontalSliderVisible(false);
 		chartSettings.setVerticalSliderVisible(false);


### PR DESCRIPTION
This depends on https://github.com/eclipse/swtchart/pull/348 which now allows charts to be styled individually. https://github.com/eclipse/chemclipse/pull/1365 actually styled the containers, which then indirectly controlled the charts and caused some inconsistencies and leakage.