### PR TITLE
Fixed missing file content matcher default implementation for PCR, NMR, Sequences and Quantitation DBs

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/schema/org.eclipse.chemclipse.converter.quantitationDatabaseSupplier.exsd
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/schema/org.eclipse.chemclipse.converter.quantitationDatabaseSupplier.exsd
@@ -135,6 +135,16 @@ The value must not contain unallowed file system characters like: \/:*?&quot;&lt
                </appinfo>
             </annotation>
          </attribute>
+         <attribute name="importContentMatcher" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn="org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher:org.eclipse.chemclipse.converter.core.IFileContentMatcher"/>
+               </appinfo>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/schema/org.eclipse.chemclipse.converter.sequenceImportSupplier.exsd
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/schema/org.eclipse.chemclipse.converter.sequenceImportSupplier.exsd
@@ -111,6 +111,16 @@ The value must not contain unallowed file system characters like: \/:*?&quot;&lt
                </appinfo>
             </annotation>
          </attribute>
+         <attribute name="importContentMatcher" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn="org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher:org.eclipse.chemclipse.converter.core.IFileContentMatcher"/>
+               </appinfo>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 
@@ -123,32 +133,8 @@ The value must not contain unallowed file system characters like: \/:*?&quot;&lt
       </documentation>
    </annotation>
 
-   <annotation>
-      <appinfo>
-         <meta.section type="examples"/>
-      </appinfo>
-      <documentation>
-         [Enter extension point usage example here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appinfo>
-         <meta.section type="apiinfo"/>
-      </appinfo>
-      <documentation>
-         [Enter API information here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appinfo>
-         <meta.section type="implementation"/>
-      </appinfo>
-      <documentation>
-         [Enter information about supplied implementation of this extension point.]
-      </documentation>
-   </annotation>
 
    <annotation>
       <appinfo>
@@ -156,7 +142,7 @@ The value must not contain unallowed file system characters like: \/:*?&quot;&lt
       </appinfo>
       <documentation>
          /*******************************************************************************
- * Copyright (c) 2018 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/quantitation/QuantDBConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/quantitation/QuantDBConverter.java
@@ -14,7 +14,9 @@ package org.eclipse.chemclipse.converter.quantitation;
 
 import java.io.File;
 
+import org.eclipse.chemclipse.converter.core.IFileContentMatcher;
 import org.eclipse.chemclipse.converter.core.IMagicNumberMatcher;
+import org.eclipse.chemclipse.converter.core.NoFileContentMatcher;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationDatabase;
 import org.eclipse.chemclipse.processing.converter.ISupplier;
@@ -52,6 +54,7 @@ public class QuantDBConverter {
 	private static final String IS_EXPORTABLE = "isExportable"; //$NON-NLS-1$
 	private static final String IS_IMPORTABLE = "isImportable"; //$NON-NLS-1$
 	private static final String IMPORT_MAGIC_NUMBER_MATCHER = "importMagicNumberMatcher"; //$NON-NLS-1$
+	private static final String IMPORT_FILE_CONTENT_MATCHER = "importContentMatcher"; //$NON-NLS-1$
 
 	/**
 	 * This class has only static methods.
@@ -170,6 +173,7 @@ public class QuantDBConverter {
 			supplier.setExportable(Boolean.valueOf(element.getAttribute(IS_EXPORTABLE)));
 			supplier.setImportable(Boolean.valueOf(element.getAttribute(IS_IMPORTABLE)));
 			supplier.setMagicNumberMatcher(getMagicNumberMatcher(element));
+			supplier.setFileContentMatcher(getFileContentMatcher(element));
 			converterSupport.add(supplier);
 		}
 		return converterSupport;
@@ -201,5 +205,16 @@ public class QuantDBConverter {
 			magicNumberMatcher = null;
 		}
 		return magicNumberMatcher;
+	}
+
+	private static IFileContentMatcher getFileContentMatcher(IConfigurationElement element) {
+
+		IFileContentMatcher fileContentMatcher;
+		try {
+			fileContentMatcher = (IFileContentMatcher)element.createExecutableExtension(IMPORT_FILE_CONTENT_MATCHER);
+		} catch(Exception e) {
+			fileContentMatcher = new NoFileContentMatcher(); // default to a dummy implementation that allows everything
+		}
+		return fileContentMatcher;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/sequence/SequenceConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/sequence/SequenceConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -14,7 +14,9 @@ package org.eclipse.chemclipse.converter.sequence;
 
 import java.io.File;
 
+import org.eclipse.chemclipse.converter.core.IFileContentMatcher;
 import org.eclipse.chemclipse.converter.core.IMagicNumberMatcher;
+import org.eclipse.chemclipse.converter.core.NoFileContentMatcher;
 import org.eclipse.chemclipse.converter.model.reports.ISequence;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.processing.converter.ISupplier;
@@ -40,6 +42,7 @@ public class SequenceConverter {
 	private static final String FILE_NAME = "fileName"; //$NON-NLS-1$
 	private static final String IMPORT_CONVERTER = "importConverter"; //$NON-NLS-1$
 	private static final String IMPORT_MAGIC_NUMBER_MATCHER = "importMagicNumberMatcher"; //$NON-NLS-1$
+	private static final String IMPORT_FILE_CONTENT_MATCHER = "importContentMatcher"; //$NON-NLS-1$
 
 	/**
 	 * This class has only static methods.
@@ -122,6 +125,7 @@ public class SequenceConverter {
 			supplier.setDescription(element.getAttribute(DESCRIPTION));
 			supplier.setFilterName(element.getAttribute(FILTER_NAME));
 			supplier.setMagicNumberMatcher(getMagicNumberMatcher(element));
+			supplier.setFileContentMatcher(getFileContentMatcher(element));
 			sequenceConverterSupport.add(supplier);
 		}
 		return sequenceConverterSupport;
@@ -146,5 +150,16 @@ public class SequenceConverter {
 			magicNumberMatcher = null;
 		}
 		return magicNumberMatcher;
+	}
+
+	private static IFileContentMatcher getFileContentMatcher(IConfigurationElement element) {
+
+		IFileContentMatcher fileContentMatcher;
+		try {
+			fileContentMatcher = (IFileContentMatcher)element.createExecutableExtension(IMPORT_FILE_CONTENT_MATCHER);
+		} catch(Exception e) {
+			fileContentMatcher = new NoFileContentMatcher(); // default to a dummy implementation that allows everything
+		}
+		return fileContentMatcher;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter/schema/org.eclipse.chemclipse.nmr.converter.scanSupplier.exsd
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter/schema/org.eclipse.chemclipse.nmr.converter.scanSupplier.exsd
@@ -6,7 +6,7 @@
          <meta.schema plugin="org.eclipse.chemclipse.nmr.converter" id="org.eclipse.chemclipse.nmr.converter.scanSupplier" name="Scan Supplier NMR"/>
       </appinfo>
       <documentation>
-         [Enter description of this extension point.]
+         Nuclear Magnetic Resonance spectroscopy file format converter
       </documentation>
    </annotation>
 
@@ -138,6 +138,16 @@
                </appinfo>
             </annotation>
          </attribute>
+         <attribute name="importContentMatcher" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn="org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher:org.eclipse.chemclipse.converter.core.IFileContentMatcher"/>
+               </appinfo>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 
@@ -146,36 +156,12 @@
          <meta.section type="since"/>
       </appinfo>
       <documentation>
-         [Enter the first release in which this extension point appears.]
+         0.8.0
       </documentation>
    </annotation>
 
-   <annotation>
-      <appinfo>
-         <meta.section type="examples"/>
-      </appinfo>
-      <documentation>
-         [Enter extension point usage example here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appinfo>
-         <meta.section type="apiinfo"/>
-      </appinfo>
-      <documentation>
-         [Enter API information here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appinfo>
-         <meta.section type="implementation"/>
-      </appinfo>
-      <documentation>
-         [Enter information about supplied implementation of this extension point.]
-      </documentation>
-   </annotation>
 
    <annotation>
       <appinfo>
@@ -183,7 +169,7 @@
       </appinfo>
       <documentation>
          /*******************************************************************************
- * Copyright (c) 2018 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter/src/org/eclipse/chemclipse/nmr/converter/core/ScanConverterNMR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter/src/org/eclipse/chemclipse/nmr/converter/core/ScanConverterNMR.java
@@ -46,6 +46,7 @@ public class ScanConverterNMR {
 	 * This class has only static methods.
 	 */
 	private ScanConverterNMR() {
+
 	}
 
 	public static IProcessingInfo<IMeasurement> convert(final File file, final String converterId, final IProgressMonitor monitor) {
@@ -81,14 +82,12 @@ public class ScanConverterNMR {
 							error.addMessages(processingInfo);
 						} else {
 							Object object = processingInfo.getProcessingResult();
-							if(object instanceof IComplexSignalMeasurement<?>) {
-								IComplexSignalMeasurement<?> measurement = (IComplexSignalMeasurement<?>)object;
+							if(object instanceof IComplexSignalMeasurement<?> measurement) {
 								ProcessingInfo<Collection<IComplexSignalMeasurement<?>>> info = new ProcessingInfo<>();
 								info.setProcessingResult(Collections.singleton(measurement));
 								info.addMessages(processingInfo);
 								return info;
-							} else if(object instanceof Collection<?>) {
-								Collection<?> collection = (Collection<?>)object;
+							} else if(object instanceof Collection<?> collection) {
 								ProcessingInfo<Collection<IComplexSignalMeasurement<?>>> info = new ProcessingInfo<>();
 								info.setProcessingResult((Collection<IComplexSignalMeasurement<?>>)collection);
 								info.addMessages(processingInfo);
@@ -103,7 +102,7 @@ public class ScanConverterNMR {
 		return error;
 	}
 
-	public static IProcessingInfo<?> export(final File file, final IComplexSignalMeasurement<?> measurement, final String converterId, final IProgressMonitor monitor) {
+	public static IProcessingInfo<Void> export(final File file, final IComplexSignalMeasurement<?> measurement, final String converterId, final IProgressMonitor monitor) {
 
 		try {
 			IScanExportConverter exportConverter = getScanExportConverter(converterId);
@@ -114,7 +113,7 @@ public class ScanConverterNMR {
 			}
 			return getProcessingError(file);
 		} catch(Exception e) {
-			ProcessingInfo<Object> processingInfo = new ProcessingInfo<>();
+			ProcessingInfo<Void> processingInfo = new ProcessingInfo<>();
 			processingInfo.addErrorMessage(converterId, "Failed to export", e);
 			return processingInfo;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter/src/org/eclipse/chemclipse/nmr/converter/core/ScanConverterNMR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter/src/org/eclipse/chemclipse/nmr/converter/core/ScanConverterNMR.java
@@ -19,7 +19,9 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.chemclipse.converter.core.Converter;
+import org.eclipse.chemclipse.converter.core.IFileContentMatcher;
 import org.eclipse.chemclipse.converter.core.IMagicNumberMatcher;
+import org.eclipse.chemclipse.converter.core.NoFileContentMatcher;
 import org.eclipse.chemclipse.converter.exceptions.NoConverterAvailableException;
 import org.eclipse.chemclipse.converter.scan.IScanConverterSupport;
 import org.eclipse.chemclipse.converter.scan.ScanConverterSupport;
@@ -188,6 +190,7 @@ public class ScanConverterNMR {
 				supplier.setExportable(Boolean.valueOf(element.getAttribute(Converter.IS_EXPORTABLE)));
 				supplier.setImportable(Boolean.valueOf(element.getAttribute(Converter.IS_IMPORTABLE)));
 				supplier.setMagicNumberMatcher(getMagicNumberMatcher(element));
+				supplier.setFileContentMatcher(getFileContentMatcher(element));
 				converterSupport.add(supplier);
 			}
 		}
@@ -203,6 +206,17 @@ public class ScanConverterNMR {
 			magicNumberMatcher = null;
 		}
 		return magicNumberMatcher;
+	}
+
+	private static IFileContentMatcher getFileContentMatcher(IConfigurationElement element) {
+
+		IFileContentMatcher fileContentMatcher;
+		try {
+			fileContentMatcher = (IFileContentMatcher)element.createExecutableExtension(Converter.IMPORT_FILE_CONTENT_MATCHER);
+		} catch(Exception e) {
+			fileContentMatcher = new NoFileContentMatcher(); // default to a dummy implementation that allows everything
+		}
+		return fileContentMatcher;
 	}
 
 	private static <T> IProcessingInfo<T> getProcessingError(File file) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter/schema/org.eclipse.chemclipse.pcr.converter.plateSupplier.exsd
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter/schema/org.eclipse.chemclipse.pcr.converter.plateSupplier.exsd
@@ -6,7 +6,7 @@
          <meta.schema plugin="org.eclipse.chemclipse.pcr.converter" id="org.eclipse.chemclipse.pcr.converter.plateSupplier" name="Plate Supplier PCR"/>
       </appinfo>
       <documentation>
-         [Enter description of this extension point.]
+         real-time Polymerase Chain Reaction file format import converter
       </documentation>
    </annotation>
 
@@ -138,6 +138,16 @@
                </appinfo>
             </annotation>
          </attribute>
+         <attribute name="importContentMatcher" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn="org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher:org.eclipse.chemclipse.converter.core.IFileContentMatcher"/>
+               </appinfo>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 
@@ -146,36 +156,12 @@
          <meta.section type="since"/>
       </appinfo>
       <documentation>
-         [Enter the first release in which this extension point appears.]
+         0.9.0
       </documentation>
    </annotation>
 
-   <annotation>
-      <appinfo>
-         <meta.section type="examples"/>
-      </appinfo>
-      <documentation>
-         [Enter extension point usage example here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appinfo>
-         <meta.section type="apiinfo"/>
-      </appinfo>
-      <documentation>
-         [Enter API information here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appinfo>
-         <meta.section type="implementation"/>
-      </appinfo>
-      <documentation>
-         [Enter information about supplied implementation of this extension point.]
-      </documentation>
-   </annotation>
 
    <annotation>
       <appinfo>
@@ -183,7 +169,7 @@
       </appinfo>
       <documentation>
          /*******************************************************************************
- * Copyright (c) 2018 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter/src/org/eclipse/chemclipse/pcr/converter/core/PlateConverterPCR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter/src/org/eclipse/chemclipse/pcr/converter/core/PlateConverterPCR.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -16,7 +16,9 @@ import java.io.File;
 import java.util.List;
 
 import org.eclipse.chemclipse.converter.core.Converter;
+import org.eclipse.chemclipse.converter.core.IFileContentMatcher;
 import org.eclipse.chemclipse.converter.core.IMagicNumberMatcher;
+import org.eclipse.chemclipse.converter.core.NoFileContentMatcher;
 import org.eclipse.chemclipse.converter.exceptions.NoConverterAvailableException;
 import org.eclipse.chemclipse.converter.scan.IScanConverterSupport;
 import org.eclipse.chemclipse.converter.scan.ScanConverterSupport;
@@ -191,6 +193,7 @@ public class PlateConverterPCR {
 				supplier.setExportable(Boolean.valueOf(element.getAttribute(Converter.IS_EXPORTABLE)));
 				supplier.setImportable(Boolean.valueOf(element.getAttribute(Converter.IS_IMPORTABLE)));
 				supplier.setMagicNumberMatcher(getMagicNumberMatcher(element));
+				supplier.setFileContentMatcher(getFileContentMatcher(element));
 				converterSupport.add(supplier);
 			}
 		}
@@ -206,6 +209,17 @@ public class PlateConverterPCR {
 			magicNumberMatcher = null;
 		}
 		return magicNumberMatcher;
+	}
+
+	private static IFileContentMatcher getFileContentMatcher(IConfigurationElement element) {
+
+		IFileContentMatcher fileContentMatcher;
+		try {
+			fileContentMatcher = (IFileContentMatcher)element.createExecutableExtension(Converter.IMPORT_FILE_CONTENT_MATCHER);
+		} catch(Exception e) {
+			fileContentMatcher = new NoFileContentMatcher(); // default to a dummy implementation that allows everything
+		}
+		return fileContentMatcher;
 	}
 
 	private static IProcessingInfo<File> getProcessingErrorExport(File file) {


### PR DESCRIPTION
This completes https://github.com/eclipse/chemclipse/pull/1431/