### PR TITLE
Added our own implementation of SPLASH spectra hash

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/META-INF/MANIFEST.MF
@@ -18,7 +18,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.chromatogram.xxd.calculator;bundle-version="0.8.0",
  org.eclipse.chemclipse.processing,
  com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.12.1",
- org.apache.commons.math3;bundle-version="3.6.1"
+ org.apache.commons.math3;bundle-version="3.6.1",
+ org.apache.commons.commons-codec;bundle-version="1.15.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.msd.model.core,
@@ -31,6 +32,7 @@ Export-Package: org.eclipse.chemclipse.msd.model.core,
  org.eclipse.chemclipse.msd.model.noise,
  org.eclipse.chemclipse.msd.model.notifier,
  org.eclipse.chemclipse.msd.model.preferences,
+ org.eclipse.chemclipse.msd.model.splash,
  org.eclipse.chemclipse.msd.model.statistics,
  org.eclipse.chemclipse.msd.model.support,
  org.eclipse.chemclipse.msd.model.util,

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/splash/IntensityThenMassComparator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/splash/IntensityThenMassComparator.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.model.splash;
+
+import java.util.Comparator;
+
+import org.eclipse.chemclipse.msd.model.core.IIon;
+
+public class IntensityThenMassComparator implements Comparator<IIon> {
+
+	public int compare(IIon i1, IIon i2) {
+
+		int result = Double.compare(i2.getAbundance(), i1.getAbundance());
+		if(result == 0) {
+			result = Double.compare(i1.getIon(), i2.getIon());
+		}
+		return result;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/splash/MassThenIntensityComparator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/splash/MassThenIntensityComparator.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.model.splash;
+
+import java.util.Comparator;
+
+import org.eclipse.chemclipse.msd.model.core.IIon;
+
+public class MassThenIntensityComparator implements Comparator<IIon> {
+
+	public int compare(IIon i1, IIon i2) {
+
+		int result = Double.compare(i1.getIon(), (i2.getIon()));
+		if(result == 0) {
+			result = Double.compare(i2.getAbundance(), i1.getAbundance());
+		}
+		return result;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/splash/SplashFactory.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/splash/SplashFactory.java
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.model.splash;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.model.exceptions.AbundanceLimitExceededException;
+import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.msd.model.exceptions.IonLimitExceededException;
+import org.eclipse.chemclipse.msd.model.implementation.Ion;
+
+/**
+ * @see Wohlgemuth, G, et al. SPLASH, a Hashed Identifier for Mass Spectra.
+ *      Nature Biotechnology 34, 1099-101 (2016).
+ *      <a href="https://doi.org/10.1038/nbt.3689">https://doi.org/10.1038/nbt.3689</a>
+ */
+public class SplashFactory {
+
+	private static final Logger logger = Logger.getLogger(SplashFactory.class);
+	//
+	private static final float NORMALIZATION_FACTOR = 100f;
+	private static final int SPLASH_VERSION = 0;
+	private static final int SPECTRA_TYPE = 1; // MS
+	private static final String HASH_SEPERATOR = "-";
+	//
+	private static final double EPS_CORRECTION = 1.0e-7d;
+	//
+	private static final int PREFILTER_BASE = 3;
+	private static final int PREFILTER_LENGTH = 10;
+	private static final int PREFILTER_BIN_SIZE = 5;
+	//
+	private static final int SIMILARITY_BASE = 10;
+	private static final int SIMILARITY_LENGTH = 10;
+	private static final int SIMILARITY_BIN_SIZE = 100;
+	//
+	private static final char[] BASE_36_MAP = new char[]{ //
+			'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', //
+			'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', //
+			'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z' //
+	};
+	//
+	private static final String ION_SEPERATOR = " ";
+	private static final long MZ_PRECISION_FACTOR = (long)Math.pow(10, 6);
+	private static final long INTENSITY_PRECISION_FACTOR = (long)Math.pow(10, 0);
+	//
+	private String splash;
+
+	public SplashFactory(IScanMSD massSpectrum) {
+
+		try {
+			IScanMSD normalizedMassSpectrum = massSpectrum.makeDeepCopy().normalize(NORMALIZATION_FACTOR);
+			StringBuilder stringBuilder = new StringBuilder();
+			stringBuilder.append("splash" + SPECTRA_TYPE + SPLASH_VERSION);
+			stringBuilder.append(HASH_SEPERATOR);
+			List<IIon> filteredIons = filterSpectrum(normalizedMassSpectrum, 10, 0.1);
+			String prefilterHistogram = calculateHistogramBlock(filteredIons, PREFILTER_BASE, PREFILTER_LENGTH, PREFILTER_BIN_SIZE);
+			stringBuilder.append(translateBase(prefilterHistogram, PREFILTER_BASE, 36, 4));
+			stringBuilder.append(HASH_SEPERATOR);
+			stringBuilder.append(calculateHistogramBlock(normalizedMassSpectrum.getIons(), SIMILARITY_BASE, SIMILARITY_LENGTH, SIMILARITY_BIN_SIZE));
+			stringBuilder.append(HASH_SEPERATOR);
+			stringBuilder.append(encodeSpectrum(normalizedMassSpectrum));
+			splash = stringBuilder.toString();
+		} catch(CloneNotSupportedException e) {
+			logger.error(e);
+		} catch(AbundanceLimitExceededException e) {
+			logger.error(e);
+		} catch(IonLimitExceededException e) {
+			logger.error(e);
+		}
+	}
+
+	public String getSplash() {
+
+		return splash;
+	}
+
+	private List<IIon> filterSpectrum(IScanMSD massSpectrum, int topIons, double basePeakPercentage) throws AbundanceLimitExceededException, IonLimitExceededException {
+
+		double basePeakIntensity = massSpectrum.getBasePeakAbundance();
+		List<IIon> ions = massSpectrum.getIons();
+		if(basePeakPercentage >= 0) {
+			List<IIon> filteredIons = new ArrayList<IIon>();
+			for(IIon ion : ions) {
+				if((double)ion.getAbundance() + EPS_CORRECTION >= basePeakPercentage * basePeakIntensity)
+					filteredIons.add(new Ion(ion.getIon(), ion.getAbundance()));
+			}
+			ions = filteredIons;
+		}
+		if(topIons > 0 && ions.size() > topIons) {
+			Collections.sort(ions, new IntensityThenMassComparator());
+			ions = ions.subList(0, topIons);
+		}
+		return ions;
+	}
+
+	private String calculateHistogramBlock(List<IIon> ions, int base, int length, int binSize) {
+
+		double[] binnedIons = new double[length];
+		double maxIntensity = 0;
+		for(IIon ion : ions) {
+			int bin = (int)(ion.getIon() / binSize) % length;
+			binnedIons[bin] += ion.getAbundance();
+			if(binnedIons[bin] > maxIntensity) {
+				maxIntensity = binnedIons[bin];
+			}
+		}
+		for(int i = 0; i < length; i++) {
+			binnedIons[i] = (base - 1) * binnedIons[i] / maxIntensity;
+		}
+		StringBuilder result = new StringBuilder();
+		for(int i = 0; i < length; i++) {
+			int bin = (int)(EPS_CORRECTION + binnedIons[i]);
+			result.append(BASE_36_MAP[bin]);
+		}
+		return result.toString();
+	}
+
+	protected String translateBase(String number, int initialBase, int finalBase, int fill) {
+
+		int n = Integer.parseInt(number, initialBase);
+		StringBuilder result = new StringBuilder();
+		while(n > 0) {
+			result.insert(0, BASE_36_MAP[n % finalBase]);
+			n /= finalBase;
+		}
+		while(result.length() < fill) {
+			result.insert(0, '0');
+		}
+		return result.toString();
+	}
+
+	protected String encodeSpectrum(IScanMSD spectrum) {
+
+		List<IIon> ions = new ArrayList<IIon>(spectrum.getIons());
+		StringBuilder buffer = new StringBuilder();
+		Collections.sort(ions, new MassThenIntensityComparator());
+		for(int i = 0; i < ions.size(); i++) {
+			buffer.append(formatMZ(ions.get(i).getIon()));
+			buffer.append(":");
+			buffer.append(formatIntensity(ions.get(i).getAbundance()));
+			if(i < ions.size() - 1) {
+				buffer.append(ION_SEPERATOR);
+			}
+		}
+		String block = buffer.toString();
+		String hash = DigestUtils.sha256Hex(block).substring(0, 20);
+		return hash;
+	}
+
+	private String formatMZ(double value) {
+
+		return String.format("%d", (long)((value + EPS_CORRECTION) * MZ_PRECISION_FACTOR));
+	}
+
+	private String formatIntensity(double value) {
+
+		return String.format("%d", (long)((value + EPS_CORRECTION) * INTENSITY_PRECISION_FACTOR));
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/MassSpectrumListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/MassSpectrumListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -60,6 +60,7 @@ public class MassSpectrumListUI extends ExtendedTableViewer {
 	public static final String INCHI = "InChI";
 	public static final String REFERENCE_IDENTIFIER = "Reference Identifier";
 	public static final String COMMENTS = "Comments";
+	public static final String SPLASH = "Splash";
 	//
 	private String[] titles = {//
 			NAME, //
@@ -75,7 +76,8 @@ public class MassSpectrumListUI extends ExtendedTableViewer {
 			SMILES, //
 			INCHI, //
 			REFERENCE_IDENTIFIER, //
-			COMMENTS//
+			COMMENTS, //
+			SPLASH //
 	};
 	private int[] bounds = {//
 			300, //
@@ -91,7 +93,8 @@ public class MassSpectrumListUI extends ExtendedTableViewer {
 			100, //
 			100, //
 			100, //
-			100 //
+			100, //
+			300 //
 	};
 	//
 	private ITableLabelProvider labelProvider;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/editingsupport/LibraryTextEditingSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/editingsupport/LibraryTextEditingSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import java.text.DecimalFormat;
 import org.eclipse.chemclipse.model.core.AbstractChromatogram;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.msd.model.core.IRegularLibraryMassSpectrum;
+import org.eclipse.chemclipse.msd.model.splash.SplashFactory;
 import org.eclipse.chemclipse.msd.swt.ui.components.massspectrum.MassSpectrumListUI;
 import org.eclipse.chemclipse.support.text.ValueFormat;
 import org.eclipse.chemclipse.support.ui.swt.ExtendedTableViewer;
@@ -32,6 +33,7 @@ public class LibraryTextEditingSupport extends EditingSupport {
 	private DecimalFormat decimalFormat;
 
 	public LibraryTextEditingSupport(ExtendedTableViewer tableViewer, String columnLabel) {
+
 		super(tableViewer);
 		//
 		this.tableViewer = tableViewer;
@@ -57,8 +59,7 @@ public class LibraryTextEditingSupport extends EditingSupport {
 	protected Object getValue(Object element) {
 
 		Object object = null;
-		if(element instanceof IRegularLibraryMassSpectrum) {
-			IRegularLibraryMassSpectrum libraryMassSpectrum = (IRegularLibraryMassSpectrum)element;
+		if(element instanceof IRegularLibraryMassSpectrum libraryMassSpectrum) {
 			ILibraryInformation libraryInformation = libraryMassSpectrum.getLibraryInformation();
 			//
 			switch(columnLabel) {
@@ -92,6 +93,9 @@ public class LibraryTextEditingSupport extends EditingSupport {
 				case MassSpectrumListUI.COMMENTS:
 					object = libraryInformation.getComments();
 					break;
+				case MassSpectrumListUI.SPLASH:
+					object = new SplashFactory(libraryMassSpectrum).getSplash();
+					break;
 			}
 		}
 		return object;
@@ -100,8 +104,7 @@ public class LibraryTextEditingSupport extends EditingSupport {
 	@Override
 	protected void setValue(Object element, Object value) {
 
-		if(element instanceof IRegularLibraryMassSpectrum) {
-			IRegularLibraryMassSpectrum libraryMassSpectrum = (IRegularLibraryMassSpectrum)element;
+		if(element instanceof IRegularLibraryMassSpectrum libraryMassSpectrum) {
 			ILibraryInformation libraryInformation = libraryMassSpectrum.getLibraryInformation();
 			//
 			switch(columnLabel) {
@@ -134,6 +137,9 @@ public class LibraryTextEditingSupport extends EditingSupport {
 					break;
 				case MassSpectrumListUI.COMMENTS:
 					libraryInformation.setComments(value.toString());
+					break;
+				case MassSpectrumListUI.SPLASH:
+					// calculated property
 					break;
 			}
 			tableViewer.refresh();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/provider/MassSpectrumListFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/provider/MassSpectrumListFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -53,16 +53,14 @@ public class MassSpectrumListFilter extends ViewerFilter {
 		/*
 		 * ILibraryMassSpectrum
 		 */
-		if(element instanceof ILibraryMassSpectrum) {
+		if(element instanceof ILibraryMassSpectrum libraryMassSpectrum) {
 			//
-			ILibraryMassSpectrum libraryMassSpectrum = (ILibraryMassSpectrum)element;
 			ILibraryInformation libraryInformation = libraryMassSpectrum.getLibraryInformation();
 			if(libraryInformationSupport.containsSearchText(libraryInformation, searchText, caseSensitive)) {
 				return true;
 			}
-		} else if(element instanceof IScanMSD) {
+		} else if(element instanceof IScanMSD massSpectrum) {
 			//
-			IScanMSD massSpectrum = (IScanMSD)element;
 			for(IIdentificationTarget massSpectrumTarget : massSpectrum.getTargets()) {
 				IIdentificationTarget identificationEntry = (IIdentificationTarget)massSpectrumTarget;
 				ILibraryInformation libraryInformation = identificationEntry.getLibraryInformation();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/provider/MassSpectrumListLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/provider/MassSpectrumListLabelProvider.java
@@ -19,6 +19,7 @@ import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.model.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.msd.model.core.IRegularLibraryMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.msd.model.splash.SplashFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
 import org.eclipse.chemclipse.support.ui.provider.AbstractChemClipseLabelProvider;
@@ -158,6 +159,11 @@ public class MassSpectrumListLabelProvider extends AbstractChemClipseLabelProvid
 			case 13:
 				if(libraryInformation != null) {
 					text = libraryInformation.getComments();
+				}
+				break;
+			case 14:
+				if(massSpectrum != null) {
+					text = new SplashFactory(massSpectrum).getSplash();
 				}
 				break;
 			default:

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/provider/MassSpectrumListTableComparator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/provider/MassSpectrumListTableComparator.java
@@ -15,6 +15,7 @@ import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.msd.model.core.IRegularLibraryMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.msd.model.splash.SplashFactory;
 import org.eclipse.chemclipse.support.ui.swt.AbstractRecordTableComparator;
 import org.eclipse.chemclipse.support.ui.swt.IRecordTableComparator;
 import org.eclipse.jface.viewers.Viewer;
@@ -112,6 +113,9 @@ public class MassSpectrumListTableComparator extends AbstractRecordTableComparat
 				if(libraryInformation1 != null && libraryInformation2 != null) {
 					sortOrder = libraryInformation2.getComments().compareTo(libraryInformation1.getComments());
 				}
+				break;
+			case 14:
+				new SplashFactory(massSpectrum1).getSplash().compareTo(new SplashFactory(massSpectrum2).getSplash());
 				break;
 			default:
 				sortOrder = 0;

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/splash/Splash_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/splash/Splash_Test.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Lablicate GmbH.
+ * 
+ * All rights reserved. This
+ * program and the accompanying materials are made available under the terms of
+ * the Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.model.splash;
+
+import org.eclipse.chemclipse.msd.model.core.IVendorMassSpectrum;
+import org.eclipse.chemclipse.msd.model.implementation.Ion;
+import org.eclipse.chemclipse.msd.model.implementation.VendorMassSpectrum;
+
+import junit.framework.TestCase;
+
+public class Splash_Test extends TestCase {
+
+	IVendorMassSpectrum massSpectrum;
+
+	@Override
+	protected void setUp() throws Exception {
+
+		super.setUp();
+		massSpectrum = new VendorMassSpectrum();
+		massSpectrum.addIon(new Ion(100, 1));
+		massSpectrum.addIon(new Ion(101, 2));
+		massSpectrum.addIon(new Ion(102, 3));
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+
+		super.tearDown();
+	}
+
+	public void testSplash() {
+
+		assertEquals("splash10-0udi-0900000000-f5bf6f6a4a1520a35d4f", new SplashFactory(massSpectrum).getSplash());
+	}
+}


### PR DESCRIPTION
I was first hesitant because of possible incompatible implementations, but I now ported https://github.com/berlinguyinca/spectra-hash/tree/master/core so that we can also use the ChemClipse data types and not have a redundant implementation of spectra and ions especially for performance reasons. Another point is that the provided Maven package is hosted on an unreliable university server that is incompatible with the current version of Maven, and I don't see progress on https://github.com/berlinguyinca/spectra-hash/issues/48.

Use case for this is duplicate detection on mass spectra databases. It is shown in the library MS editor and you can copy it and paste for example at https://massbank.eu/MassBank/Search