### PR TITLE
Removed generic typing in *ChromatogramFilter

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter.ui/src/org/eclipse/chemclipse/chromatogram/filter/ui/core/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter.ui/src/org/eclipse/chemclipse/chromatogram/filter/ui/core/ChromatogramFilter.java
@@ -47,7 +47,6 @@ public class ChromatogramFilter extends AbstractChromatogramFilter {
 
 	private static final String IDENTIFIER = Messages.scanMaximaDetectorUI;
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/AbstractChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/AbstractChromatogramFilter.java
@@ -13,30 +13,29 @@
 package org.eclipse.chemclipse.chromatogram.filter.core.chromatogram;
 
 import org.eclipse.chemclipse.chromatogram.filter.l10n.Messages;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
-import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 
-public abstract class AbstractChromatogramFilter<T extends IPeak, C extends IChromatogram<T>, R> implements IChromatogramFilter<T, C, R> {
+public abstract class AbstractChromatogramFilter implements IChromatogramFilter {
 
 	private static final String DESCRIPTION = Messages.chromatogramFilter;
 
 	@Override
-	public IProcessingInfo<R> validate(IChromatogramSelection<T, C> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings) {
+	public IProcessingInfo<IChromatogramFilterResult> validate(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings) {
 
-		IProcessingInfo<R> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = new ProcessingInfo<>();
 		processingInfo.addMessages(validateChromatogramSelection(chromatogramSelection));
 		processingInfo.addMessages(validateFilterSettings(chromatogramFilterSettings));
 		return processingInfo;
 	}
 
 	@Override
-	public IProcessingInfo<R> validateChromatogramSelection(IChromatogramSelection<T, C> chromatogramSelection) {
+	public IProcessingInfo<IChromatogramFilterResult> validateChromatogramSelection(IChromatogramSelection<?, ?> chromatogramSelection) {
 
-		IProcessingInfo<R> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = new ProcessingInfo<>();
 		if(chromatogramSelection == null) {
 			processingInfo.addErrorMessage(DESCRIPTION, Messages.chromatogramSelectionInvalid);
 		} else {
@@ -48,9 +47,9 @@ public abstract class AbstractChromatogramFilter<T extends IPeak, C extends IChr
 	}
 
 	@Override
-	public IProcessingInfo<R> validateFilterSettings(IChromatogramFilterSettings chromatogramFilterSettings) {
+	public IProcessingInfo<IChromatogramFilterResult> validateFilterSettings(IChromatogramFilterSettings chromatogramFilterSettings) {
 
-		IProcessingInfo<R> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = new ProcessingInfo<>();
 		if(chromatogramFilterSettings == null) {
 			processingInfo.addErrorMessage(DESCRIPTION, Messages.invalidFilterSettings);
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/AbstractChromatogramSignalFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/AbstractChromatogramSignalFilter.java
@@ -37,18 +37,16 @@ import org.eclipse.chemclipse.wsd.model.xwc.IExtractedSingleWavelengthSignal;
 import org.eclipse.chemclipse.wsd.model.xwc.IExtractedSingleWavelengthSignals;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public abstract class AbstractChromatogramSignalFilter extends AbstractChromatogramFilter implements IChromatogramFilter {
 
 	protected abstract IChromatogramFilterResult applyFilter(ITotalScanSignals totalSignals, IChromatogramFilterSettings filterSettings, IProgressMonitor monitor);
 
 	protected abstract IChromatogramFilterResult applyFilter(ITotalScanSignals totalSignals, IProgressMonitor monitor);
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
 			IChromatogramFilterResult chromatogramFilterResult = process(chromatogramSelection, chromatogramFilterSettings, monitor);
 			chromatogramSelection.getChromatogram().setDirty(true);
@@ -57,11 +55,10 @@ public abstract class AbstractChromatogramSignalFilter extends AbstractChromatog
 		return processingInfo;
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validateChromatogramSelection(chromatogramSelection);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validateChromatogramSelection(chromatogramSelection);
 		if(!processingInfo.hasErrorMessages()) {
 			IChromatogramFilterResult chromatogramFilterResult = process(chromatogramSelection, null, monitor);
 			processingInfo.setProcessingResult(chromatogramFilterResult);
@@ -69,7 +66,7 @@ public abstract class AbstractChromatogramSignalFilter extends AbstractChromatog
 		return processingInfo;
 	}
 
-	private IChromatogramFilterResult process(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	private IChromatogramFilterResult process(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
 		if(chromatogramSelection instanceof IChromatogramSelectionMSD chromatogramSelectionMSD) {
 			return process(chromatogramSelectionMSD, chromatogramFilterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/ChromatogramFilter.java
@@ -12,6 +12,7 @@
 package org.eclipse.chemclipse.chromatogram.filter.core.chromatogram;
 
 import org.eclipse.chemclipse.chromatogram.filter.l10n.Messages;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
@@ -56,21 +57,20 @@ public class ChromatogramFilter {
 	 * @param filterId
 	 * @return {@link IProcessingInfo}
 	 */
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	public static IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, String filterId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, String filterId, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo;
+		IProcessingInfo<IChromatogramFilterResult> processingInfo;
 		IChromatogramFilter chromatogramFilter = getChromatogramFilter(filterId);
 		if(chromatogramFilter != null) {
 			try {
 				processingInfo = chromatogramFilter.applyFilter(chromatogramSelection, chromatogramFilterSettings, monitor);
 			} catch(Exception e) {
 				logger.error(e);
-				processingInfo = new ProcessingInfo();
+				processingInfo = new ProcessingInfo<>();
 				processingInfo.addErrorMessage(Messages.chromatogramFilter, e.getLocalizedMessage());
 			}
 		} else {
-			processingInfo = new ProcessingInfo();
+			processingInfo = new ProcessingInfo<>();
 			processingInfo.addErrorMessage(Messages.chromatogramFilter, Messages.noChromatogramFilterAvailable);
 		}
 		return processingInfo;
@@ -86,21 +86,20 @@ public class ChromatogramFilter {
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	public static IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, String filterId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, String filterId, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo;
+		IProcessingInfo<IChromatogramFilterResult> processingInfo;
 		IChromatogramFilter chromatogramFilter = getChromatogramFilter(filterId);
 		if(chromatogramFilter != null) {
 			try {
 				processingInfo = chromatogramFilter.applyFilter(chromatogramSelection, monitor);
 			} catch(Exception e) {
 				logger.error(e);
-				processingInfo = new ProcessingInfo();
+				processingInfo = new ProcessingInfo<>();
 				processingInfo.addErrorMessage(Messages.chromatogramFilter, e.getLocalizedMessage());
 			}
 		} else {
-			processingInfo = new ProcessingInfo();
+			processingInfo = new ProcessingInfo<>();
 			processingInfo.addErrorMessage(Messages.chromatogramFilter, Messages.noChromatogramFilterAvailable);
 		}
 		return processingInfo;
@@ -140,14 +139,14 @@ public class ChromatogramFilter {
 	 * Returns a {@link IChromatogramFilter} instance given by the filterId or
 	 * null, if none is available.
 	 */
-	private static IChromatogramFilter<?, ?, ?> getChromatogramFilter(final String filterId) {
+	private static IChromatogramFilter getChromatogramFilter(final String filterId) {
 
 		IConfigurationElement element;
 		element = getConfigurationElement(filterId);
-		IChromatogramFilter<?, ?, ?> instance = null;
+		IChromatogramFilter instance = null;
 		if(element != null) {
 			try {
-				instance = (IChromatogramFilter<?, ?, ?>)element.createExecutableExtension(FILTER);
+				instance = (IChromatogramFilter)element.createExecutableExtension(FILTER);
 			} catch(CoreException e) {
 				logger.warn(e);
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/IChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/IChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,15 +12,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.filter.core.chromatogram;
 
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
-import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 
-public interface IChromatogramFilter<P extends IPeak, C extends IChromatogram<P>, R> {
+public interface IChromatogramFilter {
 
 	/**
 	 * Apply the filter in the given chromatogram selection and take care of the
@@ -33,7 +32,7 @@ public interface IChromatogramFilter<P extends IPeak, C extends IChromatogram<P>
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	IProcessingInfo<R> applyFilter(IChromatogramSelection<P, C> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor);
+	IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor);
 
 	/**
 	 * Apply the filter in the given chromatogram selection.
@@ -44,7 +43,7 @@ public interface IChromatogramFilter<P extends IPeak, C extends IChromatogram<P>
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	IProcessingInfo<R> applyFilter(IChromatogramSelection<P, C> chromatogramSelection, IProgressMonitor monitor);
+	IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor);
 
 	/**
 	 * Validates the selection and settings and returns a process info instance.
@@ -53,7 +52,7 @@ public interface IChromatogramFilter<P extends IPeak, C extends IChromatogram<P>
 	 * @param chromatogramFilterSettings
 	 * @return {@link IProcessingInfo}
 	 */
-	IProcessingInfo<R> validate(IChromatogramSelection<P, C> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings);
+	IProcessingInfo<IChromatogramFilterResult> validate(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings);
 
 	/**
 	 * Validates that chromatogram selection and the stored chromatogram are not
@@ -62,7 +61,7 @@ public interface IChromatogramFilter<P extends IPeak, C extends IChromatogram<P>
 	 * @param chromatogramSelection
 	 * @return {@link IProcessingInfo}
 	 */
-	IProcessingInfo<R> validateChromatogramSelection(IChromatogramSelection<P, C> chromatogramSelection);
+	IProcessingInfo<IChromatogramFilterResult> validateChromatogramSelection(IChromatogramSelection<?, ?> chromatogramSelection);
 
 	/**
 	 * Validates that the filter settings are not null.
@@ -70,5 +69,5 @@ public interface IChromatogramFilter<P extends IPeak, C extends IChromatogram<P>
 	 * @param chromatogramFilterSettings
 	 * @return {@link IProcessingInfo}
 	 */
-	IProcessingInfo<R> validateFilterSettings(IChromatogramFilterSettings chromatogramFilterSettings);
+	IProcessingInfo<IChromatogramFilterResult> validateFilterSettings(IChromatogramFilterSettings chromatogramFilterSettings);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/ChromatogramFilterReset.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/ChromatogramFilterReset.java
@@ -24,12 +24,10 @@ import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilterReset extends AbstractChromatogramFilter implements IChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
 		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
@@ -43,7 +41,7 @@ public class ChromatogramFilterReset extends AbstractChromatogramFilter implemen
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsReset filterSettings = PreferenceSupplier.getFilterSettingsReset();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/ChromatogramFilterSelection.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/ChromatogramFilterSelection.java
@@ -28,12 +28,10 @@ import org.eclipse.chemclipse.processing.core.MessageType;
 import org.eclipse.chemclipse.processing.core.ProcessingMessage;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilterSelection extends AbstractChromatogramFilter implements IChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
 		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
@@ -88,7 +86,7 @@ public class ChromatogramFilterSelection extends AbstractChromatogramFilter impl
 	}
 
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsSelection filterSettings = PreferenceSupplier.getFilterSettingsSelection();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/PeakTargetsToReferencesFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/PeakTargetsToReferencesFilter.java
@@ -28,12 +28,10 @@ import org.eclipse.chemclipse.model.support.TargetTransferSupport;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class PeakTargetsToReferencesFilter extends AbstractTransferFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
 		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
@@ -47,22 +45,21 @@ public class PeakTargetsToReferencesFilter extends AbstractTransferFilter {
 	}
 
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		PeakTargetsToReferencesSettings settings = PreferenceSupplier.getPeaksToReferencesTransferSettings();
 		return applyFilter(chromatogramSelection, settings, monitor);
 	}
 
-	@SuppressWarnings("unchecked")
-	private void transferTargets(IChromatogramSelection chromatogramSelection, PeakTargetsToReferencesSettings settings) {
+	private void transferTargets(IChromatogramSelection<?, ?> chromatogramSelection, PeakTargetsToReferencesSettings settings) {
 
 		TargetTransferSupport targetTransferSupport = new TargetTransferSupport();
-		List<IChromatogram> referencedChromatograms = chromatogramSelection.getChromatogram().getReferencedChromatograms();
+		List<IChromatogram<?>> referencedChromatograms = chromatogramSelection.getChromatogram().getReferencedChromatograms();
 		if(!referencedChromatograms.isEmpty()) {
 			int retentionTimeDelta = (int)(settings.getDeltaRetentionTime() * IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
 			boolean useBestTargetOnly = settings.isUseBestTargetOnly();
 			List<? extends IPeak> peaksSource = extractPeaks(chromatogramSelection);
-			for(IChromatogram referencedChromatogram : referencedChromatograms) {
+			for(IChromatogram<?> referencedChromatogram : referencedChromatograms) {
 				List<? extends IPeak> peaksSink = extractPeaks(referencedChromatogram);
 				targetTransferSupport.transferPeakTargets(peaksSource, peaksSink, retentionTimeDelta, useBestTargetOnly);
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/ScanTargetsToPeakFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/ScanTargetsToPeakFilter.java
@@ -35,12 +35,10 @@ import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ScanTargetsToPeakFilter extends AbstractTransferFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
 		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
@@ -54,13 +52,13 @@ public class ScanTargetsToPeakFilter extends AbstractTransferFilter {
 	}
 
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		ScanTargetsToPeakSettings settings = PreferenceSupplier.getScanToPeakTargetTransferSettings();
 		return applyFilter(chromatogramSelection, settings, monitor);
 	}
 
-	private void transferTargets(IChromatogramSelection chromatogramSelection, ScanTargetsToPeakSettings settings) {
+	private void transferTargets(IChromatogramSelection<?, ?> chromatogramSelection, ScanTargetsToPeakSettings settings) {
 
 		List<IScan> identifiedScans = extractIdentifiedScans(chromatogramSelection);
 		List<? extends IPeak> peaks = extractPeaks(chromatogramSelection);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/ScanTargetsToReferencesFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/ScanTargetsToReferencesFilter.java
@@ -27,12 +27,10 @@ import org.eclipse.chemclipse.model.support.TargetTransferSupport;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ScanTargetsToReferencesFilter extends AbstractTransferFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
 		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
@@ -46,21 +44,20 @@ public class ScanTargetsToReferencesFilter extends AbstractTransferFilter {
 	}
 
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		ScanTargetsToReferencesSettings settings = PreferenceSupplier.getScansToReferencesTransferSettings();
 		return applyFilter(chromatogramSelection, settings, monitor);
 	}
 
-	@SuppressWarnings("unchecked")
-	private void transferTargets(IChromatogramSelection chromatogramSelection, ScanTargetsToReferencesSettings settings) {
+	private void transferTargets(IChromatogramSelection<?, ?> chromatogramSelection, ScanTargetsToReferencesSettings settings) {
 
 		TargetTransferSupport targetTransferSupport = new TargetTransferSupport();
-		List<IChromatogram> referencedChromatograms = chromatogramSelection.getChromatogram().getReferencedChromatograms();
+		List<IChromatogram<?>> referencedChromatograms = chromatogramSelection.getChromatogram().getReferencedChromatograms();
 		if(!referencedChromatograms.isEmpty()) {
 			boolean useBestTargetOnly = settings.isUseBestTargetOnly();
 			List<IScan> scansSource = extractIdentifiedScans(chromatogramSelection);
-			for(IChromatogram referencedChromatogram : referencedChromatograms) {
+			for(IChromatogram<?> referencedChromatogram : referencedChromatograms) {
 				targetTransferSupport.transferScanTargets(scansSource, referencedChromatogram, useBestTargetOnly);
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier.ui/src/org/eclipse/chemclipse/chromatogram/msd/identifier/ui/core/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier.ui/src/org/eclipse/chemclipse/chromatogram/msd/identifier/ui/core/ChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Lablicate GmbH.
+ * Copyright (c) 2021, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.IMassSpectrumIdentifierSupplier;
@@ -31,14 +32,12 @@ import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilter extends AbstractChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
 			Shell shell = DisplayUtils.getShell();
 			if(shell != null) {
@@ -70,13 +69,13 @@ public class ChromatogramFilter extends AbstractChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		IChromatogramFilterSettings filterSettings = new FilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);
 	}
 
-	private void identifyScanMaxima(Shell shell, IChromatogramSelection chromatogramSelection, Display display, IProgressMonitor monitor) {
+	private void identifyScanMaxima(Shell shell, IChromatogramSelection<?, ?> chromatogramSelection, Display display, IProgressMonitor monitor) {
 
 		ChromatogramFilterDialog dialog = new ChromatogramFilterDialog(shell);
 		if(IDialogConstants.OK_ID == dialog.open()) {
@@ -92,8 +91,8 @@ public class ChromatogramFilter extends AbstractChromatogramFilter {
 				List<IScanMSD> massSpectra = new ArrayList<>();
 				for(int i = startScan; i <= stopScan; i++) {
 					IScan scan = chromatogram.getScan(i);
-					if(scan instanceof IScanMSD && scan.getTargets().size() > 0) {
-						massSpectra.add((IScanMSD)scan);
+					if(scan instanceof IScanMSD scanMSD && !scan.getTargets().isEmpty()) {
+						massSpectra.add(scanMSD);
 					}
 				}
 				/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.ui/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/baselinesubtract/ui/core/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.ui/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/baselinesubtract/ui/core/ChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Lablicate GmbH.
+ * Copyright (c) 2019, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@ package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.core.ChromatogramSubtractor;
@@ -28,14 +29,12 @@ import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.widgets.Shell;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilter extends AbstractChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
 			Shell shell = DisplayUtils.getShell();
 			if(shell != null) {
@@ -67,15 +66,15 @@ public class ChromatogramFilter extends AbstractChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		ChromatogramFilterSettings filterSettings = PreferenceSupplier.getFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);
 	}
 
-	private void subtractChromatogram(Shell shell, IChromatogramSelection chromatogramSelectionMaster) {
+	private void subtractChromatogram(Shell shell, IChromatogramSelection<?, ?> chromatogramSelectionMaster) {
 
-		IChromatogram chromatogramMaster = chromatogramSelectionMaster.getChromatogram();
+		IChromatogram<?> chromatogramMaster = chromatogramSelectionMaster.getChromatogram();
 		ChromatogramEditorDialog dialog = new ChromatogramEditorDialog(shell, chromatogramMaster);
 		//
 		if(IDialogConstants.OK_ID == dialog.open()) {
@@ -84,7 +83,7 @@ public class ChromatogramFilter extends AbstractChromatogramFilter {
 				/*
 				 * Check that both chromatograms are not the same
 				 */
-				IChromatogram chromatogramSubtract = chromatogramSelectionSubtract.getChromatogram();
+				IChromatogram<?> chromatogramSubtract = chromatogramSelectionSubtract.getChromatogram();
 				if(chromatogramMaster != chromatogramSubtract) {
 					int startRetentionTime = chromatogramSelectionMaster.getStartRetentionTime();
 					int stopRetentionTime = chromatogramSelectionMaster.getStopRetentionTime();

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/baselinesubtract/core/BaselineFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/baselinesubtract/core/BaselineFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,6 +12,8 @@
 package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.core;
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
+import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.IChromatogramFilter;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.model.baseline.IBaselineModel;
 import org.eclipse.chemclipse.model.core.IChromatogram;
@@ -21,13 +23,12 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
-public class BaselineFilter extends AbstractChromatogramFilter {
+public class BaselineFilter extends AbstractChromatogramFilter implements IChromatogramFilter {
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+		IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 		int startScan = chromatogram.getScanNumber(chromatogramSelection.getStartRetentionTime());
 		int stopScan = chromatogram.getScanNumber(chromatogramSelection.getStopRetentionTime());
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
@@ -45,11 +46,11 @@ public class BaselineFilter extends AbstractChromatogramFilter {
 		chromatogram.removeAllPeaks();
 		baselineModel.removeBaseline();
 		chromatogramSelection.getChromatogram().setDirty(true);
-		return new ProcessingInfo();
+		return new ProcessingInfo<>();
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		return applyFilter(chromatogramSelection, null, monitor);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/baselinesubtract/core/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/baselinesubtract/core/ChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@ package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.preferences.PreferenceSupplier;
@@ -22,14 +23,12 @@ import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilter extends AbstractChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
 			BaselineSubtractProcessor.removeBaseline(chromatogramSelection, monitor);
 			chromatogramSelection.getChromatogram().setDirty(true);
@@ -39,7 +38,7 @@ public class ChromatogramFilter extends AbstractChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		ChromatogramFilterSettings filterSettings = PreferenceSupplier.getFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.invert/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/invert/core/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.invert/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/invert/core/ChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Lablicate GmbH.
+ * Copyright (c) 2020, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,25 +13,23 @@ package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.invert.core;
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.invert.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.invert.settings.FilterSettings;
 import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilter extends AbstractChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
 			applyFilter(chromatogramSelection);
 			chromatogramSelection.getChromatogram().setDirty(true);
@@ -41,16 +39,15 @@ public class ChromatogramFilter extends AbstractChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettings filterSettings = PreferenceSupplier.getFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);
 	}
 
-	@SuppressWarnings("unchecked")
-	private void applyFilter(IChromatogramSelection chromatogramSelection) {
+	private void applyFilter(IChromatogramSelection<?, ?> chromatogramSelection) {
 
-		IChromatogram<? extends IPeak> chromatogram = chromatogramSelection.getChromatogram();
+		IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 		float maxSignal = chromatogram.getMaxSignal();
 		//
 		for(IScan scan : chromatogram.getScans()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/meannormalizer/core/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/meannormalizer/core/ChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@ package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer.c
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer.exceptions.FilterException;
@@ -31,15 +32,13 @@ import org.eclipse.chemclipse.model.signals.TotalScanSignalsModifier;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilter extends AbstractChromatogramFilter {
 
 	// TODO IProgressMonitor
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
 			if(chromatogramFilterSettings instanceof FilterSettings) {
 				try {
@@ -56,20 +55,19 @@ public class ChromatogramFilter extends AbstractChromatogramFilter {
 
 	// TODO Junit
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettings filterSettings = PreferenceSupplier.getFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);
 	}
 
-	@SuppressWarnings("unchecked")
-	private void applyMeanNormalizerFilter(IChromatogramSelection chromatogramSelection) throws FilterException {
+	private void applyMeanNormalizerFilter(IChromatogramSelection<?, ?> chromatogramSelection) throws FilterException {
 
 		/*
 		 * Get the chromatogram to determine the start and stop scan of the
 		 * chromatogram selection.
 		 */
-		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+		IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 		int startScan = chromatogram.getScanNumber(chromatogramSelection.getStartRetentionTime());
 		int stopScan = chromatogram.getScanNumber(chromatogramSelection.getStopRetentionTime());
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/multiplier/core/DivisorChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/multiplier/core/DivisorChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,6 +12,7 @@
 package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.core;
 
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.exceptions.FilterException;
@@ -21,18 +22,15 @@ import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class DivisorChromatogramFilter extends ModifierChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
-			if(chromatogramFilterSettings instanceof DivisorSettings) {
+			if(chromatogramFilterSettings instanceof DivisorSettings filterSettings) {
 				try {
-					DivisorSettings filterSettings = (DivisorSettings)chromatogramFilterSettings;
 					float divisor = filterSettings.getDivisor();
 					applyFilter(chromatogramSelection, divisor, false);
 					chromatogramSelection.getChromatogram().setDirty(true);
@@ -46,7 +44,7 @@ public class DivisorChromatogramFilter extends ModifierChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		DivisorSettings filterSettings = PreferenceSupplier.getFilterSettingsDivisor();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/multiplier/core/ModifierChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/multiplier/core/ModifierChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,7 +21,6 @@ import org.eclipse.chemclipse.model.signals.ITotalScanSignals;
 import org.eclipse.chemclipse.model.signals.TotalScanSignalExtractor;
 import org.eclipse.chemclipse.model.signals.TotalScanSignalsModifier;
 
-@SuppressWarnings("rawtypes")
 public abstract class ModifierChromatogramFilter extends AbstractChromatogramFilter {
 
 	protected void applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, float factor, boolean multiply) throws FilterException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/multiplier/core/MultiplierChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/multiplier/core/MultiplierChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,6 +12,7 @@
 package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.core;
 
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.exceptions.FilterException;
@@ -21,18 +22,15 @@ import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class MultiplierChromatogramFilter extends ModifierChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
-			if(chromatogramFilterSettings instanceof MultiplierSettings) {
+			if(chromatogramFilterSettings instanceof MultiplierSettings filterSettings) {
 				try {
-					MultiplierSettings filterSettings = (MultiplierSettings)chromatogramFilterSettings;
 					float multiplier = filterSettings.getMultiplier();
 					applyFilter(chromatogramSelection, multiplier, true);
 					chromatogramSelection.getChromatogram().setDirty(true);
@@ -46,7 +44,7 @@ public class MultiplierChromatogramFilter extends ModifierChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		MultiplierSettings filterSettings = PreferenceSupplier.getFilterSettingsMultiplier();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/normalizer/core/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/normalizer/core/ChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@ package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer.core;
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer.exceptions.FilterException;
@@ -29,17 +30,14 @@ import org.eclipse.chemclipse.model.signals.TotalScanSignalsModifier;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilter extends AbstractChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
-			if(chromatogramFilterSettings instanceof FilterSettings) {
-				FilterSettings filterSettings = (FilterSettings)chromatogramFilterSettings;
+			if(chromatogramFilterSettings instanceof FilterSettings filterSettings) {
 				float normalizationBase = filterSettings.getNormalizationBase();
 				try {
 					applyNormalizerFilter(chromatogramSelection, normalizationBase);
@@ -55,16 +53,15 @@ public class ChromatogramFilter extends AbstractChromatogramFilter {
 
 	// TODO JUnit
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettings filterSettings = PreferenceSupplier.getFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);
 	}
 
-	@SuppressWarnings("unchecked")
-	private void applyNormalizerFilter(IChromatogramSelection chromatogramSelection, float normalizationBase) throws FilterException {
+	private void applyNormalizerFilter(IChromatogramSelection<?, ?> chromatogramSelection, float normalizationBase) throws FilterException {
 
-		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+		IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 		int startScan = chromatogram.getScanNumber(chromatogramSelection.getStartRetentionTime());
 		int stopScan = chromatogram.getScanNumber(chromatogramSelection.getStopRetentionTime());
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/rtshifter/core/ChromatogramFilterGapFiller.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/rtshifter/core/ChromatogramFilterGapFiller.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Lablicate GmbH.
+ * Copyright (c) 2021, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@ package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.core;
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.core.internal.support.GapFiller;
@@ -22,17 +23,14 @@ import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilterGapFiller extends AbstractChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
-			if(chromatogramFilterSettings instanceof FilterSettingsGapFiller) {
-				FilterSettingsGapFiller filterSettings = (FilterSettingsGapFiller)chromatogramFilterSettings;
+			if(chromatogramFilterSettings instanceof FilterSettingsGapFiller filterSettings) {
 				GapFiller.autofillScans(chromatogramSelection, filterSettings);
 				chromatogramSelection.getChromatogram().setDirty(true);
 				processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, "The chromatogram has been autofilled successfully."));
@@ -42,7 +40,7 @@ public class ChromatogramFilterGapFiller extends AbstractChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsGapFiller filterSettings = PreferenceSupplier.getFilterSettingsFillGaps();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/rtshifter/core/ChromatogramFilterShift.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/rtshifter/core/ChromatogramFilterShift.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Lablicate GmbH.
+ * Copyright (c) 2011, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@ package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.core;
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.core.internal.support.RetentionTimeShifter;
@@ -23,17 +24,14 @@ import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilterShift extends AbstractChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
-			if(chromatogramFilterSettings instanceof FilterSettingsShift) {
-				FilterSettingsShift filterSettingsShift = (FilterSettingsShift)chromatogramFilterSettings;
+			if(chromatogramFilterSettings instanceof FilterSettingsShift filterSettingsShift) {
 				try {
 					RetentionTimeShifter.shiftRetentionTimes(chromatogramSelection, filterSettingsShift);
 					chromatogramSelection.getChromatogram().setDirty(true);
@@ -47,7 +45,7 @@ public class ChromatogramFilterShift extends AbstractChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsShift filterSettings = PreferenceSupplier.getFilterSettingsShift();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/rtshifter/core/ChromatogramFilterStretch.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/rtshifter/core/ChromatogramFilterStretch.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@ package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.core;
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.core.internal.support.RetentionTimeStretcher;
@@ -23,17 +24,14 @@ import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilterStretch extends AbstractChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
-			if(chromatogramFilterSettings instanceof FilterSettingsStretch) {
-				FilterSettingsStretch filterSettings = (FilterSettingsStretch)chromatogramFilterSettings;
+			if(chromatogramFilterSettings instanceof FilterSettingsStretch filterSettings) {
 				try {
 					RetentionTimeStretcher.stretchChromatogram(chromatogramSelection, filterSettings);
 					chromatogramSelection.getChromatogram().setDirty(true);
@@ -47,7 +45,7 @@ public class ChromatogramFilterStretch extends AbstractChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsStretch filterSettings = PreferenceSupplier.getFilterSettingsStretch();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterCleaner.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterCleaner.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.exceptions.FilterException;
@@ -40,11 +41,10 @@ import org.eclipse.core.runtime.SubMonitor;
 @SuppressWarnings("rawtypes")
 public class FilterCleaner extends AbstractChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
 			try {
 				applyChromatogramCleanerFilter(chromatogramSelection, monitor);
@@ -60,7 +60,7 @@ public class FilterCleaner extends AbstractChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsCleaner filterSettings = PreferenceSupplier.getCleanerFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterDeleteIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterDeleteIdentifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Lablicate GmbH.
+ * Copyright (c) 2020, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@ package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.core;
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.exceptions.FilterException;
@@ -27,18 +28,15 @@ import org.eclipse.chemclipse.processing.core.ProcessingMessage;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
 
-@SuppressWarnings("rawtypes")
 public class FilterDeleteIdentifier extends AbstractChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
 			try {
-				if(chromatogramFilterSettings instanceof FilterSettingsDeleteIdentifier) {
-					FilterSettingsDeleteIdentifier settings = (FilterSettingsDeleteIdentifier)chromatogramFilterSettings;
+				if(chromatogramFilterSettings instanceof FilterSettingsDeleteIdentifier settings) {
 					if(settings.isDeleteScanIdentifications()) {
 						removeScanIdentifications(chromatogramSelection, monitor);
 						processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, "Delete Scan Targets", "Scan Targets have been removed successfully."));
@@ -54,15 +52,15 @@ public class FilterDeleteIdentifier extends AbstractChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsDeleteIdentifier filterSettings = PreferenceSupplier.getDeleteIdentifierFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);
 	}
 
-	private void removeScanIdentifications(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) throws FilterException {
+	private void removeScanIdentifications(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) throws FilterException {
 
-		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+		IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 		int startScan = chromatogram.getScanNumber(chromatogramSelection.getStartRetentionTime());
 		int stopScan = chromatogram.getScanNumber(chromatogramSelection.getStopRetentionTime());
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Delete Scan Targets from chromatogram.", stopScan - startScan);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterDuplicator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterDuplicator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,9 +19,9 @@ import java.util.TreeMap;
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
-import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.exceptions.FilterException;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.settings.FilterSettingsDuplicator;
 import org.eclipse.chemclipse.csd.model.core.IScanCSD;
@@ -45,34 +45,29 @@ import org.eclipse.core.runtime.IProgressMonitor;
 @SuppressWarnings("rawtypes")
 public class FilterDuplicator extends AbstractChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
-			try {
-				if(chromatogramFilterSettings instanceof FilterSettingsDuplicator settings) {
-					applyScanDuplicatorFilter(chromatogramSelection, settings, monitor);
-					processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, "Scan Duplicator", "Scans have been duplicated successfully."));
-					processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, "Scans have been duplicated successfully."));
-					chromatogramSelection.getChromatogram().setDirty(true);
-				}
-			} catch(FilterException e) {
-				processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.EXCEPTION, e.getMessage()));
+			if(chromatogramFilterSettings instanceof FilterSettingsDuplicator settings) {
+				applyScanDuplicatorFilter(chromatogramSelection, settings);
+				processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, "Scan Duplicator", "Scans have been duplicated successfully."));
+				processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, "Scans have been duplicated successfully."));
+				chromatogramSelection.getChromatogram().setDirty(true);
 			}
 		}
 		return processingInfo;
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsDuplicator filterSettings = PreferenceSupplier.getDuplicatorFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);
 	}
 
-	private void applyScanDuplicatorFilter(IChromatogramSelection chromatogramSelection, FilterSettingsDuplicator settings, IProgressMonitor monitor) throws FilterException {
+	private void applyScanDuplicatorFilter(IChromatogramSelection chromatogramSelection, FilterSettingsDuplicator settings) {
 
 		if(chromatogramSelection != null) {
 			/*
@@ -106,7 +101,7 @@ public class FilterDuplicator extends AbstractChromatogramFilter {
 					int retentionTimeCenter = (int)((scanNext.getRetentionTime() + scan.getRetentionTime()) / 2.0d);
 					float intensityCenter = (scanNext.getTotalSignal() + scan.getTotalSignal()) / 2.0f;
 					//
-					if(scan instanceof IScanCSD currentScan) {
+					if(scan instanceof IScanCSD) {
 						/*
 						 * CSD
 						 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterRemover.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterRemover.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Lablicate GmbH.
+ * Copyright (c) 2011, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.exceptions.FilterException;
@@ -30,18 +31,15 @@ import org.eclipse.chemclipse.processing.core.MessageType;
 import org.eclipse.chemclipse.processing.core.ProcessingMessage;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class FilterRemover extends AbstractChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
 			try {
-				if(chromatogramFilterSettings instanceof FilterSettingsRemover) {
-					FilterSettingsRemover settings = (FilterSettingsRemover)chromatogramFilterSettings;
+				if(chromatogramFilterSettings instanceof FilterSettingsRemover settings) {
 					ScanRemoverPattern scanRemoverPattern = new ScanRemoverPattern(settings.getScanRemoverPattern());
 					applyScanRemoverFilter(chromatogramSelection, scanRemoverPattern, monitor);
 					processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, "Scan Remover", "Scans have been removed successfully."));
@@ -56,7 +54,7 @@ public class FilterRemover extends AbstractChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsRemover filterSettings = PreferenceSupplier.getRemoverFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);
@@ -69,7 +67,7 @@ public class FilterRemover extends AbstractChromatogramFilter {
 	 * @param chromatogramSelection
 	 * @throws FilterException
 	 */
-	private void applyScanRemoverFilter(IChromatogramSelection chromatogramSelection, ScanRemoverPattern scanRemoverPattern, IProgressMonitor monitor) throws FilterException {
+	private void applyScanRemoverFilter(IChromatogramSelection<?, ?> chromatogramSelection, ScanRemoverPattern scanRemoverPattern, IProgressMonitor monitor) throws FilterException {
 
 		if(chromatogramSelection != null && scanRemoverPattern != null) {
 			/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterRetentionIndexSelector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterRetentionIndexSelector.java
@@ -16,9 +16,9 @@ import java.util.Set;
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
-import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.exceptions.FilterException;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.settings.FilterSettingsRetentionIndexSelector;
 import org.eclipse.chemclipse.model.core.IChromatogram;
@@ -36,35 +36,29 @@ import org.eclipse.core.runtime.IProgressMonitor;
 @SuppressWarnings("rawtypes")
 public class FilterRetentionIndexSelector extends AbstractChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
-			try {
-				if(chromatogramFilterSettings instanceof FilterSettingsRetentionIndexSelector settings) {
-					selectRetentionIndices(chromatogramSelection, settings, monitor);
-					processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, "Select Retention Index", "The retention indices have been selected successfully."));
-					processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, "Retention Index selection was successful."));
-					chromatogramSelection.getChromatogram().setDirty(true);
-				}
-			} catch(FilterException e) {
-				processingInfo.addMessage(new ProcessingMessage(MessageType.WARN, "Select Retention Index", e.getMessage()));
-				processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.EXCEPTION, e.getMessage()));
+			if(chromatogramFilterSettings instanceof FilterSettingsRetentionIndexSelector settings) {
+				selectRetentionIndices(chromatogramSelection, settings);
+				processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, "Select Retention Index", "The retention indices have been selected successfully."));
+				processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, "Retention Index selection was successful."));
+				chromatogramSelection.getChromatogram().setDirty(true);
 			}
 		}
 		return processingInfo;
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsRetentionIndexSelector filterSettings = PreferenceSupplier.getFilterSettingsRetentionIndexSelector();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);
 	}
 
-	private void selectRetentionIndices(IChromatogramSelection<?, ?> chromatogramSelection, FilterSettingsRetentionIndexSelector settings, IProgressMonitor monitor) throws FilterException {
+	private void selectRetentionIndices(IChromatogramSelection<?, ?> chromatogramSelection, FilterSettingsRetentionIndexSelector settings) {
 
 		String searchColumn = settings.getSearchColumn();
 		if(!searchColumn.isEmpty()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterScanMerger.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterScanMerger.java
@@ -19,9 +19,9 @@ import java.util.TreeMap;
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
-import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.exceptions.FilterException;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.settings.FilterSettingsScanMerger;
 import org.eclipse.chemclipse.csd.model.core.IScanCSD;
@@ -42,39 +42,33 @@ import org.eclipse.chemclipse.xir.model.core.ISignalXIR;
 import org.eclipse.chemclipse.xir.model.implementation.ScanISD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class FilterScanMerger extends AbstractChromatogramFilter {
 
 	private static final String MESSAGE = "The scans have been merged.";
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
-			try {
-				if(chromatogramFilterSettings instanceof FilterSettingsScanMerger settings) {
-					applyScanMergerFilter(chromatogramSelection, settings, monitor);
-					processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, "Scan Merger", MESSAGE));
-					processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, MESSAGE));
-					chromatogramSelection.getChromatogram().setDirty(true);
-				}
-			} catch(FilterException e) {
-				processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.EXCEPTION, e.getMessage()));
+			if(chromatogramFilterSettings instanceof FilterSettingsScanMerger settings) {
+				applyScanMergerFilter(chromatogramSelection, settings, monitor);
+				processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, "Scan Merger", MESSAGE));
+				processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, MESSAGE));
+				chromatogramSelection.getChromatogram().setDirty(true);
 			}
 		}
 		return processingInfo;
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsScanMerger filterSettings = PreferenceSupplier.getScanMergerFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);
 	}
 
-	private void applyScanMergerFilter(IChromatogramSelection chromatogramSelection, FilterSettingsScanMerger settings, IProgressMonitor monitor) throws FilterException {
+	private void applyScanMergerFilter(IChromatogramSelection<?, ?> chromatogramSelection, FilterSettingsScanMerger settings, IProgressMonitor monitor) {
 
 		if(chromatogramSelection != null) {
 			/*
@@ -103,11 +97,11 @@ public class FilterScanMerger extends AbstractChromatogramFilter {
 						int retentionTimeCenter = (int)((scanNext.getRetentionTime() + scan.getRetentionTime()) / 2.0d);
 						float totalSignalMerged = (float)((scan.getTotalSignal() + scanNext.getTotalSignal()) / 2.0d);
 						//
-						if(scan instanceof IScanCSD currentScan) {
+						if(scan instanceof IScanCSD) {
 							/*
 							 * CSD
 							 */
-							if(scanNext instanceof IScanCSD nextScan) {
+							if(scanNext instanceof IScanCSD) {
 								IScanCSD scanMerged = new ScanCSD(totalSignalMerged);
 								scanMerged.setRetentionTime(retentionTimeCenter);
 								scansMerged.add(scanMerged);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterScanSelector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterScanSelector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@ package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.core;
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.exceptions.FilterException;
@@ -31,16 +32,14 @@ import org.eclipse.core.runtime.IProgressMonitor;
 @SuppressWarnings("rawtypes")
 public class FilterScanSelector extends AbstractChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
 			try {
-				if(chromatogramFilterSettings instanceof FilterSettingsScanSelector) {
-					FilterSettingsScanSelector settings = (FilterSettingsScanSelector)chromatogramFilterSettings;
-					selectScan(chromatogramSelection, settings, monitor);
+				if(chromatogramFilterSettings instanceof FilterSettingsScanSelector settings) {
+					selectScan(chromatogramSelection, settings);
 					processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, "Select Scan", "The scan has been selected successfully."));
 					processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, "Scan selection was successful."));
 					chromatogramSelection.getChromatogram().setDirty(true);
@@ -54,13 +53,13 @@ public class FilterScanSelector extends AbstractChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsScanSelector filterSettings = PreferenceSupplier.getFilterSettingsScanSelector();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);
 	}
 
-	private void selectScan(IChromatogramSelection chromatogramSelection, FilterSettingsScanSelector filterSettingsScanSelector, IProgressMonitor monitor) throws FilterException {
+	private void selectScan(IChromatogramSelection chromatogramSelection, FilterSettingsScanSelector filterSettingsScanSelector) throws FilterException {
 
 		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
 		int startScan = chromatogram.getScanNumber(chromatogramSelection.getStartRetentionTime());

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/unitsumnormalizer/core/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/unitsumnormalizer/core/ChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 Lablicate GmbH.
+ * Copyright (c) 2015, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@ package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalize
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer.exceptions.FilterException;
@@ -30,14 +31,12 @@ import org.eclipse.chemclipse.model.signals.TotalScanSignalsModifier;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilter extends AbstractChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
 			if(chromatogramFilterSettings instanceof FilterSettings) {
 				try {
@@ -53,20 +52,19 @@ public class ChromatogramFilter extends AbstractChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettings filterSettings = PreferenceSupplier.getFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);
 	}
 
-	@SuppressWarnings("unchecked")
-	private void applyUnitSumNormalizerFilter(IChromatogramSelection chromatogramSelection) throws FilterException {
+	private void applyUnitSumNormalizerFilter(IChromatogramSelection<?, ?> chromatogramSelection) throws FilterException {
 
 		/*
 		 * Get the chromatogram to determine the start and stop scan of the
 		 * chromatogram selection.
 		 */
-		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+		IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 		int startScan = chromatogram.getScanNumber(chromatogramSelection.getStartRetentionTime());
 		int stopScan = chromatogram.getScanNumber(chromatogramSelection.getStopRetentionTime());
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/filter/ChromatogramFilterAdjust.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/filter/ChromatogramFilterAdjust.java
@@ -14,6 +14,7 @@ package org.eclipse.chemclipse.ux.extension.xxd.ui.filter;
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.IChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
@@ -24,14 +25,12 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.swt.widgets.Display;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilterAdjust extends AbstractChromatogramFilter implements IChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
 			if(chromatogramFilterSettings instanceof FilterSettingsAdjust) {
 				UpdateNotifierUI.update(Display.getDefault(), IChemClipseEvents.TOPIC_EDITOR_CHROMATOGRAM_ADJUST, ExtensionMessages.adjustChromatogramEditor);
@@ -43,7 +42,7 @@ public class ChromatogramFilterAdjust extends AbstractChromatogramFilter impleme
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsAdjust filterSettings = new FilterSettingsAdjust();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/meannormalizer/core/MeanNormalizerFilter_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/meannormalizer/core/MeanNormalizerFilter_1_Test.java
@@ -15,7 +15,6 @@ import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.IChromatogra
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer.settings.FilterSettings;
 import org.eclipse.core.runtime.NullProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class MeanNormalizerFilter_1_Test extends ChromatogramImporterTestCase {
 
 	private IChromatogramFilter chromatogramFilter;
@@ -37,7 +36,6 @@ public class MeanNormalizerFilter_1_Test extends ChromatogramImporterTestCase {
 		super.tearDown();
 	}
 
-	@SuppressWarnings("unchecked")
 	public void testApplyFilter_1() {
 
 		float totalSignal;

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/mediannormalizer/core/MedianNormalizerFilter_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/mediannormalizer/core/MedianNormalizerFilter_1_Test.java
@@ -18,7 +18,6 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 
 public class MedianNormalizerFilter_1_Test extends ChromatogramImporterTestCase {
 
-	@SuppressWarnings("rawtypes")
 	private IChromatogramFilter chromatogramFilter;
 	private FilterSettings filterSettings;
 
@@ -38,7 +37,6 @@ public class MedianNormalizerFilter_1_Test extends ChromatogramImporterTestCase 
 		super.tearDown();
 	}
 
-	@SuppressWarnings("unchecked")
 	public void testApplyFilter_1() {
 
 		float totalSignal;

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/multiplier/core/MultiplierFilter_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/multiplier/core/MultiplierFilter_1_Test.java
@@ -17,7 +17,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 
 public class MultiplierFilter_1_Test extends ChromatogramImporterTestCase {
 
-	private IChromatogramFilter<?, ?, ?> chromatogramFilter;
+	private IChromatogramFilter chromatogramFilter;
 	private MultiplierSettings multiplierFilterSettings;
 
 	@Override
@@ -37,7 +37,6 @@ public class MultiplierFilter_1_Test extends ChromatogramImporterTestCase {
 		super.tearDown();
 	}
 
-	@SuppressWarnings("unchecked")
 	public void testApplyFilter_1() {
 
 		float totalSignal;

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/normalizer/core/NormalizerFilter_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/normalizer/core/NormalizerFilter_1_Test.java
@@ -15,7 +15,6 @@ import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.IChromatogra
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer.settings.FilterSettings;
 import org.eclipse.core.runtime.NullProgressMonitor;
 
-@SuppressWarnings({"rawtypes"})
 public class NormalizerFilter_1_Test extends ChromatogramImporterTestCase {
 
 	private IChromatogramFilter chromatogramFilter;
@@ -38,7 +37,6 @@ public class NormalizerFilter_1_Test extends ChromatogramImporterTestCase {
 		super.tearDown();
 	}
 
-	@SuppressWarnings("unchecked")
 	public void testApplyFilter_1() {
 
 		float totalSignal;

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/unitsumnormalizer/core/UnitSumNormalizerFilter_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/unitsumnormalizer/core/UnitSumNormalizerFilter_1_Test.java
@@ -16,7 +16,6 @@ import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.IChromatogra
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer.settings.FilterSettings;
 import org.eclipse.core.runtime.NullProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class UnitSumNormalizerFilter_1_Test extends ChromatogramImporterTestCase {
 
 	private IChromatogramFilter chromatogramFilter;
@@ -38,7 +37,6 @@ public class UnitSumNormalizerFilter_1_Test extends ChromatogramImporterTestCase
 		super.tearDown();
 	}
 
-	@SuppressWarnings("unchecked")
 	public void testApplyFilter_1() {
 
 		float totalSignal;


### PR DESCRIPTION
https://github.com/eclipse/chemclipse/commit/46845ef68ac3ef96e41720da6618275622b17035 is when a large and hard to solve accident happened. If you follow the generic types, then, especially `R` the result of the filters does not resolve, causing frustrating impossible puzzles. I assume that is also the reason why it was never properly applied everywhere. I therefore reverted it in the realm of the chromatogram filters and resolved the suppressed warnings to prove my typing is correct. It also avoids the cryptic one letter type abbreviation which stem from the Java style guide.