### PR TITLE
Drop support for .zip mass spectra databases

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank/plugin.xml
@@ -14,31 +14,6 @@
             isExportable="false"
             isImportable="true">
       </MassSpectrumSupplier>
-      <MassSpectrumSupplier
-            description="Reads MassBank mass spectra."
-            exportConverter="org.eclipse.chemclipse.msd.converter.supplier.massbank.converter.MassBankExportConverter"
-            fileExtension=".zip"
-            filterName="Compressed MassBank Mass Spectrum (*.zip)"
-            id="org.eclipse.chemclipse.msd.converter.supplier.massbank"
-            importConverter="org.eclipse.chemclipse.msd.converter.supplier.massbank.converter.MassBankImportConverter"
-            importMagicNumberMatcher="org.eclipse.chemclipse.msd.converter.supplier.massbank.converter.MagicNumberMatcher"
-            isExportable="false"
-            isImportable="true">
-      </MassSpectrumSupplier>
-   </extension>
-   <extension
-         point="org.eclipse.chemclipse.msd.converter.databaseSupplier">
-      <DatabaseSupplier
-            description="Reads MassBank reference spectra databases"
-            exportConverter="org.eclipse.chemclipse.msd.converter.supplier.massbank.converter.MassBankExportConverter"
-            fileExtension=".zip"
-            filterName="Compressed MassBank Database (*.zip)"
-            id="org.eclipse.chemclipse.msd.converter.supplier.massbank.DatabaseSupplier"
-            importConverter="org.eclipse.chemclipse.msd.converter.supplier.massbank.converter.MassBankImportConverter"
-            importMagicNumberMatcher="org.eclipse.chemclipse.msd.converter.supplier.massbank.converter.MagicNumberMatcher"
-            isExportable="false"
-            isImportable="true">
-      </DatabaseSupplier>
    </extension>
 
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank/src/org/eclipse/chemclipse/msd/converter/supplier/massbank/converter/MagicNumberMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank/src/org/eclipse/chemclipse/msd/converter/supplier/massbank/converter/MagicNumberMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -8,14 +8,10 @@
  * 
  * Contributors:
  * Dr. Philip Wenig - initial API and implementation
- * Christoph Läubrich - accept zipped data
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.converter.supplier.massbank.converter;
 
 import java.io.File;
-import java.util.Enumeration;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import org.eclipse.chemclipse.converter.core.AbstractMagicNumberMatcher;
 import org.eclipse.chemclipse.converter.core.IMagicNumberMatcher;
@@ -25,30 +21,6 @@ public class MagicNumberMatcher extends AbstractMagicNumberMatcher implements IM
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		if(checkFileExtension(file, ".txt")) {
-			return true;
-		} else if(checkFileExtension(file, ".zip")) {
-			try (ZipFile zipFile = new ZipFile(file)) {
-				Enumeration<? extends ZipEntry> entries = zipFile.entries();
-				while(entries.hasMoreElements()) {
-					ZipEntry entry = entries.nextElement();
-					String name = entry.getName();
-					if(name.startsWith("MassBank-data-")) {
-						return true;
-					} else if(name.endsWith("List_of_Contributors_Prefixes_and_Projects.md")) {
-						return true;
-					} else if(name.endsWith("MassBank.txt")) {
-						return true;
-					}
-				}
-			} catch(Exception e) {
-				/*
-				 * java.lang.IllegalArgumentException: MALFORMED
-				 * at java.util.zip.ZipCoder.toString(ZipCoder.java:58)
-				 */
-			}
-		}
-		//
-		return false;
+		return file.getName().startsWith("MSBNK-") && checkFileExtension(file, ".txt");
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank/src/org/eclipse/chemclipse/msd/converter/supplier/massbank/model/VendorLibraryMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank/src/org/eclipse/chemclipse/msd/converter/supplier/massbank/model/VendorLibraryMassSpectrum.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,9 +19,6 @@ import org.eclipse.chemclipse.msd.model.exceptions.IonLimitExceededException;
 import org.eclipse.chemclipse.msd.model.implementation.Ion;
 
 public class VendorLibraryMassSpectrum extends AbstractRegularLibraryMassSpectrum {
-
-	public VendorLibraryMassSpectrum() {
-	}
 
 	/**
 	 * Renew the serialVersionUID any time you have changed some fields or

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/plugin.xml
@@ -15,18 +15,4 @@
             isImportable="true">
       </MassSpectrumSupplier>
    </extension>
-   <extension
-         point="org.eclipse.chemclipse.msd.converter.databaseSupplier">
-      <DatabaseSupplier
-            description="Reads SIRIUS mass spectra"
-            exportConverter="org.eclipse.chemclipse.msd.converter.supplier.sirius.converter.SiriusExportConverter"
-            fileExtension=".zip"
-            filterName="Compressed SIRIUS Mass Spectrum Database (*.zip)"
-            id="org.eclipse.chemclipse.msd.converter.supplier.sirius.DatabaseSupplier"
-            importConverter="org.eclipse.chemclipse.msd.converter.supplier.sirius.converter.SiriusImportConverter"
-            importMagicNumberMatcher="org.eclipse.chemclipse.msd.converter.supplier.sirius.converter.MagicNumberMatcher"
-            isExportable="false"
-            isImportable="true">
-      </DatabaseSupplier>
-   </extension>
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/src/org/eclipse/chemclipse/msd/converter/supplier/sirius/converter/MagicNumberMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/src/org/eclipse/chemclipse/msd/converter/supplier/sirius/converter/MagicNumberMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Lablicate GmbH.
+ * Copyright (c) 2021, 2023 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,9 +12,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.sirius.converter;
 
 import java.io.File;
-import java.util.Enumeration;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import org.eclipse.chemclipse.converter.core.AbstractMagicNumberMatcher;
 import org.eclipse.chemclipse.converter.core.IMagicNumberMatcher;
@@ -24,26 +21,6 @@ public class MagicNumberMatcher extends AbstractMagicNumberMatcher implements IM
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		if(checkFileExtension(file, ".ms")) {
-			return true;
-		} else if(checkFileExtension(file, ".zip")) {
-			try (ZipFile zipFile = new ZipFile(file)) {
-				Enumeration<? extends ZipEntry> entries = zipFile.entries();
-				while(entries.hasMoreElements()) {
-					ZipEntry entry = entries.nextElement();
-					if(entry.getName().endsWith(".ms")) {
-						return true;
-					}
-				}
-			} catch(Exception e) {
-				/*
-				 * Logging is expensive and slows the performance.
-				 * Hence, deactivate logging here.
-				 */
-				// logger.warn("Non UTF-8 entry in " + file.getName(), e);
-			}
-		}
-		//
-		return false;
+		return checkFilePrefix(file, "CCMSLIB") && checkFileExtension(file, ".ms");
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/src/org/eclipse/chemclipse/msd/converter/supplier/sirius/io/SiriusReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/src/org/eclipse/chemclipse/msd/converter/supplier/sirius/io/SiriusReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Lablicate GmbH.
+ * Copyright (c) 2021, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,9 +18,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.Enumeration;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
@@ -59,41 +56,17 @@ public class SiriusReader extends AbstractMassSpectraReader implements IMassSpec
 	@Override
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
-		if(file.getName().toLowerCase().endsWith(".zip")) {
-			if(monitor != null) {
-				monitor.beginTask("Reading mass spectras from " + file.getName(), IProgressMonitor.UNKNOWN);
+		IMassSpectra massSpectra = new MassSpectra();
+		try (FileInputStream inputStream = new FileInputStream(file)) {
+			IScanMSD massSpectrum = readMassSpectrum(inputStream);
+			if(!massSpectrum.isEmpty()) {
+				massSpectra.addMassSpectrum(massSpectrum);
 			}
-			IMassSpectra massSpectra = new MassSpectra();
-			massSpectra.setConverterId("SIRIUS");
-			try (ZipFile zipFile = new ZipFile(file)) {
-				Enumeration<? extends ZipEntry> entries = zipFile.entries();
-				while(entries.hasMoreElements()) {
-					ZipEntry entry = entries.nextElement();
-					if(entry.isDirectory()) {
-						continue;
-					}
-					if(entry.getName().toLowerCase().endsWith(".ms")) {
-						IScanMSD massSpectrum = readMassSpectrum(zipFile.getInputStream(entry), null);
-						if(!massSpectrum.isEmpty()) {
-							massSpectra.addMassSpectrum(massSpectrum);
-						}
-					}
-				}
-			}
-			return massSpectra;
-		} else {
-			IMassSpectra massSpectra = new MassSpectra();
-			try (FileInputStream inputStream = new FileInputStream(file)) {
-				IScanMSD massSpectrum = readMassSpectrum(inputStream, monitor);
-				if(!massSpectrum.isEmpty()) {
-					massSpectra.addMassSpectrum(massSpectrum);
-				}
-			}
-			return massSpectra;
 		}
+		return massSpectra;
 	}
 
-	public static IScanMSD readMassSpectrum(InputStream stream, IProgressMonitor monitor) throws IOException {
+	public static IScanMSD readMassSpectrum(InputStream stream) throws IOException {
 
 		VendorLibraryMassSpectrum massSpectrum = new VendorLibraryMassSpectrum();
 		ILibraryInformation libraryInformation = massSpectrum.getLibraryInformation();
@@ -127,18 +100,21 @@ public class SiriusReader extends AbstractMassSpectraReader implements IMassSpec
 			}
 			if(line.startsWith(INCHI)) {
 				String value = line.split(INCHI)[1].trim();
-				if(!value.equals("N/A"))
+				if(!value.equals("N/A")) {
 					libraryInformation.setInChI(value);
+				}
 			}
 			if(line.startsWith(CASNUMBER)) {
 				String value = line.split(CASNUMBER)[1].trim();
-				if(!value.equals("N/A"))
+				if(!value.equals("N/A")) {
 					libraryInformation.setCasNumber(value);
+				}
 			}
 			if(line.startsWith(SMILES)) {
 				String value = line.split(SMILES)[1].trim();
-				if(!value.equals("N/A"))
+				if(!value.equals("N/A")) {
 					libraryInformation.setSmiles(value);
+				}
 			}
 			if(line.startsWith(EXACTMASS)) {
 				String value = line.split(EXACTMASS)[1].trim();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSequenceExplorerUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSequenceExplorerUI.java
@@ -12,6 +12,7 @@
 package org.eclipse.chemclipse.ux.extension.xxd.ui.swt;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -21,6 +22,7 @@ import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.types.DataType;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
+import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.support.ui.provider.AbstractLabelProvider;
 import org.eclipse.chemclipse.support.ui.swt.EnhancedComboViewer;
 import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
@@ -107,14 +109,14 @@ public class ExtendedSequenceExplorerUI extends Composite implements IExtendedPa
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Toggle search toolbar.");
 		button.setText("");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SEARCH, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SEARCH, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 
 				boolean visible = PartSupport.toggleCompositeVisibility(toolbarSearch);
-				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SEARCH, IApplicationImage.SIZE_16x16, visible));
+				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SEARCH, IApplicationImageProvider.SIZE_16x16, visible));
 			}
 		});
 		//
@@ -126,7 +128,7 @@ public class ExtendedSequenceExplorerUI extends Composite implements IExtendedPa
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Reset the sequence file editor.");
 		button.setText("");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_RESET, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_RESET, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -188,8 +190,7 @@ public class ExtendedSequenceExplorerUI extends Composite implements IExtendedPa
 			@Override
 			public String getText(Object element) {
 
-				if(element instanceof File) {
-					File file = (File)element;
+				if(element instanceof File file) {
 					return file.getName();
 				}
 				return null;
@@ -204,9 +205,7 @@ public class ExtendedSequenceExplorerUI extends Composite implements IExtendedPa
 			public void widgetSelected(SelectionEvent e) {
 
 				Object object = comboViewer.getStructuredSelection().getFirstElement();
-				if(object instanceof File) {
-					//
-					File file = (File)object;
+				if(object instanceof File file) {
 					preferenceStore.setValue(PreferenceConstants.P_SEQUENCE_EXPLORER_PATH_PARENT_FOLDER, file.getAbsolutePath());
 					if(preferenceStore.getBoolean(PreferenceConstants.P_SEQUENCE_EXPLORER_USE_SUBFOLDER)) {
 						List<File> files = getDirectories(file);
@@ -226,7 +225,7 @@ public class ExtendedSequenceExplorerUI extends Composite implements IExtendedPa
 		Button button = new Button(parent, SWT.PUSH);
 		button.setText("");
 		button.setToolTipText("Select the root folder.");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_ADD, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_ADD, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -258,8 +257,7 @@ public class ExtendedSequenceExplorerUI extends Composite implements IExtendedPa
 			@Override
 			public String getText(Object element) {
 
-				if(element instanceof File) {
-					File file = (File)element;
+				if(element instanceof File file) {
 					return file.getName();
 				}
 				return null;
@@ -276,12 +274,9 @@ public class ExtendedSequenceExplorerUI extends Composite implements IExtendedPa
 			public void widgetSelected(SelectionEvent e) {
 
 				Object object = comboViewer.getStructuredSelection().getFirstElement();
-				if(object instanceof File) {
-					File file = (File)object;
-					if(file.isDirectory()) {
-						preferenceStore.setValue(PreferenceConstants.P_SEQUENCE_EXPLORER_PATH_SUB_FOLDER, file.getAbsolutePath());
-						setSequenceListContent(file);
-					}
+				if(object instanceof File file && file.isDirectory()) {
+					preferenceStore.setValue(PreferenceConstants.P_SEQUENCE_EXPLORER_PATH_SUB_FOLDER, file.getAbsolutePath());
+					setSequenceListContent(file);
 				}
 			}
 		});
@@ -303,8 +298,7 @@ public class ExtendedSequenceExplorerUI extends Composite implements IExtendedPa
 			public void mouseDoubleClick(MouseEvent e) {
 
 				Object object = sequenceFilesUI.getStructuredSelection().getFirstElement();
-				if(object instanceof File) {
-					File file = (File)object;
+				if(object instanceof File file) {
 					supplierEditorSupport.openEditor(file, false);
 				}
 			}
@@ -318,7 +312,7 @@ public class ExtendedSequenceExplorerUI extends Composite implements IExtendedPa
 		Button button = new Button(parent, SWT.PUSH);
 		button.setText("Open Sequences");
 		button.setToolTipText("Open the selected sequences.");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_IMPORT, IApplicationImage.SIZE_16x16));
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_IMPORT, IApplicationImageProvider.SIZE_16x16));
 		GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
 		gridData.horizontalSpan = 2;
 		button.setLayoutData(gridData);
@@ -331,8 +325,7 @@ public class ExtendedSequenceExplorerUI extends Composite implements IExtendedPa
 				int[] indices = table.getSelectionIndices();
 				for(int index : indices) {
 					Object object = table.getItem(index).getData();
-					if(object instanceof File) {
-						File file = (File)object;
+					if(object instanceof File file) {
 						supplierEditorSupport.openEditor(file, true);
 					}
 				}
@@ -360,7 +353,7 @@ public class ExtendedSequenceExplorerUI extends Composite implements IExtendedPa
 		Collections.sort(files);
 		rootFolderComboViewer.setInput(files);
 		//
-		if(files.size() > 0) {
+		if(!files.isEmpty()) {
 			int index = getSelectedDirectoryIndex(files, preferenceStore.getString(PreferenceConstants.P_SEQUENCE_EXPLORER_PATH_PARENT_FOLDER));
 			File file = files.get(index);
 			rootFolderComboViewer.getCombo().select(index);
@@ -375,7 +368,7 @@ public class ExtendedSequenceExplorerUI extends Composite implements IExtendedPa
 		Collections.sort(files);
 		subFolderComboViewer.setInput(files);
 		//
-		if(files.size() > 0) {
+		if(!files.isEmpty()) {
 			int index = getSelectedDirectoryIndex(files, preferenceStore.getString(PreferenceConstants.P_SEQUENCE_EXPLORER_PATH_SUB_FOLDER));
 			File file = files.get(index);
 			subFolderComboViewer.getCombo().select(index);
@@ -405,8 +398,11 @@ public class ExtendedSequenceExplorerUI extends Composite implements IExtendedPa
 				dialog.run(true, true, runnable);
 				List<File> files = runnable.getSequenceFiles();
 				sequenceFilesUI.setInput(files);
-			} catch(Exception e) {
-				logger.error(e);
+			} catch(InvocationTargetException e) {
+				logger.error(e.getCause());
+			} catch(InterruptedException e) {
+				logger.warn(e);
+				Thread.currentThread().interrupt();
 			}
 		} else {
 			sequenceFilesUI.setInput(null);


### PR DESCRIPTION
This essentially reverts https://github.com/eclipse/chemclipse/issues/147 and parts of https://github.com/eclipse/chemclipse/pull/584 but we can't just open every `*.zip` go through all its contents (twice) with such a generic and popular file format for performance reasons. However, https://github.com/MassBank/MassBank-data/releases now also has compiled `.msp` downloads so there already is a way around this.