### PR TITLE
Reduced suppressed warning rawtypes

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.filter/src/org/eclipse/chemclipse/chromatogram/csd/filter/core/chromatogram/ChromatogramFilterCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.filter/src/org/eclipse/chemclipse/chromatogram/csd/filter/core/chromatogram/ChromatogramFilterCSD.java
@@ -72,7 +72,7 @@ public class ChromatogramFilterCSD {
 	// TODO JUnit
 	/**
 	 * Applies the specified filter, but retrieves the IChromatogramFilterSettings dynamically.<br/>
-	 * See also method: applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, String filterId, IProgressMonitor monitor)
+	 * See also method: applyFilter(IChromatogramSelection<?, ?>chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, String filterId, IProgressMonitor monitor)
 	 * 
 	 * @param chromatogramSelection
 	 * @param filterId

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter.ui/src/org/eclipse/chemclipse/chromatogram/filter/ui/core/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter.ui/src/org/eclipse/chemclipse/chromatogram/filter/ui/core/ChromatogramFilter.java
@@ -42,13 +42,12 @@ import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Shell;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilter extends AbstractChromatogramFilter {
 
 	private static final String IDENTIFIER = Messages.scanMaximaDetectorUI;
 
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
 		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		//
@@ -90,13 +89,13 @@ public class ChromatogramFilter extends AbstractChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		IChromatogramFilterSettings filterSettings = new MaxDetectorFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);
 	}
 
-	private void detectScanMaxima(Shell shell, IChromatogramSelection chromatogramSelection, MaxDetectorFilterSettings filterSettings) {
+	private void detectScanMaxima(Shell shell, IChromatogramSelection<?,?> chromatogramSelection, MaxDetectorFilterSettings filterSettings) {
 
 		ChromatogramFilterDialog dialog = new ChromatogramFilterDialog(shell);
 		if(IDialogConstants.OK_ID == dialog.open()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/ChromatogramFilter.java
@@ -79,7 +79,7 @@ public class ChromatogramFilter {
 	// TODO JUnit
 	/**
 	 * Applies the specified filter, but retrieves the IChromatogramFilterSettings dynamically.<br/>
-	 * See also method: applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, String filterId, IProgressMonitor monitor)
+	 * See also method: applyFilter(IChromatogramSelection<?, ?>chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, String filterId, IProgressMonitor monitor)
 	 * 
 	 * @param chromatogramSelection
 	 * @param filterId

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/AbstractTransferFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/AbstractTransferFilter.java
@@ -27,13 +27,11 @@ import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
 import org.eclipse.chemclipse.wsd.model.core.selection.ChromatogramSelectionWSD;
 
-@SuppressWarnings("rawtypes")
 public abstract class AbstractTransferFilter extends AbstractChromatogramFilter implements IChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
-	protected List<IScan> extractIdentifiedScans(IChromatogramSelection chromatogramSelection) {
+	protected List<IScan> extractIdentifiedScans(IChromatogramSelection<?, ?> chromatogramSelection) {
 
-		IChromatogram<? extends IPeak> chromatogram = chromatogramSelection.getChromatogram();
+		IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 		//
 		int startRetentionTime = chromatogramSelection.getStartRetentionTime();
 		int stopRetentionTime = chromatogramSelection.getStopRetentionTime();
@@ -51,7 +49,7 @@ public abstract class AbstractTransferFilter extends AbstractChromatogramFilter 
 		return identifiedScans;
 	}
 
-	protected List<? extends IPeak> extractPeaks(IChromatogram chromatogram) {
+	protected List<? extends IPeak> extractPeaks(IChromatogram<?> chromatogram) {
 
 		if(chromatogram instanceof IChromatogramCSD chromatogramCSD) {
 			return extractPeaks(new ChromatogramSelectionCSD(chromatogramCSD));
@@ -64,8 +62,7 @@ public abstract class AbstractTransferFilter extends AbstractChromatogramFilter 
 		}
 	}
 
-	@SuppressWarnings("unchecked")
-	protected List<? extends IPeak> extractPeaks(IChromatogramSelection chromatogramSelection) {
+	protected List<? extends IPeak> extractPeaks(IChromatogramSelection<?, ?> chromatogramSelection) {
 
 		return chromatogramSelection.getChromatogram().getPeaks(chromatogramSelection);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/ChromatogramFilterTransform.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/impl/ChromatogramFilterTransform.java
@@ -33,12 +33,10 @@ import org.eclipse.chemclipse.msd.model.implementation.VendorMassSpectrum;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilterTransform extends AbstractChromatogramFilter implements IChromatogramFilter {
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
 		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
@@ -65,7 +63,7 @@ public class ChromatogramFilterTransform extends AbstractChromatogramFilter impl
 	}
 
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsTransform filterSettings = PreferenceSupplier.getFilterSettingsTransform();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/ChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Lablicate GmbH.
+ * Copyright (c) 2011, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,6 +12,7 @@
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.core;
 
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.msd.filter.core.chromatogram.AbstractChromatogramFilterMSD;
@@ -32,15 +33,14 @@ import org.eclipse.core.runtime.IProgressMonitor;
 public class ChromatogramFilter extends AbstractChromatogramFilterMSD {
 
 	@Override
-	public IProcessingInfo<?> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo<Object> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = new ProcessingInfo<>();
 		processingInfo.addMessages(validate(chromatogramSelection, chromatogramFilterSettings));
 		//
 		if(!processingInfo.hasErrorMessages()) {
-			if(chromatogramFilterSettings instanceof ChromatogramFilterSettings) {
+			if(chromatogramFilterSettings instanceof ChromatogramFilterSettings filterSettings) {
 				try {
-					ChromatogramFilterSettings filterSettings = (ChromatogramFilterSettings)chromatogramFilterSettings;
 					applyBackfoldingFilter(chromatogramSelection, filterSettings, monitor);
 					processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, "The chromatogram selection has been successfully backfolded."));
 				} catch(FilterException e) {
@@ -54,7 +54,7 @@ public class ChromatogramFilter extends AbstractChromatogramFilterMSD {
 
 	// TODO Junit
 	@Override
-	public IProcessingInfo<?> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
 
 		ChromatogramFilterSettings filterSettings = PreferenceSupplier.getFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/core/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/core/ChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Lablicate GmbH.
+ * Copyright (c) 2011, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,6 +12,7 @@
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.core;
 
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.msd.filter.core.chromatogram.AbstractChromatogramFilterMSD;
@@ -31,18 +32,17 @@ import org.eclipse.core.runtime.IProgressMonitor;
 
 public class ChromatogramFilter extends AbstractChromatogramFilterMSD {
 
-	private static int MOVING_AVERAGE_WINDOW = 5;
+	private static final int MOVING_AVERAGE_WINDOW = 5;
 
 	@Override
-	public IProcessingInfo<?> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo<Object> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = new ProcessingInfo<>();
 		processingInfo.addMessages(validate(chromatogramSelection, chromatogramFilterSettings));
 		//
 		if(!processingInfo.hasErrorMessages()) {
-			if(chromatogramFilterSettings instanceof FilterSettings) {
+			if(chromatogramFilterSettings instanceof FilterSettings filterSettings) {
 				try {
-					FilterSettings filterSettings = (FilterSettings)chromatogramFilterSettings;
 					applyCodaFilter(chromatogramSelection, filterSettings);
 					processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, "The chromatogram selection has been successfully cleaned by the coda algorithm."));
 				} catch(FilterException e) {
@@ -56,7 +56,7 @@ public class ChromatogramFilter extends AbstractChromatogramFilterMSD {
 
 	// TODO JUnit
 	@Override
-	public IProcessingInfo<?> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
 
 		IChromatogramFilterSettings chromatogramFilterSettings = PreferenceSupplier.getChromatogramFilterSettings();
 		return applyFilter(chromatogramSelection, chromatogramFilterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/core/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/core/ChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2022 Lablicate GmbH.
+ * Copyright (c) 2010, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This
  * program and the accompanying materials are made available under the terms of
@@ -14,6 +14,7 @@ package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.core;
 
 import java.util.List;
 
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.msd.filter.core.chromatogram.AbstractChromatogramFilterMSD;
@@ -37,15 +38,14 @@ import org.eclipse.core.runtime.IProgressMonitor;
 public class ChromatogramFilter extends AbstractChromatogramFilterMSD {
 
 	@Override
-	public IProcessingInfo<?> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo<Object> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = new ProcessingInfo<>();
 		processingInfo.addMessages(validate(chromatogramSelection, chromatogramFilterSettings));
 		//
 		if(!processingInfo.hasErrorMessages()) {
-			if(chromatogramFilterSettings instanceof FilterSettings) {
+			if(chromatogramFilterSettings instanceof FilterSettings filterSettings) {
 				try {
-					FilterSettings filterSettings = (FilterSettings)chromatogramFilterSettings;
 					TraceSettingUtil ionSettingsUtil = new TraceSettingUtil();
 					IMarkedIons ionsToRemove = new MarkedIons(ionSettingsUtil.extractTraces(ionSettingsUtil.deserialize(filterSettings.getIonsToRemove())), MarkedTraceModus.INCLUDE);
 					IMarkedIons ionsToPreserve = new MarkedIons(ionSettingsUtil.extractTraces(ionSettingsUtil.deserialize(filterSettings.getIonsToPreserve())), MarkedTraceModus.INCLUDE);
@@ -69,7 +69,7 @@ public class ChromatogramFilter extends AbstractChromatogramFilterMSD {
 
 	// TODO JUnit
 	@Override
-	public IProcessingInfo<?> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettings filterSettings = PreferenceSupplier.getFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/DenoiseOperation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/DenoiseOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -39,8 +39,7 @@ public class DenoiseOperation extends AbstractOperation {
 	private IExtractedIonSignals extractedIonSignals;
 	private IExtractedIonSignals previousExtractedIonSignals;
 
-	@SuppressWarnings("rawtypes")
-	public DenoiseOperation(IChromatogramSelection chromatogramSelection, IExtractedIonSignals extractedIonSignals) {
+	public DenoiseOperation(IChromatogramSelection<?, ?> chromatogramSelection, IExtractedIonSignals extractedIonSignals) {
 
 		super("Denoise");
 		this.chromatogramSelection = chromatogramSelection;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/ionremover/core/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/ionremover/core/ChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,6 +12,7 @@
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover.core;
 
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.msd.filter.core.chromatogram.AbstractChromatogramFilterMSD;
@@ -32,15 +33,14 @@ import org.eclipse.core.runtime.IProgressMonitor;
 public class ChromatogramFilter extends AbstractChromatogramFilterMSD {
 
 	@Override
-	public IProcessingInfo<?> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo<Object> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = new ProcessingInfo<>();
 		processingInfo.addMessages(validate(chromatogramSelection, chromatogramFilterSettings));
 		//
 		if(!processingInfo.hasErrorMessages()) {
-			if(chromatogramFilterSettings instanceof ChromatogramFilterSettings) {
+			if(chromatogramFilterSettings instanceof ChromatogramFilterSettings filterSettings) {
 				try {
-					ChromatogramFilterSettings filterSettings = (ChromatogramFilterSettings)chromatogramFilterSettings;
 					TraceSettingUtil ionSettingUtil = new TraceSettingUtil();
 					IMarkedIons ionsToRemove = new MarkedIons(ionSettingUtil.extractTraces(ionSettingUtil.deserialize(filterSettings.getIonsToRemove())), MarkedTraceModus.INCLUDE);
 					applyIonRemoverFilter(chromatogramSelection, ionsToRemove, monitor);
@@ -56,7 +56,7 @@ public class ChromatogramFilter extends AbstractChromatogramFilterMSD {
 
 	// TODO JUnit
 	@Override
-	public IProcessingInfo<?> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
 
 		ChromatogramFilterSettings filterSettings = PreferenceSupplier.getFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);
@@ -77,7 +77,7 @@ public class ChromatogramFilter extends AbstractChromatogramFilterMSD {
 		if(ionsToRemove == null) {
 			throw new FilterException("The excluded ions instance was null.");
 		}
-		if(ionsToRemove.getIonsNominal().size() == 0) {
+		if(ionsToRemove.getIonsNominal().isEmpty()) {
 			throw new FilterException("There was no ion stored to be excluded.");
 		}
 		IVendorMassSpectrum supplierMassSpectrum;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/splitter/core/ChromatogramFilterMSx.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/splitter/core/ChromatogramFilterMSx.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Lablicate GmbH.
+ * Copyright (c) 2020, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.msd.filter.core.chromatogram.AbstractChromatogramFilterMSD;
@@ -36,27 +37,25 @@ import org.eclipse.core.runtime.IProgressMonitor;
 public class ChromatogramFilterMSx extends AbstractChromatogramFilterMSD {
 
 	@Override
-	public IProcessingInfo<?> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo<?> validation = validate(chromatogramSelection, chromatogramFilterSettings);
-		IProcessingInfo<Object> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<IChromatogramFilterResult> validation = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = new ProcessingInfo<>();
 		processingInfo.addMessages(validation);
 		//
 		if(!processingInfo.hasErrorMessages()) {
 			//
 			IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
-			if(chromatogram instanceof IChromatogramMSD) {
+			if(chromatogram instanceof IChromatogramMSD chromatogramMSD) {
 				//
 				Map<Short, List<IScan>> splittedScanMap = new HashMap<>();
 				//
-				IChromatogramMSD chromatogramMSD = (IChromatogramMSD)chromatogram;
 				for(IScan scan : chromatogramMSD.getScans()) {
-					if(scan instanceof IRegularMassSpectrum) {
-						IRegularMassSpectrum massSpectrum = (IRegularMassSpectrum)scan;
+					if(scan instanceof IRegularMassSpectrum massSpectrum) {
 						short massSpectrometer = massSpectrum.getMassSpectrometer();
 						List<IScan> scans = splittedScanMap.get(massSpectrometer);
 						if(scans == null) {
-							scans = new ArrayList<IScan>();
+							scans = new ArrayList<>();
 							splittedScanMap.put(massSpectrometer, scans);
 						}
 						scans.add(scan);
@@ -90,7 +89,7 @@ public class ChromatogramFilterMSx extends AbstractChromatogramFilterMSD {
 	}
 
 	@Override
-	public IProcessingInfo<?> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsMSx splitterSettings = PreferenceSupplier.getFilterSettingsMSx();
 		return applyFilter(chromatogramSelection, splitterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/splitter/core/ChromatogramFilterSIM.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/splitter/core/ChromatogramFilterSIM.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Lablicate GmbH.
+ * Copyright (c) 2021, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.msd.filter.core.chromatogram.AbstractChromatogramFilterMSD;
@@ -33,15 +34,15 @@ import org.eclipse.core.runtime.IProgressMonitor;
 public class ChromatogramFilterSIM extends AbstractChromatogramFilterMSD {
 
 	@Override
-	public IProcessingInfo<?> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo<?> validation = validate(chromatogramSelection, chromatogramFilterSettings);
-		IProcessingInfo<Object> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<IChromatogramFilterResult> validation = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = new ProcessingInfo<>();
 		processingInfo.addMessages(validation);
 		//
 		FilterSettingsSIM filterSettings;
-		if(chromatogramFilterSettings instanceof FilterSettingsSIM) {
-			filterSettings = (FilterSettingsSIM)chromatogramFilterSettings;
+		if(chromatogramFilterSettings instanceof FilterSettingsSIM filterSettingsSIM) {
+			filterSettings = filterSettingsSIM;
 		} else {
 			filterSettings = PreferenceSupplier.getFilterSettingsSIM();
 		}
@@ -50,17 +51,15 @@ public class ChromatogramFilterSIM extends AbstractChromatogramFilterMSD {
 		if(!processingInfo.hasErrorMessages()) {
 			//
 			IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
-			if(chromatogram instanceof IChromatogramMSD) {
+			if(chromatogram instanceof IChromatogramMSD chromatogramMSD) {
 				/*
 				 * Parse the scans.
 				 */
 				List<IScanMSD> fullScans = new ArrayList<>();
 				List<IScanMSD> simScans = new ArrayList<>();
 				//
-				IChromatogramMSD chromatogramMSD = (IChromatogramMSD)chromatogram;
 				for(IScan scan : chromatogramMSD.getScans()) {
-					if(scan instanceof IScanMSD) {
-						IScanMSD scanMSD = (IScanMSD)scan;
+					if(scan instanceof IScanMSD scanMSD) {
 						if(scanMSD.getNumberOfIons() <= limitIons) {
 							simScans.add(scanMSD);
 						} else {
@@ -82,7 +81,7 @@ public class ChromatogramFilterSIM extends AbstractChromatogramFilterMSD {
 	}
 
 	@Override
-	public IProcessingInfo<?> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsSIM settings = PreferenceSupplier.getFilterSettingsSIM();
 		return applyFilter(chromatogramSelection, settings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/calculator/SubtractCalculator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/calculator/SubtractCalculator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -42,7 +42,6 @@ public class SubtractCalculator {
 	 * @param chromatogramSelection
 	 * @param filterSettings
 	 */
-	@SuppressWarnings("rawtypes")
 	public void subtractPeakMassSpectraFromChromatogramSelection(IChromatogramSelectionMSD chromatogramSelection, ChromatogramFilterSettings filterSettings) {
 
 		/*
@@ -69,17 +68,16 @@ public class SubtractCalculator {
 		/*
 		 * Subtract the mass spectrum from each scan.
 		 */
-		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+		IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 		int startScan = chromatogram.getScanNumber(chromatogramSelection.getStartRetentionTime());
 		int stopScan = chromatogram.getScanNumber(chromatogramSelection.getStopRetentionTime());
 		//
 		for(int scanNumber = startScan; scanNumber <= stopScan; scanNumber++) {
 			IScan scan = chromatogram.getScan(scanNumber);
-			if(scan instanceof IVendorMassSpectrum) {
+			if(scan instanceof IVendorMassSpectrum targetMassSpectrum) {
 				/*
 				 * Try to subtract the mass spectrum.
 				 */
-				IScanMSD targetMassSpectrum = (IVendorMassSpectrum)scan;
 				adjustIntensityValues(targetMassSpectrum, subtractMassSpectrumMap, useNominalMasses, useNormalize);
 			}
 		}
@@ -101,7 +99,7 @@ public class SubtractCalculator {
 		/*
 		 * Test if null.
 		 */
-		if(peaks == null || peaks.size() == 0 || peakFilterSettings == null) {
+		if(peaks == null || peaks.isEmpty() || peakFilterSettings == null) {
 			return;
 		}
 		/*
@@ -167,7 +165,7 @@ public class SubtractCalculator {
 	 */
 	public Map<Double, Float> getMassSpectrumMap(IScanMSD massSpectrum, boolean useNominalMasses, boolean normalize) {
 
-		Map<Double, Float> massSpectrumMap = new HashMap<Double, Float>();
+		Map<Double, Float> massSpectrumMap = new HashMap<>();
 		if(massSpectrum != null) {
 			try {
 				/*
@@ -223,7 +221,7 @@ public class SubtractCalculator {
 			return;
 		}
 		//
-		List<IIon> ionsToRemove = new ArrayList<IIon>();
+		List<IIon> ionsToRemove = new ArrayList<>();
 		for(IIon ion : targetMassSpectrum.getIons()) {
 			/*
 			 * Get the nominal mass if needed.

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/core/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/core/ChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -25,19 +25,16 @@ import org.eclipse.chemclipse.processing.core.MessageType;
 import org.eclipse.chemclipse.processing.core.ProcessingMessage;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilter extends AbstractChromatogramFilterMSD {
 
 	private static final String DESCRIPTION = "Subtract Filter Chromatogram";
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
-			if(chromatogramFilterSettings instanceof ChromatogramFilterSettings) {
-				ChromatogramFilterSettings filterSettings = (ChromatogramFilterSettings)chromatogramFilterSettings;
+			if(chromatogramFilterSettings instanceof ChromatogramFilterSettings filterSettings) {
 				SubtractCalculator subtractCalculator = new SubtractCalculator();
 				subtractCalculator.subtractPeakMassSpectraFromChromatogramSelection(chromatogramSelection, filterSettings);
 				processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, DESCRIPTION, "The mass spectrum has been subtracted successfully from the chromatogram selection."));
@@ -52,7 +49,7 @@ public class ChromatogramFilter extends AbstractChromatogramFilterMSD {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
 
 		ChromatogramFilterSettings filterSettings = PreferenceSupplier.getFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/AbstractChromatogramFilterMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/AbstractChromatogramFilterMSD.java
@@ -17,8 +17,7 @@ import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 
-@SuppressWarnings("rawtypes")
-public abstract class AbstractChromatogramFilterMSD implements IChromatogramFilterMSD {
+public abstract class AbstractChromatogramFilterMSD implements IChromatogramFilterMSD<IChromatogramFilterResult> {
 
 	private static final String DESCRIPTION = "Chromatogram Filter";
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/ChromatogramFilterMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/ChromatogramFilterMSD.java
@@ -76,7 +76,7 @@ public class ChromatogramFilterMSD {
 	// TODO JUnit
 	/**
 	 * Applies the specified filter, but retrieves the IChromatogramFilterSettings dynamically.<br/>
-	 * See also method: applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, String filterId, IProgressMonitor monitor)
+	 * See also method: applyFilter(IChromatogramSelection<?, ?>chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, String filterId, IProgressMonitor monitor)
 	 *
 	 * @param chromatogramSelection
 	 * @param filterId

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/impl/ChromatogramFilterAdjust.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/impl/ChromatogramFilterAdjust.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Lablicate GmbH.
+ * Copyright (c) 2020, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,6 +12,7 @@
 package org.eclipse.chemclipse.chromatogram.msd.filter.impl;
 
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.msd.filter.core.chromatogram.AbstractChromatogramFilterMSD;
@@ -32,16 +33,14 @@ import org.eclipse.chemclipse.msd.model.xic.IExtractedIonSignals;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilterAdjust extends AbstractChromatogramFilterMSD {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramFilterAdjust.class);
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
 			if(chromatogramFilterSettings instanceof FilterSettingsAdjust) {
 				/*
@@ -62,8 +61,7 @@ public class ChromatogramFilterAdjust extends AbstractChromatogramFilterMSD {
 						//
 						for(int i = startScan; i <= stopScan; i++) {
 							IScan scan = chromatogram.getScan(i);
-							if(scan instanceof IScanMSD) {
-								IScanMSD scanMSD = (IScanMSD)scan;
+							if(scan instanceof IScanMSD scanMSD) {
 								IExtractedIonSignal extractedIonSignalOriginal = scanMSD.getExtractedIonSignal();
 								IExtractedIonSignal extractedIonSignalAdjusted = extractedIonSignals.getExtractedIonSignal(i);
 								int startMZ = extractedIonSignalAdjusted.getStartIon();
@@ -103,7 +101,7 @@ public class ChromatogramFilterAdjust extends AbstractChromatogramFilterMSD {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsAdjust filterSettings = PreferenceSupplier.getFilterSettingsAdjust();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/impl/ChromatogramFilterZeroValueRemoval.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/impl/ChromatogramFilterZeroValueRemoval.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Lablicate GmbH.
+ * Copyright (c) 2020, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,6 +12,7 @@
 package org.eclipse.chemclipse.chromatogram.msd.filter.impl;
 
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.msd.filter.core.chromatogram.AbstractChromatogramFilterMSD;
@@ -26,9 +27,9 @@ import org.eclipse.core.runtime.IProgressMonitor;
 public class ChromatogramFilterZeroValueRemoval extends AbstractChromatogramFilterMSD {
 
 	@Override
-	public IProcessingInfo<?> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo<Object> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = new ProcessingInfo<>();
 		processingInfo.addMessages(validate(chromatogramSelection, chromatogramFilterSettings));
 		//
 		if(!processingInfo.hasErrorMessages()) {
@@ -36,7 +37,6 @@ public class ChromatogramFilterZeroValueRemoval extends AbstractChromatogramFilt
 				/*
 				 * No settings needed yet.
 				 */
-				// FilterSettingsAdjust filterSettings = (FilterSettingsAdjust)chromatogramFilterSettings;
 				if(chromatogramSelection instanceof IChromatogramSelectionMSD) {
 					IChromatogramSelectionMSD chromatogramSelectionMSD = chromatogramSelection;
 					ExtractedMatrix extract = new ExtractedMatrix(chromatogramSelectionMSD);
@@ -87,7 +87,7 @@ public class ChromatogramFilterZeroValueRemoval extends AbstractChromatogramFilt
 	}
 
 	@Override
-	public IProcessingInfo<?> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsAdjust filterSettings = PreferenceSupplier.getFilterSettingsAdjust();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/amdis/internal/identifier/AmdisIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/amdis/internal/identifier/AmdisIdentifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -22,6 +22,7 @@ import org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis.runt
 import org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis.settings.IOnsiteSettings;
 import org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis.settings.SettingsAMDIS;
 import org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis.support.PeakProcessorSupport;
+import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IPeaks;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -36,7 +37,7 @@ import org.eclipse.core.runtime.SubMonitor;
 
 public class AmdisIdentifier {
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	@SuppressWarnings({"unchecked"})
 	public IProcessingResult<Void> calulateAndSetDeconvolutedPeaks(IChromatogramSelectionMSD chromatogramSelection, SettingsAMDIS settingsAMDIS, IProgressMonitor monitor) throws InterruptedException {
 
 		SubMonitor subMonitor = SubMonitor.convert(monitor, 100);
@@ -81,7 +82,7 @@ public class AmdisIdentifier {
 				return result;
 			}
 			//
-			IPeaks peaks = amdisPeaks.getProcessingResult();
+			IPeaks<IPeak> peaks = (IPeaks<IPeak>)amdisPeaks.getProcessingResult();
 			if(peaks == null) {
 				result.addErrorMessage(PreferenceSupplier.IDENTIFIER, "Parsing peaks does not return a result");
 				return result;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/amdis/support/PeakProcessorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/amdis/support/PeakProcessorSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -69,10 +69,9 @@ public class PeakProcessorSupport {
 		String modelPeakMarker = "MP" + modelPeakOption.value();
 		//
 		for(IPeak peak : peaks) {
-			if(peak instanceof IPeakMSD) {
+			if(peak instanceof IPeakMSD peakMSD) {
 				String header = peak.getTemporaryData();
 				try {
-					IPeakMSD peakMSD = (IPeakMSD)peak;
 					IPeakModelMSD peakModelMSD = peakMSD.getPeakModel();
 					//
 					int startScan = peakModelMSD.getTemporarilyInfo(IPeakReader.TEMP_INFO_START_SCAN) instanceof Integer ? (int)peakModelMSD.getTemporarilyInfo(IPeakReader.TEMP_INFO_START_SCAN) : 0;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.filter/src/org/eclipse/chemclipse/chromatogram/wsd/filter/core/chromatogram/ChromatogramFilterWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.filter/src/org/eclipse/chemclipse/chromatogram/wsd/filter/core/chromatogram/ChromatogramFilterWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -74,7 +74,7 @@ public class ChromatogramFilterWSD {
 	// TODO JUnit
 	/**
 	 * Applies the specified filter, but retrieves the IChromatogramFilterSettings dynamically.<br/>
-	 * See also method: applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, String filterId, IProgressMonitor monitor)
+	 * See also method: applyFilter(IChromatogramSelection<?, ?>chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, String filterId, IProgressMonitor monitor)
 	 * 
 	 * @param chromatogramSelection
 	 * @param filterId

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -69,10 +69,9 @@ public class BaselineDetector {
 	 * @param monitor
 	 * @return IProcessingInfo
 	 */
-	@SuppressWarnings("rawtypes")
-	public static IProcessingInfo setBaseline(IChromatogramSelection chromatogramSelection, IBaselineDetectorSettings baselineDetectorSettings, final String detectorId, IProgressMonitor monitor) {
+	public static IProcessingInfo<?> setBaseline(IChromatogramSelection<?, ?> chromatogramSelection, IBaselineDetectorSettings baselineDetectorSettings, final String detectorId, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo;
+		IProcessingInfo<?> processingInfo;
 		IBaselineDetector detector = getBaselineDetector(detectorId);
 		if(detector != null && chromatogramSelection != null) {
 			processingInfo = detector.setBaseline(chromatogramSelection, baselineDetectorSettings, monitor);
@@ -91,10 +90,9 @@ public class BaselineDetector {
 	 * @param monitor
 	 * @return IProcessingInfo
 	 */
-	@SuppressWarnings("rawtypes")
-	public static IProcessingInfo setBaseline(IChromatogramSelection chromatogramSelection, final String detectorId, IProgressMonitor monitor) {
+	public static IProcessingInfo<?> setBaseline(IChromatogramSelection<?, ?> chromatogramSelection, final String detectorId, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo;
+		IProcessingInfo<?> processingInfo;
 		IBaselineDetector detector = getBaselineDetector(detectorId);
 		if(detector != null) {
 			processingInfo = detector.setBaseline(chromatogramSelection, monitor);
@@ -172,7 +170,7 @@ public class BaselineDetector {
 
 	private static IProcessingInfo<?> getNoDetectorAvailableProcessingInfo() {
 
-		IProcessingInfo<?> processingInfo = new ProcessingInfo<Object>();
+		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
 		IProcessingMessage processingMessage = new ProcessingMessage(MessageType.ERROR, "Baseline Detector", NO_DETECTOR_AVAILABLE);
 		processingInfo.addMessage(processingMessage);
 		return processingInfo;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorProcessTypeSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Lablicate GmbH.
+ * Copyright (c) 2019, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -56,6 +56,7 @@ public class BaselineDetectorProcessTypeSupplier implements IProcessTypeSupplier
 
 		@SuppressWarnings("unchecked")
 		public BaselineDetectorProcessorSupplier(IBaselineDetectorSupplier supplier, IProcessTypeSupplier parent) {
+
 			super(supplier.getId(), supplier.getDetectorName(), supplier.getDescription(), (Class<IBaselineDetectorSettings>)supplier.getSettingsClass(), parent, DataType.MSD, DataType.CSD, DataType.WSD);
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/PageCalibrationTable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/PageCalibrationTable.java
@@ -64,15 +64,14 @@ public class PageCalibrationTable extends AbstractExtendedWizardPage {
 
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public void setVisible(boolean visible) {
 
 		super.setVisible(visible);
 		if(visible) {
-			IChromatogramSelection chromatogramSelection = wizardElements.getChromatogramSelection();
+			IChromatogramSelection<?, ?> chromatogramSelection = wizardElements.getChromatogramSelection();
 			if(chromatogramSelection != null && chromatogramSelection.getChromatogram() != null) {
-				IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+				IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 				updateChromatogramChart(chromatogramSelection);
 				RetentionIndexExtractor retentionIndexExtractor = new RetentionIndexExtractor();
 				ISeparationColumnIndices separationColumnIndices = retentionIndexExtractor.extract(chromatogram);
@@ -144,7 +143,7 @@ public class PageCalibrationTable extends AbstractExtendedWizardPage {
 					int retentionTime = retentionIndexEntry.getRetentionTime();
 					IChromatogramSelection chromatogramSelection = wizardElements.getChromatogramSelection();
 					if(chromatogramSelection != null && chromatogramSelection.getChromatogram() != null) {
-						IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+						IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 						IPeak selectedPeak = getSelectedPeak(chromatogram, retentionTime);
 						if(selectedPeak != null) {
 							chromatogramSelection.setSelectedPeak(selectedPeak);
@@ -187,8 +186,7 @@ public class PageCalibrationTable extends AbstractExtendedWizardPage {
 		updateStatus(message);
 	}
 
-	@SuppressWarnings("rawtypes")
-	private void updateChromatogramChart(IChromatogramSelection chromatogramSelection) {
+	private void updateChromatogramChart(IChromatogramSelection<?, ?> chromatogramSelection) {
 
 		chromatogramPeakChart.updateChromatogram(chromatogramSelection);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/PagePeakAssignment.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/PagePeakAssignment.java
@@ -106,13 +106,12 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
 	public void setVisible(boolean visible) {
 
 		super.setVisible(visible);
 		if(visible) {
-			IChromatogramSelection chromatogramSelection = wizardElements.getChromatogramSelection();
+			IChromatogramSelection<?, ?> chromatogramSelection = wizardElements.getChromatogramSelection();
 			if(chromatogramSelection != null && chromatogramSelection.getChromatogram() != null) {
 				/*
 				 * Set the start index.
@@ -126,7 +125,7 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 				/*
 				 * Set the first selection.
 				 */
-				IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+				IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 				List<? extends IPeak> peaks = chromatogram.getPeaks();
 				peakTableViewerUI.setInput(peaks);
 				peakTableViewerUI.getTable().setSelection(0);
@@ -258,7 +257,6 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 		button.setLayoutData(gridData);
 		button.addSelectionListener(new SelectionAdapter() {
 
-			@SuppressWarnings({"rawtypes", "unchecked"})
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 
@@ -266,9 +264,9 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 				messageBox.setText("Auto assign standards");
 				messageBox.setMessage("Would you like to set all standards automatically?");
 				if(messageBox.open() == SWT.YES) {
-					IChromatogramSelection chromatogramSelection = wizardElements.getChromatogramSelection();
+					IChromatogramSelection<?, ?> chromatogramSelection = wizardElements.getChromatogramSelection();
 					if(chromatogramSelection != null && chromatogramSelection.getChromatogram() != null) {
-						IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+						IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 						List<? extends IPeak> chromatogramPeaks = chromatogram.getPeaks();
 						List<String> selectedIndices = wizardElements.getSelectedIndices();
 						//

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/PagePeakSelection.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/PagePeakSelection.java
@@ -88,7 +88,7 @@ public class PagePeakSelection extends AbstractExtendedWizardPage {
 			IChromatogramSelection chromatogramSelection = getChromatogramSelection();
 			wizardElements.setChromatogramSelection(chromatogramSelection);
 			if(chromatogramSelection != null) {
-				IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+				IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 				/*
 				 * Hide the mass spectrum view if it is CSD data.
 				 */
@@ -215,15 +215,14 @@ public class PagePeakSelection extends AbstractExtendedWizardPage {
 		}
 	}
 
-	@SuppressWarnings({"rawtypes"})
-	private IChromatogramSelection getChromatogramSelection() {
+	private IChromatogramSelection<?, ?> getChromatogramSelection() {
 
-		IChromatogramSelection chromatogramSelection = null;
+		IChromatogramSelection<?, ?> chromatogramSelection = null;
 		ChromatogramImportRunnable runnable = new ChromatogramImportRunnable(wizardElements);
 		//
 		try {
 			getContainer().run(true, false, runnable);
-			IChromatogram chromatogram = runnable.getChromatogram();
+			IChromatogram<?> chromatogram = runnable.getChromatogram();
 			if(chromatogram instanceof IChromatogramMSD chromatogramMSD) {
 				chromatogramSelection = new ChromatogramSelectionMSD(chromatogramMSD);
 			} else if(chromatogram instanceof IChromatogramCSD chromatogramCSD) {
@@ -260,7 +259,6 @@ public class PagePeakSelection extends AbstractExtendedWizardPage {
 		return peakList;
 	}
 
-	@SuppressWarnings({"rawtypes"})
 	private void validateSelection() {
 
 		String message = null;
@@ -275,7 +273,7 @@ public class PagePeakSelection extends AbstractExtendedWizardPage {
 		}
 		//
 		if(message == null) {
-			IChromatogram chromatogram = wizardElements.getChromatogramSelection().getChromatogram();
+			IChromatogram<?> chromatogram = wizardElements.getChromatogramSelection().getChromatogram();
 			if(chromatogram == null || chromatogram.getPeaks().isEmpty()) {
 				message = "There is no peak available.";
 			}
@@ -286,8 +284,7 @@ public class PagePeakSelection extends AbstractExtendedWizardPage {
 		updateStatus(message);
 	}
 
-	@SuppressWarnings("rawtypes")
-	private void updateChromatogramChart(IChromatogramSelection chromatogramSelection) {
+	private void updateChromatogramChart(IChromatogramSelection<?, ?> chromatogramSelection) {
 
 		chromatogramPeakChart.updateChromatogram(chromatogramSelection);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/RetentionIndexWizardElements.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/RetentionIndexWizardElements.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -31,8 +31,7 @@ public class RetentionIndexWizardElements extends ChromatogramWizardElements {
 	private String stopIndexName = "";
 	private boolean useAlreadyDetectedPeaks = false;
 	//
-	@SuppressWarnings("rawtypes")
-	private IChromatogramSelection chromatogramSelection;
+	private IChromatogramSelection<?, ?> chromatogramSelection;
 	private ISeparationColumnIndices separationColumnIndices = new SeparationColumnIndices();
 	//
 	private boolean retentionIndexDataIsValidated = false;
@@ -141,14 +140,12 @@ public class RetentionIndexWizardElements extends ChromatogramWizardElements {
 		this.useAlreadyDetectedPeaks = useAlreadyDetectedPeaks;
 	}
 
-	@SuppressWarnings("rawtypes")
-	public IChromatogramSelection getChromatogramSelection() {
+	public IChromatogramSelection<?, ?> getChromatogramSelection() {
 
 		return chromatogramSelection;
 	}
 
-	@SuppressWarnings("rawtypes")
-	public void setChromatogramSelection(IChromatogramSelection chromatogramSelection) {
+	public void setChromatogramSelection(IChromatogramSelection<?, ?> chromatogramSelection) {
 
 		this.chromatogramSelection = chromatogramSelection;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/WizardCreateRetentionIndexFile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/WizardCreateRetentionIndexFile.java
@@ -197,16 +197,15 @@ public class WizardCreateRetentionIndexFile extends AbstractFileWizard {
 			 */
 			String path = calibrationFile.getAbsolutePath();
 			File chromatogramFile = new File(path.substring(0, path.length() - CALIBRATION_FILE_EXTENSION.length()) + CHROMATOGRAM_FILE_EXTENSION);
-			@SuppressWarnings("rawtypes")
-			IChromatogramSelection chromatogramSelection = wizardElements.getChromatogramSelection();
+			IChromatogramSelection<?, ?> chromatogramSelection = wizardElements.getChromatogramSelection();
 			if(wizardElements.isUseMassSpectrometryData()) {
-				if(chromatogramSelection instanceof IChromatogramSelectionMSD) {
-					IChromatogramMSD chromatogramMSD = ((IChromatogramSelectionMSD)chromatogramSelection).getChromatogram();
+				if(chromatogramSelection instanceof IChromatogramSelectionMSD chromatogramSelectionMSD) {
+					IChromatogramMSD chromatogramMSD = chromatogramSelectionMSD.getChromatogram();
 					ChromatogramConverterMSD.getInstance().convert(chromatogramFile, chromatogramMSD, CHROMATOGRAM_CONVERTER_ID, monitor);
 				}
 			} else {
-				if(chromatogramSelection instanceof IChromatogramSelectionCSD) {
-					IChromatogramCSD chromatogramCSD = ((IChromatogramSelectionCSD)chromatogramSelection).getChromatogram();
+				if(chromatogramSelection instanceof IChromatogramSelectionCSD chromatogramSelectionCSD) {
+					IChromatogramCSD chromatogramCSD = chromatogramSelectionCSD.getChromatogram();
 					ChromatogramConverterCSD.getInstance().convert(chromatogramFile, chromatogramCSD, CHROMATOGRAM_CONVERTER_ID, monitor);
 				}
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/impl/RetentionIndexExtractor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/impl/RetentionIndexExtractor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -26,8 +26,7 @@ import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 
 public class RetentionIndexExtractor {
 
-	@SuppressWarnings("rawtypes")
-	public ISeparationColumnIndices extract(IChromatogram chromatogram) {
+	public ISeparationColumnIndices extract(IChromatogram<?> chromatogram) {
 
 		ISeparationColumnIndices separationColumnIndices = new SeparationColumnIndices();
 		separationColumnIndices.setSeparationColumn(chromatogram.getSeparationColumnIndices().getSeparationColumn());
@@ -54,10 +53,9 @@ public class RetentionIndexExtractor {
 		return separationColumnIndices;
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	private List<? extends IPeak> getPeaks(IChromatogram chromatogram) {
+	private List<? extends IPeak> getPeaks(IChromatogram<?> chromatogram) {
 
-		List<IPeak> peaks = new ArrayList<IPeak>();
+		List<IPeak> peaks = new ArrayList<>();
 		peaks.addAll(chromatogram.getPeaks());
 		return peaks;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/core/chromatogram/AbstractChromatogramCalculator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/core/chromatogram/AbstractChromatogramCalculator.java
@@ -36,10 +36,9 @@ public abstract class AbstractChromatogramCalculator implements IChromatogramCal
 	 * @param chromatogramSelection
 	 * @return {@link IProcessingInfo}
 	 */
-	@SuppressWarnings("rawtypes")
-	private IProcessingInfo validateChromatogramSelection(IChromatogramSelection chromatogramSelection) {
+	private IProcessingInfo<?> validateChromatogramSelection(IChromatogramSelection<?, ?> chromatogramSelection) {
 
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
 		if(chromatogramSelection == null) {
 			processingInfo.addErrorMessage(DESCRIPTION, "The chromatogram selection is not valid.");
 		} else {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/core/chromatogram/ChromatogramCalculator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/core/chromatogram/ChromatogramCalculator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -57,16 +57,15 @@ public class ChromatogramCalculator {
 	 * @param filterId
 	 * @return {@link IChromatogramCalculatorProcessingInfo}
 	 */
-	@SuppressWarnings("rawtypes")
-	public static IProcessingInfo applyCalculator(IChromatogramSelection chromatogramSelection, IChromatogramCalculatorSettings chromatogramCalculatorSettings, String filterId, IProgressMonitor monitor) {
+	public static IProcessingInfo<?> applyCalculator(IChromatogramSelection<?, ?> chromatogramSelection, IChromatogramCalculatorSettings chromatogramCalculatorSettings, String filterId, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo;
+		IProcessingInfo<?> processingInfo;
 		IChromatogramCalculator chromatogramCalculator = getChromatogramCalculator(filterId);
 		if(chromatogramCalculator != null) {
 			processingInfo = chromatogramCalculator.applyCalculator(chromatogramSelection, chromatogramCalculatorSettings, monitor);
 			chromatogramSelection.getChromatogram().setDirty(true);
 		} else {
-			processingInfo = new ProcessingInfo();
+			processingInfo = new ProcessingInfo<>();
 			processingInfo.addErrorMessage(PROCESSING_DESCRIPTION, NO_CHROMATOGRAM_CALCULATOR_AVAILABLE);
 		}
 		return processingInfo;
@@ -75,22 +74,21 @@ public class ChromatogramCalculator {
 	// TODO JUnit
 	/**
 	 * Applies the specified filter, but retrieves the IChromatogramFilterSettings dynamically.<br/>
-	 * See also method: applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, String filterId, IProgressMonitor monitor)
+	 * See also method: applyFilter(IChromatogramSelection<?, ?>chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, String filterId, IProgressMonitor monitor)
 	 * 
 	 * @param chromatogramSelection
 	 * @param calculatorId
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	@SuppressWarnings("rawtypes")
-	public static IProcessingInfo applyCalculator(IChromatogramSelection chromatogramSelection, String calculatorId, IProgressMonitor monitor) {
+	public static IProcessingInfo<?> applyCalculator(IChromatogramSelection<?, ?> chromatogramSelection, String calculatorId, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo;
+		IProcessingInfo<?> processingInfo;
 		IChromatogramCalculator chromatogramCalculator = getChromatogramCalculator(calculatorId);
 		if(chromatogramCalculator != null) {
 			processingInfo = chromatogramCalculator.applyCalculator(chromatogramSelection, monitor);
 		} else {
-			processingInfo = new ProcessingInfo();
+			processingInfo = new ProcessingInfo<>();
 			processingInfo.addErrorMessage(PROCESSING_DESCRIPTION, NO_CHROMATOGRAM_CALCULATOR_AVAILABLE);
 		}
 		return processingInfo;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/rtshifter/core/internal/support/AbstractRetentionTimeModifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/rtshifter/core/internal/support/AbstractRetentionTimeModifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,10 +18,9 @@ import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 
 public abstract class AbstractRetentionTimeModifier {
 
-	@SuppressWarnings("rawtypes")
-	protected static void adjustScanDelayAndRetentionTimeRange(IChromatogramSelection chromatogramSelection) throws FilterException {
+	protected static void adjustScanDelayAndRetentionTimeRange(IChromatogramSelection<?, ?> chromatogramSelection) throws FilterException {
 
-		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+		IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 		if(chromatogram.getNumberOfScans() <= 0) {
 			throw new FilterException("There is no scan available.");
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/rtshifter/core/internal/support/RetentionTimeShifter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/rtshifter/core/internal/support/RetentionTimeShifter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Lablicate GmbH.
+ * Copyright (c) 2011, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,7 +20,6 @@ import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 
-@SuppressWarnings("rawtypes")
 public class RetentionTimeShifter extends AbstractRetentionTimeModifier {
 
 	/*
@@ -30,7 +29,7 @@ public class RetentionTimeShifter extends AbstractRetentionTimeModifier {
 
 	}
 
-	public static void shiftRetentionTimes(IChromatogramSelection chromatogramSelection, FilterSettingsShift filterSettings) throws FilterException {
+	public static void shiftRetentionTimes(IChromatogramSelection<?, ?>chromatogramSelection, FilterSettingsShift filterSettings) throws FilterException {
 
 		if(chromatogramSelection == null || chromatogramSelection.getChromatogram() == null) {
 			throw new FilterException("The chromatogram must not be null.");
@@ -41,11 +40,11 @@ public class RetentionTimeShifter extends AbstractRetentionTimeModifier {
 		adjustScanDelayAndRetentionTimeRange(chromatogramSelection);
 	}
 
-	private static List<Integer> adjustRetentionTimesAndReturnScansToRemove(IChromatogramSelection chromatogramSelection, FilterSettingsShift filterSettings) {
+	private static List<Integer> adjustRetentionTimesAndReturnScansToRemove(IChromatogramSelection<?, ?> chromatogramSelection, FilterSettingsShift filterSettings) {
 
 		boolean isShiftAllScans = filterSettings.isShiftAllScans();
 		int millisecondToShift = filterSettings.getMillisecondsShift();
-		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+		IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 		//
 		int startScan;
 		int stopScan;
@@ -83,7 +82,7 @@ public class RetentionTimeShifter extends AbstractRetentionTimeModifier {
 		return scansToRemove;
 	}
 
-	private static int getRetentionTimeLeftBorder(IChromatogram chromatogram, int startScan) {
+	private static int getRetentionTimeLeftBorder(IChromatogram<?> chromatogram, int startScan) {
 
 		int retentionTime = 0;
 		int scanLeftBorder = startScan - 1;
@@ -94,7 +93,7 @@ public class RetentionTimeShifter extends AbstractRetentionTimeModifier {
 		return retentionTime;
 	}
 
-	private static int getRetentionTimeRightBorder(IChromatogram chromatogram, int stopScan) {
+	private static int getRetentionTimeRightBorder(IChromatogram<?> chromatogram, int stopScan) {
 
 		int retentionTime = Integer.MAX_VALUE;
 		int scanRightBorder = stopScan + 1;
@@ -105,9 +104,9 @@ public class RetentionTimeShifter extends AbstractRetentionTimeModifier {
 		return retentionTime;
 	}
 
-	private static IChromatogram removeMarkedScans(IChromatogramSelection chromatogramSelection, List<Integer> scansToRemove) {
+	private static IChromatogram<?> removeMarkedScans(IChromatogramSelection<?, ?> chromatogramSelection, List<Integer> scansToRemove) {
 
-		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+		IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 		int counter = 0;
 		for(int scan : scansToRemove) {
 			chromatogram.removeScan(scan - counter);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/rtshifter/core/internal/support/RetentionTimeStretcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/rtshifter/core/internal/support/RetentionTimeStretcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -22,16 +22,16 @@ public class RetentionTimeStretcher extends AbstractRetentionTimeModifier {
 	 * Use only static methods.
 	 */
 	private RetentionTimeStretcher() {
+
 	}
 
-	@SuppressWarnings("rawtypes")
-	public static void stretchChromatogram(IChromatogramSelection chromatogramSelection, FilterSettingsStretch filterSettings) throws FilterException {
+	public static void stretchChromatogram(IChromatogramSelection<?, ?> chromatogramSelection, FilterSettingsStretch filterSettings) throws FilterException {
 
 		if(chromatogramSelection == null || chromatogramSelection.getChromatogram() == null) {
 			throw new FilterException("The chromatogram must not be null.");
 		}
 		//
-		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+		IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 		int scanRange = chromatogram.getNumberOfScans() - 1;
 		if(scanRange > 0) {
 			float retentionTimeRange = filterSettings.getChromatogramLength() - filterSettings.getScanDelay();

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/core/ChromatogramFilterMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/core/ChromatogramFilterMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Lablicate GmbH.
+ * Copyright (c) 2020, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -31,7 +31,6 @@ import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.operations.OperationHistoryFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFilterMSD extends AbstractChromatogramFilterMSD {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramFilterMSD.class);
@@ -55,7 +54,7 @@ public class ChromatogramFilterMSD extends AbstractChromatogramFilterMSD {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
 		IProcessingInfo<IChromatogramFilterResult> processingInfo = new ProcessingInfo<>();
 		processingInfo.setProcessingResult(process(chromatogramSelection, chromatogramFilterSettings, monitor));
@@ -70,7 +69,7 @@ public class ChromatogramFilterMSD extends AbstractChromatogramFilterMSD {
 	}
 
 	@Override
-	public IProcessingInfo applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
 
 		ChromatogramFilterSettings chromatogramFilterSettings = PreferenceSupplier.getFilterSettingsMSD();
 		IProcessingInfo<IChromatogramFilterResult> processingInfo = new ProcessingInfo<>();

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/processor/SavitzkyGolayProcessor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/processor/SavitzkyGolayProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 Lablicate GmbH.
+ * Copyright (c) 2015, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -25,15 +25,13 @@ import org.eclipse.chemclipse.model.signals.ITotalScanSignals;
 import org.eclipse.chemclipse.model.signals.TotalScanSignalExtractor;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class SavitzkyGolayProcessor {
 
-	@SuppressWarnings("unchecked")
-	public static IChromatogramFilterResult smooth(IChromatogramSelection chromatogramSelection, boolean validatePositive, ChromatogramFilterSettings filterSettings, IProgressMonitor monitor) {
+	public static IChromatogramFilterResult smooth(IChromatogramSelection<?, ?> chromatogramSelection, boolean validatePositive, ChromatogramFilterSettings filterSettings, IProgressMonitor monitor) {
 
 		IChromatogramFilterResult chromatogramFilterResult;
 		try {
-			IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+			IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 			TotalScanSignalExtractor signalExtractor = new TotalScanSignalExtractor(chromatogram);
 			ITotalScanSignals totalScanSignals = signalExtractor.getTotalScanSignals(chromatogramSelection, validatePositive);
 			//

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterCleaner.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterCleaner.java
@@ -38,11 +38,11 @@ import org.eclipse.core.runtime.SubMonitor;
  * This filter removes empty scans.
  *
  */
-@SuppressWarnings("rawtypes")
+
 public class FilterCleaner extends AbstractChromatogramFilter {
 
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?>chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
 		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
@@ -60,15 +60,15 @@ public class FilterCleaner extends AbstractChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?>chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsCleaner filterSettings = PreferenceSupplier.getCleanerFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);
 	}
 
-	private void applyChromatogramCleanerFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) throws FilterException {
+	private void applyChromatogramCleanerFilter(IChromatogramSelection<?, ?>chromatogramSelection, IProgressMonitor monitor) throws FilterException {
 
-		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+		IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 		int startScan = chromatogram.getScanNumber(chromatogramSelection.getStartRetentionTime());
 		int stopScan = chromatogram.getScanNumber(chromatogramSelection.getStopRetentionTime());
 		List<Integer> scansToRemove = new ArrayList<Integer>();

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterDuplicator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterDuplicator.java
@@ -42,11 +42,11 @@ import org.eclipse.chemclipse.wsd.model.core.implementation.ScanSignalWSD;
 import org.eclipse.chemclipse.wsd.model.core.implementation.ScanWSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
+
 public class FilterDuplicator extends AbstractChromatogramFilter {
 
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?>chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
 		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
@@ -61,13 +61,13 @@ public class FilterDuplicator extends AbstractChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?>chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsDuplicator filterSettings = PreferenceSupplier.getDuplicatorFilterSettings();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);
 	}
 
-	private void applyScanDuplicatorFilter(IChromatogramSelection chromatogramSelection, FilterSettingsDuplicator settings) {
+	private void applyScanDuplicatorFilter(IChromatogramSelection<?, ?>chromatogramSelection, FilterSettingsDuplicator settings) {
 
 		if(chromatogramSelection != null) {
 			/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterRetentionIndexSelector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterRetentionIndexSelector.java
@@ -33,11 +33,11 @@ import org.eclipse.chemclipse.processing.core.MessageType;
 import org.eclipse.chemclipse.processing.core.ProcessingMessage;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
+
 public class FilterRetentionIndexSelector extends AbstractChromatogramFilter {
 
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?>chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
 		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
@@ -52,7 +52,7 @@ public class FilterRetentionIndexSelector extends AbstractChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?>chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsRetentionIndexSelector filterSettings = PreferenceSupplier.getFilterSettingsRetentionIndexSelector();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterScanSelector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterScanSelector.java
@@ -29,11 +29,11 @@ import org.eclipse.chemclipse.processing.core.MessageType;
 import org.eclipse.chemclipse.processing.core.ProcessingMessage;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
+
 public class FilterScanSelector extends AbstractChromatogramFilter {
 
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?>chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
 		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
@@ -53,15 +53,15 @@ public class FilterScanSelector extends AbstractChromatogramFilter {
 	}
 
 	@Override
-	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection<?, ?>chromatogramSelection, IProgressMonitor monitor) {
 
 		FilterSettingsScanSelector filterSettings = PreferenceSupplier.getFilterSettingsScanSelector();
 		return applyFilter(chromatogramSelection, filterSettings, monitor);
 	}
 
-	private void selectScan(IChromatogramSelection chromatogramSelection, FilterSettingsScanSelector filterSettingsScanSelector) throws FilterException {
+	private void selectScan(IChromatogramSelection<?, ?>chromatogramSelection, FilterSettingsScanSelector filterSettingsScanSelector) throws FilterException {
 
-		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+		IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 		int startScan = chromatogram.getScanNumber(chromatogramSelection.getStartRetentionTime());
 		int stopScan = chromatogram.getScanNumber(chromatogramSelection.getStopRetentionTime());
 		int scanNumber = getScanNumber(chromatogram, filterSettingsScanSelector);
@@ -74,7 +74,7 @@ public class FilterScanSelector extends AbstractChromatogramFilter {
 		}
 	}
 
-	private int getScanNumber(IChromatogram chromatogram, FilterSettingsScanSelector filterSettingsScanSelector) {
+	private int getScanNumber(IChromatogram<?> chromatogram, FilterSettingsScanSelector filterSettingsScanSelector) {
 
 		int scanNumber;
 		double value = filterSettingsScanSelector.getScanSelectorValue();

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/supplier/trapezoid/internal/support/PeakIntegratorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/supplier/trapezoid/internal/support/PeakIntegratorSupport.java
@@ -52,8 +52,7 @@ public class PeakIntegratorSupport {
 		return peakIntegrationResults;
 	}
 
-	@SuppressWarnings("rawtypes")
-	public IPeakIntegrationResults calculatePeakIntegrationResults(IChromatogramSelection chromatogramSelection, PeakIntegrationSettings peakIntegrationSettings, IProgressMonitor monitor) throws ValueMustNotBeNullException {
+	public IPeakIntegrationResults calculatePeakIntegrationResults(IChromatogramSelection<?, ?> chromatogramSelection, PeakIntegrationSettings peakIntegrationSettings, IProgressMonitor monitor) throws ValueMustNotBeNullException {
 
 		/*
 		 * Get the chromatogram.

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse/src/org/eclipse/chemclipse/chromatogram/xxd/quantitation/supplier/chemclipse/core/PeakQuantifierISTD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse/src/org/eclipse/chemclipse/chromatogram/xxd/quantitation/supplier/chemclipse/core/PeakQuantifierISTD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -59,14 +59,12 @@ public class PeakQuantifierISTD extends AbstractPeakQuantifier implements IPeakQ
 		return quantify(peaks, peakQuantifierSettings, monitor);
 	}
 
-	@SuppressWarnings("rawtypes")
-	public IProcessingInfo quantifySelectedPeak(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<?> quantifySelectedPeak(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		return calculatorISTD.quantifySelectedPeak(chromatogramSelection, monitor);
 	}
 
-	@SuppressWarnings("rawtypes")
-	public IProcessingInfo quantifyAllPeaks(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<?> quantifyAllPeaks(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor) {
 
 		return calculatorISTD.quantifyAllPeaks(chromatogramSelection, monitor);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse/src/org/eclipse/chemclipse/chromatogram/xxd/quantitation/supplier/chemclipse/internal/core/PeakQuantitationCalculatorISTD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse/src/org/eclipse/chemclipse/chromatogram/xxd/quantitation/supplier/chemclipse/internal/core/PeakQuantitationCalculatorISTD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -114,8 +114,8 @@ public class PeakQuantitationCalculatorISTD extends AbstractPeakQuantitationCalc
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
-	private List<? extends IPeak> getInternalStandardPeaks(IChromatogram chromatogram) {
+	
+	private List<? extends IPeak> getInternalStandardPeaks(IChromatogram<?> chromatogram) {
 
 		if(chromatogram != null) {
 			if(chromatogram instanceof IChromatogramMSD) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/io/ReportWriter1.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/io/ReportWriter1.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 Lablicate GmbH.
+ * Copyright (c) 2012, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -133,8 +133,7 @@ public class ReportWriter1 {
 	 * @param chromatogram
 	 * @param monitor
 	 */
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	private void reportChromatogram(PrintWriter printWriter, IChromatogram chromatogram, IProgressMonitor monitor) {
+	private void reportChromatogram(PrintWriter printWriter, IChromatogram<?> chromatogram, IProgressMonitor monitor) {
 
 		/*
 		 * Print
@@ -198,8 +197,7 @@ public class ReportWriter1 {
 		printWriter.println("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
 	}
 
-	@SuppressWarnings("rawtypes")
-	private String getChromatogramType(IChromatogram chromatogram) {
+	private String getChromatogramType(IChromatogram<?> chromatogram) {
 
 		if(chromatogram instanceof IChromatogramCSD) {
 			return "CSD";
@@ -463,8 +461,7 @@ public class ReportWriter1 {
 		return false;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private void reportChromatogramIdentificationResults(PrintWriter printWriter, IChromatogram chromatogram, String messageNoResults, IProgressMonitor monitor) {
+	private void reportChromatogramIdentificationResults(PrintWriter printWriter, IChromatogram<?> chromatogram, String messageNoResults, IProgressMonitor monitor) {
 
 		/*
 		 * Get the targets

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/io/ReportWriter4.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/io/ReportWriter4.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Lablicate GmbH.
+ * Copyright (c) 2020, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -75,8 +75,7 @@ public class ReportWriter4 {
 	 * @param chromatogram
 	 * @param monitor
 	 */
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	private void reportChromatogram(PrintWriter printWriter, IChromatogram chromatogram, IProgressMonitor monitor) {
+	private void reportChromatogram(PrintWriter printWriter, IChromatogram<?> chromatogram, IProgressMonitor monitor) {
 
 		List<IPeak> peaks = new ArrayList<>(chromatogram.getPeaks());
 		Collections.sort(peaks, peakComparator);

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/comparators/ReportComparator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/comparators/ReportComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,11 +15,10 @@ import java.util.Comparator;
 
 import org.eclipse.chemclipse.converter.model.reports.IReport;
 
-@SuppressWarnings("rawtypes")
-public class ReportComparator implements Comparator<IReport> {
+public class ReportComparator implements Comparator<IReport<?>> {
 
 	@Override
-	public int compare(IReport report1, IReport report2) {
+	public int compare(IReport<?> report1, IReport<?> report2) {
 
 		return Integer.compare(report1.getReportNumber(), report2.getReportNumber());
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/model/reports/Reports.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/model/reports/Reports.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,8 +13,7 @@ package org.eclipse.chemclipse.converter.model.reports;
 
 import java.util.ArrayList;
 
-@SuppressWarnings("rawtypes")
-public class Reports<T extends IReport> extends ArrayList<T> implements IReports<T> {
+public class Reports<T extends IReport<?>> extends ArrayList<T> implements IReports<T> {
 
 	/**
 	 * Renew this UUID on change.

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/AbstractChromatogramCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/AbstractChromatogramCSD.java
@@ -74,9 +74,9 @@ public abstract class AbstractChromatogramCSD extends AbstractChromatogram<IChro
 		return null;
 	}
 
-	@SuppressWarnings("rawtypes")
+	
 	@Override
-	public void fireUpdate(IChromatogramSelection chromatogramSelection) {
+	public void fireUpdate(IChromatogramSelection<?, ?>chromatogramSelection) {
 
 		/*
 		 * Fire an update to inform all listeners.

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/selection/ChromatogramSelectionCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/selection/ChromatogramSelectionCSD.java
@@ -49,11 +49,10 @@ public class ChromatogramSelectionCSD extends AbstractChromatogramSelection<IChr
 		selectedScan = null;
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public IChromatogramCSD getChromatogramCSD() {
 
-		IChromatogram chromatogram = getChromatogram();
+		IChromatogram<?> chromatogram = getChromatogram();
 		if(chromatogram instanceof IChromatogramCSD chromatogramCSD) {
 			return chromatogramCSD;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/baseline/BaselineModel.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/baseline/BaselineModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -31,24 +31,23 @@ import org.eclipse.chemclipse.numeric.equations.Equations;
  */
 public class BaselineModel implements IBaselineModel {
 
-	@SuppressWarnings("rawtypes")
-	private transient IChromatogram chromatogram;
+	private IChromatogram<?> chromatogram;
 	/*
 	 * The start retention time is the key.
 	 */
-	private NavigableMap<Integer, IBaselineSegment> baselineSegments = new TreeMap<Integer, IBaselineSegment>();
+	private NavigableMap<Integer, IBaselineSegment> baselineSegments = new TreeMap<>();
 	private float defaultBackgroundAbundance;
 	private boolean interpolate;
 
-	@SuppressWarnings("rawtypes")
-	public BaselineModel(IChromatogram chromatogram) {
+	public BaselineModel(IChromatogram<?> chromatogram) {
+
 		this.chromatogram = chromatogram;
 		this.defaultBackgroundAbundance = 0f;
 		this.interpolate = false;
 	}
 
-	@SuppressWarnings("rawtypes")
-	public BaselineModel(IChromatogram chromatogram, float defaultBackgroundAbundance) {
+	public BaselineModel(IChromatogram<?> chromatogram, float defaultBackgroundAbundance) {
+
 		this.chromatogram = chromatogram;
 		this.defaultBackgroundAbundance = defaultBackgroundAbundance;
 		if(Double.isNaN(defaultBackgroundAbundance)) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeak.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeak.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -37,11 +37,11 @@ public abstract class AbstractPeak implements IPeak {
 	private String detectorDescription = "";
 	private String quantifierDescription = "";
 	private boolean activeForAnalysis = true;
-	private List<IIntegrationEntry> integrationEntries = new ArrayList<IIntegrationEntry>();
+	private List<IIntegrationEntry> integrationEntries = new ArrayList<>();
 	private final IIntegrationConstraints integrationConstraints = new IntegrationConstraints();
-	private final Set<IQuantitationEntry> quantitationEntries = new HashSet<IQuantitationEntry>();
-	private final List<IInternalStandard> internalStandards = new ArrayList<IInternalStandard>();
-	private final Set<String> quantitationReferences = new HashSet<String>(); // Used to quantify against certain ISTDs or ESTDs
+	private final Set<IQuantitationEntry> quantitationEntries = new HashSet<>();
+	private final List<IInternalStandard> internalStandards = new ArrayList<>();
+	private final Set<String> quantitationReferences = new HashSet<>(); // Used to quantify against certain ISTDs or ESTDs
 	private final Set<String> classifier = new LinkedHashSet<>();
 	/*
 	 * Transient
@@ -127,7 +127,7 @@ public abstract class AbstractPeak implements IPeak {
 	public double getIntegratedArea() {
 
 		double integratedArea = 0.0d;
-		if(integrationEntries.size() > 0) {
+		if(!integrationEntries.isEmpty()) {
 			for(IIntegrationEntry integrationEntry : integrationEntries) {
 				integratedArea += integrationEntry.getIntegratedArea();
 			}
@@ -247,8 +247,7 @@ public abstract class AbstractPeak implements IPeak {
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
-	protected void validateChromatogram(IChromatogram chromatogram) throws IllegalArgumentException {
+	protected void validateChromatogram(IChromatogram<?> chromatogram) throws IllegalArgumentException {
 
 		/*
 		 * Do not allow that the parentChromatogram is null.
@@ -262,8 +261,7 @@ public abstract class AbstractPeak implements IPeak {
 	 * Check that the peak model is within the chromatogram retention time
 	 * borders.
 	 */
-	@SuppressWarnings("rawtypes")
-	protected void validateRetentionTimes(IChromatogram chromatogram, IPeakModel peakModel) throws PeakException {
+	protected void validateRetentionTimes(IChromatogram<?> chromatogram, IPeakModel peakModel) throws PeakException {
 
 		int start = chromatogram.getStartRetentionTime();
 		int stop = chromatogram.getStopRetentionTime();

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractScan.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractScan.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 Lablicate GmbH.
+ * Copyright (c) 2012, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -28,8 +28,7 @@ public abstract class AbstractScan extends AbstractSignal implements IScan {
 	 * methods.
 	 */
 	private static final long serialVersionUID = 642924518234776409L;
-	@SuppressWarnings("rawtypes")
-	private transient IChromatogram parentChromatogram;
+	private transient IChromatogram<?> parentChromatogram;
 	//
 	private int retentionTime = 0;
 	private int retentionTimeColumn1 = 0; // GCxGC, LCxLC
@@ -56,7 +55,7 @@ public abstract class AbstractScan extends AbstractSignal implements IScan {
 	private boolean isDirty = false;
 	private String identifier = "";
 
-	public AbstractScan() {
+	protected AbstractScan() {
 
 	}
 
@@ -67,7 +66,7 @@ public abstract class AbstractScan extends AbstractSignal implements IScan {
 	 * @param templateScan
 	 *            {@link IScan scan} that is used as a template
 	 */
-	public AbstractScan(IScan templateScan) {
+	protected AbstractScan(IScan templateScan) {
 
 		this.parentChromatogram = templateScan.getParentChromatogram();
 		this.retentionIndex = templateScan.getRetentionIndex();
@@ -90,16 +89,14 @@ public abstract class AbstractScan extends AbstractSignal implements IScan {
 		return getTotalSignal();
 	}
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Override
-	public IChromatogram getParentChromatogram() {
+	public IChromatogram<?> getParentChromatogram() {
 
 		return parentChromatogram;
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
-	public void setParentChromatogram(IChromatogram parentChromatogram) {
+	public void setParentChromatogram(IChromatogram<?> parentChromatogram) {
 
 		this.parentChromatogram = parentChromatogram;
 	}
@@ -192,7 +189,7 @@ public abstract class AbstractScan extends AbstractSignal implements IScan {
 		if(additionalRetentionIndices == null) {
 			return false;
 		} else {
-			return (additionalRetentionIndices.size() > 0) ? true : false;
+			return (additionalRetentionIndices.size() > 0);
 		}
 	}
 
@@ -210,7 +207,7 @@ public abstract class AbstractScan extends AbstractSignal implements IScan {
 	public void setRetentionIndex(SeparationColumnType separationColumnType, float retentionIndex) {
 
 		if(additionalRetentionIndices == null) {
-			additionalRetentionIndices = new HashMap<SeparationColumnType, Float>();
+			additionalRetentionIndices = new HashMap<>();
 		}
 		/*
 		 * Add the index.
@@ -228,9 +225,9 @@ public abstract class AbstractScan extends AbstractSignal implements IScan {
 	public Map<SeparationColumnType, Float> getRetentionIndicesTyped() {
 
 		if(additionalRetentionIndices == null) {
-			return new HashMap<SeparationColumnType, Float>();
+			return new HashMap<>();
 		} else {
-			return new HashMap<SeparationColumnType, Float>(additionalRetentionIndices);
+			return new HashMap<>(additionalRetentionIndices);
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IChromatogramProcessorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IChromatogramProcessorSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 Lablicate GmbH.
+ * Copyright (c) 2015, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,6 +20,6 @@ public interface IChromatogramProcessorSupport {
 	 * 
 	 * @param chromatogramSelection
 	 */
-	@SuppressWarnings("rawtypes")
-	void fireUpdate(IChromatogramSelection chromatogramSelection);
+	
+	void fireUpdate(IChromatogramSelection<?, ?>chromatogramSelection);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IPeaks.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IPeaks.java
@@ -25,7 +25,7 @@ public interface IPeaks<T extends IPeak> {
 
 	/**
 	 * 
-	 * @return the name of this IPeaks list or <code>null</code> if none is available
+	 * @return the name of this IPeaks<?> list or <code>null</code> if none is available
 	 */
 	default String getName() {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/peak/IPeakIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/peak/IPeakIdentifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -58,6 +58,5 @@ public interface IPeakIdentifier {
 	 */
 	IProcessingInfo<?> identify(List<IPeak> peaks, IProgressMonitor monitor);
 
-	@SuppressWarnings("rawtypes")
-	IProcessingInfo identify(IChromatogramSelection chromatogramSelection, IProgressMonitor monitor);
+	IProcessingInfo<?> identify(IChromatogramSelection<?, ?> chromatogramSelection, IProgressMonitor monitor);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/implementation/Chromatogram.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/implementation/Chromatogram.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -36,7 +36,7 @@ public class Chromatogram extends AbstractChromatogram implements IChromatogram 
 	}
 
 	@Override
-	public void fireUpdate(IChromatogramSelection chromatogramSelection) {
+	public void fireUpdate(IChromatogramSelection<?, ?> chromatogramSelection) {
 
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/processor/AbstractChromatogramProcessor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/processor/AbstractChromatogramProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Lablicate GmbH.
+ * Copyright (c) 2015, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,17 +15,17 @@ import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 
 public abstract class AbstractChromatogramProcessor implements IChromatogramProcessor {
 
-	@SuppressWarnings("rawtypes")
-	private IChromatogramSelection chromatogramSelection;
+	
+	private IChromatogramSelection<?, ?>chromatogramSelection;
 
-	@SuppressWarnings("rawtypes")
-	public AbstractChromatogramProcessor(IChromatogramSelection chromatogramSelection) {
+	
+	public AbstractChromatogramProcessor(IChromatogramSelection<?, ?>chromatogramSelection) {
 		this.chromatogramSelection = chromatogramSelection;
 	}
 
-	@SuppressWarnings("rawtypes")
+	
 	@Override
-	public IChromatogramSelection getChromatogramSelection() {
+	public IChromatogramSelection<?, ?>getChromatogramSelection() {
 
 		return chromatogramSelection;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/processor/IChromatogramProcessor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/processor/IChromatogramProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Lablicate GmbH.
+ * Copyright (c) 2015, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -29,8 +29,8 @@ public interface IChromatogramProcessor {
 	 * 
 	 * @return {@link IChromatogramSelection}
 	 */
-	@SuppressWarnings("rawtypes")
-	IChromatogramSelection getChromatogramSelection();
+	
+	IChromatogramSelection<?, ?>getChromatogramSelection();
 
 	/**
 	 * Executes an implemented chromatogram modifier action.<br/>

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/signals/ITotalScanSignalExtractor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/signals/ITotalScanSignalExtractor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 Lablicate GmbH.
+ * Copyright (c) 2012, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -70,11 +70,11 @@ public interface ITotalScanSignalExtractor {
 	 * @param chromatogramSelection
 	 * @return {@link ITotalScanSignal}
 	 */
-	@SuppressWarnings("rawtypes")
-	ITotalScanSignals getTotalScanSignals(IChromatogramSelection chromatogramSelection);
+	
+	ITotalScanSignals getTotalScanSignals(IChromatogramSelection<?, ?>chromatogramSelection);
 
-	@SuppressWarnings("rawtypes")
-	ITotalScanSignals getTotalScanSignals(IChromatogram chromatogram, boolean validatePositive, boolean condenseCycleNumberScans);
+	
+	ITotalScanSignals getTotalScanSignals(IChromatogram<?> chromatogram, boolean validatePositive, boolean condenseCycleNumberScans);
 
 	/**
 	 * Returns the total scan signals given by the selection.
@@ -83,9 +83,9 @@ public interface ITotalScanSignalExtractor {
 	 * @param chromatogramSelection
 	 * @return {@link ITotalScanSignal}
 	 */
-	@SuppressWarnings("rawtypes")
-	ITotalScanSignals getTotalScanSignals(IChromatogramSelection chromatogramSelection, boolean validatePositive);
+	
+	ITotalScanSignals getTotalScanSignals(IChromatogramSelection<?, ?>chromatogramSelection, boolean validatePositive);
 
-	@SuppressWarnings("rawtypes")
-	ITotalScanSignals getTotalScanSignals(IChromatogramSelection chromatogramSelection, boolean validatePositive, boolean condenseCycleNumberScans);
+	
+	ITotalScanSignals getTotalScanSignals(IChromatogramSelection<?, ?>chromatogramSelection, boolean validatePositive, boolean condenseCycleNumberScans);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/signals/ITotalScanSignals.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/signals/ITotalScanSignals.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -28,8 +28,8 @@ public interface ITotalScanSignals extends Iterable<Integer> {
 	 * 
 	 * @return {@link IChromatogram}
 	 */
-	@SuppressWarnings("rawtypes")
-	IChromatogram getChromatogram();
+	
+	IChromatogram<?> getChromatogram();
 
 	/**
 	 * Adds an {@link ITotalScanSignal} instance at the end of the stored

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/signals/TotalScanSignalExtractor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/signals/TotalScanSignalExtractor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 Lablicate GmbH.
+ * Copyright (c) 2012, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -156,15 +156,15 @@ public class TotalScanSignalExtractor implements ITotalScanSignalExtractor {
 	}
 
 	@Override
-	@SuppressWarnings("rawtypes")
-	public ITotalScanSignals getTotalScanSignals(IChromatogramSelection chromatogramSelection) {
+	
+	public ITotalScanSignals getTotalScanSignals(IChromatogramSelection<?, ?>chromatogramSelection) {
 
 		return getTotalScanSignals(chromatogramSelection, true);
 	}
 
-	@SuppressWarnings("rawtypes")
+	
 	@Override
-	public ITotalScanSignals getTotalScanSignals(IChromatogram chromatogram, boolean validatePositive, boolean condenseCycleNumberScans) {
+	public ITotalScanSignals getTotalScanSignals(IChromatogram<?> chromatogram, boolean validatePositive, boolean condenseCycleNumberScans) {
 
 		/*
 		 * If the chromatogram selection is null, return an empty
@@ -182,15 +182,15 @@ public class TotalScanSignalExtractor implements ITotalScanSignalExtractor {
 	}
 
 	@Override
-	@SuppressWarnings("rawtypes")
-	public ITotalScanSignals getTotalScanSignals(IChromatogramSelection chromatogramSelection, boolean validatePositive) {
+	
+	public ITotalScanSignals getTotalScanSignals(IChromatogramSelection<?, ?>chromatogramSelection, boolean validatePositive) {
 
 		return getTotalScanSignals(chromatogramSelection, validatePositive, false);
 	}
 
 	@Override
-	@SuppressWarnings("rawtypes")
-	public ITotalScanSignals getTotalScanSignals(IChromatogramSelection chromatogramSelection, boolean validatePositive, boolean condenseCycleNumberScans) {
+	
+	public ITotalScanSignals getTotalScanSignals(IChromatogramSelection<?, ?>chromatogramSelection, boolean validatePositive, boolean condenseCycleNumberScans) {
 
 		/*
 		 * If the chromatogram selection is null, return an empty

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/signals/TotalScanSignals.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/signals/TotalScanSignals.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -28,8 +28,7 @@ public class TotalScanSignals implements ITotalScanSignals {
 	private List<ITotalScanSignal> signals;
 	private int startScan;
 	private int stopScan;
-	@SuppressWarnings("rawtypes")
-	private IChromatogram chromatogram = null;
+	private IChromatogram<?> chromatogram = null;
 
 	/**
 	 * Creates a TotalIonSignals instance with the given scan length.
@@ -46,14 +45,13 @@ public class TotalScanSignals implements ITotalScanSignals {
 			startScan = 1;
 			stopScan = numberOfScans;
 		}
-		signals = new ArrayList<ITotalScanSignal>(numberOfScans);
+		signals = new ArrayList<>(numberOfScans);
 	}
 
 	/**
 	 * Sets additionally the parent chromatogram to the signals instance.
 	 */
-	@SuppressWarnings("rawtypes")
-	public TotalScanSignals(int numberOfScans, IChromatogram chromatogram) {
+	public TotalScanSignals(int numberOfScans, IChromatogram<?> chromatogram) {
 
 		this(numberOfScans);
 		this.chromatogram = chromatogram;
@@ -81,7 +79,7 @@ public class TotalScanSignals implements ITotalScanSignals {
 		} else {
 			numberOfScans = stop - start + 1;
 		}
-		signals = new ArrayList<ITotalScanSignal>(numberOfScans);
+		signals = new ArrayList<>(numberOfScans);
 		this.startScan = start;
 		this.stopScan = stop;
 	}
@@ -93,8 +91,7 @@ public class TotalScanSignals implements ITotalScanSignals {
 	 * @param stopScan
 	 * @param chromatogram
 	 */
-	@SuppressWarnings("rawtypes")
-	public TotalScanSignals(int startScan, int stopScan, IChromatogram chromatogram) {
+	public TotalScanSignals(int startScan, int stopScan, IChromatogram<?> chromatogram) {
 
 		this(startScan, stopScan);
 		this.chromatogram = chromatogram;
@@ -106,15 +103,14 @@ public class TotalScanSignals implements ITotalScanSignals {
 
 		this(new ChromatogramSelection(chromatogram));
 	}
-
 	// TODO JUnit
-	@SuppressWarnings("rawtypes")
-	public TotalScanSignals(IChromatogramSelection chromatogramSelection) {
+
+	public TotalScanSignals(IChromatogramSelection<?, ?> chromatogramSelection) {
 
 		chromatogram = chromatogramSelection.getChromatogram();
 		startScan = chromatogram.getScanNumber(chromatogramSelection.getStartRetentionTime());
 		stopScan = chromatogram.getScanNumber(chromatogramSelection.getStopRetentionTime());
-		signals = new ArrayList<ITotalScanSignal>();
+		signals = new ArrayList<>();
 		//
 		for(int scan = startScan; scan <= stopScan; scan++) {
 			/*
@@ -128,9 +124,8 @@ public class TotalScanSignals implements ITotalScanSignals {
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
-	public IChromatogram getChromatogram() {
+	public IChromatogram<?> getChromatogram() {
 
 		return chromatogram;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/statistics/AbstractSample.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/statistics/AbstractSample.java
@@ -16,8 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-@SuppressWarnings("rawtypes")
-public abstract class AbstractSample<D extends ISampleData> implements ISample {
+public abstract class AbstractSample<D extends ISampleData<?>> implements ISample {
 
 	private String sampleName = "";
 	private String groupName = "";
@@ -130,6 +129,7 @@ public abstract class AbstractSample<D extends ISampleData> implements ISample {
 		if(getClass() != obj.getClass()) {
 			return false;
 		}
+		@SuppressWarnings("rawtypes")
 		AbstractSample other = (AbstractSample)obj;
 		return Objects.equals(sampleName, other.sampleName);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/statistics/ISample.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/statistics/ISample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 Lablicate GmbH.
+ * Copyright (c) 2015, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -31,8 +31,7 @@ public interface ISample {
 
 	void setDescription(String description);
 
-	@SuppressWarnings("rawtypes")
-	List<? extends ISampleData> getSampleData();
+	List<? extends ISampleData<?>> getSampleData();
 
 	boolean isSelected();
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/TargetTransferSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/TargetTransferSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Lablicate GmbH.
+ * Copyright (c) 2019, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This
  * program and the accompanying materials are made available under the terms of
@@ -73,8 +73,8 @@ public class TargetTransferSupport {
 		return null;
 	}
 
-	@SuppressWarnings("rawtypes")
-	public String transferScanTargets(List<IScan> scansSource, IChromatogram chromatogramSink, boolean useBestTargetOnly) {
+	
+	public String transferScanTargets(List<IScan> scansSource, IChromatogram<?> chromatogramSink, boolean useBestTargetOnly) {
 
 		if(scansSource.size() > 0) {
 			for(IScan scanSource : scansSource) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/updates/IChromatogramSelectionUpdateListener.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/updates/IChromatogramSelectionUpdateListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,6 +15,6 @@ import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 
 public interface IChromatogramSelectionUpdateListener {
 
-	@SuppressWarnings("rawtypes")
-	void update(IChromatogramSelection chromatogramSelection);
+	
+	void update(IChromatogramSelection<?, ?>chromatogramSelection);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUPeakExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUPeakExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -24,14 +24,14 @@ import org.eclipse.core.runtime.IProgressMonitor;
 public class ELUPeakExportConverter extends AbstractPeakExportConverter {
 
 	@Override
-	public IProcessingInfo<IPeaks<?>> convert(File file, IPeaks peaks, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<IPeaks> convert(File file, IPeaks peaks, boolean append, IProgressMonitor monitor) {
 
 		return getNoSupportMessage();
 	}
 
-	private IProcessingInfo<IPeaks<?>> getNoSupportMessage() {
+	private IProcessingInfo<IPeaks> getNoSupportMessage() {
 
-		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<IPeaks<?>>();
+		IProcessingInfo<IPeaks> processingInfo = new ProcessingInfo<>();
 		processingInfo.addErrorMessage("ELU Peak Export", "There are no capabilities to export peaks in ELU format.");
 		return processingInfo;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLPeakExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLPeakExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 Lablicate GmbH.
+ * Copyright (c) 2012, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -67,7 +67,7 @@ public class MSLPeakExportConverter extends AbstractPeakExportConverter {
 		return processingInfo;
 	}
 
-	private IProcessingInfo validate(File file, IPeaks peaks) {
+	private IProcessingInfo validate(File file, IPeaks<?> peaks) {
 
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		processingInfo.addMessages(super.validate(file));

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPPeakExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPPeakExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 Lablicate GmbH.
+ * Copyright (c) 2012, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -67,7 +67,7 @@ public class MSPPeakExportConverter extends AbstractPeakExportConverter {
 		return processingInfo;
 	}
 
-	private IProcessingInfo validate(File file, IPeaks peaks) {
+	private IProcessingInfo validate(File file, IPeaks<?> peaks) {
 
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		processingInfo.addMessages(super.validate(file));

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/ELUReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/ELUReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -47,7 +47,6 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ELUReader implements IPeakReader {
 
 	/*
@@ -210,13 +209,12 @@ public class ELUReader implements IPeakReader {
 	 * @param scanInterval
 	 * @return {@link IProcessingInfo}
 	 */
-	@SuppressWarnings("unchecked")
-	private void extractAmdisPeaks(String content, int scanInterval, IProcessingInfo processingInfo) {
+	private void extractAmdisPeaks(String content, int scanInterval, IProcessingInfo<IPeaks<?>> processingInfo) {
 
 		if(scanInterval <= 0) {
 			processingInfo.addErrorMessage("AMDIS ELU Parser", "There seems to be no peak in the file. The scan interval is <= 0.");
 		} else {
-			IPeaks peaks = new Peaks();
+			IPeaks<?> peaks = new Peaks();
 			Matcher matcher = PEAK_DATA_PATTERN.matcher(content);
 			while(matcher.find()) {
 				/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/massspectrum/AbstractMassSpectrumExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/massspectrum/AbstractMassSpectrumExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -20,7 +20,7 @@ import org.eclipse.chemclipse.processing.core.MessageType;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingMessage;
 
-@SuppressWarnings("rawtypes")
+@SuppressWarnings("rawtypes") // TODO this can't both be IScanMSD and IMassSpectra so the generic approach is likely false
 public abstract class AbstractMassSpectrumExportConverter extends AbstractExportConverter implements IMassSpectrumExportConverter {
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogramMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogramMSD.java
@@ -131,9 +131,8 @@ public abstract class AbstractChromatogramMSD extends AbstractChromatogram<IChro
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
-	public void fireUpdate(IChromatogramSelection chromatogramSelection) {
+	public void fireUpdate(IChromatogramSelection<?, ?>chromatogramSelection) {
 
 		/*
 		 * Fire an update to inform all listeners.

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IChromatogramMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IChromatogramMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -17,7 +17,7 @@ import org.eclipse.chemclipse.msd.model.core.support.IMarkedIons;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 /**
- * Why does IChromatogram extends ({@link IChromatogramOverview})?<br/>
+ * Why does IChromatogram<?> extends ({@link IChromatogramOverview})?<br/>
  * See the description in ({@link AbstractChromatogramMSD}).
  */
 public interface IChromatogramMSD extends IChromatogram<IChromatogramPeakMSD> {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/provider/SynonymsListContentProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/provider/SynonymsListContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -18,12 +18,10 @@ import org.eclipse.jface.viewers.Viewer;
 
 public class SynonymsListContentProvider implements IStructuredContentProvider {
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public Object[] getElements(Object inputElement) {
 
-		if(inputElement instanceof Set) {
-			Set set = (Set)inputElement;
+		if(inputElement instanceof Set<?> set) {
 			return set.toArray();
 		} else {
 			return null;

--- a/chemclipse/plugins/org.eclipse.chemclipse.pdfbox.extensions/src/org/eclipse/chemclipse/pdfbox/extensions/core/PageUtil.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pdfbox.extensions/src/org/eclipse/chemclipse/pdfbox/extensions/core/PageUtil.java
@@ -465,8 +465,7 @@ public class PageUtil {
 	 * @return float
 	 * @throws IOException
 	 */
-	@SuppressWarnings("rawtypes")
-	private float calculateX(IReferenceElement referenceElement, float elementWidth, float maxWidth) throws IOException {
+	private float calculateX(IReferenceElement<?> referenceElement, float elementWidth, float maxWidth) throws IOException {
 
 		float x;
 		ReferenceX referenceX = referenceElement.getReferenceX();
@@ -493,8 +492,7 @@ public class PageUtil {
 	 * @param elementHeight
 	 * @return float
 	 */
-	@SuppressWarnings("rawtypes")
-	private float calculateY(IReferenceElement referenceElement, float elementHeight) {
+	private float calculateY(IReferenceElement<?> referenceElement, float elementHeight) {
 
 		float y;
 		ReferenceY referenceY = referenceElement.getReferenceY();

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/provider/SelectViewContentProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/provider/SelectViewContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 Lablicate GmbH.
+ * Copyright (c) 2012, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -31,9 +31,8 @@ public class SelectViewContentProvider implements IStructuredContentProvider {
 	@Override
 	public Object[] getElements(Object inputElement) {
 
-		if(inputElement instanceof List) {
-			@SuppressWarnings("rawtypes")
-			List parts = (List)inputElement;
+		if(inputElement instanceof List<?>) {
+			List<?> parts = (List<?>)inputElement;
 			return parts.toArray();
 		} else {
 			return null;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/dialogs/ReferencedChromatogramDialog.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/dialogs/ReferencedChromatogramDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -29,26 +29,25 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 
-@SuppressWarnings("rawtypes")
 public class ReferencedChromatogramDialog extends TitleAreaDialog {
 
-	private IChromatogram chromatogram;
+	private IChromatogram<?> chromatogram;
 	private List<Button> checkBoxList;
-	private List<IChromatogram> selectedChromatograms;
+	private List<IChromatogram<?>> selectedChromatograms;
 
-	public ReferencedChromatogramDialog(Shell parentShell, IChromatogram chromatogram) {
+	public ReferencedChromatogramDialog(Shell parentShell, IChromatogram<?> chromatogram) {
+
 		super(parentShell);
 		this.chromatogram = chromatogram;
-		checkBoxList = new ArrayList<Button>();
-		selectedChromatograms = new ArrayList<IChromatogram>();
+		checkBoxList = new ArrayList<>();
+		selectedChromatograms = new ArrayList<>();
 	}
 
-	public List<IChromatogram> getSelectedChromatograms() {
+	public List<IChromatogram<?>> getSelectedChromatograms() {
 
 		return selectedChromatograms;
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	protected Control createDialogArea(Composite parent) {
 
@@ -96,9 +95,9 @@ public class ReferencedChromatogramDialog extends TitleAreaDialog {
 		 */
 		Composite referencedChromatogramsComposite = new Composite(elementComposite, SWT.NONE);
 		referencedChromatogramsComposite.setLayout(new GridLayout(1, true));
-		List<IChromatogram> references = chromatogram.getReferencedChromatograms();
+		List<IChromatogram<?>> references = chromatogram.getReferencedChromatograms();
 		int counter = 1;
-		for(IChromatogram chromatogram : references) {
+		for(IChromatogram<?> chromatogram : references) {
 			/*
 			 * Enables to mark the referenced chromatogram to be opened in a new editor.
 			 */
@@ -157,7 +156,7 @@ public class ReferencedChromatogramDialog extends TitleAreaDialog {
 			 * Get only the selected elements.
 			 */
 			if(button.getSelection() == true) {
-				IChromatogram chromatogram = (IChromatogram)button.getData();
+				IChromatogram<?> chromatogram = (IChromatogram<?>)button.getData();
 				selectedChromatograms.add(chromatogram);
 			}
 			/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/editors/IChromatogramEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/editors/IChromatogramEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,6 +15,5 @@ import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 
 public interface IChromatogramEditor extends IChemClipseEditor {
 
-	@SuppressWarnings("rawtypes")
-	IChromatogramSelection getChromatogramSelection();
+	IChromatogramSelection<?, ?>getChromatogramSelection();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/editors/IChromatogramProjectEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/editors/IChromatogramProjectEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,6 +17,5 @@ import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 
 public interface IChromatogramProjectEditor extends IChemClipseEditor {
 
-	@SuppressWarnings("rawtypes")
-	List<IChromatogramSelection> getChromatogramSelections();
+	List<IChromatogramSelection<?, ?>> getChromatogramSelections();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/ISupplierFileEditorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/ISupplierFileEditorSupport.java
@@ -62,7 +62,6 @@ public interface ISupplierFileEditorSupport extends ISupplierFileIdentifier {
 		openEditor(file, object, elementId, contributionURI, iconURI, tooltip, false);
 	}
 
-	@SuppressWarnings("rawtypes")
 	default void openEditor(File file, Object object, String elementId, String contributionURI, String iconURI, String tooltip, boolean batch) {
 
 		EModelService modelService = Activator.getDefault().getModelService();
@@ -133,24 +132,24 @@ public interface ISupplierFileEditorSupport extends ISupplierFileIdentifier {
 				if(file == null) {
 					if(object != null) {
 						part.setObject(object);
-						if(object instanceof IChromatogram) {
+						if(object instanceof IChromatogram<?> chromatogram) {
 							String type = "";
-							if(object instanceof IChromatogramMSD chromatogramMSD) {
+							if(object instanceof IChromatogramMSD) {
 								type = " [MSD]";
-							} else if(object instanceof IChromatogramCSD chromatogramCSD) {
+							} else if(object instanceof IChromatogramCSD) {
 								type = " [CSD]";
-							} else if(object instanceof IChromatogramWSD chromatogramWSD) {
+							} else if(object instanceof IChromatogramWSD) {
 								type = " [WSD]";
-							} else if(object instanceof IChromatogramISD chromatogramISD) {
+							} else if(object instanceof IChromatogramISD) {
 								type = " [ISD]";
 							}
-							part.setLabel(((IChromatogram)object).getName() + type);
-						} else if(object instanceof IMassSpectra) {
-							part.setLabel(((IMassSpectra)object).getName());
+							part.setLabel(chromatogram.getName() + type);
+						} else if(object instanceof IMassSpectra massSpectra) {
+							part.setLabel(massSpectra.getName());
 						} else if(object instanceof ISpectrumXIR) {
 							part.setLabel("FTIR");
-						} else if(object instanceof IMeasurement) {
-							part.setLabel(((IMeasurement)object).getDataName());
+						} else if(object instanceof IMeasurement measurement) {
+							part.setLabel(measurement.getDataName());
 						}
 					} else {
 						part.setObject(null);
@@ -160,7 +159,7 @@ public interface ISupplierFileEditorSupport extends ISupplierFileIdentifier {
 					/*
 					 * Get the file to load via the map.
 					 */
-					Map<String, Object> map = new HashMap<String, Object>();
+					Map<String, Object> map = new HashMap<>();
 					map.put(EditorSupport.MAP_FILE, file.getAbsolutePath());
 					map.put(EditorSupport.MAP_BATCH, batch);
 					part.setObject(map);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/custom/ISelectionListener.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/custom/ISelectionListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Lablicate GmbH.
+ * Copyright (c) 2020, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,6 +15,5 @@ import org.eclipse.chemclipse.model.core.IChromatogram;
 
 public interface ISelectionListener {
 
-	@SuppressWarnings("rawtypes")
-	void update(IChromatogram chromatogram, SelectionCoordinates selectionCoordinates);
+	void update(IChromatogram<?> chromatogram, SelectionCoordinates selectionCoordinates);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/dialogs/ChromatogramEditorDialog.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/dialogs/ChromatogramEditorDialog.java
@@ -35,14 +35,13 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramEditorDialog extends Dialog {
 
 	private static final int WIDTH = 450;
 	private static final int HEIGHT = 150;
 	//
-	private IChromatogram chromatogramMaster = null;
-	private IChromatogramSelection chromatogramSelection = null;
+	private IChromatogram<?> chromatogramMaster = null;
+	private IChromatogramSelection<?, ?> chromatogramSelection = null;
 	//
 	private ComboViewer comboViewer;
 	private EditorUpdateSupport editorUpdateSupport = new EditorUpdateSupport();
@@ -59,7 +58,7 @@ public class ChromatogramEditorDialog extends Dialog {
 	 * @param parentShell
 	 * @param chromatogramMaster
 	 */
-	public ChromatogramEditorDialog(Shell parentShell, IChromatogram chromatogramMaster) {
+	public ChromatogramEditorDialog(Shell parentShell, IChromatogram<?> chromatogramMaster) {
 
 		super(parentShell);
 		this.chromatogramMaster = chromatogramMaster;
@@ -78,7 +77,7 @@ public class ChromatogramEditorDialog extends Dialog {
 		return true;
 	}
 
-	public IChromatogramSelection getChromatogramSelection() {
+	public IChromatogramSelection<?, ?> getChromatogramSelection() {
 
 		return chromatogramSelection;
 	}
@@ -120,7 +119,7 @@ public class ChromatogramEditorDialog extends Dialog {
 			@Override
 			public String getText(Object element) {
 
-				if(element instanceof IChromatogramSelection chromatogramSelection) {
+				if(element instanceof IChromatogramSelection<?, ?> chromatogramSelection) {
 					String name = chromatogramSelection.getChromatogram().getName();
 					String type = ChromatogramDataSupport.getChromatogramType(chromatogramSelection);
 					return getChromatogramLabel(name, type, "Editor");
@@ -139,8 +138,8 @@ public class ChromatogramEditorDialog extends Dialog {
 			public void widgetSelected(SelectionEvent e) {
 
 				Object object = comboViewer.getStructuredSelection().getFirstElement();
-				if(object instanceof IChromatogramSelection) {
-					chromatogramSelection = (IChromatogramSelection)object;
+				if(object instanceof IChromatogramSelection<?, ?> firstChromatogramSelection) {
+					chromatogramSelection = firstChromatogramSelection;
 				}
 			}
 		});
@@ -160,12 +159,12 @@ public class ChromatogramEditorDialog extends Dialog {
 		return label;
 	}
 
-	private void updateComboViewer(IChromatogram chromatogramMaster) {
+	private void updateComboViewer(IChromatogram<?> chromatogramMaster) {
 
-		List<IChromatogramSelection> chromatogramSelections = editorUpdateSupport.getChromatogramSelections();
+		List<IChromatogramSelection<?, ?>> chromatogramSelections = editorUpdateSupport.getChromatogramSelections();
 		if(chromatogramMaster != null) {
-			List<IChromatogramSelection> removeSelections = new ArrayList<>();
-			for(IChromatogramSelection chromatogramSelection : chromatogramSelections) {
+			List<IChromatogramSelection<?, ?>> removeSelections = new ArrayList<>();
+			for(IChromatogramSelection<?, ?> chromatogramSelection : chromatogramSelections) {
 				if(chromatogramSelection.getChromatogram() == chromatogramMaster) {
 					removeSelections.add(chromatogramSelection);
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/dialogs/TargetTransferDialog.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/dialogs/TargetTransferDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Lablicate GmbH.
+ * Copyright (c) 2019, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -23,11 +23,11 @@ import org.eclipse.swt.widgets.Shell;
 
 public class TargetTransferDialog extends Dialog {
 
-	@SuppressWarnings("rawtypes")
-	private IChromatogramSelection chromatogramSelection;
+	
+	private IChromatogramSelection<?, ?>chromatogramSelection;
 
-	@SuppressWarnings("rawtypes")
-	public TargetTransferDialog(Shell shell, IChromatogramSelection chromatogramSelection) {
+	
+	public TargetTransferDialog(Shell shell, IChromatogramSelection<?, ?>chromatogramSelection) {
 		super(shell);
 		this.chromatogramSelection = chromatogramSelection;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
@@ -90,7 +90,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtchart.ICustomPaintListener;
 
-@SuppressWarnings("rawtypes")
 public abstract class AbstractChromatogramEditor extends AbstractUpdater<ExtendedChromatogramUI> implements IChromatogramEditor {
 
 	private static final Logger logger = Logger.getLogger(AbstractChromatogramEditor.class);
@@ -220,7 +219,7 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 	public boolean saveAs() {
 
 		boolean saveSuccessful = false;
-		IChromatogramSelection chromatogramSelection = extendedChromatogramUI.getChromatogramSelection();
+		IChromatogramSelection<?, ?> chromatogramSelection = extendedChromatogramUI.getChromatogramSelection();
 		if(chromatogramSelection != null) {
 			try {
 				/*
@@ -237,7 +236,7 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 	}
 
 	@Override
-	public IChromatogramSelection getChromatogramSelection() {
+	public IChromatogramSelection<?, ?> getChromatogramSelection() {
 
 		return extendedChromatogramUI.getChromatogramSelection();
 	}
@@ -261,7 +260,7 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 
 	private synchronized void initialize(Composite parent) {
 
-		IChromatogramSelection chromatogramSelection = loadChromatogram();
+		IChromatogramSelection<?, ?> chromatogramSelection = loadChromatogram();
 		createEditorPages(parent);
 		extendedChromatogramUI.updateChromatogramSelection(chromatogramSelection);
 		processChromatogram(chromatogramSelection);
@@ -279,10 +278,10 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 
 		if(objects.size() == 1) {
 			Object object = objects.get(0);
-			if(object instanceof IChromatogramSelection chromatogramSelection) {
+			if(object instanceof IChromatogramSelection<?, ?> chromatogramSelection) {
 				if(extendedChromatogramUI.isActiveChromatogramSelection(chromatogramSelection)) {
 					extendedChromatogramUI.update();
-					IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+					IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 					if(chromatogram != null) {
 						dirtyable.setDirty(chromatogram.isDirty());
 					}
@@ -318,7 +317,7 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 		return TOPIC_CHROMATOGRAM.equals(topic) || TOPIC_SCAN.equals(topic) || TOPIC_PEAK.equals(topic) || TOPIC_EDITOR_UPDATE.equals(topic) || TOPIC_EDITOR_ADJUST.equals(topic) || TOPIC_TOOLBAR_UPDATE.equals(topic);
 	}
 
-	private void processChromatogram(IChromatogramSelection chromatogramSelection) {
+	private void processChromatogram(IChromatogramSelection<?, ?> chromatogramSelection) {
 
 		File file = new File(preferenceStore.getString(PreferenceConstants.P_CHROMATOGRAM_LOAD_PROCESS_METHOD));
 		if(chromatogramSelection != null) {
@@ -344,9 +343,9 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 		}
 	}
 
-	private synchronized IChromatogramSelection loadChromatogram() {
+	private synchronized IChromatogramSelection<?, ?> loadChromatogram() {
 
-		IChromatogramSelection chromatogramSelection = null;
+		IChromatogramSelection<?, ?> chromatogramSelection = null;
 		try {
 			Object object = part.getObject();
 			if(object instanceof Map) {
@@ -380,9 +379,9 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 		return chromatogramSelection;
 	}
 
-	private synchronized IChromatogramSelection loadChromatogramSelection(File file, boolean batch) throws ChromatogramIsNullException {
+	private synchronized IChromatogramSelection<?, ?> loadChromatogramSelection(File file, boolean batch) throws ChromatogramIsNullException {
 
-		IChromatogramSelection chromatogramSelection = null;
+		IChromatogramSelection<?, ?> chromatogramSelection = null;
 		ProgressMonitorDialog dialog = new ProgressMonitorDialog(shell);
 		ChromatogramImportRunnable runnable = new ChromatogramImportRunnable(file, dataType);
 		//
@@ -407,14 +406,14 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 
 	private void saveChromatogram(IProgressMonitor monitor) throws NoChromatogramConverterAvailableException {
 
-		IChromatogramSelection chromatogramSelection = extendedChromatogramUI.getChromatogramSelection();
+		IChromatogramSelection<?, ?> chromatogramSelection = extendedChromatogramUI.getChromatogramSelection();
 		if(chromatogramSelection != null && shell != null) {
-			IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+			IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 			String converterId = chromatogram.getConverterId();
 			if(converterId != null && !converterId.equals("") && chromatogramFile != null) {
 				monitor.subTask(ExtensionMessages.saveChromatogram);
 				//
-				IProcessingInfo processingInfo = null;
+				IProcessingInfo<?> processingInfo = null;
 				if(chromatogram instanceof IChromatogramMSD chromatogramMSD) {
 					processingInfo = ChromatogramConverterMSD.getInstance().convert(chromatogramFile, chromatogramMSD, converterId, monitor);
 				} else if(chromatogram instanceof IChromatogramCSD chromatogramCSD) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ChromatogramEditor3x.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ChromatogramEditor3x.java
@@ -184,9 +184,9 @@ public class ChromatogramEditor3x extends EditorPart implements IChromatogramEdi
 		return false;
 	}
 
-	@SuppressWarnings("rawtypes")
+	
 	@Override
-	public IChromatogramSelection getChromatogramSelection() {
+	public IChromatogramSelection<?, ?>getChromatogramSelection() {
 
 		if(chromatogramEditor != null) {
 			return chromatogramEditor.getChromatogramSelection();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/editors/ChromatogramFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/editors/ChromatogramFileSupport.java
@@ -41,7 +41,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Shell;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramFileSupport {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramFileSupport.class);
@@ -50,12 +49,12 @@ public class ChromatogramFileSupport {
 
 	}
 
-	public static boolean saveChromatogram(Shell shell, IChromatogram chromatogram, DataType dataType) throws NoConverterAvailableException {
+	public static boolean saveChromatogram(Shell shell, IChromatogram<?> chromatogram, DataType dataType) throws NoConverterAvailableException {
 
 		return saveChromatogram(shell, chromatogram, dataType, UserManagement.getUserHome());
 	}
 
-	public static boolean saveChromatogram(Shell shell, IChromatogram chromatogram, DataType dataType, String filterPath) throws NoConverterAvailableException {
+	public static boolean saveChromatogram(Shell shell, IChromatogram<?> chromatogram, DataType dataType, String filterPath) throws NoConverterAvailableException {
 
 		if(chromatogram == null || shell == null) {
 			return false;
@@ -92,8 +91,9 @@ public class ChromatogramFileSupport {
 				} else {
 					String extension = FilenameUtils.getExtension(fileDialog.getFileName());
 					Optional<ISupplier> guessedSupplier = chromatogramConverterSupport.getSupplier().stream().filter(s -> s.getFileExtension().contains(extension)).findFirst();
-					if(guessedSupplier.isEmpty())
+					if(guessedSupplier.isEmpty()) {
 						return false;
+					}
 					validateAndExportFile(shell, chromatogram, dataType, filePath, overwrite, guessedSupplier.get());
 					return true;
 				}
@@ -210,7 +210,7 @@ public class ChromatogramFileSupport {
 		return converterSupport;
 	}
 
-	public static void writeFile(Shell shell, File file, IChromatogram chromatogram, ISupplier supplier, DataType dataType) {
+	public static void writeFile(Shell shell, File file, IChromatogram<?> chromatogram, ISupplier supplier, DataType dataType) {
 
 		if(file == null || chromatogram == null || supplier == null) {
 			return;
@@ -233,7 +233,7 @@ public class ChromatogramFileSupport {
 		}
 	}
 
-	private static void validateAndExportFile(Shell shell, IChromatogram chromatogram, DataType dataType, String filePath, boolean overwrite, ISupplier selectedSupplier) {
+	private static void validateAndExportFile(Shell shell, IChromatogram<?> chromatogram, DataType dataType, String filePath, boolean overwrite, ISupplier selectedSupplier) {
 
 		File chromatogramFolder = null;
 		boolean folderExists = false;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/IntegrationAreaContentProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/IntegrationAreaContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -19,18 +19,15 @@ import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.jface.viewers.IStructuredContentProvider;
 import org.eclipse.jface.viewers.Viewer;
 
-@SuppressWarnings("rawtypes")
 public class IntegrationAreaContentProvider implements IStructuredContentProvider {
 
 	@Override
 	public Object[] getElements(Object inputElement) {
 
-		if(inputElement instanceof IPeak) {
-			IPeak peak = (IPeak)inputElement;
+		if(inputElement instanceof IPeak peak) {
 			List<? extends IIntegrationEntry> integrationEntries = peak.getIntegrationEntries();
 			return integrationEntries.toArray();
-		} else if(inputElement instanceof IChromatogram) {
-			IChromatogram chromatogram = (IChromatogram)inputElement;
+		} else if(inputElement instanceof IChromatogram<?> chromatogram) {
 			List<? extends IIntegrationEntry> integrationEntries = chromatogram.getChromatogramIntegrationEntries();
 			return integrationEntries.toArray();
 		} else {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/RetentionIndexContentProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/RetentionIndexContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,12 +19,11 @@ import org.eclipse.jface.viewers.Viewer;
 
 public class RetentionIndexContentProvider implements IStructuredContentProvider {
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public Object[] getElements(Object inputElement) {
 
 		if(inputElement instanceof ISeparationColumnIndices) {
-			return ((Map)inputElement).values().toArray();
+			return ((Map<?, ?>)inputElement).values().toArray();
 		}
 		return null;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/runnables/ChromatogramLengthModifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/runnables/ChromatogramLengthModifier.java
@@ -19,27 +19,25 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramLengthModifier implements IRunnableWithProgress {
 
-	private IChromatogramSelection chromatogramSelection;
+	private IChromatogramSelection<?, ?> chromatogramSelection;
 	private int scanDelay;
 	private int chromatogramLength;
 
-	public ChromatogramLengthModifier(IChromatogramSelection chromatogramSelection, int scanDelay, int chromatogramLength) {
+	public ChromatogramLengthModifier(IChromatogramSelection<?, ?> chromatogramSelection, int scanDelay, int chromatogramLength) {
 
 		this.chromatogramSelection = chromatogramSelection;
 		this.scanDelay = scanDelay;
 		this.chromatogramLength = chromatogramLength;
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
 
 		try {
 			monitor.beginTask(ExtensionMessages.chromatogramLengthModified, IProgressMonitor.UNKNOWN);
-			IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+			IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 			int scanRange = chromatogram.getNumberOfScans() - 1;
 			if(scanRange > 0) {
 				/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/methods/WidgetItem.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/methods/WidgetItem.java
@@ -203,7 +203,6 @@ public class WidgetItem {
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
 	private Control createControl(Composite parent) {
 
 		Class<?> rawType = inputValue.getRawType();
@@ -237,6 +236,7 @@ public class WidgetItem {
 				/*
 				 * Combo
 				 */
+				@SuppressWarnings("rawtypes")
 				Enum[] enums = (Enum[])rawType.getEnumConstants();
 				ComboViewer viewer = createLabeledEnumComboViewerWidget(parent, enums);
 				return viewer.getControl();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/operations/DeletePeaksOperation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/operations/DeletePeaksOperation.java
@@ -27,14 +27,13 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.swt.widgets.Display;
 
-@SuppressWarnings("rawtypes")
 public class DeletePeaksOperation extends AbstractOperation {
 
 	private IChromatogramSelection<?, ?> chromatogramSelection;
 	private Display display;
 	private List<IPeak> peaksToDelete;
 
-	public DeletePeaksOperation(Display display, IChromatogramSelection chromatogramSelection, List<IPeak> peaksToDelete) {
+	public DeletePeaksOperation(Display display, IChromatogramSelection<?, ?> chromatogramSelection, List<IPeak> peaksToDelete) {
 
 		super(ExtensionMessages.deletePeaks);
 		this.display = display;
@@ -60,7 +59,7 @@ public class DeletePeaksOperation extends AbstractOperation {
 		return !peaksToDelete.isEmpty();
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Override
 	public IStatus execute(IProgressMonitor monitor, IAdaptable info) throws ExecutionException {
 
@@ -90,7 +89,7 @@ public class DeletePeaksOperation extends AbstractOperation {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	public IStatus undo(IProgressMonitor monitor, IAdaptable info) throws ExecutionException {
 
 		IChromatogram chromatogram = chromatogramSelection.getChromatogram();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/operations/DeleteScanTargetsOperation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/operations/DeleteScanTargetsOperation.java
@@ -29,7 +29,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.swt.widgets.Display;
 
-@SuppressWarnings("rawtypes")
+
 public class DeleteScanTargetsOperation extends AbstractOperation {
 
 	private IChromatogramSelection<?, ?> chromatogramSelection;
@@ -37,7 +37,7 @@ public class DeleteScanTargetsOperation extends AbstractOperation {
 	private List<IScan> scansToClear;
 	private List<IScan> backupScans;
 
-	public DeleteScanTargetsOperation(Display display, IChromatogramSelection chromatogramSelection, List<IScan> scansToClear) {
+	public DeleteScanTargetsOperation(Display display, IChromatogramSelection<?, ?>chromatogramSelection, List<IScan> scansToClear) {
 
 		super(ExtensionMessages.deleteScanTargets);
 		this.display = display;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/part/support/EditorUpdateSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/part/support/EditorUpdateSupport.java
@@ -43,8 +43,7 @@ public class EditorUpdateSupport {
 	private static final Logger logger = Logger.getLogger(EditorUpdateSupport.class);
 	private EPartService partService = Activator.getDefault().getPartService();
 
-	@SuppressWarnings("rawtypes")
-	public IChromatogramSelection getActiveEditorSelection() {
+	public IChromatogramSelection<?, ?> getActiveEditorSelection() {
 
 		if(partService != null) {
 			try {
@@ -66,10 +65,9 @@ public class EditorUpdateSupport {
 		return null;
 	}
 
-	@SuppressWarnings("rawtypes")
-	public List<IChromatogramSelection> getChromatogramSelections() {
+	public List<IChromatogramSelection<?, ?>> getChromatogramSelections() {
 
-		List<IChromatogramSelection> chromatogramSelections = new ArrayList<>();
+		List<IChromatogramSelection<?, ?>> chromatogramSelections = new ArrayList<>();
 		if(partService != null) {
 			try {
 				Collection<MPart> parts = partService.getParts();
@@ -221,26 +219,23 @@ public class EditorUpdateSupport {
 		return quantitationDatabases;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private void addChromatogramSelection(List<IChromatogramSelection> chromatogramSelections, IChromatogramSelection selection) {
+	private void addChromatogramSelection(List<IChromatogramSelection<?, ?>> chromatogramSelections, IChromatogramSelection<?, ?> selection) {
 
 		if(selection != null) {
 			chromatogramSelections.add(selection);
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
-	private void addChromatogramSelections(List<IChromatogramSelection> chromatogramSelections, List<IChromatogramSelection> selections) {
+	private void addChromatogramSelections(List<IChromatogramSelection<?, ?>> chromatogramSelections, List<IChromatogramSelection<?, ?>> selections) {
 
 		if(selections != null && !selections.isEmpty()) {
 			chromatogramSelections.addAll(selections);
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
-	private List<IChromatogramSelection> extractChromatogramSelections(Object object) {
+	private List<IChromatogramSelection<?, ?>> extractChromatogramSelections(Object object) {
 
-		List<IChromatogramSelection> chromatogramSelections = new ArrayList<>();
+		List<IChromatogramSelection<?, ?>> chromatogramSelections = new ArrayList<>();
 		//
 		if(object != null) {
 			/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/support/charts/ChromatogramChartSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/support/charts/ChromatogramChartSupport.java
@@ -218,8 +218,7 @@ public class ChromatogramChartSupport {
 		return lineSeriesData;
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	private ILineSeriesData getLineSeriesData(IChromatogram chromatogram, int startScan, int stopScan, String seriesId, DisplayType dataType, Derivative derivative, Color color, IMarkedTraces<? extends IMarkedTrace> signals, boolean baseline, boolean useRetentionIndex) {
+	private ILineSeriesData getLineSeriesData(IChromatogram<?> chromatogram, int startScan, int stopScan, String seriesId, DisplayType dataType, Derivative derivative, Color color, IMarkedTraces<? extends IMarkedTrace> signals, boolean baseline, boolean useRetentionIndex) {
 
 		IBaselineModel baselineModel = null;
 		if(baseline) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/support/charts/ChromatogramDataSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/support/charts/ChromatogramDataSupport.java
@@ -45,11 +45,10 @@ public class ChromatogramDataSupport {
 
 	private static PeakRetentionTimeComparator peakRetentionTimeComparator = new PeakRetentionTimeComparator(SortOrder.ASC);
 
-	@SuppressWarnings("rawtypes")
 	public static String getChromatogramEditorLabel(IChromatogramSelection<?, ?> chromatogramSelection) {
 
 		if(chromatogramSelection != null) {
-			IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+			IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 			return chromatogram.getName() + " " + getChromatogramType(chromatogramSelection);
 		} else {
 			return "";
@@ -105,12 +104,12 @@ public class ChromatogramDataSupport {
 
 		if(object instanceof IChromatogramSelection) {
 			return (IChromatogramSelection<?, ?>)object;
-		} else if(object instanceof IChromatogramCSD) {
-			return new ChromatogramSelectionCSD((IChromatogramCSD)object);
-		} else if(object instanceof IChromatogramMSD) {
-			return new ChromatogramSelectionMSD((IChromatogramMSD)object);
-		} else if(object instanceof IChromatogramWSD) {
-			return new ChromatogramSelectionWSD((IChromatogramWSD)object);
+		} else if(object instanceof IChromatogramCSD chromatogramCSD) {
+			return new ChromatogramSelectionCSD(chromatogramCSD);
+		} else if(object instanceof IChromatogramMSD chromatogramMSD) {
+			return new ChromatogramSelectionMSD(chromatogramMSD);
+		} else if(object instanceof IChromatogramWSD chromatogramWSD) {
+			return new ChromatogramSelectionWSD(chromatogramWSD);
 		} else {
 			return null;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ChromatogramActionUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ChromatogramActionUI.java
@@ -67,8 +67,7 @@ public class ChromatogramActionUI extends Composite {
 	private ComboViewer comboChromatogramAction;
 	private Button buttonChromatogramAction;
 	//
-	@SuppressWarnings("rawtypes")
-	private IChromatogramSelection chromatogramSelection;
+	private IChromatogramSelection<?, ?> chromatogramSelection;
 	private String selectedActionId = "";
 	private final HashMap<String, ChromatogramEditorActionExtension> actionHashMap = new HashMap<>();
 	private final IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
@@ -79,8 +78,7 @@ public class ChromatogramActionUI extends Composite {
 		initialize();
 	}
 
-	@SuppressWarnings("rawtypes")
-	public void setChromatogramActionMenu(IChromatogramSelection chromatogramSelection) {
+	public void setChromatogramActionMenu(IChromatogramSelection<?, ?> chromatogramSelection) {
 
 		this.chromatogramSelection = chromatogramSelection;
 		boolean enabled = enableChromatogramActionMenu(chromatogramSelection);
@@ -187,8 +185,7 @@ public class ChromatogramActionUI extends Composite {
 		return button;
 	}
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	private boolean setChromatogramActionItems(Control parent, IChromatogramSelection chromatogramSelection) {
+	private boolean setChromatogramActionItems(Control parent, IChromatogramSelection<?, ?> chromatogramSelection) {
 
 		/*
 		 * Fill the hash map.
@@ -222,8 +219,7 @@ public class ChromatogramActionUI extends Composite {
 		return success;
 	}
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	private boolean enableChromatogramActionMenu(IChromatogramSelection chromatogramSelection) {
+	private boolean enableChromatogramActionMenu(IChromatogramSelection<?, ?> chromatogramSelection) {
 
 		boolean enabled = false;
 		IConfigurationElement[] elements = getConfigurationElements();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/DataShiftControllerUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/DataShiftControllerUI.java
@@ -373,7 +373,6 @@ public class DataShiftControllerUI extends Composite implements IExtendedPartUI 
 		button.setData(KEY_MIRROR_MODUS, DisplayModus.NORMAL);
 		button.addSelectionListener(new SelectionAdapter() {
 
-			@SuppressWarnings("rawtypes")
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 
@@ -392,7 +391,7 @@ public class DataShiftControllerUI extends Composite implements IExtendedPartUI 
 						displayModus = DisplayModus.MIRROR;
 						int i = 0;
 						int modulo = preferences.getInt(PreferenceConstants.P_MODULO_AUTO_MIRROR_CHROMATOGRAMS);
-						for(ISeries series : baseChart.getSeriesSet().getSeries()) {
+						for(ISeries<?> series : baseChart.getSeriesSet().getSeries()) {
 							if(i % modulo == 1) {
 								String seriesId = series.getId();
 								if(!mirroredSeries.contains(seriesId)) {
@@ -407,7 +406,7 @@ public class DataShiftControllerUI extends Composite implements IExtendedPartUI 
 						 * If status is mirrored, then set the series to normal.
 						 */
 						displayModus = DisplayModus.NORMAL;
-						for(ISeries series : baseChart.getSeriesSet().getSeries()) {
+						for(ISeries<?> series : baseChart.getSeriesSet().getSeries()) {
 							String seriesId = series.getId();
 							if(mirroredSeries.contains(seriesId)) {
 								baseChart.multiplySeries(seriesId, IExtendedChart.Y_AXIS, -1.0d);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramOverlayUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramOverlayUI.java
@@ -144,8 +144,7 @@ public class ExtendedChromatogramOverlayUI extends Composite implements IExtende
 	//
 	private final IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
 	//
-	@SuppressWarnings("rawtypes")
-	private final Map<IChromatogramSelection, List<String>> chromatogramSelections = new LinkedHashMap<>();
+	private final Map<IChromatogramSelection<?, ?>, List<String>> chromatogramSelections = new LinkedHashMap<>();
 
 	public ExtendedChromatogramOverlayUI(Composite parent, int style) {
 
@@ -171,8 +170,7 @@ public class ExtendedChromatogramOverlayUI extends Composite implements IExtende
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
-	public void update(List<IChromatogramSelection> chromatogramSelections) {
+	public void update(List<IChromatogramSelection<?, ?>> chromatogramSelections) {
 
 		this.chromatogramSelections.clear();
 		for(IChromatogramSelection<?, ?> selection : chromatogramSelections) {
@@ -569,7 +567,6 @@ public class ExtendedChromatogramOverlayUI extends Composite implements IExtende
 		chartControl.set(chromatogramRulerChart);
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void refreshUpdateOverlayChart() {
 
 		ChromatogramChart chromatogramChart = chartControl.get();
@@ -595,7 +592,7 @@ public class ExtendedChromatogramOverlayUI extends Composite implements IExtende
 			LinkedHashSet<String> usefulTypes = new LinkedHashSet<>();
 			//
 			int i = 0;
-			for(Entry<IChromatogramSelection, List<String>> entry : chromatogramSelections.entrySet()) {
+			for(Entry<IChromatogramSelection<?, ?>, List<String>> entry : chromatogramSelections.entrySet()) {
 				IChromatogramSelection<?, ?> chromatogramSelection = entry.getKey();
 				if(previousChromatograms != chromatogramSelections.size()) {
 					if(chromatogramSelection instanceof IChromatogramSelectionCSD) {
@@ -660,7 +657,7 @@ public class ExtendedChromatogramOverlayUI extends Composite implements IExtende
 			/*
 			 * Delete non-available series.
 			 */
-			for(ISeries series : baseChart.getSeriesSet().getSeries()) {
+			for(ISeries<?> series : baseChart.getSeriesSet().getSeries()) {
 				String seriesId = series.getId();
 				if(!availableSeriesIds.contains(seriesId)) {
 					baseChart.deleteSeries(seriesId);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedInternalStandardsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedInternalStandardsUI.java
@@ -24,6 +24,7 @@ import org.eclipse.chemclipse.model.quantitation.IInternalStandard;
 import org.eclipse.chemclipse.model.quantitation.InternalStandard;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
+import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.support.comparator.SortOrder;
 import org.eclipse.chemclipse.support.ui.events.IKeyEventProcessor;
 import org.eclipse.chemclipse.support.ui.menu.ITableMenuEntry;
@@ -216,7 +217,7 @@ public class ExtendedInternalStandardsUI extends Composite implements IExtendedP
 		Button button = new Button(parent, SWT.PUSH);
 		button.setText("");
 		button.setToolTipText("Cancel Operation");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_CANCEL, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_CANCEL, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -235,7 +236,7 @@ public class ExtendedInternalStandardsUI extends Composite implements IExtendedP
 		Button button = new Button(parent, SWT.PUSH);
 		button.setText("");
 		button.setToolTipText("Add Internal Standard");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_ADD, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_ADD, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -262,7 +263,7 @@ public class ExtendedInternalStandardsUI extends Composite implements IExtendedP
 		Button button = new Button(parent, SWT.PUSH);
 		button.setText("");
 		button.setToolTipText("Delete Internal Standard");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_DELETE, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_DELETE, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -366,7 +367,7 @@ public class ExtendedInternalStandardsUI extends Composite implements IExtendedP
 		Button button = new Button(parent, SWT.PUSH);
 		button.setText("");
 		button.setToolTipText("Insert Internal Standard");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EXECUTE, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EXECUTE, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -384,14 +385,14 @@ public class ExtendedInternalStandardsUI extends Composite implements IExtendedP
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Toggle info toolbar.");
 		button.setText("");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 
 				boolean visible = PartSupport.toggleCompositeVisibility(toolbarInfo);
-				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImage.SIZE_16x16, visible));
+				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImageProvider.SIZE_16x16, visible));
 			}
 		});
 		//
@@ -403,7 +404,7 @@ public class ExtendedInternalStandardsUI extends Composite implements IExtendedP
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Toggle modify toolbar.");
 		button.setText("");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_DEFAULT, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_DEFAULT, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -418,9 +419,9 @@ public class ExtendedInternalStandardsUI extends Composite implements IExtendedP
 				}
 				//
 				if(visible) {
-					button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_ACTIVE, IApplicationImage.SIZE_16x16));
+					button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_ACTIVE, IApplicationImageProvider.SIZE_16x16));
 				} else {
-					button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_DEFAULT, IApplicationImage.SIZE_16x16));
+					button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_DEFAULT, IApplicationImageProvider.SIZE_16x16));
 				}
 			}
 		});
@@ -433,7 +434,7 @@ public class ExtendedInternalStandardsUI extends Composite implements IExtendedP
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Enable/disable to edit the table.");
 		button.setText("");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_ENTRY_DEFAULT, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_ENTRY_DEFAULT, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -441,7 +442,7 @@ public class ExtendedInternalStandardsUI extends Composite implements IExtendedP
 
 				boolean editEnabled = !internalStandardsListUI.isEditEnabled();
 				internalStandardsListUI.setEditEnabled(editEnabled);
-				button.setImage(ApplicationImageFactory.getInstance().getImage((editEnabled) ? IApplicationImage.IMAGE_EDIT_ENTRY_ACTIVE : IApplicationImage.IMAGE_EDIT_ENTRY_DEFAULT, IApplicationImage.SIZE_16x16));
+				button.setImage(ApplicationImageFactory.getInstance().getImage((editEnabled) ? IApplicationImage.IMAGE_EDIT_ENTRY_ACTIVE : IApplicationImage.IMAGE_EDIT_ENTRY_DEFAULT, IApplicationImageProvider.SIZE_16x16));
 				updatePeak();
 			}
 		});
@@ -513,7 +514,6 @@ public class ExtendedInternalStandardsUI extends Composite implements IExtendedP
 		});
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void deleteInternalStandards(Shell shell) {
 
 		if(peak != null) {
@@ -525,11 +525,11 @@ public class ExtendedInternalStandardsUI extends Composite implements IExtendedP
 				 * Delete ISTD
 				 */
 				enableButtonFields(ACTION_DELETE);
-				Iterator iterator = internalStandardsListUI.getStructuredSelection().iterator();
+				Iterator<?> iterator = internalStandardsListUI.getStructuredSelection().iterator();
 				while(iterator.hasNext()) {
 					Object object = iterator.next();
-					if(object instanceof IInternalStandard) {
-						deleteInternalStandard((IInternalStandard)object);
+					if(object instanceof IInternalStandard internalStandard) {
+						deleteInternalStandard(internalStandard);
 					}
 				}
 				updatePeak();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakChartUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -54,7 +54,7 @@ import org.eclipse.swtchart.extensions.core.IMouseSupport;
 import org.eclipse.swtchart.extensions.events.AbstractHandledEventProcessor;
 import org.eclipse.swtchart.extensions.events.IHandledEventProcessor;
 
-@SuppressWarnings("rawtypes")
+
 public class ExtendedPeakChartUI extends Composite implements IExtendedPartUI {
 
 	private static final Logger logger = Logger.getLogger(ExtendedPeakChartUI.class);
@@ -338,7 +338,7 @@ public class ExtendedPeakChartUI extends Composite implements IExtendedPartUI {
 		return button;
 	}
 
-	private void addPeaks(IChromatogram chromatogram, IPeak peakOriginal, IPeak peak1, IPeak peak2) {
+	private void addPeaks(IChromatogram<?> chromatogram, IPeak peakOriginal, IPeak peak1, IPeak peak2) {
 
 		if(peak1 != null || peak2 != null) {
 			removePeakFromChromatogram(chromatogram, peakOriginal);
@@ -347,7 +347,7 @@ public class ExtendedPeakChartUI extends Composite implements IExtendedPartUI {
 		}
 	}
 
-	private void removePeakFromChromatogram(IChromatogram chromatogram, IPeak peak) {
+	private void removePeakFromChromatogram(IChromatogram<?> chromatogram, IPeak peak) {
 
 		if(peak != null) {
 			if(chromatogram instanceof IChromatogramMSD && peak instanceof IChromatogramPeakMSD) {
@@ -360,7 +360,7 @@ public class ExtendedPeakChartUI extends Composite implements IExtendedPartUI {
 		}
 	}
 
-	private void addPeakToChromatogram(IChromatogram chromatogram, IPeak peak) {
+	private void addPeakToChromatogram(IChromatogram<?> chromatogram, IPeak peak) {
 
 		if(peak != null) {
 			if(chromatogram instanceof IChromatogramMSD) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakDetectorUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakDetectorUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -80,7 +80,7 @@ import org.eclipse.swtchart.extensions.linecharts.ILineSeriesData;
 import org.eclipse.swtchart.extensions.linecharts.ILineSeriesSettings;
 import org.eclipse.swtchart.extensions.linecharts.LineChart;
 
-@SuppressWarnings("rawtypes")
+
 public class ExtendedPeakDetectorUI extends Composite implements IExtendedPartUI {
 
 	private static final Logger logger = Logger.getLogger(ExtendedPeakDetectorUI.class);
@@ -132,7 +132,7 @@ public class ExtendedPeakDetectorUI extends Composite implements IExtendedPartUI
 	private Button buttonAddPeak;
 	private AtomicReference<ChromatogramChart> chartControl = new AtomicReference<>();
 	//
-	private IChromatogramSelection chromatogramSelection;
+	private IChromatogramSelection<?, ?>chromatogramSelection;
 	private IPeak peak;
 	//
 	private BaselineSelectionPaintListener baselineSelectionPaintListener;
@@ -310,10 +310,10 @@ public class ExtendedPeakDetectorUI extends Composite implements IExtendedPartUI
 		return true;
 	}
 
-	public void update(IChromatogramSelection chromatogramSelection) {
+	public void update(IChromatogramSelection<?, ?>chromatogramSelection) {
 
 		this.chromatogramSelection = chromatogramSelection;
-		IChromatogram chromatogram = null;
+		IChromatogram<?> chromatogram = null;
 		if(chromatogramSelection != null) {
 			chromatogram = chromatogramSelection.getChromatogram();
 		}
@@ -468,7 +468,7 @@ public class ExtendedPeakDetectorUI extends Composite implements IExtendedPartUI
 			public void widgetSelected(SelectionEvent e) {
 
 				if(peak != null) {
-					IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+					IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 					if(chromatogram instanceof IChromatogramMSD) {
 						if(peak instanceof IChromatogramPeakMSD) {
 							IChromatogramPeakMSD peakMSD = (IChromatogramPeakMSD)peak;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakQuantReferencesUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakQuantReferencesUI.java
@@ -276,7 +276,6 @@ public class ExtendedPeakQuantReferencesUI extends Composite implements IExtende
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void deleteReferences(Shell shell) {
 
 		MessageBox messageBox = new MessageBox(shell, SWT.ICON_QUESTION | SWT.YES | SWT.NO);
@@ -284,11 +283,11 @@ public class ExtendedPeakQuantReferencesUI extends Composite implements IExtende
 		messageBox.setMessage("Would you like to delete the selected quantitations?");
 		if(messageBox.open() == SWT.YES) {
 			//
-			Iterator iterator = tableViewer.get().getStructuredSelection().iterator();
+			Iterator<?> iterator = tableViewer.get().getStructuredSelection().iterator();
 			while(iterator.hasNext()) {
 				Object object = iterator.next();
-				if(object instanceof String) {
-					deleteReference((String)object);
+				if(object instanceof String text) {
+					deleteReference(text);
 				}
 			}
 			updateReferences();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakQuantitationListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakQuantitationListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Lablicate GmbH.
+ * Copyright (c) 2020, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -43,6 +43,7 @@ public class ExtendedPeakQuantitationListUI extends Composite implements IExtend
 		createControl();
 	}
 
+	@Override
 	public boolean setFocus() {
 
 		tableViewer.get().getTable().setFocus();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
@@ -95,7 +95,6 @@ import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swtchart.extensions.core.IKeyboardSupport;
 import org.eclipse.ui.PlatformUI;
 
-@SuppressWarnings("rawtypes")
 public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI, ConfigurableUI<PeakScanListUIConfig> {
 
 	private static final Logger logger = Logger.getLogger(ExtendedPeakScanListUI.class);
@@ -120,6 +119,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 	private Button buttonTableEdit;
 	private AtomicReference<PeakScanListUI> tableViewer = new AtomicReference<>();
 	//
+	@SuppressWarnings("rawtypes")
 	private IChromatogramSelection chromatogramSelection;
 	//
 	private boolean showScans;
@@ -144,7 +144,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 		List<Object> objects = dataUpdateSupport.getUpdates(IChemClipseEvents.TOPIC_CHROMATOGRAM_XXD_UPDATE_SELECTION);
 		if(!objects.isEmpty()) {
 			Object last = objects.get(0);
-			if(last instanceof IChromatogramSelection chromatogramSelection) {
+			if(last instanceof IChromatogramSelection<?, ?> chromatogramSelection) {
 				updateChromatogramSelection(chromatogramSelection);
 			}
 		}
@@ -153,7 +153,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 		return true;
 	}
 
-	public void updateChromatogramSelection(IChromatogramSelection chromatogramSelection) {
+	public void updateChromatogramSelection(IChromatogramSelection<?, ?> chromatogramSelection) {
 
 		if(hasChanged(chromatogramSelection)) {
 			this.chromatogramSelection = chromatogramSelection;
@@ -175,7 +175,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 			currentModCount = chromatogramSelection.getChromatogram().getModCount();
 			lastRange = new RetentionTimeRange(chromatogramSelection);
 			tableViewer.get().setInput(chromatogramSelection, showPeaks, showPeaksInRange, showScans, showScansInRange);
-			IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+			IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 			if(chromatogram instanceof IChromatogramMSD) {
 				buttonSave.setEnabled(true);
 			}
@@ -483,7 +483,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 			/*
 			 * Selected Items.
 			 */
-			Iterator iterator = tableViewer.get().getStructuredSelection().iterator();
+			Iterator<?> iterator = tableViewer.get().getStructuredSelection().iterator();
 			List<IScan> scanTargetsToClear = new ArrayList<>();
 			List<IPeak> peaksToDelete = new ArrayList<>();
 			/*
@@ -528,11 +528,10 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 
 	private void setPeaksActiveForAnalysis(boolean activeForAnalysis) {
 
-		Iterator iterator = tableViewer.get().getStructuredSelection().iterator();
+		Iterator<?> iterator = tableViewer.get().getStructuredSelection().iterator();
 		while(iterator.hasNext()) {
 			Object object = iterator.next();
-			if(object instanceof IPeak) {
-				IPeak peak = (IPeak)object;
+			if(object instanceof IPeak peak) {
 				peak.setActiveForAnalysis(activeForAnalysis);
 			}
 		}
@@ -545,12 +544,11 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 		messageBox.setText("Internal Standard (ISTD)");
 		messageBox.setMessage("Would you like to modify the internal standards?");
 		if(messageBox.open() == SWT.YES) {
-			Iterator iterator = tableViewer.get().getStructuredSelection().iterator();
+			Iterator<?> iterator = tableViewer.get().getStructuredSelection().iterator();
 			exitloop:
 			while(iterator.hasNext()) {
 				Object object = iterator.next();
-				if(object instanceof IPeak) {
-					IPeak peak = (IPeak)object;
+				if(object instanceof IPeak peak) {
 					if(peak.getIntegratedArea() > 0) {
 						InternalStandardDialog dialog = new InternalStandardDialog(display.getActiveShell(), peak);
 						if(dialog.open() == Window.OK) {
@@ -572,12 +570,11 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 		messageBox.setText("Classifier");
 		messageBox.setMessage("Would you like to modify the classifier?");
 		if(messageBox.open() == SWT.YES) {
-			Iterator iterator = tableViewer.get().getStructuredSelection().iterator();
+			Iterator<?> iterator = tableViewer.get().getStructuredSelection().iterator();
 			exitloop:
 			while(iterator.hasNext()) {
 				Object object = iterator.next();
-				if(object instanceof IPeak) {
-					IPeak peak = (IPeak)object;
+				if(object instanceof IPeak peak) {
 					ClassifierDialog dialog = new ClassifierDialog(display.getActiveShell(), peak);
 					if(dialog.open() == Window.OK) {
 						peak.removeClassifier();
@@ -613,7 +610,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 		//
 		if(!selection.isEmpty()) {
 			buttonDelete.setEnabled(true);
-			List list = selection.toList();
+			List<?> list = selection.toList();
 			if(list.size() > 1) {
 				/*
 				 * Add in the future to select/display more than one peak.
@@ -628,12 +625,10 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 				List<IScan> scansIdentify = new ArrayList<>();
 				//
 				for(Object item : list) {
-					if(item instanceof IPeak) {
-						IPeak peak = (IPeak)item;
+					if(item instanceof IPeak peak) {
 						selectedPeaks.add(peak);
 						scansIdentify.add(peak.getPeakModel().getPeakMaximum());
-					} else if(item instanceof IScan) {
-						IScan scan = (IScan)item;
+					} else if(item instanceof IScan scan) {
 						selectedIdentifiedScans.add(scan);
 						scansIdentify.add(scan);
 					}
@@ -713,7 +708,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 
 				IStructuredSelection selection = tableViewer.get().getStructuredSelection();
 				if(!selection.isEmpty()) {
-					List list = selection.toList();
+					List<?> list = selection.toList();
 					if(list.size() == 2) {
 						IScanMSD massSpectrum1 = getScanMSD(list.get(0));
 						IScanMSD massSpectrum2 = getScanMSD(list.get(1));
@@ -868,7 +863,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 						/*
 						 * Peaks
 						 */
-						IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+						IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 						Table table = tableViewer.get().getTable();
 						int[] indices = table.getSelectionIndices();
 						List<IPeak> peaks;
@@ -936,7 +931,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 			/*
 			 * Display the selected and total amount of peaks/scans
 			 */
-			IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+			IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 			String chromatogramLabel = ChromatogramDataSupport.getChromatogramLabel(chromatogram);
 			//
 			int peaks = 0;
@@ -1049,7 +1044,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 		return scanList;
 	}
 
-	private boolean hasChanged(IChromatogramSelection chromatogramSelection) {
+	private boolean hasChanged(IChromatogramSelection<?, ?> chromatogramSelection) {
 
 		boolean referenceChanged = this.chromatogramSelection != chromatogramSelection;
 		if(!referenceChanged && chromatogramSelection != null) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedQuantResponseListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedQuantResponseListUI.java
@@ -279,7 +279,6 @@ public class ExtendedQuantResponseListUI extends Composite implements IExtendedP
 		});
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void deleteSignals(Shell shell) {
 
 		MessageBox messageBox = new MessageBox(shell, SWT.ICON_QUESTION | SWT.YES | SWT.NO);
@@ -289,11 +288,11 @@ public class ExtendedQuantResponseListUI extends Composite implements IExtendedP
 			/*
 			 * Delete
 			 */
-			Iterator iterator = tableViewer.get().getStructuredSelection().iterator();
+			Iterator<?> iterator = tableViewer.get().getStructuredSelection().iterator();
 			while(iterator.hasNext()) {
 				Object object = iterator.next();
 				if(object instanceof IResponseSignal) {
-					quantitationCompound.getResponseSignals().remove((IResponseSignal)object);
+					quantitationCompound.getResponseSignals().remove(object);
 				}
 			}
 			updateInput();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedQuantSignalsListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedQuantSignalsListUI.java
@@ -279,7 +279,6 @@ public class ExtendedQuantSignalsListUI extends Composite implements IExtendedPa
 		});
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void deleteSignals(Shell shell) {
 
 		MessageBox messageBox = new MessageBox(shell, SWT.ICON_QUESTION | SWT.YES | SWT.NO);
@@ -289,11 +288,11 @@ public class ExtendedQuantSignalsListUI extends Composite implements IExtendedPa
 			/*
 			 * Delete
 			 */
-			Iterator iterator = tableViewer.get().getStructuredSelection().iterator();
+			Iterator<?> iterator = tableViewer.get().getStructuredSelection().iterator();
 			while(iterator.hasNext()) {
 				Object object = iterator.next();
 				if(object instanceof IQuantitationSignal) {
-					quantitationCompound.getQuantitationSignals().remove((IQuantitationSignal)object);
+					quantitationCompound.getQuantitationSignals().remove(object);
 				}
 			}
 			updateInput();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedQuantitationListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedQuantitationListUI.java
@@ -162,7 +162,6 @@ public class ExtendedQuantitationListUI extends Composite implements IExtendedPa
 		});
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void deleteQuantitationEntries(Shell shell) {
 
 		MessageBox messageBox = new MessageBox(shell, SWT.ICON_QUESTION | SWT.YES | SWT.NO);
@@ -172,7 +171,7 @@ public class ExtendedQuantitationListUI extends Composite implements IExtendedPa
 			/*
 			 * Delete Quantitation Entry
 			 */
-			Iterator iterator = quantitationListUI.getStructuredSelection().iterator();
+			Iterator<?> iterator = quantitationListUI.getStructuredSelection().iterator();
 			while(iterator.hasNext()) {
 				Object object = iterator.next();
 				if(object instanceof IQuantitationEntry) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanBrowseUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanBrowseUI.java
@@ -44,7 +44,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 
-@SuppressWarnings("rawtypes")
 public class ExtendedScanBrowseUI extends Composite implements IExtendedPartUI {
 
 	private Composite toolbarInfo;
@@ -141,8 +140,8 @@ public class ExtendedScanBrowseUI extends Composite implements IExtendedPartUI {
 			@Override
 			public String getText(Object element) {
 
-				if(element instanceof Type) {
-					return ((Type)element).getLabel();
+				if(element instanceof Type type) {
+					return type.getLabel();
 				}
 				return null;
 			}
@@ -196,9 +195,8 @@ public class ExtendedScanBrowseUI extends Composite implements IExtendedPartUI {
 			public String getText(Object element) {
 
 				String label = "";
-				if(element instanceof IChromatogramSelection) {
-					IChromatogramSelection chromatogramSelection = (IChromatogramSelection)element;
-					IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+				if(element instanceof IChromatogramSelection<?, ?> chromatogramSelection) {
+					IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 					label = ChromatogramDataSupport.getReferenceLabel(chromatogram, -1, false);
 				}
 				return label;
@@ -300,9 +298,8 @@ public class ExtendedScanBrowseUI extends Composite implements IExtendedPartUI {
 		IScan referenceScan = null;
 		IStructuredSelection structuredSelection = comboViewerSource.getStructuredSelection();
 		Object object = structuredSelection.getFirstElement();
-		if(object instanceof IChromatogramSelection) {
-			IChromatogramSelection chromatogramSelection = (IChromatogramSelection)object;
-			IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+		if(object instanceof IChromatogramSelection<?, ?> chromatogramSelection) {
+			IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 			int scanNumber = chromatogram.getScanNumber(masterRetentionTime);
 			referenceScan = chromatogram.getScan(scanNumber);
 		}
@@ -315,7 +312,7 @@ public class ExtendedScanBrowseUI extends Composite implements IExtendedPartUI {
 
 		updateLabel(scan);
 		updateChart(scan);
-		updateComboViewer(scan);
+		updateComboViewer();
 		updatePreviousAndNextButton();
 	}
 
@@ -330,7 +327,8 @@ public class ExtendedScanBrowseUI extends Composite implements IExtendedPartUI {
 		scanChartUI.getBaseChart().redraw();
 	}
 
-	private void updateComboViewer(IScan scan) {
+	@SuppressWarnings("rawtypes")
+	private void updateComboViewer() {
 
 		Type type = getSelectedType();
 		List<IChromatogramSelection> chromatogramSelections = new ArrayList<>();
@@ -375,22 +373,21 @@ public class ExtendedScanBrowseUI extends Composite implements IExtendedPartUI {
 	private Type getSelectedType() {
 
 		Object object = comboViewerType.getStructuredSelection().getFirstElement();
-		if(object instanceof Type) {
-			return (Type)object;
+		if(object instanceof Type type) {
+			return type;
 		}
 		return Type.BOTH;
 	}
 
-	@SuppressWarnings({"unchecked"})
-	private List<IChromatogramSelection> extractInternal() {
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	private List<IChromatogramSelection<?, ?>> extractInternal() {
 
-		List<IChromatogramSelection> chromatogramSelections = new ArrayList<>();
+		List<IChromatogramSelection<?, ?>> chromatogramSelections = new ArrayList<>();
 		if(chromatogramSelection != null) {
 			Object object = chromatogramSelection.getChromatogram();
-			if(object instanceof IChromatogram) {
-				IChromatogram chromatogram = (IChromatogram)object;
-				List<IChromatogram> chromatograms = chromatogram.getReferencedChromatograms();
-				for(IChromatogram chromatogramReference : chromatograms) {
+			if(object instanceof IChromatogram<?> chromatogram) {
+				List<IChromatogram<?>> chromatograms = chromatogram.getReferencedChromatograms();
+				for(IChromatogram<?> chromatogramReference : chromatograms) {
 					chromatogramSelections.add(new ChromatogramSelection(chromatogramReference));
 				}
 			}
@@ -398,13 +395,14 @@ public class ExtendedScanBrowseUI extends Composite implements IExtendedPartUI {
 		return chromatogramSelections;
 	}
 
+	@SuppressWarnings("rawtypes")
 	private List<IChromatogramSelection> extractExternal() {
 
 		List<IChromatogramSelection> chromatogramSelections = new ArrayList<>();
 		EditorUpdateSupport editorUpdateSupport = new EditorUpdateSupport();
 		if(chromatogramSelection != null) {
-			IChromatogram chromatogram = chromatogramSelection.getChromatogram();
-			for(IChromatogramSelection chromatogramSelectionEditor : editorUpdateSupport.getChromatogramSelections()) {
+			IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
+			for(IChromatogramSelection<?, ?> chromatogramSelectionEditor : editorUpdateSupport.getChromatogramSelections()) {
 				if(chromatogram != chromatogramSelectionEditor.getChromatogram()) {
 					chromatogramSelections.add(chromatogramSelectionEditor);
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanInfoUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanInfoUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Lablicate GmbH.
+ * Copyright (c) 2020, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -50,13 +50,12 @@ public class ExtendedScanInfoUI extends Composite implements IExtendedPartUI {
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	public void setInput(Object input) {
 
-		if(input instanceof IChromatogramSelection) {
-			IChromatogramSelection chromatogramSelection = (IChromatogramSelection)input;
+		if(input instanceof IChromatogramSelection chromatogramSelection) {
 			IChromatogram<IPeak> chromatogram = chromatogramSelection.getChromatogram();
 			labelInfo.setText(chromatogram.getName());
 			int startRetentionTime = chromatogramSelection.getStartRetentionTime();
 			int stopRetentionTime = chromatogramSelection.getStopRetentionTime();
-			List<IScan> selectedScans = new ArrayList<IScan>();
+			List<IScan> selectedScans = new ArrayList<>();
 			for(IScan scan : chromatogram.getScans()) {
 				if(scan.getRetentionTime() >= startRetentionTime && scan.getRetentionTime() <= stopRetentionTime) {
 					selectedScans.add(scan);
@@ -142,8 +141,8 @@ public class ExtendedScanInfoUI extends Composite implements IExtendedPartUI {
 
 				IStructuredSelection structuredSelection = scanInfoListUI.getStructuredSelection();
 				Object object = structuredSelection.getFirstElement();
-				if(object instanceof IScanMSD) {
-					UpdateNotifierUI.update(e.display, (IScanMSD)object);
+				if(object instanceof IScanMSD scanMSD) {
+					UpdateNotifierUI.update(e.display, scanMSD);
 				}
 			}
 		});

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanTableUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanTableUI.java
@@ -715,7 +715,6 @@ public class ExtendedScanTableUI extends Composite implements IExtendedPartUI {
 		updateObject();
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void deleteTraces(Shell shell) {
 
 		MessageBox messageBox = new MessageBox(shell, SWT.ICON_QUESTION | SWT.YES | SWT.NO);
@@ -725,7 +724,7 @@ public class ExtendedScanTableUI extends Composite implements IExtendedPartUI {
 			/*
 			 * Delete the signal
 			 */
-			Iterator iterator = scanTableUI.getStructuredSelection().iterator();
+			Iterator<?> iterator = scanTableUI.getStructuredSelection().iterator();
 			while(iterator.hasNext()) {
 				Object object = iterator.next();
 				deleteSignal(object);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/HeaderDataListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/HeaderDataListUI.java
@@ -18,6 +18,7 @@ import org.eclipse.chemclipse.model.core.IMeasurementInfo;
 import org.eclipse.chemclipse.model.updates.IUpdateListener;
 import org.eclipse.chemclipse.support.ui.provider.ListContentProvider;
 import org.eclipse.chemclipse.support.ui.swt.ExtendedTableViewer;
+import org.eclipse.chemclipse.support.ui.swt.IRecordTableComparator;
 import org.eclipse.chemclipse.swt.ui.support.Colors;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.HeaderDataEditingSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.HeaderDataLabelProvider;
@@ -85,7 +86,7 @@ public class HeaderDataListUI extends ExtendedTableViewer {
 	public void sortTable() {
 
 		int column = 0;
-		int sortOrder = HeaderDataTableComparator.DESCENDING;
+		int sortOrder = IRecordTableComparator.DESCENDING;
 		//
 		tableComparator.setColumn(column);
 		tableComparator.setDirection(sortOrder);
@@ -115,14 +116,12 @@ public class HeaderDataListUI extends ExtendedTableViewer {
 		if(tableViewerColumn != null) {
 			tableViewerColumn.setLabelProvider(new StyledCellLabelProvider() {
 
-				@SuppressWarnings("rawtypes")
 				@Override
 				public void update(ViewerCell cell) {
 
 					if(cell != null && measurementInfo != null) {
 						Object object = cell.getElement();
-						if(object instanceof Map.Entry) {
-							Map.Entry entry = (Map.Entry)object;
+						if(object instanceof Map.Entry<?, ?> entry) {
 							String key = entry.getKey().toString();
 							if(measurementInfo.isKeyProtected(key)) {
 								cell.setForeground(Colors.DARK_GRAY);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/IChromatogramReferencesListener.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/IChromatogramReferencesListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,6 +15,5 @@ import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 
 public interface IChromatogramReferencesListener {
 
-	@SuppressWarnings("rawtypes")
-	void update(IChromatogramSelection chromatogramSelection);
+	void update(IChromatogramSelection<?, ?>chromatogramSelection);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakChartUI.java
@@ -223,7 +223,6 @@ public class PeakChartUI extends ScrollableChart {
 		applySettings(chartSettings);
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void addLineSeriesData(List<ILineSeriesData> lineSeriesDataList) {
 
 		/*
@@ -241,7 +240,7 @@ public class PeakChartUI extends ScrollableChart {
 					ISeriesData optimizedSeriesData = calculateSeries(seriesData);
 					ILineSeriesSettings lineSeriesSettings = lineSeriesData.getSettings();
 					lineSeriesSettings.getSeriesSettingsHighlight(); // Initialize
-					ILineSeries lineSeries = (ILineSeries)createSeries(optimizedSeriesData, lineSeriesSettings);
+					ILineSeries<?> lineSeries = (ILineSeries<?>)createSeries(optimizedSeriesData, lineSeriesSettings);
 					baseChart.applySeriesSettings(lineSeries, lineSeriesSettings);
 				} catch(SeriesException e) {
 					//

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakTracesUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakTracesUI.java
@@ -298,7 +298,6 @@ public class PeakTracesUI extends ScrollableChart {
 		applySettings(chartSettings);
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void addLineSeriesData(List<ILineSeriesData> lineSeriesDataList) {
 
 		/*
@@ -316,7 +315,7 @@ public class PeakTracesUI extends ScrollableChart {
 					ISeriesData optimizedSeriesData = calculateSeries(seriesData);
 					ILineSeriesSettings lineSeriesSettings = lineSeriesData.getSettings();
 					lineSeriesSettings.getSeriesSettingsHighlight(); // Initialize
-					ILineSeries lineSeries = (ILineSeries)createSeries(optimizedSeriesData, lineSeriesSettings);
+					ILineSeries<?> lineSeries = (ILineSeries<?>)createSeries(optimizedSeriesData, lineSeriesSettings);
 					baseChart.applySeriesSettings(lineSeries, lineSeriesSettings);
 				} catch(SeriesException e) {
 					//

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
@@ -560,7 +560,6 @@ public class ScanChartUI extends ScrollableChart {
 		addSeriesLabelMarker(labelPaintListener);
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void addBarSeriesData(List<IBarSeriesData> barSeriesDataList) {
 
 		/*
@@ -578,7 +577,7 @@ public class ScanChartUI extends ScrollableChart {
 					ISeriesData optimizedSeriesData = calculateSeries(seriesData, COMPRESS_TO_LENGTH);
 					IBarSeriesSettings barSeriesSettings = barSeriesData.getSettings();
 					barSeriesSettings.getSeriesSettingsHighlight(); // Initialize
-					IBarSeries barSeries = (IBarSeries)createSeries(optimizedSeriesData, barSeriesSettings);
+					IBarSeries<?> barSeries = (IBarSeries<?>)createSeries(optimizedSeriesData, barSeriesSettings);
 					barSeriesSettings.setBarOverlay(true);
 					baseChart.applySeriesSettings(barSeries, barSeriesSettings);
 					/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ChromatogramAlignmentUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ChromatogramAlignmentUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -55,8 +55,7 @@ public class ChromatogramAlignmentUI extends Composite implements IChromatogramS
 	private ChromatogramSourceCombo chromatogramSourceCombo;
 	private List<Button> buttons = new ArrayList<>();
 	//
-	@SuppressWarnings("rawtypes")
-	private IChromatogramSelection chromatogramSelectionSource = null;
+	private IChromatogramSelection<?, ?>chromatogramSelectionSource = null;
 	private List<IChromatogramSelection<?, ?>> chromatogramSelectionsInternal = new ArrayList<>();
 	//
 	private EditorUpdateSupport editorUpdateSupport = new EditorUpdateSupport();
@@ -69,8 +68,7 @@ public class ChromatogramAlignmentUI extends Composite implements IChromatogramS
 	}
 
 	@Override
-	@SuppressWarnings("rawtypes")
-	public void update(IChromatogramSelection chromatogramSelectionSource) {
+	public void update(IChromatogramSelection<?, ?>chromatogramSelectionSource) {
 
 		this.chromatogramSelectionSource = chromatogramSelectionSource;
 		enableButtons();
@@ -232,7 +230,6 @@ public class ChromatogramAlignmentUI extends Composite implements IChromatogramS
 		label.setLayoutData(gridData);
 	}
 
-	@SuppressWarnings("rawtypes")
 	private boolean setRanges() {
 
 		if(chromatogramSelectionSource != null) {
@@ -244,7 +241,7 @@ public class ChromatogramAlignmentUI extends Composite implements IChromatogramS
 			/*
 			 * Editor
 			 */
-			for(IChromatogramSelection selection : getTargetChromatogramSelections()) {
+			for(IChromatogramSelection<?, ?>selection : getTargetChromatogramSelections()) {
 				if(selection != chromatogramSelectionSource) {
 					/*
 					 * Don't fire an update. The next time the selection is on focus,
@@ -264,14 +261,13 @@ public class ChromatogramAlignmentUI extends Composite implements IChromatogramS
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void modifyChromatogramLength(Shell shell, String modifyLengthType) {
 
 		MessageBox messageBox = new MessageBox(shell, SWT.ICON_QUESTION | SWT.YES | SWT.NO);
 		messageBox.setText("Modify Chromatogram Length");
 		messageBox.setMessage("Would you like to modify the length of all opened chromatograms? Peaks will be deleted.");
 		if(messageBox.open() == SWT.YES) {
-			IChromatogram chromatogram = getChromatogram(modifyLengthType);
+			IChromatogram<?> chromatogram = getChromatogram(modifyLengthType);
 			if(chromatogram != null) {
 				/*
 				 * Settings
@@ -290,7 +286,7 @@ public class ChromatogramAlignmentUI extends Composite implements IChromatogramS
 				/*
 				 * Modify chromatograms.
 				 */
-				for(IChromatogramSelection chromatogramSelection : getTargetChromatogramSelections()) {
+				for(IChromatogramSelection<?, ?> chromatogramSelection : getTargetChromatogramSelections()) {
 					if(realignChromatogram(modifyLengthType, chromatogramSelection, chromatogram)) {
 						IRunnableWithProgress runnable = new ChromatogramLengthModifier(chromatogramSelection, scanDelay, chromatogramLength);
 						ProgressMonitorDialog monitor = new ProgressMonitorDialog(shell);
@@ -300,6 +296,7 @@ public class ChromatogramAlignmentUI extends Composite implements IChromatogramS
 							logger.warn(e);
 						} catch(InterruptedException e) {
 							logger.warn(e);
+							Thread.currentThread().interrupt();
 						}
 					}
 					/*
@@ -313,8 +310,7 @@ public class ChromatogramAlignmentUI extends Composite implements IChromatogramS
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
-	private boolean realignChromatogram(String modifyLengthType, IChromatogramSelection chromatogramSelection, IChromatogram chromatogram) {
+	private boolean realignChromatogram(String modifyLengthType, IChromatogramSelection<?, ?> chromatogramSelection, IChromatogram<?> chromatogram) {
 
 		/*
 		 * Don't re-align the template chromatogram.
@@ -329,10 +325,9 @@ public class ChromatogramAlignmentUI extends Composite implements IChromatogramS
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IChromatogram getChromatogram(String modifyLengthType) {
+	private IChromatogram<?> getChromatogram(String modifyLengthType) {
 
-		IChromatogram chromatogram;
+		IChromatogram<?> chromatogram;
 		switch(modifyLengthType) {
 			case MODIFY_LENGTH_SHORTEST:
 				chromatogram = getShortestChromatogram();
@@ -360,12 +355,11 @@ public class ChromatogramAlignmentUI extends Composite implements IChromatogramS
 	 * 
 	 * @return IChromatogram
 	 */
-	@SuppressWarnings("rawtypes")
-	private IChromatogram getShortestChromatogram() {
+	private IChromatogram<?> getShortestChromatogram() {
 
-		IChromatogram chromatogram = null;
+		IChromatogram<?> chromatogram = null;
 		int maxRetentionTime = Integer.MAX_VALUE;
-		for(IChromatogramSelection chromatogramSelection : getTargetChromatogramSelections()) {
+		for(IChromatogramSelection<?, ?> chromatogramSelection : getTargetChromatogramSelections()) {
 			if(chromatogramSelection.getChromatogram().getStopRetentionTime() < maxRetentionTime) {
 				maxRetentionTime = chromatogramSelection.getChromatogram().getStopRetentionTime();
 				chromatogram = chromatogramSelection.getChromatogram();
@@ -379,12 +373,11 @@ public class ChromatogramAlignmentUI extends Composite implements IChromatogramS
 	 * 
 	 * @return IChromatogram
 	 */
-	@SuppressWarnings("rawtypes")
-	private IChromatogram getLongestChromatogram() {
+	private IChromatogram<?> getLongestChromatogram() {
 
-		IChromatogram chromatogram = null;
+		IChromatogram<?> chromatogram = null;
 		int minRetentionTime = Integer.MIN_VALUE;
-		for(IChromatogramSelection chromatogramSelection : getTargetChromatogramSelections()) {
+		for(IChromatogramSelection<?, ?> chromatogramSelection : getTargetChromatogramSelections()) {
 			if(chromatogramSelection.getChromatogram().getStopRetentionTime() > minRetentionTime) {
 				minRetentionTime = chromatogramSelection.getChromatogram().getStopRetentionTime();
 				chromatogram = chromatogramSelection.getChromatogram();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ChromatogramMoveArrowKeyHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ChromatogramMoveArrowKeyHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -61,10 +61,10 @@ public class ChromatogramMoveArrowKeyHandler extends AbstractHandledEventProcess
 		handleArrowMoveWindowSelection(keyCode);
 	}
 
-	@SuppressWarnings("rawtypes")
+	
 	private void handleArrowMoveWindowSelection(int keyCode) {
 
-		IChromatogramSelection chromatogramSelection = extendedChromatogramUI.getChromatogramSelection();
+		IChromatogramSelection<?, ?>chromatogramSelection = extendedChromatogramUI.getChromatogramSelection();
 		if(chromatogramSelection != null) {
 			if(keyCode == SWT.ARROW_RIGHT || keyCode == SWT.ARROW_LEFT) {
 				/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ChromatogramSelectionHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ChromatogramSelectionHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -25,11 +25,11 @@ public class ChromatogramSelectionHandler implements ICustomSelectionHandler {
 		this.extendedChromatogramUI = extendedChromatogramUI;
 	}
 
-	@SuppressWarnings("rawtypes")
+	
 	@Override
 	public void handleUserSelection(Event event) {
 
-		IChromatogramSelection chromatogramSelection = extendedChromatogramUI.getChromatogramSelection();
+		IChromatogramSelection<?, ?>chromatogramSelection = extendedChromatogramUI.getChromatogramSelection();
 		if(chromatogramSelection != null) {
 			/*
 			 * Get the range.

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -177,7 +177,7 @@ import org.eclipse.swtchart.extensions.preferences.PreferencePage;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
 
-@SuppressWarnings("rawtypes")
+
 public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, IExtendedPartUI {
 
 	private static final Logger logger = Logger.getLogger(ExtendedChromatogramUI.class);
@@ -315,7 +315,7 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 
 	public boolean fireUpdateChromatogram(Display display) {
 
-		IChromatogramSelection chromatogramSelection = getChromatogramSelection();
+		IChromatogramSelection<?, ?>chromatogramSelection = getChromatogramSelection();
 		if(chromatogramSelection != null && eventBroker != null) {
 			UpdateNotifierUI.update(display, chromatogramSelection);
 		}
@@ -325,7 +325,7 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 	public boolean fireUpdatePeak(Display display) {
 
 		boolean update = false;
-		IChromatogramSelection chromatogramSelection = getChromatogramSelection();
+		IChromatogramSelection<?, ?>chromatogramSelection = getChromatogramSelection();
 		if(chromatogramSelection != null && eventBroker != null) {
 			final IPeak peak = chromatogramSelection.getSelectedPeak();
 			if(peak != null) {
@@ -339,7 +339,7 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 	public boolean fireUpdateScan(Display display) {
 
 		boolean update = false;
-		IChromatogramSelection chromatogramSelection = getChromatogramSelection();
+		IChromatogramSelection<?, ?>chromatogramSelection = getChromatogramSelection();
 		if(chromatogramSelection != null && eventBroker != null) {
 			final IScan scan = chromatogramSelection.getSelectedScan();
 			if(scan != null) {
@@ -355,7 +355,7 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 		return chromatogramChart;
 	}
 
-	public synchronized void updateChromatogramSelection(IChromatogramSelection chromatogramSelection) {
+	public synchronized void updateChromatogramSelection(IChromatogramSelection<?, ?>chromatogramSelection) {
 
 		setChromatogramSelectionInternal(chromatogramSelection);
 		chromatogramBaselinesUI.update(chromatogramSelection.getChromatogram());
@@ -377,7 +377,7 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 		}
 	}
 
-	private void setChromatogramSelectionInternal(IChromatogramSelection chromatogramSelection) {
+	private void setChromatogramSelectionInternal(IChromatogramSelection<?, ?>chromatogramSelection) {
 
 		if(this.chromatogramSelection != chromatogramSelection) {
 			DataCategory dataCategory = DataCategory.AUTO_DETECT;
@@ -478,12 +478,12 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 		}
 	}
 
-	public IChromatogramSelection getChromatogramSelection() {
+	public IChromatogramSelection<?, ?>getChromatogramSelection() {
 
 		return chromatogramSelection;
 	}
 
-	public boolean isActiveChromatogramSelection(IChromatogramSelection chromatogramSelection) {
+	public boolean isActiveChromatogramSelection(IChromatogramSelection<?, ?>chromatogramSelection) {
 
 		return (this.chromatogramSelection == chromatogramSelection);
 	}
@@ -774,7 +774,7 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 
 		if(targetDisplaySettings == null) {
 			if(chromatogramSelection != null) {
-				IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+				IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 				targetDisplaySettings = chromatogram;
 			}
 		}
@@ -1156,7 +1156,7 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 			public void execute(IProcessMethod processMethod, IProgressMonitor monitor) {
 
 				IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
-				IChromatogramSelection chromatogramSelection = getChromatogramSelection();
+				IChromatogramSelection<?, ?>chromatogramSelection = getChromatogramSelection();
 				ProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, processingInfo, processTypeSupport), IChromatogramSelectionProcessSupplier.createConsumer(chromatogramSelection));
 				chromatogramSelection.getChromatogram().setDirty(true); // TODO: check each entry
 				updateResult(processingInfo);
@@ -1218,7 +1218,7 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 					 * Transfer to references?
 					 */
 					if(preferenceStore.getBoolean(PreferenceConstants.P_CHROMATOGRAM_TRANSFER_COLUMN_TYPE_TO_REFERENCES)) {
-						for(IChromatogram chromatogramReference : chromatogram.getReferencedChromatograms()) {
+						for(IChromatogram<?> chromatogramReference : chromatogram.getReferencedChromatograms()) {
 							chromatogramReference.getSeparationColumnIndices().setSeparationColumn(separationColumn);
 						}
 					}
@@ -1568,7 +1568,7 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 		 * Scan Axis
 		 */
 		if(chromatogramSelection != null) {
-			IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+			IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 			if(chromatogram != null) {
 				IChartSettings chartSettings = chromatogramChart.getChartSettings();
 				ISecondaryAxisSettings axisSettings = ChartSupport.getSecondaryAxisSettingsX(titleScans, chartSettings);
@@ -1619,7 +1619,7 @@ public class ExtendedChromatogramUI extends Composite implements ToolbarConfig, 
 		axisSettings.setTitleFont(titleFont);
 	}
 
-	private void updateToolbar(Composite composite, IChromatogramSelection chromatogramSelection) {
+	private void updateToolbar(Composite composite, IChromatogramSelection<?, ?>chromatogramSelection) {
 
 		if(composite instanceof IChromatogramSelectionUpdateListener listener) {
 			listener.update(chromatogramSelection);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedQuantCompoundListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedQuantCompoundListUI.java
@@ -21,6 +21,7 @@ import org.eclipse.chemclipse.model.quantitation.IQuantitationCompound;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationDatabase;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
+import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.support.ui.events.IKeyEventProcessor;
 import org.eclipse.chemclipse.support.ui.menu.ITableMenuEntry;
 import org.eclipse.chemclipse.support.ui.swt.ExtendedTableViewer;
@@ -159,14 +160,14 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Toggle the info toolbar.");
 		button.setText("");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 
 				boolean visible = PartSupport.toggleCompositeVisibility(toolbarInfo);
-				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImage.SIZE_16x16, visible));
+				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImageProvider.SIZE_16x16, visible));
 			}
 		});
 		//
@@ -178,7 +179,7 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Toggle the header toolbar.");
 		button.setText("");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_HEADER_DATA, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_HEADER_DATA, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -186,9 +187,9 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 
 				boolean visible = PartSupport.toggleCompositeVisibility(toolbarHeader);
 				if(visible) {
-					button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_HEADER_DATA, IApplicationImage.SIZE_16x16));
+					button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_HEADER_DATA, IApplicationImageProvider.SIZE_16x16));
 				} else {
-					button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_HEADER_DATA, IApplicationImage.SIZE_16x16));
+					button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_HEADER_DATA, IApplicationImageProvider.SIZE_16x16));
 				}
 			}
 		});
@@ -201,7 +202,7 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Toggle modify toolbar.");
 		button.setText("");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_DEFAULT, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_DEFAULT, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -209,9 +210,9 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 
 				boolean visible = PartSupport.toggleCompositeVisibility(toolbarModify);
 				if(visible) {
-					button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_ACTIVE, IApplicationImage.SIZE_16x16));
+					button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_ACTIVE, IApplicationImageProvider.SIZE_16x16));
 				} else {
-					button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_DEFAULT, IApplicationImage.SIZE_16x16));
+					button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_DEFAULT, IApplicationImageProvider.SIZE_16x16));
 				}
 			}
 		});
@@ -225,7 +226,7 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Create Response Tables");
 		button.setText("");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_CALCULATE, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_CALCULATE, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -235,13 +236,11 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 					IStructuredSelection structuredSelection = quantCompoundListUI.getStructuredSelection();
 					if(!structuredSelection.isEmpty()) {
 						if(MessageDialog.openQuestion(e.display.getActiveShell(), DESCRIPTION, "Would you like to create new concentration response and signal tables for the selected entries?")) {
-							@SuppressWarnings("rawtypes")
-							Iterator iterator = structuredSelection.iterator();
+							Iterator<?> iterator = structuredSelection.iterator();
 							while(iterator.hasNext()) {
 								Object object = iterator.next();
-								if(object instanceof IQuantitationCompound) {
-									IQuantitationCompound quantitationCompound = (IQuantitationCompound)object;
-									if(quantitationCompound.getQuantitationPeaks().size() > 0) {
+								if(object instanceof IQuantitationCompound quantitationCompound) {
+									if(!quantitationCompound.getQuantitationPeaks().isEmpty()) {
 										quantitationCompound.calculateSignalTablesFromPeaks();
 									} else {
 										logger.warn("There are no quantitation peaks stored: " + quantitationCompound);
@@ -389,7 +388,7 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Add a new compound.");
 		button.setText("");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_ADD, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_ADD, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -407,7 +406,7 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Delete the selected compounds.");
 		button.setText("");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_DELETE, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_DELETE, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -441,7 +440,7 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Enable/disable to edit the table.");
 		button.setText("");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_ENTRY_DEFAULT, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_ENTRY_DEFAULT, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -449,7 +448,7 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 
 				boolean editEnabled = !quantCompoundListUI.isEditEnabled();
 				quantCompoundListUI.setEditEnabled(editEnabled);
-				button.setImage(ApplicationImageFactory.getInstance().getImage((editEnabled) ? IApplicationImage.IMAGE_EDIT_ENTRY_ACTIVE : IApplicationImage.IMAGE_EDIT_ENTRY_DEFAULT, IApplicationImage.SIZE_16x16));
+				button.setImage(ApplicationImageFactory.getInstance().getImage((editEnabled) ? IApplicationImage.IMAGE_EDIT_ENTRY_ACTIVE : IApplicationImage.IMAGE_EDIT_ENTRY_DEFAULT, IApplicationImageProvider.SIZE_16x16));
 				updateInput();
 			}
 		});
@@ -462,14 +461,14 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Toggle search toolbar.");
 		button.setText("");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SEARCH, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SEARCH, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 
 				boolean visible = PartSupport.toggleCompositeVisibility(toolbarSearch);
-				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SEARCH, IApplicationImage.SIZE_16x16, visible));
+				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SEARCH, IApplicationImageProvider.SIZE_16x16, visible));
 			}
 		});
 		//
@@ -481,7 +480,7 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Save");
 		button.setText("");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SAVE, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SAVE, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -501,7 +500,7 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Reset");
 		button.setText("");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_RESET, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_RESET, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -524,7 +523,6 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 		});
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void deleteCompounds(Shell shell) {
 
 		MessageBox messageBox = new MessageBox(shell, SWT.ICON_QUESTION | SWT.YES | SWT.NO);
@@ -534,7 +532,7 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 			/*
 			 * Delete
 			 */
-			Iterator iterator = quantCompoundListUI.getStructuredSelection().iterator();
+			Iterator<?> iterator = quantCompoundListUI.getStructuredSelection().iterator();
 			while(iterator.hasNext()) {
 				Object object = iterator.next();
 				if(object instanceof IQuantitationCompound) {
@@ -592,8 +590,7 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 			public void selectionChanged(SelectionChangedEvent event) {
 
 				Object object = listUI.getStructuredSelection().getFirstElement();
-				if(object instanceof IQuantitationCompound) {
-					IQuantitationCompound quantitationCompound = (IQuantitationCompound)object;
+				if(object instanceof IQuantitationCompound quantitationCompound) {
 					UpdateNotifierUI.update(getDisplay(), quantitationCompound);
 				}
 			}
@@ -694,8 +691,8 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 
 	private void updateWidgets() {
 
-		buttonSave.setEnabled((saveHandler == null) ? false : true);
-		boolean enabled = (quantitationDatabase == null) ? false : true;
+		buttonSave.setEnabled(saveHandler != null);
+		boolean enabled = quantitationDatabase != null;
 		textSignal.setEnabled(enabled);
 		buttonAdd.setEnabled(enabled);
 		buttonDelete.setEnabled(enabled);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/PeakTargetTransferUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/PeakTargetTransferUI.java
@@ -74,8 +74,7 @@ public class PeakTargetTransferUI extends Composite implements IChromatogramSele
 	private Button checkBoxTransfer;
 	private Button buttonExecute;
 	//
-	@SuppressWarnings("rawtypes")
-	private IChromatogramSelection chromatogramSelectionSource;
+	private IChromatogramSelection<?, ?> chromatogramSelectionSource;
 	//
 	private ChromatogramDataSupport chromatogramDataSupport = new ChromatogramDataSupport();
 	private EditorUpdateSupport editorUpdateSupport = new EditorUpdateSupport();
@@ -88,8 +87,7 @@ public class PeakTargetTransferUI extends Composite implements IChromatogramSele
 	}
 
 	@Override
-	@SuppressWarnings("rawtypes")
-	public void update(IChromatogramSelection chromatogramSelectionSource) {
+	public void update(IChromatogramSelection<?, ?> chromatogramSelectionSource) {
 
 		this.chromatogramSelectionSource = chromatogramSelectionSource;
 		updateInput();
@@ -166,23 +164,20 @@ public class PeakTargetTransferUI extends Composite implements IChromatogramSele
 		comboViewer.setContentProvider(new ListContentProvider());
 		comboViewer.setLabelProvider(new AbstractLabelProvider() {
 
-			@SuppressWarnings("rawtypes")
 			@Override
 			public String getText(Object element) {
 
-				if(element instanceof IChromatogramSelection) {
+				if(element instanceof IChromatogramSelection<?, ?> chromatogramSelection) {
 					/*
 					 * Editor
 					 */
-					IChromatogramSelection chromatogramSelection = (IChromatogramSelection)element;
 					String name = chromatogramSelection.getChromatogram().getName();
 					String type = ChromatogramDataSupport.getChromatogramType(chromatogramSelection);
 					return getChromatogramLabel(name, type, "External");
-				} else if(element instanceof IChromatogram) {
+				} else if(element instanceof IChromatogram<?> chromatogram) {
 					/*
 					 * Reference
 					 */
-					IChromatogram chromatogram = (IChromatogram)element;
 					String name = chromatogram.getName();
 					String type = ChromatogramDataSupport.getChromatogramType(chromatogram);
 					return getChromatogramLabel(name, type, "Internal");
@@ -297,12 +292,11 @@ public class PeakTargetTransferUI extends Composite implements IChromatogramSele
 		button.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		button.addSelectionListener(new SelectionAdapter() {
 
-			@SuppressWarnings("rawtypes")
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 
 				Object object = comboViewerSink.getStructuredSelection().getFirstElement();
-				IChromatogramSelection chromatogramSelectionSink = chromatogramDataSupport.getChromatogramSelection(object);
+				IChromatogramSelection<?, ?> chromatogramSelectionSink = chromatogramDataSupport.getChromatogramSelection(object);
 				transferTargets(chromatogramSelectionSource, chromatogramSelectionSink, e.display.getActiveShell());
 			}
 		});
@@ -336,7 +330,7 @@ public class PeakTargetTransferUI extends Composite implements IChromatogramSele
 		chromatogramSourceCombo.setEnabled(chromatogramSelectionSource != null);
 		//
 		Object object = comboViewerSink.getStructuredSelection().getFirstElement();
-		if(object instanceof IChromatogramSelection || object instanceof IChromatogram) {
+		if(object instanceof IChromatogramSelection<?, ?> || object instanceof IChromatogram) {
 			buttonExecute.setEnabled(true);
 			checkBoxTransfer.setEnabled(true);
 		}
@@ -346,13 +340,12 @@ public class PeakTargetTransferUI extends Composite implements IChromatogramSele
 		textTimeDelta.setEnabled(comboType.getText().equals(TYPE_PEAKS));
 	}
 
-	@SuppressWarnings("rawtypes")
-	private List<IChromatogramSelection> getFilteredEditorChromatogramSelections() {
+	private List<IChromatogramSelection<?, ?>> getFilteredEditorChromatogramSelections() {
 
-		List<IChromatogramSelection> chromatogramSelections = new ArrayList<IChromatogramSelection>();
+		List<IChromatogramSelection<?, ?>> chromatogramSelections = new ArrayList<>();
 		if(chromatogramSelectionSource != null) {
 			String nameSource = ChromatogramDataSupport.getChromatogramEditorLabel(chromatogramSelectionSource);
-			for(IChromatogramSelection chromatogramSelectionTarget : editorUpdateSupport.getChromatogramSelections()) {
+			for(IChromatogramSelection<?, ?> chromatogramSelectionTarget : editorUpdateSupport.getChromatogramSelections()) {
 				String nameTarget = ChromatogramDataSupport.getChromatogramEditorLabel(chromatogramSelectionTarget);
 				if(!nameSource.equals(nameTarget)) {
 					chromatogramSelections.add(chromatogramSelectionTarget);
@@ -376,8 +369,7 @@ public class PeakTargetTransferUI extends Composite implements IChromatogramSele
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
-	private void transferTargets(IChromatogramSelection chromatogramSelectionSource, IChromatogramSelection chromatogramSelectionSink, Shell shell) {
+	private void transferTargets(IChromatogramSelection<?, ?> chromatogramSelectionSource, IChromatogramSelection<?, ?> chromatogramSelectionSink, Shell shell) {
 
 		if(chromatogramSelectionSource != null) {
 			if(chromatogramSelectionSink != null && chromatogramSelectionSink != chromatogramSelectionSource) {
@@ -405,8 +397,7 @@ public class PeakTargetTransferUI extends Composite implements IChromatogramSele
 		}
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	private void transferPeakTargets(IChromatogramSelection chromatogramSelectionSource, IChromatogramSelection chromatogramSelectionSink, Shell shell) {
+	private void transferPeakTargets(IChromatogramSelection<?, ?> chromatogramSelectionSource, IChromatogramSelection<?, ?> chromatogramSelectionSink, Shell shell) {
 
 		TargetTransferSupport targetTransferSupport = new TargetTransferSupport();
 		//
@@ -423,13 +414,12 @@ public class PeakTargetTransferUI extends Composite implements IChromatogramSele
 		}
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	private void transferScanTargets(IChromatogramSelection chromatogramSelectionSource, IChromatogramSelection chromatogramSelectionSink, Shell shell) {
+	private void transferScanTargets(IChromatogramSelection<?, ?> chromatogramSelectionSource, IChromatogramSelection<?, ?> chromatogramSelectionSink, Shell shell) {
 
 		TargetTransferSupport targetTransferSupport = new TargetTransferSupport();
 		//
 		List<IScan> scansSource = ChromatogramDataSupport.getIdentifiedScans(chromatogramSelectionSource.getChromatogram(), chromatogramSelectionSource);
-		IChromatogram chromatogramSink = chromatogramSelectionSink.getChromatogram();
+		IChromatogram<?> chromatogramSink = chromatogramSelectionSink.getChromatogram();
 		boolean useBestTargetOnly = preferenceStore.getBoolean(PreferenceConstants.P_CHROMATOGRAM_TRANSFER_BEST_TARGET_ONLY);
 		//
 		String message = targetTransferSupport.transferScanTargets(scansSource, chromatogramSink, useBestTargetOnly);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ScanSelectionHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ScanSelectionHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -50,13 +50,13 @@ public class ScanSelectionHandler extends AbstractHandledEventProcessor implemen
 		return SWT.NONE;
 	}
 
-	@SuppressWarnings("rawtypes")
+	
 	@Override
 	public void handleEvent(BaseChart baseChart, Event event) {
 
-		IChromatogramSelection chromatogramSelection = extendedChromatogramUI.getChromatogramSelection();
+		IChromatogramSelection<?, ?>chromatogramSelection = extendedChromatogramUI.getChromatogramSelection();
 		if(chromatogramSelection != null) {
-			IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+			IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 			int retentionTime = (int)baseChart.getSelectedPrimaryAxisValue(event.x, IExtendedChart.X_AXIS);
 			int scanNumber = chromatogram.getScanNumber(retentionTime);
 			IScan scan = chromatogram.getScan(scanNumber);

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/AbstractChromatogramWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/AbstractChromatogramWSD.java
@@ -94,9 +94,9 @@ public abstract class AbstractChromatogramWSD extends AbstractChromatogram<IChro
 		return null;
 	}
 
-	@SuppressWarnings("rawtypes")
+	
 	@Override
-	public void fireUpdate(IChromatogramSelection chromatogramSelection) {
+	public void fireUpdate(IChromatogramSelection<?, ?>chromatogramSelection) {
 
 		/*
 		 * Fire an update to inform all listeners.

--- a/chemclipse/plugins/org.eclipse.chemclipse.xir.model/src/org/eclipse/chemclipse/xir/model/core/AbstractChromatogramISD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xir.model/src/org/eclipse/chemclipse/xir/model/core/AbstractChromatogramISD.java
@@ -29,9 +29,9 @@ public abstract class AbstractChromatogramISD extends AbstractChromatogram<IChro
 		return integratedArea;
 	}
 
-	@SuppressWarnings("rawtypes")
+	
 	@Override
-	public void fireUpdate(IChromatogramSelection chromatogramSelection) {
+	public void fireUpdate(IChromatogramSelection<?, ?>chromatogramSelection) {
 
 		/*
 		 * Fire an update to inform all listeners.

--- a/chemclipse/plugins/org.eclipse.chemclipse.xir.model/src/org/eclipse/chemclipse/xir/model/core/selection/ChromatogramSelectionISD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xir.model/src/org/eclipse/chemclipse/xir/model/core/selection/ChromatogramSelectionISD.java
@@ -20,7 +20,6 @@ import org.eclipse.chemclipse.xir.model.core.IChromatogramISD;
 import org.eclipse.chemclipse.xir.model.core.IChromatogramPeakISD;
 import org.eclipse.chemclipse.xir.model.core.IScanISD;
 
-@SuppressWarnings("rawtypes")
 public class ChromatogramSelectionISD extends AbstractChromatogramSelection<IChromatogramPeakISD, IChromatogramISD> implements IChromatogramSelectionISD {
 
 	private IScanISD selectedScan;
@@ -59,7 +58,7 @@ public class ChromatogramSelectionISD extends AbstractChromatogramSelection<IChr
 	public void reset(boolean fireUpdate) {
 
 		super.reset(fireUpdate);
-		IChromatogram chromatogram = getChromatogram();
+		IChromatogram<?> chromatogram = getChromatogram();
 		/*
 		 * Scan
 		 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/csd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/csd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1300.java
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.csd.converter.supplier.chemclipse.internal.io;
 import java.io.BufferedOutputStream;
 import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Collection;
@@ -70,7 +69,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 	private static final String CLASSIFIER_DELIMITER = " ";
 
 	@Override
-	public void writeChromatogram(File file, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotWriteableException, IOException {
+	public void writeChromatogram(File file, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
 		/*
 		 * ZIP
@@ -93,17 +92,17 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 		/*
 		 * Referenced Chromatograms
 		 */
 		List<IChromatogram<?>> referencedChromatograms = chromatogram.getReferencedChromatograms();
-		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
+		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms);
 		writeReferencedChromatograms(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -556,7 +555,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram<?>> referencedChromatograms, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram<?>> referencedChromatograms) throws IOException {
 
 		ZipEntry zipEntryType = new ZipEntry(directoryPrefix + IFormat.FILE_REFERENCE_INFO);
 		zipOutputStream.putNextEntry(zipEntryType);
@@ -565,7 +564,6 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void writeReferencedChromatograms(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram<?>> referencedChromatograms, IProgressMonitor monitor) throws IOException {
 
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Write Chromatogram", referencedChromatograms.size() * 20);
@@ -575,7 +573,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 			ChromatogramWriterWSD chromatogramWriterWSD = new ChromatogramWriterWSD();
 			//
 			int i = 0;
-			for(IChromatogram referencedChromatogram : referencedChromatograms) {
+			for(IChromatogram<?> referencedChromatogram : referencedChromatograms) {
 				/*
 				 * Create the measurement folder.
 				 */
@@ -584,7 +582,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 				zipOutputStream.putNextEntry(zipEntryType);
 				DataOutputStream dataOutputStream = new DataOutputStream(zipOutputStream);
 				//
-				if(referencedChromatogram instanceof IChromatogramMSD) {
+				if(referencedChromatogram instanceof IChromatogramMSD chromatogramMSD) {
 					/*
 					 * MSD
 					 */
@@ -594,8 +592,8 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 					prefix += IFormat.DIR_CHROMATOGRAM_REFERENCE + IFormat.DIR_SEPARATOR;
 					ZipEntry zipEntryChromtogram = new ZipEntry(prefix);
 					zipOutputStream.putNextEntry(zipEntryChromtogram);
-					chromatogramWriterMSD.writeChromatogram(zipOutputStream, prefix, (IChromatogramMSD)referencedChromatogram, monitor);
-				} else if(referencedChromatogram instanceof IChromatogramCSD) {
+					chromatogramWriterMSD.writeChromatogram(zipOutputStream, prefix, chromatogramMSD, monitor);
+				} else if(referencedChromatogram instanceof IChromatogramCSD chromatogramCSD) {
 					/*
 					 * CSD
 					 */
@@ -605,8 +603,8 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 					prefix += IFormat.DIR_CHROMATOGRAM_REFERENCE + IFormat.DIR_SEPARATOR;
 					ZipEntry zipEntryChromtogram = new ZipEntry(prefix);
 					zipOutputStream.putNextEntry(zipEntryChromtogram);
-					chromatogramWriterCSD.writeChromatogram(zipOutputStream, prefix, (IChromatogramCSD)referencedChromatogram, monitor);
-				} else if(referencedChromatogram instanceof IChromatogramWSD) {
+					chromatogramWriterCSD.writeChromatogram(zipOutputStream, prefix, chromatogramCSD, monitor);
+				} else if(referencedChromatogram instanceof IChromatogramWSD chromatogramWSD) {
 					/*
 					 * WSD
 					 */
@@ -616,7 +614,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 					prefix += IFormat.DIR_CHROMATOGRAM_REFERENCE + IFormat.DIR_SEPARATOR;
 					ZipEntry zipEntryChromtogram = new ZipEntry(prefix);
 					zipOutputStream.putNextEntry(zipEntryChromtogram);
-					chromatogramWriterWSD.writeChromatogram(zipOutputStream, prefix, (IChromatogramWSD)referencedChromatogram, monitor);
+					chromatogramWriterWSD.writeChromatogram(zipOutputStream, prefix, chromatogramWSD, monitor);
 				}
 				//
 				subMonitor.worked(20);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/csd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/csd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1301.java
@@ -551,7 +551,6 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void writeReferencedChromatograms(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram<?>> referencedChromatograms, IProgressMonitor monitor) throws IOException {
 
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Write Chromatogram", referencedChromatograms.size() * 20);
@@ -561,7 +560,7 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 			ChromatogramWriterWSD chromatogramWriterWSD = new ChromatogramWriterWSD();
 			//
 			int i = 0;
-			for(IChromatogram referencedChromatogram : referencedChromatograms) {
+			for(IChromatogram<?> referencedChromatogram : referencedChromatograms) {
 				/*
 				 * Create the measurement folder.
 				 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/csd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/csd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1400.java
@@ -590,7 +590,6 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void writeReferencedChromatograms(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram<?>> referencedChromatograms, IProgressMonitor monitor) throws IOException {
 
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Write Chromatogram", referencedChromatograms.size() * 20);
@@ -600,7 +599,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 			ChromatogramWriterWSD chromatogramWriterWSD = new ChromatogramWriterWSD();
 			//
 			int i = 0;
-			for(IChromatogram referencedChromatogram : referencedChromatograms) {
+			for(IChromatogram<?> referencedChromatogram : referencedChromatograms) {
 				/*
 				 * Create the measurement folder.
 				 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/csd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/csd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1500.java
@@ -618,7 +618,6 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void writeReferencedChromatograms(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram<?>> referencedChromatograms, IProgressMonitor monitor) throws IOException {
 
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Write Chromatogram", referencedChromatograms.size() * 20);
@@ -628,7 +627,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 			ChromatogramWriterWSD chromatogramWriterWSD = new ChromatogramWriterWSD();
 			//
 			int i = 0;
-			for(IChromatogram referencedChromatogram : referencedChromatograms) {
+			for(IChromatogram<?> referencedChromatogram : referencedChromatograms) {
 				/*
 				 * Create the measurement folder.
 				 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/converter/PeakExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/converter/PeakExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -29,10 +29,9 @@ public class PeakExportConverter extends AbstractPeakExportConverter {
 		return getErrorMessage();
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IProcessingInfo getErrorMessage() {
+	private IProcessingInfo<?> getErrorMessage() {
 
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
 		processingInfo.addErrorMessage("OCB Peak Writer", "There is no capability to write peaks in *.ocb format.");
 		return processingInfo;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1300.java
@@ -683,7 +683,6 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void writeReferencedChromatograms(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram<?>> referencedChromatograms, IProgressMonitor monitor) throws IOException {
 
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Write Chromatogram", referencedChromatograms.size() * 20);
@@ -693,7 +692,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 			ChromatogramWriterWSD chromatogramWriterWSD = new ChromatogramWriterWSD();
 			//
 			int i = 0;
-			for(IChromatogram referencedChromatogram : referencedChromatograms) {
+			for(IChromatogram<?> referencedChromatogram : referencedChromatograms) {
 				/*
 				 * Create the measurement folder.
 				 */
@@ -702,7 +701,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 				zipOutputStream.putNextEntry(zipEntryType);
 				DataOutputStream dataOutputStream = new DataOutputStream(zipOutputStream);
 				//
-				if(referencedChromatogram instanceof IChromatogramMSD) {
+				if(referencedChromatogram instanceof IChromatogramMSD chromatogramMSD) {
 					/*
 					 * MSD
 					 */
@@ -712,8 +711,8 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 					prefix += IFormat.DIR_CHROMATOGRAM_REFERENCE + IFormat.DIR_SEPARATOR;
 					ZipEntry zipEntryChromtogram = new ZipEntry(prefix);
 					zipOutputStream.putNextEntry(zipEntryChromtogram);
-					chromatogramWriterMSD.writeChromatogram(zipOutputStream, prefix, (IChromatogramMSD)referencedChromatogram, monitor);
-				} else if(referencedChromatogram instanceof IChromatogramCSD) {
+					chromatogramWriterMSD.writeChromatogram(zipOutputStream, prefix, chromatogramMSD, monitor);
+				} else if(referencedChromatogram instanceof IChromatogramCSD chromatogramCSD) {
 					/*
 					 * CSD
 					 */
@@ -723,8 +722,8 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 					prefix += IFormat.DIR_CHROMATOGRAM_REFERENCE + IFormat.DIR_SEPARATOR;
 					ZipEntry zipEntryChromtogram = new ZipEntry(prefix);
 					zipOutputStream.putNextEntry(zipEntryChromtogram);
-					chromatogramWriterCSD.writeChromatogram(zipOutputStream, prefix, (IChromatogramCSD)referencedChromatogram, monitor);
-				} else if(referencedChromatogram instanceof IChromatogramWSD) {
+					chromatogramWriterCSD.writeChromatogram(zipOutputStream, prefix, chromatogramCSD, monitor);
+				} else if(referencedChromatogram instanceof IChromatogramWSD chromatogramWSD) {
 					/*
 					 * WSD
 					 */
@@ -734,7 +733,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 					prefix += IFormat.DIR_CHROMATOGRAM_REFERENCE + IFormat.DIR_SEPARATOR;
 					ZipEntry zipEntryChromtogram = new ZipEntry(prefix);
 					zipOutputStream.putNextEntry(zipEntryChromtogram);
-					chromatogramWriterWSD.writeChromatogram(zipOutputStream, prefix, (IChromatogramWSD)referencedChromatogram, monitor);
+					chromatogramWriterWSD.writeChromatogram(zipOutputStream, prefix, chromatogramWSD, monitor);
 				}
 				//
 				subMonitor.worked(20);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1301.java
@@ -684,7 +684,6 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void writeReferencedChromatograms(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram<?>> referencedChromatograms, IProgressMonitor monitor) throws IOException {
 
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Write Chromatogram", referencedChromatograms.size() * 20);
@@ -694,7 +693,7 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 			ChromatogramWriterWSD chromatogramWriterWSD = new ChromatogramWriterWSD();
 			//
 			int i = 0;
-			for(IChromatogram referencedChromatogram : referencedChromatograms) {
+			for(IChromatogram<?> referencedChromatogram : referencedChromatograms) {
 				/*
 				 * Create the measurement folder.
 				 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1400.java
@@ -723,7 +723,6 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void writeReferencedChromatograms(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram<?>> referencedChromatograms, IProgressMonitor monitor) throws IOException {
 
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Write Chromatogram", referencedChromatograms.size() * 20);
@@ -733,7 +732,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 			ChromatogramWriterWSD chromatogramWriterWSD = new ChromatogramWriterWSD();
 			//
 			int i = 0;
-			for(IChromatogram referencedChromatogram : referencedChromatograms) {
+			for(IChromatogram<?> referencedChromatogram : referencedChromatograms) {
 				/*
 				 * Create the measurement folder.
 				 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1500.java
@@ -797,7 +797,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	@SuppressWarnings("rawtypes")
+	
 	private void writeReferencedChromatograms(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram<?>> referencedChromatograms, IProgressMonitor monitor) throws IOException {
 
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Write Chromatogram", referencedChromatograms.size() * 20);
@@ -807,7 +807,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 			ChromatogramWriterWSD chromatogramWriterWSD = new ChromatogramWriterWSD();
 			//
 			int i = 0;
-			for(IChromatogram referencedChromatogram : referencedChromatograms) {
+			for(IChromatogram<?> referencedChromatogram : referencedChromatograms) {
 				/*
 				 * Create the measurement folder.
 				 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0701.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0701.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -70,7 +70,7 @@ public class PeakReader_0701 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -78,10 +78,9 @@ public class PeakReader_0701 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS);
 		//
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0801.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0801.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,14 +13,11 @@ package org.eclipse.chemclipse.msd.converter.supplier.chemclipse.internal.io;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.ZipFile;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
@@ -66,12 +63,12 @@ public class PeakReader_0801 extends AbstractZipReader implements IPeakReader {
 
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -79,10 +76,9 @@ public class PeakReader_0801 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS);
 		//
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks
@@ -137,7 +133,7 @@ public class PeakReader_0801 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
@@ -180,7 +176,7 @@ public class PeakReader_0801 extends AbstractZipReader implements IPeakReader {
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {
 
-		List<IIntegrationEntry> integrationEntries = new ArrayList<IIntegrationEntry>();
+		List<IIntegrationEntry> integrationEntries = new ArrayList<>();
 		int numberOfIntegrationEntries = dataInputStream.readInt(); // Number Integration Entries
 		for(int i = 1; i <= numberOfIntegrationEntries; i++) {
 			double ion = dataInputStream.readDouble(); // m/z
@@ -191,7 +187,7 @@ public class PeakReader_0801 extends AbstractZipReader implements IPeakReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0802.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0802.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -75,7 +75,7 @@ public class PeakReader_0802 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -83,10 +83,10 @@ public class PeakReader_0802 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS);
 		//
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0803.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0803.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -75,7 +75,7 @@ public class PeakReader_0803 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -83,10 +83,10 @@ public class PeakReader_0803 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS);
 		//
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0901.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0901.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -75,7 +75,7 @@ public class PeakReader_0901 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -83,10 +83,10 @@ public class PeakReader_0901 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS);
 		//
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0902.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0902.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -77,7 +77,7 @@ public class PeakReader_0902 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -85,10 +85,10 @@ public class PeakReader_0902 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS);
 		//
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0903.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0903.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -77,7 +77,7 @@ public class PeakReader_0903 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -85,10 +85,10 @@ public class PeakReader_0903 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS);
 		//
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1001.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -77,7 +77,7 @@ public class PeakReader_1001 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -85,10 +85,10 @@ public class PeakReader_1001 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS_MSD);
 		//
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1002.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -82,7 +82,7 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -90,10 +90,10 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS_MSD);
 		//
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1003.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 Lablicate GmbH.
+ * Copyright (c) 2015, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -82,7 +82,7 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -90,10 +90,10 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS_MSD);
 		//
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1004.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 Lablicate GmbH.
+ * Copyright (c) 2015, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -83,7 +83,7 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -91,10 +91,10 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS_MSD);
 		//
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1005.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 Lablicate GmbH.
+ * Copyright (c) 2015, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -83,7 +83,7 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -91,10 +91,10 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS_MSD);
 		//
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1006.java
@@ -84,7 +84,7 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -92,10 +92,10 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS_MSD);
 		//
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1007.java
@@ -84,7 +84,7 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -92,10 +92,10 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS_MSD);
 		//
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1100.java
@@ -87,7 +87,7 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -95,10 +95,10 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS_MSD);
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Import Peaks", numberOfPeaks);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1300.java
@@ -89,7 +89,7 @@ public class PeakReader_1300 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -97,10 +97,10 @@ public class PeakReader_1300 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS_MSD);
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Read Peaks", numberOfPeaks);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1301.java
@@ -88,7 +88,7 @@ public class PeakReader_1301 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -96,10 +96,10 @@ public class PeakReader_1301 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS_MSD);
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Read Peaks", numberOfPeaks);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1400.java
@@ -88,7 +88,7 @@ public class PeakReader_1400 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -96,10 +96,9 @@ public class PeakReader_1400 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS_MSD);
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Read Peaks", numberOfPeaks);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1500.java
@@ -88,7 +88,7 @@ public class PeakReader_1500 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo processingInfo = new ProcessingInfo();
 		try {
-			IPeaks peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -96,10 +96,9 @@ public class PeakReader_1500 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private IPeaks readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
-		IPeaks peaks = new Peaks();
+		IPeaks<?> peaks = new Peaks();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, IFormat.FILE_PEAKS_MSD);
 		int numberOfPeaks = dataInputStream.readInt(); // Number of Peaks
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Read Peaks", numberOfPeaks);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/wsd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/wsd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1300.java
@@ -597,7 +597,6 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void writeReferencedChromatograms(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram<?>> referencedChromatograms, IProgressMonitor monitor) throws IOException {
 
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Write Chromatogram", referencedChromatograms.size() * 20);
@@ -607,7 +606,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 			ChromatogramWriterWSD chromatogramWriterWSD = new ChromatogramWriterWSD();
 			//
 			int i = 0;
-			for(IChromatogram referencedChromatogram : referencedChromatograms) {
+			for(IChromatogram<?> referencedChromatogram : referencedChromatograms) {
 				/*
 				 * Create the measurement folder.
 				 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/wsd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/wsd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1301.java
@@ -583,7 +583,6 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void writeReferencedChromatograms(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram<?>> referencedChromatograms, IProgressMonitor monitor) throws IOException {
 
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Write Chromatogram", referencedChromatograms.size() * 20);
@@ -593,7 +592,7 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 			ChromatogramWriterWSD chromatogramWriterWSD = new ChromatogramWriterWSD();
 			//
 			int i = 0;
-			for(IChromatogram referencedChromatogram : referencedChromatograms) {
+			for(IChromatogram<?> referencedChromatogram : referencedChromatograms) {
 				/*
 				 * Create the measurement folder.
 				 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/wsd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/wsd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1400.java
@@ -622,7 +622,6 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void writeReferencedChromatograms(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram<?>> referencedChromatograms, IProgressMonitor monitor) throws IOException {
 
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Write Chromatogram", referencedChromatograms.size() * 20);
@@ -632,7 +631,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 			ChromatogramWriterWSD chromatogramWriterWSD = new ChromatogramWriterWSD();
 			//
 			int i = 0;
-			for(IChromatogram referencedChromatogram : referencedChromatograms) {
+			for(IChromatogram<?> referencedChromatogram : referencedChromatograms) {
 				/*
 				 * Create the measurement folder.
 				 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/wsd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/wsd/converter/supplier/chemclipse/internal/io/ChromatogramWriter_1500.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2018, 2023 Lablicate GmbH.
- * 
+ *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution,
@@ -649,7 +649,6 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void writeReferencedChromatograms(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram<?>> referencedChromatograms, IProgressMonitor monitor) throws IOException {
 
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Write Chromatogram", referencedChromatograms.size() * 20);
@@ -659,7 +658,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 			ChromatogramWriterWSD chromatogramWriterWSD = new ChromatogramWriterWSD();
 			//
 			int i = 0;
-			for(IChromatogram referencedChromatogram : referencedChromatograms) {
+			for(IChromatogram<?> referencedChromatogram : referencedChromatograms) {
 				/*
 				 * Create the measurement folder.
 				 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.peak.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/operations/DeletePeaksOperation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.peak.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/operations/DeletePeaksOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Lablicate GmbH.
+ * Copyright (c) 2021, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -23,13 +23,12 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 
-@SuppressWarnings("rawtypes")
 public class DeletePeaksOperation extends AbstractOperation {
 
 	private IChromatogramSelection<?, ?> chromatogramSelection;
 	private List<IPeak> peaksToDelete;
 
-	public DeletePeaksOperation(IChromatogramSelection chromatogramSelection, List<IPeak> peaksToDelete) {
+	public DeletePeaksOperation(IChromatogramSelection<?, ?> chromatogramSelection, List<IPeak> peaksToDelete) {
 
 		super("Delete Peaks");
 		this.chromatogramSelection = chromatogramSelection;
@@ -54,7 +53,7 @@ public class DeletePeaksOperation extends AbstractOperation {
 		return !peaksToDelete.isEmpty();
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Override
 	public IStatus execute(IProgressMonitor monitor, IAdaptable info) throws ExecutionException {
 
@@ -84,7 +83,7 @@ public class DeletePeaksOperation extends AbstractOperation {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"rawtypes", "unchecked"})
 	public IStatus undo(IProgressMonitor monitor, IAdaptable info) throws ExecutionException {
 
 		IChromatogram chromatogram = chromatogramSelection.getChromatogram();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/chart2d/ErrorResidueChart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/chart2d/ErrorResidueChart.java
@@ -48,11 +48,10 @@ public class ErrorResidueChart extends BarChart {
 		createControl();
 	}
 
-	@SuppressWarnings("rawtypes")
 	public void setInput(EvaluationPCA evaluationPCA) {
 
 		if(evaluationPCA != null) {
-			IResultsPCA resultsPCA = evaluationPCA.getResults();
+			IResultsPCA<?, ?> resultsPCA = evaluationPCA.getResults();
 			updateChart(resultsPCA);
 		} else {
 			updateChart(null);
@@ -116,8 +115,7 @@ public class ErrorResidueChart extends BarChart {
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
-	private void updateChart(IResultsPCA pcaResults) {
+	private void updateChart(IResultsPCA<?, ?> pcaResults) {
 
 		deleteSeries();
 		if(pcaResults != null) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/chart2d/ScorePlot.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/chart2d/ScorePlot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -30,12 +30,11 @@ public class ScorePlot extends AbtractPlotPCA {
 		super(parent, style, "Score Plot");
 	}
 
-	@SuppressWarnings("rawtypes")
 	public void setInput(EvaluationPCA evaluationPCA, int pcX, int pcY) {
 
 		deleteSeries();
 		if(evaluationPCA != null) {
-			IResultsPCA resultsPCA = evaluationPCA.getResults();
+			IResultsPCA<?, ?> resultsPCA = evaluationPCA.getResults();
 			addSeriesData(SeriesConverter.sampleToSeries(resultsPCA, pcX, pcY, extractedResults));
 			update(pcX, pcY, resultsPCA.getExplainedVariances());
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/chart2d/VarianceChart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/chart2d/VarianceChart.java
@@ -114,13 +114,12 @@ public class VarianceChart extends BarChart {
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void updateChart() {
 
 		deleteSeries();
 		if(evaluationPCA != null) {
 			//
-			IResultsPCA resultsPCA = evaluationPCA.getResults();
+			IResultsPCA<?, ?> resultsPCA = evaluationPCA.getResults();
 			//
 			IChartSettings chartSettings = getChartSettings();
 			IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
@@ -141,8 +140,7 @@ public class VarianceChart extends BarChart {
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
-	private String[] getCategories(IResultsPCA pcaResults) {
+	private String[] getCategories(IResultsPCA<?, ?> pcaResults) {
 
 		int size = pcaResults.getCumulativeExplainedVariances().length;
 		String[] categories = new String[size];
@@ -154,8 +152,7 @@ public class VarianceChart extends BarChart {
 		return categories;
 	}
 
-	@SuppressWarnings("rawtypes")
-	private ISeriesData getSeries(IResultsPCA pcaResults) {
+	private ISeriesData getSeries(IResultsPCA<?, ?> pcaResults) {
 
 		double[] ySeries;
 		String label;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/PcaUtils.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/PcaUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -53,7 +53,6 @@ public class PcaUtils {
 	 * @param samples
 	 * @return map where is key name of sample and value are sample data
 	 */
-	@SuppressWarnings("rawtypes")
 	public static <V extends IVariable, S extends ISample> Map<String, double[]> extractData(ISamples<V, S> samples) {
 
 		Map<String, double[]> selectedSamples = new HashMap<>();
@@ -62,7 +61,7 @@ public class PcaUtils {
 		for(S sample : samples.getSampleList()) {
 			double[] selectedSampleData = null;
 			if(sample.isSelected()) {
-				List<? extends ISampleData> data = sample.getSampleData();
+				List<? extends ISampleData<?>> data = sample.getSampleData();
 				selectedSampleData = new double[numSelected];
 				int j = 0;
 				for(int i = 0; i < data.size(); i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/ProcessorPCA.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/ProcessorPCA.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -84,7 +84,6 @@ public class ProcessorPCA {
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
 	public <V extends IVariable, S extends ISample> EvaluationPCA process(ISamplesPCA<V, S> samples, EvaluationPCA masterEvaluationPCA, IProgressMonitor monitor) throws MathIllegalArgumentException {
 
 		EvaluationPCA evaluationPCA = null;
@@ -181,7 +180,7 @@ public class ProcessorPCA {
 					 * sampleData.getData2() // e.g. PeakMSD
 					 */
 					ISample sample = sampleList.get(i);
-					List<? extends ISampleData> sampleDataList = sample.getSampleData();
+					List<? extends ISampleData<?>> sampleDataList = sample.getSampleData();
 					for(int j = 0; j < sampleDataList.size(); j++) {
 						ISampleData<?> sampleData = sampleDataList.get(j);
 						features.get(j).getSampleData().add(sampleData);
@@ -199,7 +198,6 @@ public class ProcessorPCA {
 		return evaluationPCA;
 	}
 
-	@SuppressWarnings("rawtypes")
 	private <V extends IVariable, S extends ISample> Map<ISample, double[]> extractData(ISamples<V, S> samples, Algorithm algorithm, IAnalysisSettings settings, boolean[] isSelectedVariable) {
 
 		Map<ISample, double[]> selectedSamples = new HashMap<>();
@@ -231,7 +229,7 @@ public class ProcessorPCA {
 		for(ISample sample : samples.getSampleList()) {
 			double[] selectedSampleData = null;
 			if(sample.isSelected()) {
-				List<? extends ISampleData> data = sample.getSampleData();
+				List<? extends ISampleData<?>> data = sample.getSampleData();
 				selectedSampleData = new double[numSelected];
 				int j = 0;
 				for(int i = 0; i < data.size(); i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/CenteringMean.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/CenteringMean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,7 +33,6 @@ public class CenteringMean extends AbstractCentering {
 		return "Mean centering";
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public <V extends IVariable, S extends ISample> void process(ISamples<V, S> samples) {
 
@@ -45,7 +44,7 @@ public class CenteringMean extends AbstractCentering {
 			final double value = getCenteringValue(samples.getSampleList(), i, MEAN);
 			final int j = i;
 			samples.getSampleList().stream().forEach(s -> {
-				ISampleData data = s.getSampleData().get(j);
+				ISampleData<?> data = s.getSampleData().get(j);
 				data.setModifiedData(getData(data) - value);
 			});
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/CenteringMedian.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/CenteringMedian.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,7 +33,6 @@ public class CenteringMedian extends AbstractCentering {
 		return "Median Centering";
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public <V extends IVariable, S extends ISample> void process(ISamples<V, S> samples) {
 
@@ -45,7 +44,7 @@ public class CenteringMedian extends AbstractCentering {
 			final double value = getCenteringValue(samples.getSampleList(), i, MEDIAN);
 			final int j = i;
 			samples.getSampleList().stream().forEach(s -> {
-				ISampleData data = s.getSampleData().get(j);
+				ISampleData<?> data = s.getSampleData().get(j);
 				data.setModifiedData(getData(data) - value);
 			});
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/MeanValuesReplacer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/MeanValuesReplacer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,7 +33,6 @@ public class MeanValuesReplacer extends AbstractDataModificator implements IRepl
 		return "Mean Value Setter";
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public <V extends IVariable, S extends ISample> void process(ISamples<V, S> samples) {
 
@@ -57,7 +56,7 @@ public class MeanValuesReplacer extends AbstractDataModificator implements IRepl
 			double mean = count != 0 ? sum / count : 0;
 			for(S sample : sampleList) {
 				if(sample.isSelected() || !isOnlySelected()) {
-					ISampleData sampleData = sample.getSampleData().get(i);
+					ISampleData<?> sampleData = sample.getSampleData().get(i);
 					if(Double.isNaN(getData(sampleData))) {
 						sampleData.setModifiedData(mean);
 					}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/MedianValuesReplacer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/MedianValuesReplacer.java
@@ -34,7 +34,6 @@ public class MedianValuesReplacer extends AbstractDataModificator implements IRe
 		return "Median Value Setter";
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public <V extends IVariable, S extends ISample> void process(ISamples<V, S> samples) {
 
@@ -62,7 +61,7 @@ public class MedianValuesReplacer extends AbstractDataModificator implements IRe
 			}
 			for(S sample : sampleList) {
 				if(sample.isSelected() || !isOnlySelected()) {
-					ISampleData sampleData = sample.getSampleData().get(i);
+					ISampleData<?> sampleData = sample.getSampleData().get(i);
 					if(Double.isNaN(getData(sampleData))) {
 						sampleData.setModifiedData(median);
 					}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/Normalization1Norm.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/Normalization1Norm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -39,13 +39,12 @@ public class Normalization1Norm extends AbstractDataModificator implements INorm
 		return "Normalization 1-Norm";
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public <V extends IVariable, S extends ISample> void process(ISamples<V, S> samples) {
 
 		for(ISample sample : samples.getSampleList()) {
 			if(sample.isSelected() || !isOnlySelected()) {
-				List<? extends ISampleData> sampleData = sample.getSampleData();
+				List<? extends ISampleData<?>> sampleData = sample.getSampleData();
 				double sum = IntStream.range(0, sampleData.size()).filter(i -> !sampleData.get(i).isEmpty()).filter(i -> !skipVariable(samples, i))//
 						.mapToDouble(i -> Math.abs(getData(sampleData.get(i)))).sum();
 				IntStream.range(0, sampleData.size()).filter(i -> !sampleData.get(i).isEmpty()).filter(i -> !skipVariable(samples, i))//

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/Normalization2Norm.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/Normalization2Norm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -39,13 +39,12 @@ public class Normalization2Norm extends AbstractDataModificator implements INorm
 		return "Normalization 2-Norm";
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public <V extends IVariable, S extends ISample> void process(ISamples<V, S> samples) {
 
 		for(ISample sample : samples.getSampleList()) {
 			if(sample.isSelected() || !isOnlySelected()) {
-				List<? extends ISampleData> sampleData = sample.getSampleData();
+				List<? extends ISampleData<?>> sampleData = sample.getSampleData();
 				double sum = Math.sqrt(IntStream.range(0, sampleData.size()).filter(i -> !sampleData.get(i).isEmpty()).filter(i -> !skipVariable(samples, i))//
 						.mapToDouble(i -> getData(sampleData.get(i)) * getData(sampleData.get(i))).sum());
 				IntStream.range(0, sampleData.size()).filter(i -> !sampleData.get(i).isEmpty()).filter(i -> !skipVariable(samples, i))//

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/NormalizationInfNorm.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/NormalizationInfNorm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -39,13 +39,12 @@ public class NormalizationInfNorm extends AbstractDataModificator implements INo
 		return "Normalization Inf-Norm";
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public <V extends IVariable, S extends ISample> void process(ISamples<V, S> samples) {
 
 		for(ISample sample : samples.getSampleList()) {
 			if(sample.isSelected() || !isOnlySelected()) {
-				List<? extends ISampleData> sampleData = sample.getSampleData();
+				List<? extends ISampleData<?>> sampleData = sample.getSampleData();
 				double max = IntStream.range(0, sampleData.size()).filter(i -> !sampleData.get(i).isEmpty()).filter(i -> !skipVariable(samples, i))//
 						.mapToDouble(i -> Math.abs(getData(sampleData.get(i)))).summaryStatistics().getMax();
 				IntStream.range(0, sampleData.size()).filter(i -> !sampleData.get(i).isEmpty()).filter(i -> !skipVariable(samples, i))//

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/ScalingAuto.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/ScalingAuto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -38,7 +38,6 @@ public class ScalingAuto extends AbstractScaling {
 		return "Auto Scaling";
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public <V extends IVariable, S extends ISample> void process(ISamples<V, S> samples) {
 
@@ -53,7 +52,7 @@ public class ScalingAuto extends AbstractScaling {
 			final double mean = getCenteringValue(samplesList, i, centeringType);
 			final double deviation = getStandartDeviation(samplesList, i, centeringType);
 			for(ISample sample : samplesList) {
-				ISampleData sampleData = sample.getSampleData().get(i);
+				ISampleData<?> sampleData = sample.getSampleData().get(i);
 				if((sample.isSelected() || !onlySeleted)) {
 					double data = getData(sampleData);
 					double scaleData = 0;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/ScalingLevel.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/ScalingLevel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -38,7 +38,6 @@ public class ScalingLevel extends AbstractScaling {
 		return "Level Scaling";
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public <V extends IVariable, S extends ISample> void process(ISamples<V, S> samples) {
 
@@ -52,7 +51,7 @@ public class ScalingLevel extends AbstractScaling {
 			}
 			final double mean = getCenteringValue(samplesList, i, centeringType);
 			for(ISample sample : samplesList) {
-				ISampleData sampleData = sample.getSampleData().get(i);
+				ISampleData<?> sampleData = sample.getSampleData().get(i);
 				if((sample.isSelected() || !onlySeleted)) {
 					double data = getData(sampleData);
 					double scaleData = (data - mean) / mean;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/ScalingPareto.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/ScalingPareto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -38,7 +38,6 @@ public class ScalingPareto extends AbstractScaling {
 		return "Pareto Scaling";
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public <V extends IVariable, S extends ISample> void process(ISamples<V, S> samples) {
 
@@ -53,7 +52,7 @@ public class ScalingPareto extends AbstractScaling {
 			final double mean = getCenteringValue(samplesList, i, centeringType);
 			final double deviationSqrt = Math.sqrt(getStandartDeviation(samplesList, i, centeringType));
 			for(ISample sample : samplesList) {
-				ISampleData sampleData = sample.getSampleData().get(i);
+				ISampleData<?> sampleData = sample.getSampleData().get(i);
 				if((sample.isSelected() || !onlySeleted)) {
 					double data = getData(sampleData);
 					double scaleData = (data - mean) / deviationSqrt;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/ScalingRange.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/ScalingRange.java
@@ -50,7 +50,6 @@ public class ScalingRange extends AbstractScaling {
 		return samples.stream().filter(s -> s.isSelected() || !onlySelected).map(s -> s.getSampleData().get(index)).mapToDouble(value -> getData(value)).summaryStatistics().getMin();
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public <V extends IVariable, S extends ISample> void process(ISamples<V, S> samples) {
 
@@ -66,7 +65,7 @@ public class ScalingRange extends AbstractScaling {
 			final double max = getMax(samplesList, i);
 			final double min = getMin(samplesList, i);
 			for(ISample sample : samplesList) {
-				ISampleData sampleData = sample.getSampleData().get(i);
+				ISampleData<?> sampleData = sample.getSampleData().get(i);
 				if((sample.isSelected() || !onlySelected)) {
 					double data = getData(sampleData);
 					double scaleData = (data - mean) / (max - min);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/ScalingVast.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/ScalingVast.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -38,7 +38,6 @@ public class ScalingVast extends AbstractScaling {
 		return "Vast Scaling";
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public <V extends IVariable, S extends ISample> void process(ISamples<V, S> samples) {
 
@@ -53,7 +52,7 @@ public class ScalingVast extends AbstractScaling {
 			final double mean = getCenteringValue(samplesList, i, centeringType);
 			final double variace = getVariance(samplesList, i, centeringType);
 			for(ISample sample : samplesList) {
-				ISampleData sampleData = sample.getSampleData().get(i);
+				ISampleData<?> sampleData = sample.getSampleData().get(i);
 				if((sample.isSelected() || !onlySelected)) {
 					double data = getData(sampleData);
 					double scaleData = ((data - mean) / variace) * mean;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/SmallValuesReplacer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/SmallValuesReplacer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,7 +33,6 @@ public class SmallValuesReplacer extends AbstractDataModificator implements IRep
 		return "Small Random Value Setter";
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public <V extends IVariable, S extends ISample> void process(ISamples<V, S> samples) {
 
@@ -46,7 +45,7 @@ public class SmallValuesReplacer extends AbstractDataModificator implements IRep
 			}
 			for(S sample : sampleList) {
 				if(sample.isSelected() || !isOnlySelected()) {
-					ISampleData sampleData = sample.getSampleData().get(i);
+					ISampleData<?> sampleData = sample.getSampleData().get(i);
 					if(Double.isNaN(getData(sampleData))) {
 						double replacement = -1.0;
 						while(replacement < 0) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/TransformationLOG10.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/TransformationLOG10.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,17 +33,16 @@ public class TransformationLOG10 extends AbstractDataModificator implements ITra
 		return "Decadic Logarithm Transformation";
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public <V extends IVariable, S extends ISample> void process(ISamples<V, S> samples) {
 
 		samples.getSampleList().stream().filter(s -> s.isSelected() || !isOnlySelected()).forEach(s -> {
-			List<? extends ISampleData> sampleData = s.getSampleData();
+			List<? extends ISampleData<?>> sampleData = s.getSampleData();
 			for(int i = 0; i < sampleData.size(); i++) {
 				if(skipVariable(samples, i)) {
 					continue;
 				}
-				ISampleData data = sampleData.get(i);
+				ISampleData<?> data = sampleData.get(i);
 				data.setModifiedData(10.0 * Math.log10(getData(data)));
 			}
 		});

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/TransformationPower.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/TransformationPower.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,17 +33,16 @@ public class TransformationPower extends AbstractDataModificator implements ITra
 		return "Power Transformation";
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public <V extends IVariable, S extends ISample> void process(ISamples<V, S> samples) {
 
 		samples.getSampleList().stream().filter(s -> s.isSelected() || !isOnlySelected()).forEach(s -> {
-			List<? extends ISampleData> sampleData = s.getSampleData();
+			List<? extends ISampleData<?>> sampleData = s.getSampleData();
 			for(int i = 0; i < sampleData.size(); i++) {
 				if(skipVariable(samples, i)) {
 					continue;
 				}
-				ISampleData data = sampleData.get(i);
+				ISampleData<?> data = sampleData.get(i);
 				data.setModifiedData(Math.sqrt(Math.abs(getData(data))));
 			}
 		});

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/AbstractChromatogramFilter_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/AbstractChromatogramFilter_1_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -44,7 +44,6 @@ public class AbstractChromatogramFilter_1_Test extends TestCase {
 		super.tearDown();
 	}
 
-	@SuppressWarnings("unchecked")
 	public void testConstructor_1() {
 
 		chromatogramSelection = null;
@@ -53,7 +52,6 @@ public class AbstractChromatogramFilter_1_Test extends TestCase {
 		filter.applyFilter(chromatogramSelection, chromatogramFilterSettings, new NullProgressMonitor());
 	}
 
-	@SuppressWarnings("unchecked")
 	public void testConstructor_2() {
 
 		chromatogram = new ChromatogramMSD();

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/TestChromatogramFilter.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/TestChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.core.chromatogram;
 
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -25,14 +26,14 @@ import org.eclipse.core.runtime.IProgressMonitor;
 public class TestChromatogramFilter extends AbstractChromatogramFilterMSD {
 
 	@Override
-	public IProcessingInfo<?> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
-		return new ProcessingInfo<Object>();
+		return new ProcessingInfo<>();
 	}
 
 	@Override
-	public IProcessingInfo<?> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
 
-		return new ProcessingInfo<Object>();
+		return new ProcessingInfo<>();
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/multiplier/core/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/multiplier/core/ChromatogramImporterTestCase.java
@@ -31,8 +31,7 @@ public class ChromatogramImporterTestCase extends TestCase {
 	private static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
 	//
 	protected IChromatogramMSD chromatogram;
-	@SuppressWarnings("rawtypes")
-	protected IChromatogramSelection chromatogramSelection;
+	protected IChromatogramSelection<?, ?> chromatogramSelection;
 
 	@Override
 	protected void setUp() throws Exception {

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/peak/detector/supplier/firstderivative/core/FirstDerivativePeakDetector_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/peak/detector/supplier/firstderivative/core/FirstDerivativePeakDetector_2_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -23,17 +23,15 @@ import org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderiv
 public class FirstDerivativePeakDetector_2_Test extends FirstDerivativeSlopesTestCase {
 
 	private IFirstDerivativeDetectorSlopes slopes;
-	@SuppressWarnings("rawtypes")
-	private PeakDetectorMSD firstDerivativePeakDetector;
+	private PeakDetectorMSD<?, ?, ?> firstDerivativePeakDetector;
 	private Class<?> firstDerivativePeakDetectorClass;
 	private Method method;
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	protected void setUp() throws Exception {
 
 		super.setUp();
-		firstDerivativePeakDetector = new PeakDetectorMSD();
+		firstDerivativePeakDetector = new PeakDetectorMSD<>();
 		firstDerivativePeakDetectorClass = BasePeakDetector.class;
 		slopes = getFirstDerivativeSlopes();
 		slopes.calculateMovingAverage(5);

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/peak/detector/supplier/firstderivative/core/FirstDerivativePeakDetector_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/peak/detector/supplier/firstderivative/core/FirstDerivativePeakDetector_3_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -25,18 +25,16 @@ import junit.framework.TestCase;
  */
 public class FirstDerivativePeakDetector_3_Test extends TestCase {
 
-	@SuppressWarnings("rawtypes")
-	private PeakDetectorMSD firstDerivativePeakDetector;
+	private PeakDetectorMSD<?, ?, ?> firstDerivativePeakDetector;
 	private Class<?> firstDerivativePeakDetectorClass;
 	private Method method;
 	private IRawPeak rawPeak;
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	protected void setUp() throws Exception {
 
 		super.setUp();
-		firstDerivativePeakDetector = new PeakDetectorMSD();
+		firstDerivativePeakDetector = new PeakDetectorMSD<>();
 		firstDerivativePeakDetectorClass = BasePeakDetector.class;
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/src/org/eclipse/chemclipse/msd/converter/chromatogram/TestChromatogramImportConverter.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/src/org/eclipse/chemclipse/msd/converter/chromatogram/TestChromatogramImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,6 +15,8 @@ import java.io.File;
 
 import org.eclipse.chemclipse.converter.chromatogram.AbstractChromatogramImportConverter;
 import org.eclipse.chemclipse.converter.chromatogram.IChromatogramImportConverter;
+import org.eclipse.chemclipse.model.core.IChromatogram;
+import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -23,23 +25,22 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * THIS CLASS IS NOT SUITED FOR PRODUCTIVE USE!<br/>
  * IT IS AN TESTCLASS!
  */
-@SuppressWarnings("rawtypes")
-public class TestChromatogramImportConverter extends AbstractChromatogramImportConverter implements IChromatogramImportConverter {
+public class TestChromatogramImportConverter extends AbstractChromatogramImportConverter<IChromatogram<?>> implements IChromatogramImportConverter<IChromatogram<?>> {
 
 	@Override
-	public IProcessingInfo<?> convert(File chromatogram, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogram<?>> convert(File chromatogram, IProgressMonitor monitor) {
 
-		IProcessingInfo<?> processingInfo = super.validate(chromatogram);
-		IProcessingInfo<?> processingInfoImport = new ProcessingInfo<Object>();
+		IProcessingInfo<IChromatogram<?>> processingInfo = super.validate(chromatogram);
+		IProcessingInfo<IChromatogram<?>> processingInfoImport = new ProcessingInfo<>();
 		processingInfoImport.addMessages(processingInfo);
 		return processingInfoImport;
 	}
 
 	@Override
-	public IProcessingInfo<?> convertOverview(File chromatogram, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramOverview> convertOverview(File chromatogram, IProgressMonitor monitor) {
 
-		IProcessingInfo<?> processingInfo = super.validate(chromatogram);
-		IProcessingInfo<?> processingInfoImport = new ProcessingInfo<Object>();
+		IProcessingInfo<IChromatogramOverview> processingInfo = super.validate(chromatogram);
+		IProcessingInfo<IChromatogramOverview> processingInfoImport = new ProcessingInfo<>();
 		processingInfoImport.addMessages(processingInfo);
 		return processingInfoImport;
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUReader_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUReader_2_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -24,12 +24,11 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 
 import junit.framework.TestCase;
 
-@SuppressWarnings("rawtypes")
 public class ELUReader_2_ITest extends TestCase {
 
 	private ELUReader reader;
 	private File file;
-	private IProcessingInfo processingInfo;
+	private IProcessingInfo<?> processingInfo;
 
 	@Override
 	protected void setUp() throws Exception {
@@ -51,7 +50,7 @@ public class ELUReader_2_ITest extends TestCase {
 	public void testRead_1() {
 
 		try {
-			IPeaks peaks = (IPeaks)processingInfo.getProcessingResult();
+			IPeaks<?> peaks = (IPeaks<?>)processingInfo.getProcessingResult();
 			assertEquals(1132, peaks.getPeaks().size());
 		} catch(TypeCastException e) {
 			assertTrue(false);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLExportConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLExportConverter_1_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -26,7 +26,6 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 
 import junit.framework.TestCase;
 
-@SuppressWarnings("rawtypes")
 public class MSLExportConverter_1_ITest extends TestCase {
 
 	private IDatabaseExportConverter exportConverter;
@@ -60,7 +59,7 @@ public class MSLExportConverter_1_ITest extends TestCase {
 
 	public void testExport_1() {
 
-		IProcessingInfo processingInfo = exportConverter.convert(null, massSpectrum, false, new NullProgressMonitor());
+		IProcessingInfo<?> processingInfo = exportConverter.convert(null, massSpectrum, false, new NullProgressMonitor());
 		try {
 			assertTrue(processingInfo.hasErrorMessages());
 		} catch(TypeCastException e) {
@@ -71,7 +70,7 @@ public class MSLExportConverter_1_ITest extends TestCase {
 	public void testExport_2() {
 
 		massSpectrum = null;
-		IProcessingInfo processingInfo = exportConverter.convert(exportFile, massSpectrum, false, new NullProgressMonitor());
+		IProcessingInfo<?> processingInfo = exportConverter.convert(exportFile, massSpectrum, false, new NullProgressMonitor());
 		try {
 			assertTrue(processingInfo.hasErrorMessages());
 		} catch(TypeCastException e) {
@@ -82,7 +81,7 @@ public class MSLExportConverter_1_ITest extends TestCase {
 	public void testExport_3() {
 
 		massSpectra = null;
-		IProcessingInfo processingInfo = exportConverter.convert(exportFile, massSpectra, false, new NullProgressMonitor());
+		IProcessingInfo<?> processingInfo = exportConverter.convert(exportFile, massSpectra, false, new NullProgressMonitor());
 		try {
 			assertTrue(processingInfo.hasErrorMessages());
 		} catch(TypeCastException e) {
@@ -94,7 +93,7 @@ public class MSLExportConverter_1_ITest extends TestCase {
 
 		try {
 			exportFile.setWritable(false);
-			IProcessingInfo processingInfo = exportConverter.convert(exportFile, massSpectra, false, new NullProgressMonitor());
+			IProcessingInfo<?> processingInfo = exportConverter.convert(exportFile, massSpectra, false, new NullProgressMonitor());
 			try {
 				assertTrue(processingInfo.hasErrorMessages());
 			} catch(TypeCastException e) {

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLImportConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLImportConverter_1_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -20,7 +20,6 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 
 import junit.framework.TestCase;
 
-@SuppressWarnings("rawtypes")
 public class MSLImportConverter_1_ITest extends TestCase {
 
 	private IDatabaseImportConverter importConverter;
@@ -43,21 +42,21 @@ public class MSLImportConverter_1_ITest extends TestCase {
 	public void testExceptions_1() {
 
 		importFile = null;
-		IProcessingInfo processingInfo = importConverter.convert(null, new NullProgressMonitor());
+		IProcessingInfo<?> processingInfo = importConverter.convert(null, new NullProgressMonitor());
 		assertTrue(processingInfo.hasErrorMessages());
 	}
 
 	public void testExceptions_2() {
 
 		importFile = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_EMPTY));
-		IProcessingInfo processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
+		IProcessingInfo<?> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
 		assertTrue(processingInfo.hasErrorMessages());
 	}
 
 	public void testExceptions_3() {
 
 		importFile = new File("nirvana");
-		IProcessingInfo processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
+		IProcessingInfo<?> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
 		assertTrue(processingInfo.hasErrorMessages());
 	}
 
@@ -66,7 +65,7 @@ public class MSLImportConverter_1_ITest extends TestCase {
 		importFile = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_NOT_READABLE));
 		importFile.setReadable(false);
 		try {
-			IProcessingInfo processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
+			IProcessingInfo<?> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
 			assertTrue(processingInfo.hasErrorMessages());
 		} finally {
 			importFile.setReadable(true);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPExportConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPExportConverter_1_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 Lablicate GmbH.
+ * Copyright (c) 2012, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -26,7 +26,6 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 
 import junit.framework.TestCase;
 
-@SuppressWarnings("rawtypes")
 public class MSPExportConverter_1_ITest extends TestCase {
 
 	private IDatabaseExportConverter exportConverter;
@@ -60,7 +59,7 @@ public class MSPExportConverter_1_ITest extends TestCase {
 
 	public void testExport_1() {
 
-		IProcessingInfo processingInfo = exportConverter.convert(null, massSpectrum, false, new NullProgressMonitor());
+		IProcessingInfo<?> processingInfo = exportConverter.convert(null, massSpectrum, false, new NullProgressMonitor());
 		try {
 			assertTrue(processingInfo.hasErrorMessages());
 		} catch(TypeCastException e) {
@@ -71,7 +70,7 @@ public class MSPExportConverter_1_ITest extends TestCase {
 	public void testExport_2() {
 
 		massSpectrum = null;
-		IProcessingInfo processingInfo = exportConverter.convert(exportFile, massSpectrum, false, new NullProgressMonitor());
+		IProcessingInfo<?> processingInfo = exportConverter.convert(exportFile, massSpectrum, false, new NullProgressMonitor());
 		try {
 			assertTrue(processingInfo.hasErrorMessages());
 		} catch(TypeCastException e) {
@@ -82,7 +81,7 @@ public class MSPExportConverter_1_ITest extends TestCase {
 	public void testExport_3() {
 
 		massSpectra = null;
-		IProcessingInfo processingInfo = exportConverter.convert(exportFile, massSpectra, false, new NullProgressMonitor());
+		IProcessingInfo<?> processingInfo = exportConverter.convert(exportFile, massSpectra, false, new NullProgressMonitor());
 		try {
 			assertTrue(processingInfo.hasErrorMessages());
 		} catch(TypeCastException e) {
@@ -94,7 +93,7 @@ public class MSPExportConverter_1_ITest extends TestCase {
 
 		try {
 			exportFile.setWritable(false);
-			IProcessingInfo processingInfo = exportConverter.convert(exportFile, massSpectra, false, new NullProgressMonitor());
+			IProcessingInfo<?> processingInfo = exportConverter.convert(exportFile, massSpectra, false, new NullProgressMonitor());
 			try {
 				assertTrue(processingInfo.hasErrorMessages());
 			} catch(TypeCastException e) {

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_1_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -27,7 +27,6 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 
 import junit.framework.TestCase;
 
-@SuppressWarnings("rawtypes")
 public class MSPImportConverter_1_ITest extends TestCase {
 
 	private IMassSpectra massSpectra;
@@ -38,7 +37,7 @@ public class MSPImportConverter_1_ITest extends TestCase {
 		super.setUp();
 		File importFile = new File(PathResolver.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_LIB_1_MSP));
 		IDatabaseImportConverter importConverter = new MSPDatabaseImportConverter();
-		IProcessingInfo processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
+		IProcessingInfo<?> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
 		massSpectra = (IMassSpectra)processingInfo.getProcessingResult();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/ImportConverterMslTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/ImportConverterMslTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -23,7 +23,6 @@ import org.junit.Ignore;
 
 import junit.framework.TestCase;
 
-@SuppressWarnings("rawtypes")
 @Ignore
 public class ImportConverterMslTestCase extends TestCase {
 
@@ -36,7 +35,7 @@ public class ImportConverterMslTestCase extends TestCase {
 
 		super.setUp();
 		importConverter = new MSLDatabaseImportConverter();
-		IProcessingInfo processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
+		IProcessingInfo<?> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
 		massSpectra = (IMassSpectra)processingInfo.getProcessingResult();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_2_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -34,7 +34,6 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.exceptions.TypeCastException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class MassSpectrumExportConverter_DB_2_ITest extends MassSpectrumExportConverterTestCase {
 
 	@Override
@@ -66,7 +65,7 @@ public class MassSpectrumExportConverter_DB_2_ITest extends MassSpectrumExportCo
 		}
 		assertEquals("Size before", 3, massSpectra.size());
 		exportConverter.convert(exportFile, massSpectra, false, new NullProgressMonitor());
-		IProcessingInfo processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
+		IProcessingInfo<?> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
 		try {
 			massSpectra = (IMassSpectra)processingInfo.getProcessingResult();
 		} catch(TypeCastException e) {

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_3_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -34,7 +34,6 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.exceptions.TypeCastException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class MassSpectrumExportConverter_DB_3_ITest extends MassSpectrumExportConverterTestCase {
 
 	@Override
@@ -67,7 +66,7 @@ public class MassSpectrumExportConverter_DB_3_ITest extends MassSpectrumExportCo
 		assertEquals("Size before", 3, massSpectra.size());
 		exportConverter.convert(exportFile, massSpectra, false, new NullProgressMonitor());
 		exportConverter.convert(exportFile, massSpectra, true, new NullProgressMonitor());
-		IProcessingInfo processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
+		IProcessingInfo<?> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
 		try {
 			massSpectra = (IMassSpectra)processingInfo.getProcessingResult();
 		} catch(TypeCastException e) {

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_4_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_4_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -33,7 +33,6 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.exceptions.TypeCastException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class MassSpectrumExportConverter_DB_4_ITest extends MassSpectrumExportConverterTestCase {
 
 	@Override
@@ -61,7 +60,7 @@ public class MassSpectrumExportConverter_DB_4_ITest extends MassSpectrumExportCo
 		}
 		exportConverter.convert(exportFile, ms, false, new NullProgressMonitor());
 		exportConverter.convert(exportFile, ms, true, new NullProgressMonitor());
-		IProcessingInfo processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
+		IProcessingInfo<?> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
 		try {
 			massSpectra = (IMassSpectra)processingInfo.getProcessingResult();
 		} catch(TypeCastException e) {

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_5_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_5_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -33,7 +33,6 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.exceptions.TypeCastException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class MassSpectrumExportConverter_DB_5_ITest extends MassSpectrumExportConverterTestCase {
 
 	@Override
@@ -61,7 +60,7 @@ public class MassSpectrumExportConverter_DB_5_ITest extends MassSpectrumExportCo
 		//
 		exportConverter.convert(exportFile, ms, false, new NullProgressMonitor());
 		//
-		IProcessingInfo processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
+		IProcessingInfo<?> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
 		try {
 			massSpectra = (IMassSpectra)processingInfo.getProcessingResult();
 		} catch(TypeCastException e) {


### PR DESCRIPTION
As stated in https://github.com/eclipse/chemclipse/pull/1407 the introduction of generics in this project was problematic. This reduces some easy to solve warnings that were needlessly suppressed. This makes it easier to spot the real problems that require changes to the interfaces.