### PR TITLE
Fixed a null reference exception in the welcome screen tile definition

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/views/WelcomeViewExtensionHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/views/WelcomeViewExtensionHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -542,7 +542,7 @@ public class WelcomeViewExtensionHandler {
 
 			if(delegate != null) {
 				String preferredPerspective = delegate.getPreferredPerspective();
-				if(!preferredPerspective.isEmpty()) {
+				if(preferredPerspective != null && !preferredPerspective.isEmpty()) {
 					if(!perspectiveSupport.getActivePerspectiveId().startsWith(preferredPerspective)) {
 						if(preferredPerspective != null) {
 							MPerspective perspectiveModel = perspectiveSupport.getPerspectiveModel(preferredPerspective);


### PR DESCRIPTION
https://github.com/eclipse/chemclipse/blob/abcab8433896efe18833e18ef7105ce494501e42/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/definitions/TileDefinition.java#L85-L93

promises this can be left as the default null, but that would crash.