### PR TITLE
Added abundance ranges to Chromatogram Filter → Chromatogram Selection (Select Range)

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter.ui/META-INF/MANIFEST.MF
@@ -24,6 +24,8 @@ Require-Bundle: org.eclipse.ui,
  javax.inject;bundle-version="1.0.0",
  org.eclipse.e4.core.di;bundle-version="1.2.0",
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
- com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.9.9"
+ com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.9.9",
+ org.eclipse.chemclipse.xxd.process.ui;bundle-version="0.9.0",
+ org.eclipse.chemclipse.rcp.ui.icons;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter.ui/plugin.xml
@@ -19,5 +19,19 @@
             filterSettings="org.eclipse.chemclipse.chromatogram.filter.settings.MaxDetectorFilterSettings"
             id="org.eclipse.chemclipse.chromatogram.filter.ui.scanMaximaDetector">
       </ChromatogramFilterSupplier>
-   </extension>   
+   </extension>
+   <extension
+         point="org.eclipse.chemclipse.xxd.process.ui.menu.icon">
+      <icon
+            class="org.eclipse.chemclipse.chromatogram.filter.ui.icon.ResetSelectionMenuIcon"
+            id="org.eclipse.chemclipse.chromatogram.filter.resetChromatogramSelection">
+      </icon>
+   </extension>
+   <extension
+         point="org.eclipse.chemclipse.xxd.process.ui.menu.icon">
+      <icon
+            class="org.eclipse.chemclipse.chromatogram.filter.ui.icon.SetSelectionMenuIcon"
+            id="org.eclipse.chemclipse.chromatogram.filter.setChromatogramSelection">
+      </icon>
+   </extension>
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter.ui/src/org/eclipse/chemclipse/chromatogram/filter/ui/icon/ResetSelectionMenuIcon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter.ui/src/org/eclipse/chemclipse/chromatogram/filter/ui/icon/ResetSelectionMenuIcon.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - support process method resume option
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.filter.ui.icon;
+
+import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
+import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
+import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
+import org.eclipse.chemclipse.xxd.process.ui.menu.IMenuIcon;
+import org.eclipse.swt.graphics.Image;
+
+public class ResetSelectionMenuIcon implements IMenuIcon {
+
+	@Override
+	public Image getImage() {
+
+		return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_UNZOOM, IApplicationImageProvider.SIZE_16x16);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter.ui/src/org/eclipse/chemclipse/chromatogram/filter/ui/icon/SetSelectionMenuIcon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter.ui/src/org/eclipse/chemclipse/chromatogram/filter/ui/icon/SetSelectionMenuIcon.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - support process method resume option
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.filter.ui.icon;
+
+import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
+import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
+import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
+import org.eclipse.chemclipse.xxd.process.ui.menu.IMenuIcon;
+import org.eclipse.swt.graphics.Image;
+
+public class SetSelectionMenuIcon implements IMenuIcon {
+
+	@Override
+	public Image getImage() {
+
+		return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EXECUTE_ADD, IApplicationImageProvider.SIZE_16x16);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/ChromatogramFilterSelection.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/ChromatogramFilterSelection.java
@@ -71,7 +71,15 @@ public class ChromatogramFilterSelection extends AbstractChromatogramFilter impl
 					processingInfo.addMessage(new ProcessingMessage(MessageType.WARN, Messages.selectRange, Messages.stopRetentionTimeOutsideRange));
 				}
 				//
-				chromatogramSelection.setRangeRetentionTime((int)startRetentionTime, (int)stopRetentionTime);
+				float startAbundance = filterSettings.getStartAbundance();
+				if(filterSettings.isStartAbundanceRelative()) {
+					startAbundance = chromatogramSelection.getChromatogram().getMaxSignal() * filterSettings.getStartAbundance() / 100;
+				}
+				float stopAbundance = filterSettings.getStopAbundance();
+				if(filterSettings.isStopAbundanceRelative()) {
+					stopAbundance = chromatogramSelection.getChromatogram().getMaxSignal() * filterSettings.getStopAbundance() / 100;
+				}
+				chromatogramSelection.setRanges((int)startRetentionTime, (int)stopRetentionTime, startAbundance, stopAbundance);
 				processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, Messages.chromatogramSelectionApplied));
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/settings/FilterSettingsSelection.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/settings/FilterSettingsSelection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  * 
  * Contributors:
  * Dr. Philip Wenig - initial API and implementation
+ * Matthias Mailänder - abundance ranges
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.filter.impl.settings;
 
@@ -21,15 +22,34 @@ public class FilterSettingsSelection extends AbstractChromatogramFilterSettings 
 	@JsonProperty(value = "Start RT (Minutes)", defaultValue = "1")
 	@JsonPropertyDescription(value = "Start Retention Time (Minutes), the special value '-Infinity' can be used to express the minimum possible range")
 	private double startRetentionTimeMinutes;
+	//
 	@JsonProperty(value = "Use relative Start RT", defaultValue = "false")
 	@JsonPropertyDescription(value = "If checked, the start retention time is relative to the current selection")
 	private boolean startRelative;
+	//
+	@JsonProperty(value = "Minimum Intensity", defaultValue = "0")
+	@JsonPropertyDescription(value = "The lower Y-axis range limit")
+	private float startAbundance;
+	//
+	@JsonProperty(value = "Use relative intensity minimum", defaultValue = "true")
+	@JsonPropertyDescription(value = "If checked, the start intensity is a percentage relative to max intensity.")
+	private boolean startAbundanceRelative;
+	//
 	@JsonProperty(value = "Stop RT (Minutes)", defaultValue = "10")
 	@JsonPropertyDescription(value = "Stop Retention Time (Minutes), the special value 'Infinity' can be used to express the maximum possible range")
 	private double stopRetentionTimeMinutes;
+	//
 	@JsonProperty(value = "Use relative Stop RT", defaultValue = "false")
 	@JsonPropertyDescription(value = "If checked, the stop retention time is relative to the current selection")
 	private boolean stopRelative;
+	//
+	@JsonProperty(value = "Maximum Intensity", defaultValue = "100")
+	@JsonPropertyDescription(value = "The upper Y-axis range limit")
+	private float stopAbundance;
+	//
+	@JsonProperty(value = "Use relative intensity maximum", defaultValue = "true")
+	@JsonPropertyDescription(value = "If checked, the intensity is a percentage relative to max intensity.")
+	private boolean stopAbundanceRelative;
 
 	public double getStartRetentionTimeMinutes() {
 
@@ -69,5 +89,45 @@ public class FilterSettingsSelection extends AbstractChromatogramFilterSettings 
 	public void setStopRelative(boolean stopRelative) {
 
 		this.stopRelative = stopRelative;
+	}
+
+	public float getStartAbundance() {
+
+		return startAbundance;
+	}
+
+	public void setStartAbundance(float startAbundance) {
+
+		this.startAbundance = startAbundance;
+	}
+
+	public float getStopAbundance() {
+
+		return stopAbundance;
+	}
+
+	public void setStopAbundance(float stopAbundance) {
+
+		this.stopAbundance = stopAbundance;
+	}
+
+	public boolean isStartAbundanceRelative() {
+
+		return startAbundanceRelative;
+	}
+
+	public void setStartAbundanceRelative(boolean startAbundanceRelative) {
+
+		this.startAbundanceRelative = startAbundanceRelative;
+	}
+
+	public boolean isStopAbundanceRelative() {
+
+		return stopAbundanceRelative;
+	}
+
+	public void setStopAbundanceRelative(boolean stopAbundanceRelative) {
+
+		this.stopAbundanceRelative = stopAbundanceRelative;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.ui.icons/src/org/eclipse/chemclipse/rcp/ui/icons/core/IApplicationImage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.ui.icons/src/org/eclipse/chemclipse/rcp/ui/icons/core/IApplicationImage.java
@@ -466,4 +466,6 @@ public interface IApplicationImage extends IApplicationImageProvider {
 	String IMAGE_SORT_ALPHA_DESC = "sort_alpha_desc.png";
 	//
 	String IMAGE_EXTERNAL_BROWSER = "external_browser.png";
+	//
+	String IMAGE_UNZOOM = "unzoomChromatogram.gif";
 }


### PR DESCRIPTION
These are now fully redundant to the chart menus from the top of the right-click menu. However, they can be used in process methods. I used the same iconography to make this even more clear.