### PR TITLE
Fixed append image report not combining images

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.image/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/image/ui/settings/ImageFormat.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.image/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/image/ui/settings/ImageFormat.java
@@ -35,6 +35,11 @@ public enum ImageFormat implements ILabel {
 		return format;
 	}
 
+	public String getExtension() {
+
+		return label.replace("*", "");
+	}
+
 	@Override
 	public String label() {
 


### PR DESCRIPTION
Followup to https://github.com/eclipse/chemclipse/pull/1403 which is now in line with the text reports.