### PR TITLE
Reduced rawtypes and unchecked warnings

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification/src/org/eclipse/chemclipse/chromatogram/msd/process/supplier/peakidentification/core/PeakIdentificationBatchProcess.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification/src/org/eclipse/chemclipse/chromatogram/msd/process/supplier/peakidentification/core/PeakIdentificationBatchProcess.java
@@ -32,9 +32,9 @@ import org.eclipse.chemclipse.chromatogram.xxd.integrator.core.peaks.PeakIntegra
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IPeaks;
-import org.eclipse.chemclipse.model.implementation.Peaks;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
+import org.eclipse.chemclipse.msd.model.core.PeaksMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.IProcessingMessage;
 import org.eclipse.chemclipse.processing.core.MessageType;
@@ -151,16 +151,16 @@ public class PeakIdentificationBatchProcess implements IPeakIdentificationBatchP
 			 * Write the mass spectra.
 			 */
 			File peakOutputFile = new File(outputFolder + peakIdentificationBatchJob.getName());
-			IPeaks<?> peaks = getPeaksInstance(peakList);
+			IPeaks<? extends IPeakMSD> peaks = getPeaksInstance(peakList);
 			IProcessingInfo<?> processingInfo = PeakConverterMSD.convert(peakOutputFile, peaks, false, converterId, monitor);
 			peakIdentificationProcessingInfo.addMessages(processingInfo);
 		}
 		return peakIdentificationProcessingInfo;
 	}
 
-	private IPeaks<?> getPeaksInstance(List<IPeakMSD> peakList) {
+	private IPeaks<? extends IPeakMSD> getPeaksInstance(List<IPeakMSD> peakList) {
 
-		IPeaks<?> peaks = new Peaks();
+		IPeaks<? extends IPeakMSD> peaks = new PeaksMSD();
 		for(IPeakMSD peak : peakList) {
 			peaks.addPeak(peak);
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/RetentionIndexWizardElements.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/RetentionIndexWizardElements.java
@@ -17,6 +17,8 @@ import java.util.List;
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.impl.RetentionIndexCalculator;
 import org.eclipse.chemclipse.model.columns.ISeparationColumnIndices;
 import org.eclipse.chemclipse.model.columns.SeparationColumnIndices;
+import org.eclipse.chemclipse.model.core.IChromatogram;
+import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.support.ui.wizards.ChromatogramWizardElements;
 
@@ -31,7 +33,7 @@ public class RetentionIndexWizardElements extends ChromatogramWizardElements {
 	private String stopIndexName = "";
 	private boolean useAlreadyDetectedPeaks = false;
 	//
-	private IChromatogramSelection<?, ?> chromatogramSelection;
+	private IChromatogramSelection<IPeak, IChromatogram<IPeak>> chromatogramSelection;
 	private ISeparationColumnIndices separationColumnIndices = new SeparationColumnIndices();
 	//
 	private boolean retentionIndexDataIsValidated = false;
@@ -140,12 +142,12 @@ public class RetentionIndexWizardElements extends ChromatogramWizardElements {
 		this.useAlreadyDetectedPeaks = useAlreadyDetectedPeaks;
 	}
 
-	public IChromatogramSelection<?, ?> getChromatogramSelection() {
+	public IChromatogramSelection<IPeak, IChromatogram<IPeak>> getChromatogramSelection() {
 
 		return chromatogramSelection;
 	}
 
-	public void setChromatogramSelection(IChromatogramSelection<?, ?> chromatogramSelection) {
+	public void setChromatogramSelection(IChromatogramSelection<IPeak, IChromatogram<IPeak>> chromatogramSelection) {
 
 		this.chromatogramSelection = chromatogramSelection;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/chromatogram/IChromatogramImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/chromatogram/IChromatogramImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Lablicate GmbH.
+ * Copyright (c) 2012, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -40,7 +40,7 @@ public interface IChromatogramImportConverter<R extends IChromatogram<?>> extend
 	default IProcessingInfo<IChromatogramOverview> convertOverview(File file, IProgressMonitor monitor) {
 
 		IProcessingInfo<R> chromatogramInfo = convert(file, monitor);
-		ProcessingInfo<IChromatogramOverview> info = new ProcessingInfo<IChromatogramOverview>();
+		ProcessingInfo<IChromatogramOverview> info = new ProcessingInfo<>();
 		info.addMessages(chromatogramInfo);
 		info.setProcessingResult(chromatogramInfo.getProcessingResult());
 		return info;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLDatabaseExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLDatabaseExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -33,17 +33,16 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * otherwise massSpectrum.getIdentifier().
  * 
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class MSLDatabaseExportConverter extends AbstractDatabaseExportConverter {
 
 	private static final Logger logger = Logger.getLogger(MSLDatabaseExportConverter.class);
 	private static final String DESCRIPTION = "AMDIS MSL MassSpectrum Export";
 
 	@Override
-	public IProcessingInfo convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
 
 		file = SpecificationValidatorMSL.validateSpecification(file);
-		IProcessingInfo processingInfo = validate(file, massSpectrum);
+		IProcessingInfo<File> processingInfo = validate(file, massSpectrum);
 		if(!processingInfo.hasErrorMessages()) {
 			try {
 				/*
@@ -67,10 +66,10 @@ public class MSLDatabaseExportConverter extends AbstractDatabaseExportConverter 
 	}
 
 	@Override
-	public IProcessingInfo convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
 
 		file = SpecificationValidatorMSL.validateSpecification(file);
-		IProcessingInfo processingInfo = validate(file, massSpectra);
+		IProcessingInfo<File> processingInfo = validate(file, massSpectra);
 		if(!processingInfo.hasErrorMessages()) {
 			try {
 				/*
@@ -93,17 +92,17 @@ public class MSLDatabaseExportConverter extends AbstractDatabaseExportConverter 
 		return processingInfo;
 	}
 
-	private IProcessingInfo validate(File file, IScanMSD massSpectrum) {
+	private IProcessingInfo<File> validate(File file, IScanMSD massSpectrum) {
 
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		processingInfo.addMessages(super.validate(file));
 		processingInfo.addMessages(super.validate(massSpectrum));
 		return processingInfo;
 	}
 
-	private IProcessingInfo validate(File file, IMassSpectra massSpectra) {
+	private IProcessingInfo<File> validate(File file, IMassSpectra massSpectra) {
 
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		processingInfo.addMessages(super.validate(file));
 		processingInfo.addMessages(super.validate(massSpectra));
 		return processingInfo;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLPeakExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLPeakExportConverter.java
@@ -21,6 +21,7 @@ import org.eclipse.chemclipse.model.core.IPeaks;
 import org.eclipse.chemclipse.msd.converter.peak.AbstractPeakExportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.internal.converter.SpecificationValidatorMSL;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.PeakWriterMSL;
+import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -31,21 +32,20 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * otherwise massSpectrum.getIdentifier().
  * 
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class MSLPeakExportConverter extends AbstractPeakExportConverter {
 
 	private static final Logger logger = Logger.getLogger(MSLPeakExportConverter.class);
 	private static final String DESCRIPTION = "AMDIS MSL Peak Export";
 
 	@Override
-	public IProcessingInfo convert(File file, IPeaks peaks, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IPeaks<? extends IPeakMSD> peaks, boolean append, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		/*
 		 * Checks that file and mass spectra are not null.
 		 */
 		file = SpecificationValidatorMSL.validateSpecification(file);
-		IProcessingInfo processingInfoValidate = validate(file, peaks);
+		IProcessingInfo<File> processingInfoValidate = validate(file, peaks);
 		if(processingInfoValidate.hasErrorMessages()) {
 			processingInfo.addMessages(processingInfoValidate);
 		} else {
@@ -67,9 +67,9 @@ public class MSLPeakExportConverter extends AbstractPeakExportConverter {
 		return processingInfo;
 	}
 
-	private IProcessingInfo validate(File file, IPeaks<?> peaks) {
+	private IProcessingInfo<File> validate(File file, IPeaks<?> peaks) {
 
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		processingInfo.addMessages(super.validate(file));
 		processingInfo.addMessages(super.validate(peaks));
 		return processingInfo;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPDatabaseExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPDatabaseExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 Lablicate GmbH.
+ * Copyright (c) 2012, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -33,16 +33,15 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * otherwise massSpectrum.getIdentifier().
  * 
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class MSPDatabaseExportConverter extends AbstractDatabaseExportConverter {
 
 	private static final Logger logger = Logger.getLogger(MSPDatabaseExportConverter.class);
 	private static final String DESCRIPTION = "AMDIS MSP MassSpectrum Export";
 
 	@Override
-	public IProcessingInfo convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(file, massSpectrum);
+		IProcessingInfo<File> processingInfo = validate(file, massSpectrum);
 		if(!processingInfo.hasErrorMessages()) {
 			try {
 				file = SpecificationValidatorMSP.validateSpecification(file);
@@ -67,9 +66,9 @@ public class MSPDatabaseExportConverter extends AbstractDatabaseExportConverter 
 	}
 
 	@Override
-	public IProcessingInfo convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(file, massSpectra);
+		IProcessingInfo<File> processingInfo = validate(file, massSpectra);
 		if(!processingInfo.hasErrorMessages()) {
 			try {
 				file = SpecificationValidatorMSP.validateSpecification(file);
@@ -93,17 +92,17 @@ public class MSPDatabaseExportConverter extends AbstractDatabaseExportConverter 
 		return processingInfo;
 	}
 
-	private IProcessingInfo validate(File file, IScanMSD massSpectrum) {
+	private IProcessingInfo<File> validate(File file, IScanMSD massSpectrum) {
 
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		processingInfo.addMessages(super.validate(file));
 		processingInfo.addMessages(super.validate(massSpectrum));
 		return processingInfo;
 	}
 
-	private IProcessingInfo validate(File file, IMassSpectra massSpectra) {
+	private IProcessingInfo<File> validate(File file, IMassSpectra massSpectra) {
 
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		processingInfo.addMessages(super.validate(file));
 		processingInfo.addMessages(super.validate(massSpectra));
 		return processingInfo;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPPeakExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPPeakExportConverter.java
@@ -21,6 +21,7 @@ import org.eclipse.chemclipse.model.core.IPeaks;
 import org.eclipse.chemclipse.msd.converter.peak.AbstractPeakExportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.internal.converter.SpecificationValidatorMSP;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.PeakWriterMSP;
+import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -31,21 +32,20 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * otherwise massSpectrum.getIdentifier().
  * 
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class MSPPeakExportConverter extends AbstractPeakExportConverter {
 
 	private static final Logger logger = Logger.getLogger(MSPPeakExportConverter.class);
 	private static final String DESCRIPTION = "AMDIS MSP Peak Export";
 
 	@Override
-	public IProcessingInfo convert(File file, IPeaks peaks, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IPeaks<? extends IPeakMSD> peaks, boolean append, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		/*
 		 * Checks that file and mass spectra are not null.
 		 */
 		file = SpecificationValidatorMSP.validateSpecification(file);
-		IProcessingInfo processingInfoValidate = validate(file, peaks);
+		IProcessingInfo<File> processingInfoValidate = validate(file, peaks);
 		if(processingInfoValidate.hasErrorMessages()) {
 			processingInfo.addMessages(processingInfoValidate);
 		} else {
@@ -67,9 +67,9 @@ public class MSPPeakExportConverter extends AbstractPeakExportConverter {
 		return processingInfo;
 	}
 
-	private IProcessingInfo validate(File file, IPeaks<?> peaks) {
+	private IProcessingInfo<File> validate(File file, IPeaks<?> peaks) {
 
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		processingInfo.addMessages(super.validate(file));
 		processingInfo.addMessages(super.validate(peaks));
 		return processingInfo;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/chromatogram/ChromatogramWriterMSL.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/chromatogram/ChromatogramWriterMSL.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Lablicate GmbH.
+ * Copyright (c) 2012, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,23 +12,23 @@
 package org.eclipse.chemclipse.msd.converter.supplier.amdis.io.chromatogram;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
 import org.eclipse.chemclipse.model.core.IPeaks;
-import org.eclipse.chemclipse.model.implementation.Peaks;
 import org.eclipse.chemclipse.msd.converter.io.AbstractChromatogramMSDWriter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msl.MSLPeakExportConverter;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
+import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
+import org.eclipse.chemclipse.msd.model.core.PeaksMSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 public class ChromatogramWriterMSL extends AbstractChromatogramMSDWriter {
 
 	@Override
-	public void writeChromatogram(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotWriteableException, IOException {
+	public void writeChromatogram(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
 		if(chromatogram == null || file == null) {
 			throw new IOException("The chromatogram and the file must be not null.");
@@ -36,7 +36,7 @@ public class ChromatogramWriterMSL extends AbstractChromatogramMSDWriter {
 		/*
 		 * Extract the peaks
 		 */
-		IPeaks<?> peaks = new Peaks();
+		IPeaks<? extends IPeakMSD> peaks = new PeaksMSD();
 		List<IChromatogramPeakMSD> chromatogramPeaks = chromatogram.getPeaks();
 		for(IChromatogramPeakMSD chromatogramPeak : chromatogramPeaks) {
 			peaks.addPeak(chromatogramPeak);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/chromatogram/ChromatogramWriterMSP.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/chromatogram/ChromatogramWriterMSP.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Lablicate GmbH.
+ * Copyright (c) 2012, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,11 +18,12 @@ import java.util.List;
 
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
 import org.eclipse.chemclipse.model.core.IPeaks;
-import org.eclipse.chemclipse.model.implementation.Peaks;
 import org.eclipse.chemclipse.msd.converter.io.AbstractChromatogramMSDWriter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msp.MSPPeakExportConverter;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
+import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
+import org.eclipse.chemclipse.msd.model.core.PeaksMSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 public class ChromatogramWriterMSP extends AbstractChromatogramMSDWriter {
@@ -36,7 +37,7 @@ public class ChromatogramWriterMSP extends AbstractChromatogramMSDWriter {
 		/*
 		 * Extract the peaks
 		 */
-		IPeaks<?> peaks = new Peaks();
+		IPeaks<? extends IPeakMSD> peaks = new PeaksMSD();
 		List<IChromatogramPeakMSD> chromatogramPeaks = chromatogram.getPeaks();
 		for(IChromatogramPeakMSD chromatogramPeak : chromatogramPeaks) {
 			peaks.addPeak(chromatogramPeak);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Lablicate GmbH.
+ * Copyright (c) 2011, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -23,6 +23,7 @@ import org.eclipse.chemclipse.msd.converter.io.IPeakWriter;
 import org.eclipse.chemclipse.msd.converter.peak.AbstractPeakExportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.internal.converter.SpecificationValidator;
 import org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.io.MatlabParafacPeakWriter;
+import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.IProcessingMessage;
 import org.eclipse.chemclipse.processing.core.MessageType;
@@ -30,21 +31,20 @@ import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingMessage;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class MatlabParafacPeakExportConverter extends AbstractPeakExportConverter {
 
 	private static final Logger logger = Logger.getLogger(MatlabParafacPeakExportConverter.class);
 
 	@Override
-	public IProcessingInfo convert(File file, IPeaks peaks, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IPeaks<? extends IPeakMSD> peaks, boolean append, IProgressMonitor monitor) {
 
 		IProcessingMessage processingMessage;
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		/*
 		 * Checks that file and mass spectra are not null.
 		 */
 		file = SpecificationValidator.validateSpecification(file);
-		IProcessingInfo processingInfoValidate = validate(file, peaks);
+		IProcessingInfo<File> processingInfoValidate = validate(file, peaks);
 		if(processingInfoValidate.hasErrorMessages()) {
 			processingInfo.addMessages(processingInfoValidate);
 		} else {
@@ -53,7 +53,7 @@ public class MatlabParafacPeakExportConverter extends AbstractPeakExportConverte
 				 * Convert the peaks.
 				 */
 				IPeakWriter peakWriter = new MatlabParafacPeakWriter();
-				IProcessingInfo processingInfoWriter = peakWriter.write(file, peaks, append);
+				IProcessingInfo<File> processingInfoWriter = peakWriter.write(file, peaks, append);
 				processingInfo.addMessages(processingInfoWriter);
 				processingInfo.setProcessingResult(processingInfoWriter.getProcessingResult());
 				//
@@ -74,9 +74,9 @@ public class MatlabParafacPeakExportConverter extends AbstractPeakExportConverte
 		return processingInfo;
 	}
 
-	private IProcessingInfo<?> validate(File file, IPeaks<?> peaks) {
+	private IProcessingInfo<File> validate(File file, IPeaks<?> peaks) {
 
-		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		processingInfo.addMessages(super.validate(file));
 		processingInfo.addMessages(super.validate(peaks));
 		return processingInfo;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/io/chromatogram/ChromatogramWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/io/chromatogram/ChromatogramWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 Lablicate GmbH.
+ * Copyright (c) 2012, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,23 +12,23 @@
 package org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.io.chromatogram;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
 import org.eclipse.chemclipse.model.core.IPeaks;
-import org.eclipse.chemclipse.model.implementation.Peaks;
 import org.eclipse.chemclipse.msd.converter.io.AbstractChromatogramMSDWriter;
 import org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.converter.MatlabParafacPeakExportConverter;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
+import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
+import org.eclipse.chemclipse.msd.model.core.PeaksMSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 public class ChromatogramWriter extends AbstractChromatogramMSDWriter {
 
 	@Override
-	public void writeChromatogram(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotWriteableException, IOException {
+	public void writeChromatogram(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
 		if(chromatogram == null || file == null) {
 			throw new IOException("The chromatogram and the file must be not null.");
@@ -36,7 +36,7 @@ public class ChromatogramWriter extends AbstractChromatogramMSDWriter {
 		/*
 		 * Extract the peaks
 		 */
-		IPeaks<?> peaks = new Peaks();
+		IPeaks<? extends IPeakMSD> peaks = new PeaksMSD();
 		List<IChromatogramPeakMSD> chromatogramPeaks = chromatogram.getPeaks();
 		for(IChromatogramPeakMSD chromatogramPeak : chromatogramPeaks) {
 			peaks.addPeak(chromatogramPeak);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/chromatogram/ChromatogramConverterMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/chromatogram/ChromatogramConverterMSD.java
@@ -129,7 +129,7 @@ public final class ChromatogramConverterMSD extends AbstractChromatogramConverte
 		}
 	}
 
-	@SuppressWarnings({"rawtypes", "deprecation"})
+	@SuppressWarnings({"deprecation"})
 	private void parseTargetMassLib(IChromatogramMSD chromatogramMSD, File directory) {
 
 		if(PreferenceSupplier.isParseTargetDataMassLib()) {
@@ -143,13 +143,12 @@ public final class ChromatogramConverterMSD extends AbstractChromatogramConverte
 				String referenceIdentifierPrefix = PreferenceSupplier.getReferenceIdentifierPrefix();
 				//
 				try {
-					IProcessingInfo processingInfo = massLibConverter.parseTargets(file);
+					IProcessingInfo<?> processingInfo = massLibConverter.parseTargets(file);
 					@SuppressWarnings("unchecked")
-					Map<Integer, String> targets = (Map<Integer, String>)processingInfo.getProcessingResult(Map.class);
+					Map<Integer, String> targets = processingInfo.getProcessingResult(Map.class);
 					for(Map.Entry<Integer, String> target : targets.entrySet()) {
 						IScan scan = chromatogramMSD.getScan(target.getKey());
-						if(scan != null && scan instanceof IScanMSD) {
-							IScanMSD scanMSD = (IScanMSD)scan;
+						if(scan != null && scan instanceof IScanMSD scanMSD) {
 							ILibraryInformation libraryInformation = new LibraryInformation();
 							libraryInformationSupport.extractNameAndReferenceIdentifier(target.getValue(), libraryInformation, referenceIdentifierMarker, referenceIdentifierPrefix);
 							IComparisonResult comparisonResult = ComparisonResult.createBestMatchComparisonResult();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/peak/AbstractPeakExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/peak/AbstractPeakExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Lablicate GmbH.
+ * Copyright (c) 2011, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.converter.peak;
 
+import java.io.File;
+
 import org.eclipse.chemclipse.converter.core.AbstractExportConverter;
 import org.eclipse.chemclipse.model.core.IPeaks;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
@@ -23,27 +25,27 @@ import org.eclipse.chemclipse.processing.core.ProcessingMessage;
 
 public abstract class AbstractPeakExportConverter extends AbstractExportConverter implements IPeakExportConverter {
 
-	public IProcessingInfo<?> validate(IPeakMSD peak) {
+	public IProcessingInfo<File> validate(IPeakMSD peak) {
 
 		if(peak == null) {
 			return getProcessingInfo("The peak couldn't be found.");
 		} else {
-			return new ProcessingInfo<Object>();
+			return new ProcessingInfo<>();
 		}
 	}
 
-	public IProcessingInfo<?> validate(IPeaks<?> peaks) {
+	public IProcessingInfo<File> validate(IPeaks<?> peaks) {
 
 		if(peaks == null) {
 			return getProcessingInfo("The peaks couldn't be found.");
 		} else {
-			return new ProcessingInfo<Object>();
+			return new ProcessingInfo<>();
 		}
 	}
 
-	private IProcessingInfo<?> getProcessingInfo(String message) {
+	private IProcessingInfo<File> getProcessingInfo(String message) {
 
-		IProcessingInfo<?> processingInfo = new ProcessingInfo<Object>();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		IProcessingMessage processingMessage = new ProcessingMessage(MessageType.ERROR, "Export Converter", message);
 		processingInfo.addMessage(processingMessage);
 		return processingInfo;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/peak/PeakConverterMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/peak/PeakConverterMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Lablicate GmbH.
+ * Copyright (c) 2011, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,6 +19,7 @@ import org.eclipse.chemclipse.converter.core.IMagicNumberMatcher;
 import org.eclipse.chemclipse.converter.exceptions.NoConverterAvailableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IPeaks;
+import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.IProcessingMessage;
 import org.eclipse.chemclipse.processing.core.MessageType;
@@ -74,8 +75,7 @@ public class PeakConverterMSD {
 		return getPeaks(file, monitor);
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	public static IProcessingInfo<?> convert(File file, IPeaks peaks, boolean append, String converterId, IProgressMonitor monitor) {
+	public static IProcessingInfo<?> convert(File file, IPeaks<? extends IPeakMSD> peaks, boolean append, String converterId, IProgressMonitor monitor) {
 
 		IProcessingInfo<?> processingInfo;
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/PeaksMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/PeaksMSD.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Lablicate GmbH.
+ * 
+ * All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.model.core;
+
+import org.eclipse.chemclipse.model.core.AbstractPeaks;
+
+public class PeaksMSD extends AbstractPeaks<IPeakMSD> {
+
+	public PeaksMSD() {
+
+		super(IPeakMSD.class);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/custom/ChromatogramPeakChart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/custom/ChromatogramPeakChart.java
@@ -113,8 +113,7 @@ public class ChromatogramPeakChart extends ChromatogramChart implements IRangeSu
 		updateChromatogram(chromatogramSelection, peakChartSettingsDefault);
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	public void updateChromatogram(IChromatogramSelection chromatogramSelection, PeakChartSettings peakChartSettings) {
+	public void updateChromatogram(IChromatogramSelection<?, ?> chromatogramSelection, PeakChartSettings peakChartSettings) {
 
 		this.chromatogramSelection = chromatogramSelection;
 		//
@@ -128,7 +127,7 @@ public class ChromatogramPeakChart extends ChromatogramChart implements IRangeSu
 			 * Add series
 			 */
 			targetDisplaySettings = chromatogramSelection.getChromatogram();
-			List<IPeak> peaks = chromatogramSelection.getChromatogram().getPeaks(chromatogramSelection);
+			List<? extends IPeak> peaks = chromatogramSelection.getChromatogram().getPeaks(chromatogramSelection);
 			//
 			List<ILineSeriesData> lineSeriesDataList = new ArrayList<>();
 			addChromatogramData(lineSeriesDataList, peakChartSettings);
@@ -376,7 +375,7 @@ public class ChromatogramPeakChart extends ChromatogramChart implements IRangeSu
 		}
 	}
 
-	private void addPeakData(List<IPeak> peaks, List<ILineSeriesData> lineSeriesDataList) {
+	private void addPeakData(List<? extends IPeak> peaks, List<ILineSeriesData> lineSeriesDataList) {
 
 		int symbolSize = preferenceStore.getInt(PreferenceConstants.P_CHROMATOGRAM_PEAK_LABEL_SYMBOL_SIZE);
 		PlotSymbolType symbolTypeActiveNormal = PlotSymbolType.valueOf(preferenceStore.getString(PreferenceConstants.P_CHROMATOGRAM_PEAKS_ACTIVE_NORMAL_MARKER_TYPE));

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ScanEditorNMR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ScanEditorNMR.java
@@ -277,7 +277,7 @@ public class ScanEditorNMR implements IScanEditorNMR {
 		left.setLayout(new FillLayout());
 		Composite right = new Composite(sashForm, SWT.NONE);
 		right.setLayout(new FillLayout());
-		sashForm.setWeights(new int[]{800, 200});
+		sashForm.setWeights(800, 200);
 		extendedNMRScanUI = new ExtendedNMRScanUI(left);
 		Composite composite = new Composite(right, SWT.NONE);
 		composite.setLayout(new GridLayout(1, false));
@@ -287,7 +287,6 @@ public class ScanEditorNMR implements IScanEditorNMR {
 		DynamicSettingsUI settingsUI = new DynamicSettingsUI(composite, new GridData(SWT.FILL, SWT.FILL, true, false));
 		treeViewer.addSelectionChangedListener(new ISelectionChangedListener() {
 
-			@SuppressWarnings({"rawtypes", "unchecked"})
 			@Override
 			public void selectionChanged(SelectionChangedEvent event) {
 
@@ -296,7 +295,7 @@ public class ScanEditorNMR implements IScanEditorNMR {
 					FilterContext<?, ?> context = ((Filtered<?, ?>)measurement).getFilterContext();
 					Object filteredObject = context.getFilteredObject();
 					if(filteredObject instanceof IComplexSignalMeasurement<?> original) {
-						settingsUI.setActiveContext(context, new UpdatingObserver(context, measurement, original));
+						settingsUI.setActiveContext(context, new UpdatingObserver<>(context, measurement, original));
 						composite.layout();
 						return;
 					}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedHeaderDataUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedHeaderDataUI.java
@@ -271,7 +271,6 @@ public class ExtendedHeaderDataUI extends Composite implements IExtendedPartUI {
 		});
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	private void deleteEntries(Shell shell) {
 
 		MessageBox messageBox = new MessageBox(shell, SWT.ICON_QUESTION | SWT.YES | SWT.NO);
@@ -282,11 +281,12 @@ public class ExtendedHeaderDataUI extends Composite implements IExtendedPartUI {
 			 * Delete
 			 */
 			if(measurementInfo != null) {
-				Iterator iterator = tableViewer.get().getStructuredSelection().iterator();
+				Iterator<?> iterator = tableViewer.get().getStructuredSelection().iterator();
 				Set<String> keysNotRemoved = new HashSet<>();
 				while(iterator.hasNext()) {
 					Object mapObject = iterator.next();
 					if(mapObject instanceof Map.Entry) {
+						@SuppressWarnings("unchecked")
 						Map.Entry<String, String> entry = (Map.Entry<String, String>)mapObject;
 						String key = entry.getKey();
 						try {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanInfoUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanInfoUI.java
@@ -47,7 +47,7 @@ public class ExtendedScanInfoUI extends Composite implements IExtendedPartUI {
 		createControl();
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	public void setInput(Object input) {
 
 		if(input instanceof IChromatogramSelection chromatogramSelection) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/converter/PeakExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/converter/PeakExportConverter.java
@@ -16,22 +16,22 @@ import java.io.File;
 
 import org.eclipse.chemclipse.model.core.IPeaks;
 import org.eclipse.chemclipse.msd.converter.peak.AbstractPeakExportConverter;
+import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 public class PeakExportConverter extends AbstractPeakExportConverter {
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo convert(File file, IPeaks peaks, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IPeaks<? extends IPeakMSD> peaks, boolean append, IProgressMonitor monitor) {
 
 		return getErrorMessage();
 	}
 
-	private IProcessingInfo<?> getErrorMessage() {
+	private IProcessingInfo<File> getErrorMessage() {
 
-		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		processingInfo.addErrorMessage("OCB Peak Writer", "There is no capability to write peaks in *.ocb format.");
 		return processingInfo;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/converter/PeakImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/converter/PeakImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,7 @@ import java.io.IOException;
 import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.model.core.IPeaks;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.peak.AbstractPeakImportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.chemclipse.io.PeakReaderMSD;
@@ -32,14 +33,13 @@ import org.eclipse.core.runtime.IProgressMonitor;
 
 public class PeakImportConverter extends AbstractPeakImportConverter {
 
-	private static final Logger logger = Logger.getLogger(ChromatogramImportConverter.class);
+	private static final Logger logger = Logger.getLogger(PeakImportConverter.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo convert(File file, IProgressMonitor monitor) {
+	public IProcessingInfo<IPeaks<?>> convert(File file, IProgressMonitor monitor) {
 
 		IProcessingMessage processingMessage;
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			super.validate(file);
 			file = SpecificationValidator.validateSpecification(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0701.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0701.java
@@ -13,14 +13,11 @@ package org.eclipse.chemclipse.msd.converter.supplier.chemclipse.internal.io;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.ZipFile;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
@@ -63,12 +60,11 @@ public class PeakReader_0701 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_0701.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0801.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0801.java
@@ -61,12 +61,11 @@ public class PeakReader_0801 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_0801.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0802.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0802.java
@@ -68,12 +68,11 @@ public class PeakReader_0802 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_0802.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
@@ -83,7 +82,6 @@ public class PeakReader_0802 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	
 	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
 		IPeaks<?> peaks = new Peaks();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0803.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0803.java
@@ -13,14 +13,11 @@ package org.eclipse.chemclipse.msd.converter.supplier.chemclipse.internal.io;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.ZipFile;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
@@ -68,12 +65,11 @@ public class PeakReader_0803 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_0803.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
@@ -83,7 +79,6 @@ public class PeakReader_0803 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	
 	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
 		IPeaks<?> peaks = new Peaks();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0901.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0901.java
@@ -68,12 +68,11 @@ public class PeakReader_0901 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_0901.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
@@ -83,7 +82,6 @@ public class PeakReader_0901 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	
 	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
 		IPeaks<?> peaks = new Peaks();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0902.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0902.java
@@ -13,7 +13,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.chemclipse.internal.io;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -21,8 +20,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipFile;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
@@ -70,12 +67,11 @@ public class PeakReader_0902 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_0902.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
@@ -85,7 +81,6 @@ public class PeakReader_0902 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	
 	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
 		IPeaks<?> peaks = new Peaks();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0903.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_0903.java
@@ -13,7 +13,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.chemclipse.internal.io;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -21,8 +20,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipFile;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
@@ -70,12 +67,11 @@ public class PeakReader_0903 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_0903.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
@@ -85,7 +81,6 @@ public class PeakReader_0903 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	
 	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
 		IPeaks<?> peaks = new Peaks();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1001.java
@@ -13,7 +13,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.chemclipse.internal.io;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -21,8 +20,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipFile;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
@@ -70,12 +67,11 @@ public class PeakReader_1001 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_1001.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
@@ -85,7 +81,6 @@ public class PeakReader_1001 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	
 	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
 		IPeaks<?> peaks = new Peaks();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1002.java
@@ -13,7 +13,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.chemclipse.internal.io;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -21,8 +20,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipFile;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
@@ -75,12 +72,11 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_1002.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
@@ -90,7 +86,6 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	
 	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
 		IPeaks<?> peaks = new Peaks();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1003.java
@@ -13,7 +13,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.chemclipse.internal.io;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -21,8 +20,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipFile;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
@@ -75,12 +72,11 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_1003.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
@@ -90,7 +86,6 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	
 	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
 		IPeaks<?> peaks = new Peaks();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1004.java
@@ -13,7 +13,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.chemclipse.internal.io;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -21,8 +20,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipFile;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
@@ -76,12 +73,11 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_1004.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
@@ -91,7 +87,6 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	
 	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
 		IPeaks<?> peaks = new Peaks();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1005.java
@@ -13,7 +13,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.chemclipse.internal.io;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -21,8 +20,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipFile;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
@@ -76,12 +73,11 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_1005.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
@@ -91,7 +87,6 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	
 	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
 		IPeaks<?> peaks = new Peaks();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1006.java
@@ -13,7 +13,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.chemclipse.internal.io;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -21,8 +20,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipFile;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.columns.SeparationColumnFactory;
 import org.eclipse.chemclipse.model.columns.SeparationColumnType;
@@ -77,12 +74,11 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_1006.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
@@ -92,7 +88,6 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	
 	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
 		IPeaks<?> peaks = new Peaks();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1007.java
@@ -13,7 +13,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.chemclipse.internal.io;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -21,8 +20,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipFile;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.columns.SeparationColumnFactory;
 import org.eclipse.chemclipse.model.columns.SeparationColumnType;
@@ -77,12 +74,11 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_1007.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
@@ -92,7 +88,6 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	
 	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
 		IPeaks<?> peaks = new Peaks();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1100.java
@@ -13,7 +13,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.chemclipse.internal.io;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -21,8 +20,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipFile;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.columns.SeparationColumnFactory;
 import org.eclipse.chemclipse.model.columns.SeparationColumnType;
@@ -80,12 +77,11 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_1100.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
@@ -95,7 +91,6 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	
 	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
 		IPeaks<?> peaks = new Peaks();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1300.java
@@ -14,7 +14,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.chemclipse.internal.io;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -22,8 +21,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipFile;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.columns.SeparationColumnFactory;
 import org.eclipse.chemclipse.model.columns.SeparationColumnType;
@@ -82,12 +79,11 @@ public class PeakReader_1300 extends AbstractZipReader implements IPeakReader {
 	private static final String CLASSIFIER_DELIMITER = " ";
 	private static final Logger logger = Logger.getLogger(PeakReader_1300.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
@@ -97,7 +93,6 @@ public class PeakReader_1300 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	
 	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
 		IPeaks<?> peaks = new Peaks();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1301.java
@@ -13,7 +13,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.chemclipse.internal.io;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -21,8 +20,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipFile;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.converter.io.IFileHelper;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.columns.SeparationColumnFactory;
@@ -81,12 +78,11 @@ public class PeakReader_1301 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_1301.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);
@@ -96,7 +92,6 @@ public class PeakReader_1301 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	
 	private IPeaks<?> readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
 
 		IPeaks<?> peaks = new Peaks();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1400.java
@@ -13,7 +13,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.chemclipse.internal.io;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -21,8 +20,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipFile;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.converter.io.IFileHelper;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.columns.SeparationColumnFactory;
@@ -81,12 +78,11 @@ public class PeakReader_1400 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_1400.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/msd/converter/supplier/chemclipse/internal/io/PeakReader_1500.java
@@ -13,7 +13,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.chemclipse.internal.io;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -21,8 +20,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipFile;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.converter.io.IFileHelper;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.columns.SeparationColumnFactory;
@@ -81,12 +78,11 @@ public class PeakReader_1500 extends AbstractZipReader implements IPeakReader {
 
 	private static final Logger logger = Logger.getLogger(PeakReader_1500.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IProcessingInfo<IPeaks<?>> read(File file, IProgressMonitor monitor) throws IOException {
 
 		ZipFile zipFile = new ZipFile(file);
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			IPeaks<?> peaks = readPeaksFromZipFile(zipFile, monitor);
 			processingInfo.setProcessingResult(peaks);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/xxd/converter/supplier/chemclipse/quantitation/DatabaseExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/xxd/converter/supplier/chemclipse/quantitation/DatabaseExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -24,15 +24,14 @@ import org.eclipse.chemclipse.xxd.converter.supplier.chemclipse.internal.quantit
 import org.eclipse.chemclipse.xxd.converter.supplier.chemclipse.internal.quantitation.IDatabaseWriter;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class DatabaseExportConverter<R> extends AbstractQuantDBExportConverter<R> implements IQuantDBExportConverter<R> {
+public class DatabaseExportConverter extends AbstractQuantDBExportConverter<File> implements IQuantDBExportConverter<File> {
 
 	private static final Logger logger = Logger.getLogger(DatabaseExportConverter.class);
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public IProcessingInfo convert(File file, IQuantitationDatabase quantitationDatabase, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IQuantitationDatabase quantitationDatabase, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		try {
 			IDatabaseWriter writer = new DatabaseWriter_1000();
 			writer.convert(file, quantitationDatabase, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/xxd/converter/supplier/chemclipse/quantitation/DatabaseImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/xxd/converter/supplier/chemclipse/quantitation/DatabaseImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -24,15 +24,14 @@ import org.eclipse.chemclipse.xxd.converter.supplier.chemclipse.internal.quantit
 import org.eclipse.chemclipse.xxd.converter.supplier.chemclipse.internal.quantitation.IDatabaseReader;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings({"rawtypes", "unchecked"})
-public class DatabaseImportConverter extends AbstractQuantDBImportConverter implements IQuantDBImportConverter {
+public class DatabaseImportConverter extends AbstractQuantDBImportConverter<IQuantitationDatabase> implements IQuantDBImportConverter<IQuantitationDatabase> {
 
 	private static final Logger logger = Logger.getLogger(DatabaseImportConverter.class);
 
 	@Override
-	public IProcessingInfo convert(File file, IProgressMonitor monitor) {
+	public IProcessingInfo<IQuantitationDatabase> convert(File file, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<IQuantitationDatabase> processingInfo = new ProcessingInfo<>();
 		try {
 			IDatabaseReader reader = new DatabaseReader_1000();
 			IQuantitationDatabase quantitationDatabase = reader.convert(file, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/chart2d/ErrorResidueChart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/chart2d/ErrorResidueChart.java
@@ -126,7 +126,7 @@ public class ErrorResidueChart extends BarChart {
 			primaryAxisSettingsX.setCategorySeries(getCategories(pcaResults));
 			applySettings(chartSettings);
 			//
-			List<IBarSeriesData> barSeriesDataList = new ArrayList<IBarSeriesData>();
+			List<IBarSeriesData> barSeriesDataList = new ArrayList<>();
 			ISeriesData seriesData = getSeries(pcaResults);
 			IBarSeriesData barSeriesData = new BarSeriesData(seriesData);
 			IBarSeriesSettings settings = barSeriesData.getSettings();
@@ -139,10 +139,9 @@ public class ErrorResidueChart extends BarChart {
 		}
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	private String[] getCategories(IResultsPCA pcaResults) {
+	private String[] getCategories(IResultsPCA<? extends IResultPCA, ?> pcaResults) {
 
-		List<IResultPCA> pcaResultList = pcaResults.getPcaResultList();
+		List<? extends IResultPCA> pcaResultList = pcaResults.getPcaResultList();
 		int size = pcaResultList.size();
 		String[] categories = new String[size];
 		//
@@ -154,10 +153,9 @@ public class ErrorResidueChart extends BarChart {
 		return categories;
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	private ISeriesData getSeries(IResultsPCA pcaResults) {
+	private ISeriesData getSeries(IResultsPCA<? extends IResultPCA, ?> pcaResults) {
 
-		List<IResultPCA> pcaResultList = pcaResults.getPcaResultList();
+		List<? extends IResultPCA> pcaResultList = pcaResults.getPcaResultList();
 		int size = pcaResultList.size();
 		double[] xSeries = new double[size];
 		double[] ySeries = new double[size];


### PR DESCRIPTION
This is a followup to https://github.com/eclipse/chemclipse/pull/1408 which still does not solve the whole problem, but reduces the warnings further.