### PR TITLE
Set minimum permissions required to run GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ name: Continuous Integration
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -15,6 +15,9 @@ name: License Header
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check-license-header-year:
     name: Year


### PR DESCRIPTION
This adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows according to security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token). By using the principle of least privilege, the damage a compromised workflow can do from an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action is limited.