### PR TITLE
Fixed Wikidata query from name failing

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/query/QueryEntity.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/query/QueryEntity.java
@@ -42,7 +42,7 @@ public class QueryEntity {
 		String select = Wikidata.PROP + Wikidata.BIGDATA + Wikidata.SCHEMA + Wikidata.WIKIBASE + Wikidata.WD + Wikidata.WDT + //
 				"SELECT distinct ?item WHERE { \n" + //
 				"  ?item ?label \"" + name.toLowerCase() + "\"@en . \n" + //
-				"  ?item wdt:P31 wd:Q11173 . \n" + //
+				"  ?item wdt:P31 wd:Q113145171 . \n" + //
 				"  ?article schema:about ?item . \n" + //
 				"  ?article schema:inLanguage \"en\" . \n" + //
 				"  SERVICE wikibase:label { bd:serviceParam wikibase:language \"en\". }\n" + //


### PR DESCRIPTION
[Wikidata decided to change its data structure for chemical compounds.](https://www.wikidata.org/wiki/Wikidata_talk:WikiProject_Chemistry#Metaclasses_for_chemical_entities_and_using_instance_of_(P31)/subclass_of_(P279))