### PR TITLE
Removed generics from export converters

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/quantitation/AbstractQuantDBExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/quantitation/AbstractQuantDBExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -13,5 +13,5 @@ package org.eclipse.chemclipse.converter.quantitation;
 
 import org.eclipse.chemclipse.converter.core.AbstractExportConverter;
 
-public abstract class AbstractQuantDBExportConverter<R> extends AbstractExportConverter implements IQuantDBExportConverter<R> {
+public abstract class AbstractQuantDBExportConverter extends AbstractExportConverter implements IQuantDBExportConverter {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/quantitation/IQuantDBExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/quantitation/IQuantDBExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -18,7 +18,7 @@ import org.eclipse.chemclipse.model.quantitation.IQuantitationDatabase;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public interface IQuantDBExportConverter<R> extends IExportConverter {
+public interface IQuantDBExportConverter extends IExportConverter {
 
-	IProcessingInfo<R> convert(File file, IQuantitationDatabase quantitationDatabase, IProgressMonitor monitor);
+	IProcessingInfo<File> convert(File file, IQuantitationDatabase quantitationDatabase, IProgressMonitor monitor);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/quantitation/QuantDBConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/quantitation/QuantDBConverter.java
@@ -87,14 +87,14 @@ public class QuantDBConverter {
 		return processingInfo;
 	}
 
-	public static <R> IProcessingInfo<R> convert(File file, IQuantitationDatabase quantitationDatabase, String converterId, IProgressMonitor monitor) {
+	public static IProcessingInfo<File> convert(File file, IQuantitationDatabase quantitationDatabase, String converterId, IProgressMonitor monitor) {
 
-		IProcessingInfo<R> processingInfo = null;
+		IProcessingInfo<File> processingInfo = null;
 		QuantDBConverterSupport converterSupport = getQuantDBConverterSupport();
 		exitloop:
 		for(ISupplier supplier : converterSupport.getSupplier()) {
 			if(supplier.isExportable() && supplier.getId().equals(converterId)) {
-				IQuantDBExportConverter<R> exportConverter = getExportConverter(converterId);
+				IQuantDBExportConverter exportConverter = getExportConverter(converterId);
 				processingInfo = exportConverter.convert(file, quantitationDatabase, monitor);
 				break exitloop;
 			}
@@ -123,15 +123,14 @@ public class QuantDBConverter {
 		return instance;
 	}
 
-	@SuppressWarnings("unchecked")
-	private static <R> IQuantDBExportConverter<R> getExportConverter(final String converterId) {
+	private static IQuantDBExportConverter getExportConverter(final String converterId) {
 
 		IConfigurationElement element;
 		element = getConfigurationElement(converterId);
-		IQuantDBExportConverter<R> instance = null;
+		IQuantDBExportConverter instance = null;
 		if(element != null) {
 			try {
-				instance = (IQuantDBExportConverter<R>)element.createExecutableExtension(EXPORT_CONVERTER);
+				instance = (IQuantDBExportConverter)element.createExecutableExtension(EXPORT_CONVERTER);
 			} catch(CoreException e) {
 				logger.error(e);
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUPeakExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUPeakExportConverter.java
@@ -16,22 +16,17 @@ import java.io.File;
 
 import org.eclipse.chemclipse.model.core.IPeaks;
 import org.eclipse.chemclipse.msd.converter.peak.AbstractPeakExportConverter;
+import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings({"rawtypes"})
 public class ELUPeakExportConverter extends AbstractPeakExportConverter {
 
 	@Override
-	public IProcessingInfo<IPeaks> convert(File file, IPeaks peaks, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IPeaks<? extends IPeakMSD> peaks, boolean append, IProgressMonitor monitor) {
 
-		return getNoSupportMessage();
-	}
-
-	private IProcessingInfo<IPeaks> getNoSupportMessage() {
-
-		IProcessingInfo<IPeaks> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		processingInfo.addErrorMessage("ELU Peak Export", "There are no capabilities to export peaks in ELU format.");
 		return processingInfo;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUPeakImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUPeakImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -39,7 +39,7 @@ public class ELUPeakImportConverter extends AbstractPeakImportConverter {
 	public IProcessingInfo<IPeaks<?>> convert(File file, IProgressMonitor monitor) {
 
 		IProcessingMessage processingMessage;
-		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<IPeaks<?>>();
+		IProcessingInfo<IPeaks<?>> processingInfo = new ProcessingInfo<>();
 		try {
 			super.validate(file);
 			file = SpecificationValidatorELU.validateSpecification(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.csv/src/org/eclipse/chemclipse/msd/converter/supplier/csv/core/ChromatogramImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.csv/src/org/eclipse/chemclipse/msd/converter/supplier/csv/core/ChromatogramImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Lablicate GmbH.
+ * Copyright (c) 2011, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -13,6 +13,7 @@
 package org.eclipse.chemclipse.msd.converter.supplier.csv.core;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.eclipse.chemclipse.converter.chromatogram.AbstractChromatogramImportConverter;
 import org.eclipse.chemclipse.logging.core.Logger;
@@ -39,9 +40,13 @@ public class ChromatogramImportConverter extends AbstractChromatogramImportConve
 					IChromatogramMSD chromatogram = reader.read(file, monitor);
 					processingInfo.setProcessingResult(chromatogram);
 				}
-			} catch(Exception e) {
+			} catch(InterruptedException e) {
 				logger.warn(e);
-				processingInfo.addErrorMessage(DESCRIPTION, "Something has definitely gone wrong with the file: " + file.getAbsolutePath());
+				Thread.currentThread().interrupt();
+				processingInfo.addErrorMessage(DESCRIPTION, "Failed to convert: " + file.getAbsolutePath());
+			} catch(IOException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, "Failed to convert: " + file.getAbsolutePath());
 			}
 		}
 		return processingInfo;
@@ -58,7 +63,7 @@ public class ChromatogramImportConverter extends AbstractChromatogramImportConve
 					IChromatogramOverview chromatogramOverview = reader.readOverview(file, monitor);
 					processingInfo.setProcessingResult(chromatogramOverview);
 				}
-			} catch(Exception e) {
+			} catch(IOException e) {
 				logger.warn(e);
 				processingInfo.addErrorMessage(DESCRIPTION, "Something has definitely gone wrong with the file: " + file.getAbsolutePath());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.csv/src/org/eclipse/chemclipse/msd/converter/supplier/csv/io/core/CSVPeakConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.csv/src/org/eclipse/chemclipse/msd/converter/supplier/csv/io/core/CSVPeakConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Lablicate GmbH.
+ * Copyright (c) 2020, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -96,14 +96,14 @@ public class CSVPeakConverter implements IPeakExportConverter, IPeakImportConver
 
 	// export
 	@Override
-	public IProcessingInfo<?> convert(File file, IPeaks<? extends IPeakMSD> peaks, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IPeaks<? extends IPeakMSD> peaks, boolean append, IProgressMonitor monitor) {
 
 		try {
 			try (FileOutputStream stream = new FileOutputStream(file, append)) {
 				writePeaks(peaks, new OutputStreamWriter(stream, CHARSET), !append);
 			}
 		} catch(IOException e) {
-			ProcessingInfo<Object> error = new ProcessingInfo<>();
+			ProcessingInfo<File> error = new ProcessingInfo<>();
 			error.addErrorMessage(NAME, "Export to CSV failed", e);
 			return error;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/converter/MassSpectrumExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/converter/MassSpectrumExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -25,20 +25,17 @@ public class MassSpectrumExportConverter extends AbstractMassSpectrumExportConve
 	private static final String DESCRIPTION = "mMass .msd Mass Spectra Export Converter";
 
 	@Override
-	public IProcessingInfo<IMassSpectra> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
 
-		return getProcessingInfo();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
+		processingInfo.addErrorMessage(DESCRIPTION, "It's not possible to export mass spectra as mMass .msd yet.");
+		return processingInfo;
 	}
 
 	@Override
-	public IProcessingInfo<IMassSpectra> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
 
-		return getProcessingInfo();
-	}
-
-	private IProcessingInfo<IMassSpectra> getProcessingInfo() {
-
-		IProcessingInfo<IMassSpectra> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		processingInfo.addErrorMessage(DESCRIPTION, "It's not possible to export mass spectra as mMass .msd yet.");
 		return processingInfo;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/MassSpectrumExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/MassSpectrumExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -26,20 +26,17 @@ public class MassSpectrumExportConverter extends AbstractMassSpectrumExportConve
 	private static final String DESCRIPTION = "mzXML Mass Spectra Export Converter";
 
 	@Override
-	public IProcessingInfo<IMassSpectra> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
 
-		return getProcessingInfo();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
+		processingInfo.addErrorMessage(DESCRIPTION, "It's not possible to export mass spectrum data as mzXML yet.");
+		return processingInfo;
 	}
 
 	@Override
-	public IProcessingInfo<IMassSpectra> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
 
-		return getProcessingInfo();
-	}
-
-	private IProcessingInfo<IMassSpectra> getProcessingInfo() {
-
-		IProcessingInfo<IMassSpectra> processingInfo = new ProcessingInfo<IMassSpectra>();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		processingInfo.addErrorMessage(DESCRIPTION, "It's not possible to export mass spectrum data as mzXML yet.");
 		return processingInfo;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Lablicate GmbH.
+ * Copyright (c) 2021, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -25,20 +25,17 @@ public class MassSpectrumExportConverter extends AbstractMassSpectrumExportConve
 	private static final String DESCRIPTION = "mzML Mass Spectra Export Converter";
 
 	@Override
-	public IProcessingInfo<IMassSpectra> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
 
-		return getProcessingInfo();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
+		processingInfo.addErrorMessage(DESCRIPTION, "It's not possible to export mass spectrum data as mzML yet.");
+		return processingInfo;
 	}
 
 	@Override
-	public IProcessingInfo<IMassSpectra> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
 
-		return getProcessingInfo();
-	}
-
-	private IProcessingInfo<IMassSpectra> getProcessingInfo() {
-
-		IProcessingInfo<IMassSpectra> processingInfo = new ProcessingInfo<IMassSpectra>();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		processingInfo.addErrorMessage(DESCRIPTION, "It's not possible to export mass spectrum data as mzML yet.");
 		return processingInfo;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -26,20 +26,17 @@ public class MassSpectrumExportConverter extends AbstractMassSpectrumExportConve
 	private static final String DESCRIPTION = "mzXML Mass Spectra Export Converter";
 
 	@Override
-	public IProcessingInfo<IMassSpectra> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
 
-		return getProcessingInfo();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
+		processingInfo.addErrorMessage(DESCRIPTION, "It's not possible to export mass spectrum data as mzXML yet.");
+		return processingInfo;
 	}
 
 	@Override
-	public IProcessingInfo<IMassSpectra> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
 
-		return getProcessingInfo();
-	}
-
-	private IProcessingInfo<IMassSpectra> getProcessingInfo() {
-
-		IProcessingInfo<IMassSpectra> processingInfo = new ProcessingInfo<IMassSpectra>();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		processingInfo.addErrorMessage(DESCRIPTION, "It's not possible to export mass spectrum data as mzXML yet.");
 		return processingInfo;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/massspectrum/AbstractMassSpectrumExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/massspectrum/AbstractMassSpectrumExportConverter.java
@@ -20,13 +20,12 @@ import org.eclipse.chemclipse.processing.core.MessageType;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingMessage;
 
-@SuppressWarnings("rawtypes") // TODO this can't both be IScanMSD and IMassSpectra so the generic approach is likely false
 public abstract class AbstractMassSpectrumExportConverter extends AbstractExportConverter implements IMassSpectrumExportConverter {
 
 	@Override
-	public IProcessingInfo<?> validate(IScanMSD massSpectrum) {
+	public IProcessingInfo<IScanMSD> validate(IScanMSD massSpectrum) {
 
-		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<IScanMSD> processingInfo = new ProcessingInfo<>();
 		if(massSpectrum == null) {
 			IProcessingMessage processingMessage = new ProcessingMessage(MessageType.ERROR, "Mass Spectra Export", "The is no mass spectrum to export.");
 			processingInfo.addMessage(processingMessage);
@@ -35,9 +34,9 @@ public abstract class AbstractMassSpectrumExportConverter extends AbstractExport
 	}
 
 	@Override
-	public IProcessingInfo<?> validate(IMassSpectra massSpectra) {
+	public IProcessingInfo<IMassSpectra> validate(IMassSpectra massSpectra) {
 
-		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<IMassSpectra> processingInfo = new ProcessingInfo<>();
 		if(massSpectra == null) {
 			IProcessingMessage processingMessage = new ProcessingMessage(MessageType.ERROR, "Mass Spectra Export", "The are no mass spectra to export.");
 			processingInfo.addMessage(processingMessage);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/massspectrum/IMassSpectrumExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/massspectrum/IMassSpectrumExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -23,7 +23,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 /**
  * @author eselmeister
  */
-public interface IMassSpectrumExportConverter<T> extends IExportConverter {
+public interface IMassSpectrumExportConverter extends IExportConverter {
 
 	/**
 	 * Exports the mass spectrum to the given file.
@@ -34,7 +34,7 @@ public interface IMassSpectrumExportConverter<T> extends IExportConverter {
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	IProcessingInfo<T> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor);
+	IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor);
 
 	/**
 	 * Exports the mass spectra to the given file.
@@ -45,7 +45,7 @@ public interface IMassSpectrumExportConverter<T> extends IExportConverter {
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	IProcessingInfo<T> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor);
+	IProcessingInfo<File> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor);
 
 	/**
 	 * Checks the mass spectrum instance and throws an exception if the mass
@@ -54,7 +54,7 @@ public interface IMassSpectrumExportConverter<T> extends IExportConverter {
 	 * @param massSpectrum
 	 * @return {@link IProcessingInfo}
 	 */
-	IProcessingInfo<T> validate(IScanMSD massSpectrum);
+	IProcessingInfo<IScanMSD> validate(IScanMSD massSpectrum);
 
 	/**
 	 * Checks the mass spectra instance and throws an exception if the mass
@@ -63,5 +63,5 @@ public interface IMassSpectrumExportConverter<T> extends IExportConverter {
 	 * @param massSpectrum
 	 * @return {@link IProcessingInfo}
 	 */
-	IProcessingInfo<T> validate(IMassSpectra massSpectra);
+	IProcessingInfo<IMassSpectra> validate(IMassSpectra massSpectra);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/massspectrum/MassSpectrumConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/massspectrum/MassSpectrumConverter.java
@@ -71,9 +71,8 @@ public class MassSpectrumConverter {
 		IMassSpectrumImportConverter importConverter = getMassSpectrumImportConverter(converterId);
 		if(importConverter != null) {
 			return importConverter.convert(file, monitor);
-		} else {
-			return getNoImportConverterAvailableProcessingInfo(file);
 		}
+		return getNoImportConverterAvailableProcessingInfo(file);
 	}
 
 	/**
@@ -152,13 +151,13 @@ public class MassSpectrumConverter {
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	public static <T> IProcessingInfo<T> convert(File file, IScanMSD massSpectrum, boolean append, String converterId, IProgressMonitor monitor) {
+	public static IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, String converterId, IProgressMonitor monitor) {
 
-		IProcessingInfo<T> processingInfo;
+		IProcessingInfo<File> processingInfo;
 		/*
 		 * Do not use a safe runnable here.
 		 */
-		IMassSpectrumExportConverter<T> exportConverter = getMassSpectrumExportConverter(converterId);
+		IMassSpectrumExportConverter exportConverter = getMassSpectrumExportConverter(converterId);
 		if(exportConverter != null) {
 			processingInfo = exportConverter.convert(file, massSpectrum, append, monitor);
 		} else {
@@ -177,13 +176,13 @@ public class MassSpectrumConverter {
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	public static <T> IProcessingInfo<T> convert(File file, IMassSpectra massSpectra, boolean append, String converterId, IProgressMonitor monitor) {
+	public static IProcessingInfo<File> convert(File file, IMassSpectra massSpectra, boolean append, String converterId, IProgressMonitor monitor) {
 
-		IProcessingInfo<T> processingInfo;
+		IProcessingInfo<File> processingInfo;
 		/*
 		 * Do not use a safe runnable here.
 		 */
-		IMassSpectrumExportConverter<T> exportConverter = getMassSpectrumExportConverter(converterId);
+		IMassSpectrumExportConverter exportConverter = getMassSpectrumExportConverter(converterId);
 		if(exportConverter != null) {
 			processingInfo = exportConverter.convert(file, massSpectra, append, monitor);
 		} else {
@@ -223,15 +222,14 @@ public class MassSpectrumConverter {
 	 * @param converterId
 	 * @return IMassSpectrumExportConverter
 	 */
-	@SuppressWarnings("unchecked")
-	private static <T> IMassSpectrumExportConverter<T> getMassSpectrumExportConverter(final String converterId) {
+	private static IMassSpectrumExportConverter getMassSpectrumExportConverter(final String converterId) {
 
 		IConfigurationElement element;
 		element = getConfigurationElement(converterId);
-		IMassSpectrumExportConverter<T> instance = null;
+		IMassSpectrumExportConverter instance = null;
 		if(element != null) {
 			try {
-				instance = (IMassSpectrumExportConverter<T>)element.createExecutableExtension(Converter.EXPORT_CONVERTER);
+				instance = (IMassSpectrumExportConverter)element.createExecutableExtension(Converter.EXPORT_CONVERTER);
 			} catch(CoreException e) {
 				logger.error(e);
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/peak/IPeakExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/peak/IPeakExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Lablicate GmbH.
+ * Copyright (c) 2011, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -31,5 +31,5 @@ public interface IPeakExportConverter extends IExportConverter {
 	 * @param monitor
 	 * @return IProcessingInfo
 	 */
-	IProcessingInfo<?> convert(File file, IPeaks<? extends IPeakMSD> peaks, boolean append, IProgressMonitor monitor);
+	IProcessingInfo<File> convert(File file, IPeaks<? extends IPeakMSD> peaks, boolean append, IProgressMonitor monitor);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.tsd.converter/src/org/eclipse/chemclipse/tsd/converter/core/IExportConverterTSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.tsd.converter/src/org/eclipse/chemclipse/tsd/converter/core/IExportConverterTSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Lablicate GmbH.
+ * Copyright (c) 2021, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.tsd.converter.core;
 
+import java.io.File;
 import java.io.OutputStream;
 
 import org.eclipse.chemclipse.converter.chromatogram.IChromatogramExportConverter;
@@ -21,5 +22,5 @@ import org.eclipse.core.runtime.IProgressMonitor;
 
 public interface IExportConverterTSD extends IChromatogramExportConverter {
 
-	IProcessingInfo<?> convert(OutputStream outputStream, IChromatogram<? extends IPeak> chromatogram, IProgressMonitor monitor);
+	IProcessingInfo<File> convert(OutputStream outputStream, IChromatogram<? extends IPeak> chromatogram, IProgressMonitor monitor);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanInfoUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanInfoUI.java
@@ -47,7 +47,7 @@ public class ExtendedScanInfoUI extends Composite implements IExtendedPartUI {
 		createControl();
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	public void setInput(Object input) {
 
 		if(input instanceof IChromatogramSelection chromatogramSelection) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xir.converter/src/org/eclipse/chemclipse/xir/converter/chromatogram/IExportConverterISD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xir.converter/src/org/eclipse/chemclipse/xir/converter/chromatogram/IExportConverterISD.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xir.converter.chromatogram;
 
+import java.io.File;
 import java.io.OutputStream;
 
 import org.eclipse.chemclipse.converter.chromatogram.IChromatogramExportConverter;
@@ -21,5 +22,5 @@ import org.eclipse.core.runtime.IProgressMonitor;
 
 public interface IExportConverterISD extends IChromatogramExportConverter {
 
-	IProcessingInfo<?> convert(OutputStream outputStream, IChromatogram<? extends IPeak> chromatogram, IProgressMonitor monitor);
+	IProcessingInfo<File> convert(OutputStream outputStream, IChromatogram<? extends IPeak> chromatogram, IProgressMonitor monitor);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xir.converter/src/org/eclipse/chemclipse/xir/converter/core/AbstractScanExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xir.converter/src/org/eclipse/chemclipse/xir/converter/core/AbstractScanExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -13,6 +13,5 @@ package org.eclipse.chemclipse.xir.converter.core;
 
 import org.eclipse.chemclipse.converter.core.AbstractExportConverter;
 
-@SuppressWarnings("rawtypes")
 public abstract class AbstractScanExportConverter extends AbstractExportConverter implements IScanExportConverter {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xir.converter/src/org/eclipse/chemclipse/xir/converter/core/IScanExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xir.converter/src/org/eclipse/chemclipse/xir/converter/core/IScanExportConverter.java
@@ -19,7 +19,7 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xir.model.core.ISpectrumXIR;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public interface IScanExportConverter<T> extends IExportConverter {
+public interface IScanExportConverter extends IExportConverter {
 
-	IProcessingInfo<T> convert(File file, ISpectrumXIR scan, IProgressMonitor monitor);
+	IProcessingInfo<File> convert(File file, ISpectrumXIR scan, IProgressMonitor monitor);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xir.converter/src/org/eclipse/chemclipse/xir/converter/core/ScanConverterXIR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xir.converter/src/org/eclipse/chemclipse/xir/converter/core/ScanConverterXIR.java
@@ -56,14 +56,14 @@ public class ScanConverterXIR {
 		if(importConverter != null) {
 			processingInfo = importConverter.convert(file, monitor);
 		} else {
-			processingInfo = getProcessingError(file);
+			processingInfo = getImportProcessingError(file);
 		}
 		return processingInfo;
 	}
 
 	public static IProcessingInfo<ISpectrumXIR> convert(final File file, final IProgressMonitor monitor) {
 
-		return getScan(file, false, monitor);
+		return getScan(file, monitor);
 	}
 
 	/**
@@ -74,7 +74,7 @@ public class ScanConverterXIR {
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	private static IProcessingInfo<ISpectrumXIR> getScan(final File file, boolean overview, IProgressMonitor monitor) {
+	private static IProcessingInfo<ISpectrumXIR> getScan(final File file, IProgressMonitor monitor) {
 
 		IProcessingInfo<ISpectrumXIR> processingInfo;
 		IScanConverterSupport converterSupport = getScanConverterSupport();
@@ -97,21 +97,21 @@ public class ScanConverterXIR {
 		} catch(NoConverterAvailableException e) {
 			logger.info(e);
 		}
-		return getProcessingError(file);
+		return getImportProcessingError(file);
 	}
 
-	public static IProcessingInfo<ISpectrumXIR> convert(final File file, final ISpectrumXIR scan, final String converterId, final IProgressMonitor monitor) {
+	public static IProcessingInfo<File> convert(final File file, final ISpectrumXIR scan, final String converterId, final IProgressMonitor monitor) {
 
-		IProcessingInfo<ISpectrumXIR> processingInfo;
+		IProcessingInfo<File> processingInfo;
 		/*
 		 * Do not use a safe runnable here, because an object must
 		 * be returned or null.
 		 */
-		IScanExportConverter<ISpectrumXIR> exportConverter = getScanExportConverter(converterId);
+		IScanExportConverter exportConverter = getScanExportConverter(converterId);
 		if(exportConverter != null) {
 			processingInfo = exportConverter.convert(file, scan, monitor);
 		} else {
-			processingInfo = getProcessingError(file);
+			processingInfo = getExportProcessingError(file);
 		}
 		return processingInfo;
 	}
@@ -132,15 +132,14 @@ public class ScanConverterXIR {
 		return instance;
 	}
 
-	@SuppressWarnings("unchecked")
-	private static IScanExportConverter<ISpectrumXIR> getScanExportConverter(final String converterId) {
+	private static IScanExportConverter getScanExportConverter(final String converterId) {
 
 		IConfigurationElement element;
 		element = getConfigurationElement(converterId);
-		IScanExportConverter<ISpectrumXIR> instance = null;
+		IScanExportConverter instance = null;
 		if(element != null) {
 			try {
-				instance = (IScanExportConverter<ISpectrumXIR>)element.createExecutableExtension(Converter.EXPORT_CONVERTER);
+				instance = (IScanExportConverter)element.createExecutableExtension(Converter.EXPORT_CONVERTER);
 			} catch(CoreException e) {
 				logger.error(e);
 			}
@@ -209,10 +208,17 @@ public class ScanConverterXIR {
 		return magicNumberMatcher;
 	}
 
-	private static <T> IProcessingInfo<T> getProcessingError(File file) {
+	private static IProcessingInfo<File> getExportProcessingError(File file) {
 
-		IProcessingInfo<T> processingInfo = new ProcessingInfo<>();
-		processingInfo.addErrorMessage("Scan Converter", "No suitable converter was found for: " + file);
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
+		processingInfo.addErrorMessage("Scan Converter", "No suitable export converter was found for: " + file);
+		return processingInfo;
+	}
+
+	private static IProcessingInfo<ISpectrumXIR> getImportProcessingError(File file) {
+
+		IProcessingInfo<ISpectrumXIR> processingInfo = new ProcessingInfo<>();
+		processingInfo.addErrorMessage("Scan Converter", "No suitable import converter was found for: " + file);
 		return processingInfo;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ascii/src/org/eclipse/chemclipse/msd/converter/supplier/ascii/core/MassSpectrumExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ascii/src/org/eclipse/chemclipse/msd/converter/supplier/ascii/core/MassSpectrumExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -23,20 +23,17 @@ import org.eclipse.core.runtime.IProgressMonitor;
 public class MassSpectrumExportConverter extends AbstractMassSpectrumExportConverter {
 
 	@Override
-	public IProcessingInfo<?> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
 
-		return getProcessingInfo();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
+		processingInfo.addErrorMessage("ASCII Library", "The ASCII converter has no capabilities to export a library.");
+		return processingInfo;
 	}
 
 	@Override
-	public IProcessingInfo<?> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
 
-		return getProcessingInfo();
-	}
-
-	private IProcessingInfo<?> getProcessingInfo() {
-
-		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		processingInfo.addErrorMessage("ASCII Library", "The ASCII converter has no capabilities to export a library.");
 		return processingInfo;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/csd/converter/supplier/chemclipse/converter/ChromatogramImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/csd/converter/supplier/chemclipse/converter/ChromatogramImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -46,11 +46,10 @@ public class ChromatogramImportConverter extends AbstractChromatogramImportConve
 		return processingInfo;
 	}
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Override
-	public IProcessingInfo convertOverview(File file, IProgressMonitor monitor) {
+	public IProcessingInfo<IChromatogramOverview> convertOverview(File file, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = super.validate(file);
+		IProcessingInfo<IChromatogramOverview> processingInfo = super.validate(file);
 		if(!processingInfo.hasErrorMessages()) {
 			file = SpecificationValidator.validateSpecification(file);
 			IChromatogramCSDReader reader = new ChromatogramReaderCSD();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/xxd/converter/supplier/chemclipse/quantitation/DatabaseExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.chemclipse/src/org/eclipse/chemclipse/xxd/converter/supplier/chemclipse/quantitation/DatabaseExportConverter.java
@@ -24,7 +24,7 @@ import org.eclipse.chemclipse.xxd.converter.supplier.chemclipse.internal.quantit
 import org.eclipse.chemclipse.xxd.converter.supplier.chemclipse.internal.quantitation.IDatabaseWriter;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class DatabaseExportConverter extends AbstractQuantDBExportConverter<File> implements IQuantDBExportConverter<File> {
+public class DatabaseExportConverter extends AbstractQuantDBExportConverter implements IQuantDBExportConverter {
 
 	private static final Logger logger = Logger.getLogger(DatabaseExportConverter.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/converter/ChromatogramImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/converter/ChromatogramImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 Lablicate GmbH.
+ * Copyright (c) 2013, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@
 package org.eclipse.chemclipse.msd.converter.supplier.jcampdx.converter;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.eclipse.chemclipse.converter.chromatogram.AbstractChromatogramImportConverter;
 import org.eclipse.chemclipse.converter.support.IConstants;
@@ -44,9 +45,13 @@ public class ChromatogramImportConverter extends AbstractChromatogramImportConve
 			try {
 				IChromatogramMSD chromatogram = reader.read(file, monitor);
 				processingInfo.setProcessingResult(chromatogram);
-			} catch(Exception e) {
+			} catch(IOException e) {
 				logger.warn(e);
-				processingInfo.addErrorMessage(DESCRIPTION, "Something has definitely gone wrong with the file: " + file.getAbsolutePath());
+				processingInfo.addErrorMessage(DESCRIPTION, "Failed to convert file: " + file.getAbsolutePath());
+			} catch(InterruptedException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, "Failed to convert file: " + file.getAbsolutePath());
+				Thread.currentThread().interrupt();
 			}
 		}
 		return processingInfo;
@@ -63,7 +68,7 @@ public class ChromatogramImportConverter extends AbstractChromatogramImportConve
 			try {
 				IChromatogramOverview chromatogramOverview = reader.readOverview(file, monitor);
 				processingInfo.setProcessingResult(chromatogramOverview);
-			} catch(Exception e) {
+			} catch(IOException e) {
 				logger.warn(e);
 				processingInfo.addErrorMessage(DESCRIPTION, "Something has definitely gone wrong with the file: " + file.getAbsolutePath());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/xir/converter/supplier/jcampdx/converter/ScanExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/xir/converter/supplier/jcampdx/converter/ScanExportConverter.java
@@ -20,13 +20,12 @@ import org.eclipse.chemclipse.xir.converter.core.IScanExportConverter;
 import org.eclipse.chemclipse.xir.model.core.ISpectrumXIR;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ScanExportConverter extends AbstractScanExportConverter implements IScanExportConverter {
 
 	@Override
-	public IProcessingInfo<?> convert(File file, ISpectrumXIR scan, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, ISpectrumXIR scan, IProgressMonitor monitor) {
 
-		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		processingInfo.addInfoMessage("FTIR", "Export is not available");
 		return processingInfo;
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/src/org/eclipse/chemclipse/msd/converter/massspectrum/TestMassSpectrumExportConverter.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/src/org/eclipse/chemclipse/msd/converter/massspectrum/TestMassSpectrumExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -29,9 +29,9 @@ import org.eclipse.core.runtime.IProgressMonitor;
 public class TestMassSpectrumExportConverter extends AbstractMassSpectrumExportConverter {
 
 	@Override
-	public IProcessingInfo<?> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
 
-		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		try {
 			processingInfo.addMessages(super.validate(file));
 			processingInfo.addMessages(super.validate(massSpectrum));
@@ -43,9 +43,9 @@ public class TestMassSpectrumExportConverter extends AbstractMassSpectrumExportC
 	}
 
 	@Override
-	public IProcessingInfo<?> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
+	public IProcessingInfo<File> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
 
-		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		try {
 			processingInfo.addMessages(super.validate(file));
 			processingInfo.addMessages(super.validate(massSpectra));


### PR DESCRIPTION
This is a followup to https://github.com/eclipse/chemclipse/pull/1408 essentially another part where the incomplete approach to introducing generics only led to confusion and wrong types being used. Export converter result types are always files, so it was needlessly generic.