### PR TITLE
Added support for multiple Target Identifiers

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.chemclipse.chromatogram.msd.identifier
 Eclipse-BuddyPolicy: registered
 Export-Package: org.eclipse.chemclipse.chromatogram.xxd.identifier.chromatogram,
  org.eclipse.chemclipse.chromatogram.xxd.identifier.settings,
- org.eclipse.chemclipse.chromatogram.xxd.identifier.target
+ org.eclipse.chemclipse.chromatogram.xxd.identifier.targets
 Bundle-ManifestVersion: 2
 Bundle-Name: Identifier Plug-in
 Bundle-SymbolicName: org.eclipse.chemclipse.chromatogram.xxd.identifier;singleton:=true

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/targets/ITargetIdentifierSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/targets/ITargetIdentifierSupplier.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Lablicate GmbH.
+ *
+ * All rights reserved. This
+ * program and the accompanying materials are made available under the terms of
+ * the Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.xxd.identifier.targets;
+
+import java.net.URL;
+
+import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
+import org.eclipse.chemclipse.model.identifier.core.ISupplier;
+
+public interface ITargetIdentifierSupplier extends ISupplier {
+
+	URL getURL(ILibraryInformation libraryInformation);
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/targets/ITargetIdentifierSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/targets/ITargetIdentifierSupport.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Lablicate GmbH.
+ *
+ * All rights reserved. This
+ * program and the accompanying materials are made available under the terms of
+ * the Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.xxd.identifier.targets;
+
+import java.util.Collection;
+
+import org.eclipse.chemclipse.model.exceptions.NoIdentifierAvailableException;
+import org.eclipse.chemclipse.model.identifier.core.ISupport;
+
+public interface ITargetIdentifierSupport extends ISupport {
+
+	@Override
+	ITargetIdentifierSupplier getIdentifierSupplier(String identifierId) throws NoIdentifierAvailableException;
+
+	Collection<ITargetIdentifierSupplier> getSuppliers();
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/targets/TargetIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/targets/TargetIdentifier.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Lablicate GmbH.
+ * 
+ * All rights reserved. This
+ * program and the accompanying materials are made available under the terms of
+ * the Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.xxd.identifier.targets;
+
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.core.runtime.Platform;
+
+public class TargetIdentifier {
+
+	private static final Logger logger = Logger.getLogger(TargetIdentifier.class);
+	//
+	private static final String EXTENSION_POINT = "org.eclipse.chemclipse.chromatogram.xxd.identifier.targetIdentifier";
+
+	private TargetIdentifier() {
+
+	}
+
+	public static ITargetIdentifierSupport getTargetIdentifierSupport() {
+
+		TargetIdentifierSupport identifierSupport = new TargetIdentifierSupport();
+		IExtensionRegistry registry = Platform.getExtensionRegistry();
+		IConfigurationElement[] extensions = registry.getConfigurationElementsFor(EXTENSION_POINT);
+		try {
+			for(IConfigurationElement element : extensions) {
+				Object object = element.createExecutableExtension("targetURL");
+				if(object instanceof ITargetIdentifierSupplier identifier) {
+					identifierSupport.add(identifier);
+				}
+			}
+		} catch(CoreException e) {
+			logger.warn(e);
+		}
+		return identifierSupport;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/targets/TargetIdentifierSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/targets/TargetIdentifierSupport.java
@@ -9,14 +9,16 @@
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
-package org.eclipse.chemclipse.chromatogram.xxd.identifier.target;
+package org.eclipse.chemclipse.chromatogram.xxd.identifier.targets;
 
-import java.net.URL;
+import org.eclipse.chemclipse.model.exceptions.NoIdentifierAvailableException;
+import org.eclipse.chemclipse.model.identifier.core.AbstractSupport;
 
-import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
-import org.eclipse.chemclipse.model.identifier.core.ISupplier;
+public class TargetIdentifierSupport extends AbstractSupport<ITargetIdentifierSupplier> implements ITargetIdentifierSupport {
 
-public interface ITargetIdentifierSupplier extends ISupplier {
+	@Override
+	public ITargetIdentifierSupplier getIdentifierSupplier(String identifierId) throws NoIdentifierAvailableException {
 
-	URL getURL(ILibraryInformation libraryInformation);
+		return getSpecificIdentifierSupplier(identifierId);
+	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/core/AbstractSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/core/AbstractSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -25,6 +25,7 @@ public abstract class AbstractSupport<S extends ISupplier> implements ISupport {
 	private final List<S> suppliers;
 
 	public AbstractSupport() {
+
 		suppliers = new ArrayList<>();
 	}
 
@@ -41,7 +42,7 @@ public abstract class AbstractSupport<S extends ISupplier> implements ISupport {
 	 */
 	private void areIdentifiersStored() throws NoIdentifierAvailableException {
 
-		if(suppliers.size() < 1) {
+		if(suppliers.isEmpty()) {
 			throw new NoIdentifierAvailableException();
 		}
 	}
@@ -54,7 +55,7 @@ public abstract class AbstractSupport<S extends ISupplier> implements ISupport {
 		 * Test if the suppliers ArrayList is empty.
 		 */
 		areIdentifiersStored();
-		List<String> availableIdentifiers = new ArrayList<String>();
+		List<String> availableIdentifiers = new ArrayList<>();
 		for(S supplier : suppliers) {
 			availableIdentifiers.add(supplier.getId());
 		}
@@ -92,7 +93,7 @@ public abstract class AbstractSupport<S extends ISupplier> implements ISupport {
 		 * If the ArrayList is not empty, return the registered identifier
 		 * names.<br/>
 		 */
-		ArrayList<String> identifierNames = new ArrayList<String>();
+		ArrayList<String> identifierNames = new ArrayList<>();
 		for(S supplier : suppliers) {
 			identifierNames.add(supplier.getIdentifierName());
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceConstants.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceConstants.java
@@ -256,6 +256,8 @@ public class PreferenceConstants {
 	public static final boolean DEF_ENABLE_MULTI_SUBTRACT = false;
 	public static final String P_SHOW_SUBTRACT_DIALOG = "showSubtractDialog";
 	public static final boolean DEF_SHOW_SUBTRACT_DIALOG = true;
+	public static final String P_TARGET_IDENTIFER = "targetIdentifier";
+	public static final String DEF_TARGET_IDENTIFER = "org.eclipse.chemclipse.xxd.identifier.supplier.pubchem.identifier";
 	//
 	public static final String P_SCAN_CHART_ENABLE_FIXED_RANGE_X = "scanChartEnableFixedRangeX";
 	public static final boolean DEF_SCAN_CHART_ENABLE_FIXED_RANGE_X = false;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceInitializer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceInitializer.java
@@ -94,6 +94,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		store.setDefault(PreferenceConstants.P_SCAN_IDENTIFER_WSD, PreferenceConstants.DEF_SCAN_IDENTIFER_WSD);
 		store.setDefault(PreferenceConstants.P_SHOW_SUBTRACT_DIALOG, PreferenceConstants.DEF_SHOW_SUBTRACT_DIALOG);
 		store.setDefault(PreferenceConstants.P_ENABLE_MULTI_SUBTRACT, PreferenceConstants.DEF_ENABLE_MULTI_SUBTRACT);
+		store.setDefault(PreferenceConstants.P_TARGET_IDENTIFER, PreferenceConstants.DEF_TARGET_IDENTIFER);
 		//
 		store.setDefault(PreferenceConstants.P_SCAN_CHART_ENABLE_FIXED_RANGE_X, PreferenceConstants.DEF_SCAN_CHART_ENABLE_FIXED_RANGE_X);
 		store.setDefault(PreferenceConstants.P_SCAN_CHART_FIXED_RANGE_START_X, PreferenceConstants.DEF_SCAN_CHART_FIXED_RANGE_START_X);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferencePageTargets.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferencePageTargets.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,11 +11,13 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.preferences;
 
-import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.FloatFieldEditor;
 import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.ExtendedIntegerFieldEditor;
+import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.FloatFieldEditor;
 import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpacerFieldEditor;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.swt.TargetIdentifierUI;
 import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.ui.IWorkbench;
@@ -31,6 +33,7 @@ public class PreferencePageTargets extends FieldEditorPreferencePage implements 
 		setDescription("");
 	}
 
+	@Override
 	public void createFieldEditors() {
 
 		addField(new BooleanFieldEditor(PreferenceConstants.P_USE_TARGET_LIST, "Use Target List", getFieldEditorParent()));
@@ -39,6 +42,7 @@ public class PreferencePageTargets extends FieldEditorPreferencePage implements 
 		addField(new BooleanFieldEditor(PreferenceConstants.P_TARGETS_TABLE_SHOW_DEVIATION_RT, "Show Deviation Retention Time", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceConstants.P_TARGETS_TABLE_SHOW_DEVIATION_RI, "Show Deviation Retention Index", getFieldEditorParent()));
 		addField(new DirectoryFieldEditor(PreferenceConstants.P_TARGET_TEMPLATE_LIBRARY_IMPORT_FOLDER, "Library Path", getFieldEditorParent()));
+		addField(new ComboFieldEditor(PreferenceConstants.P_TARGET_IDENTIFER, "Target Identifier:", TargetIdentifierUI.getTargetIdentifier(), getFieldEditorParent()));
 		//
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceConstants.P_USE_ABSOLUTE_DEVIATION_RETENTION_TIME, "Retention Time: Use absolute deviation", getFieldEditorParent()));
@@ -55,6 +59,7 @@ public class PreferencePageTargets extends FieldEditorPreferencePage implements 
 		addField(new FloatFieldEditor(PreferenceConstants.P_RETENTION_INDEX_DEVIATION_ABS_WARN, "Warn Deviation [abs]", PreferenceConstants.MIN_DEVIATION_RETENTION_INDEX, PreferenceConstants.MAX_DEVIATION_RETENTION_INDEX, getFieldEditorParent()));
 	}
 
+	@Override
 	public void init(IWorkbench workbench) {
 
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakTracesUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakTracesUI.java
@@ -206,7 +206,7 @@ public class ExtendedPeakTracesUI extends Composite implements IExtendedPartUI {
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Delete the selected trace.");
 		button.setText("");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_DELETE, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_DELETE, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -229,7 +229,7 @@ public class ExtendedPeakTracesUI extends Composite implements IExtendedPartUI {
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Copy the traces to clipboard.");
 		button.setText("");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_COPY_CLIPBOARD, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_COPY_CLIPBOARD, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanIdentifierUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanIdentifierUI.java
@@ -230,10 +230,8 @@ public class ScanIdentifierUI extends Composite {
 		/*
 		 * Get a default identifier.
 		 */
-		if(massSpectrumIdentifierSupplier == null) {
-			if(!identifierSuppliers.isEmpty()) {
-				massSpectrumIdentifierSupplier = identifierSuppliers.get(0);
-			}
+		if(massSpectrumIdentifierSupplier == null && !identifierSuppliers.isEmpty()) {
+			massSpectrumIdentifierSupplier = identifierSuppliers.get(0);
 		}
 		/*
 		 * Set the tooltip.
@@ -377,39 +375,35 @@ public class ScanIdentifierUI extends Composite {
 	 */
 	private void runIdentification(Display display, List<IScanMSD> massSpectra, List<IScanWSD> waveSpectra, boolean update) {
 
-		if(!massSpectra.isEmpty()) {
-			if(massSpectrumIdentifierSupplier != null) {
-				IRunnableWithProgress runnable = new MassSpectrumIdentifierRunnable(massSpectra, massSpectrumIdentifierSupplier.getId());
-				ProgressMonitorDialog monitor = new ProgressMonitorDialog(display.getActiveShell());
-				try {
-					monitor.run(true, true, runnable);
-					if(update) {
-						fireUpdate(display);
-					}
-				} catch(InvocationTargetException e) {
-					logger.warn(e);
-				} catch(InterruptedException e) {
-					Thread.currentThread().interrupt();
-					logger.warn(e);
+		if(!massSpectra.isEmpty() && massSpectrumIdentifierSupplier != null) {
+			IRunnableWithProgress runnable = new MassSpectrumIdentifierRunnable(massSpectra, massSpectrumIdentifierSupplier.getId());
+			ProgressMonitorDialog monitor = new ProgressMonitorDialog(display.getActiveShell());
+			try {
+				monitor.run(true, true, runnable);
+				if(update) {
+					fireUpdate(display);
 				}
+			} catch(InvocationTargetException e) {
+				logger.warn(e);
+			} catch(InterruptedException e) {
+				Thread.currentThread().interrupt();
+				logger.warn(e);
 			}
 		}
 		//
-		if(!waveSpectra.isEmpty()) {
-			if(waveSpectrumIdentifierSupplier != null) {
-				IRunnableWithProgress runnable = new WaveSpectrumIdentifierRunnable(waveSpectra, waveSpectrumIdentifierSupplier.getId());
-				ProgressMonitorDialog monitor = new ProgressMonitorDialog(display.getActiveShell());
-				try {
-					monitor.run(true, true, runnable);
-					if(update) {
-						fireUpdate(display);
-					}
-				} catch(InvocationTargetException e) {
-					logger.warn(e);
-				} catch(InterruptedException e) {
-					Thread.currentThread().interrupt();
-					logger.warn(e);
+		if(!waveSpectra.isEmpty() && waveSpectrumIdentifierSupplier != null) {
+			IRunnableWithProgress runnable = new WaveSpectrumIdentifierRunnable(waveSpectra, waveSpectrumIdentifierSupplier.getId());
+			ProgressMonitorDialog monitor = new ProgressMonitorDialog(display.getActiveShell());
+			try {
+				monitor.run(true, true, runnable);
+				if(update) {
+					fireUpdate(display);
 				}
+			} catch(InvocationTargetException e) {
+				logger.warn(e);
+			} catch(InterruptedException e) {
+				Thread.currentThread().interrupt();
+				logger.warn(e);
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.pubchem/src/org/eclipse/chemclipse/xxd/identifier/supplier/pubchem/identifier/PubChemExternalTargetIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.pubchem/src/org/eclipse/chemclipse/xxd/identifier/supplier/pubchem/identifier/PubChemExternalTargetIdentifier.java
@@ -15,7 +15,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 
-import org.eclipse.chemclipse.chromatogram.xxd.identifier.target.ITargetIdentifierSupplier;
+import org.eclipse.chemclipse.chromatogram.xxd.identifier.targets.ITargetIdentifierSupplier;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.identifier.IIdentifierSettings;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;


### PR DESCRIPTION
by right-clicking the URL button, like we do for scan identifiers in scan chart. Followup to https://github.com/eclipse/chemclipse/pull/1298.