### PR TITLE
Revamp PCR tabular reporting settings

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.ui/plugin.xml
@@ -4,7 +4,7 @@
    <extension
          point="org.eclipse.ui.preferencePages">
       <page
-            category="org.eclipse.chemclipse.converter.ui.converterPreferencePage"      
+            category="org.eclipse.chemclipse.rcp.app.ui.preferences.preferencePageMolecularBiology"
             class="org.eclipse.chemclipse.pcr.converter.ui.preferences.ConverterPreferencePage"
             id="org.eclipse.chemclipse.pcr.converter.ui.converterPreferencePage"
             name="Converter PCR">

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui/plugin.xml
@@ -9,6 +9,24 @@
             id="org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui.preferences.converterPreferencePage"
             name="CSV PCR Export Converter">
       </page>
+      <page
+            category="org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui.preferences.converterPreferencePage"
+            class="org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui.preferences.ChannelMappingPreferencePage"
+            id="org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui.preferences.converterPreferencePage.ChannelMapping"
+            name="PCR Channel Mapping">
+      </page>
+      <page
+            category="org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui.preferences.converterPreferencePage"
+            class="org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui.preferences.WellMappingPreferencePage"
+            id="org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui.preferences.converterPreferencePage.WellMapping"
+            name="PCR Well Mapping">
+      </page>
+      <page
+            category="org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui.preferences.converterPreferencePage"
+            class="org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui.preferences.VirtualChannelsPreferencePage"
+            id="org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui.preferences.converterPreferencePage.VirtualChannels"
+            name="Virtual PCR Channels">
+      </page>
    </extension>
    <extension
          point="org.eclipse.chemclipse.xxd.process.ui.menu.icon">

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/csv/ui/preferences/ChannelMappingPreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/csv/ui/preferences/ChannelMappingPreferencePage.java
@@ -9,22 +9,22 @@
  *
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
-package org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.preferences;
+package org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui.preferences;
 
-import org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.preferences.PreferenceSupplier;
-import org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.Activator;
+import org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.preferences.PreferenceSupplier;
+import org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui.Activator;
+import org.eclipse.chemclipse.pcr.report.supplier.tabular.ui.editors.ChannelMappingFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
-import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
-public class PreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+public class ChannelMappingPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
 
-	public PreferencePage() {
+	public ChannelMappingPreferencePage() {
 
 		super(GRID);
 		setPreferenceStore(Activator.getDefault().getPreferenceStore());
-		setDescription("Exports plates into *.xlsx reports.");
+		setDescription("Labels the headers according to these rules.");
 	}
 
 	/**
@@ -35,7 +35,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	@Override
 	public void createFieldEditors() {
 
-		addField(new StringFieldEditor(PreferenceSupplier.P_ANALYSIS_SEPARATOR, "Sample Analysis Separator:", getFieldEditorParent()));
+		addField(new ChannelMappingFieldEditor(PreferenceSupplier.P_CHANNEL_MAPPING, "", getFieldEditorParent()));
 	}
 
 	/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/csv/ui/preferences/PreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/csv/ui/preferences/PreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,10 +15,6 @@ import org.eclipse.chemclipse.model.settings.Delimiter;
 import org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui.Activator;
 import org.eclipse.chemclipse.pcr.report.supplier.tabular.model.DecimalSeparator;
-import org.eclipse.chemclipse.pcr.report.supplier.tabular.ui.editors.ChannelMappingFieldEditor;
-import org.eclipse.chemclipse.pcr.report.supplier.tabular.ui.editors.VirtualChannelFieldEditor;
-import org.eclipse.chemclipse.pcr.report.supplier.tabular.ui.editors.WellMappingFieldEditor;
-import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.LabelFieldEditor;
 import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.ui.IWorkbench;
@@ -30,7 +26,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 		super(GRID);
 		setPreferenceStore(Activator.getDefault().getPreferenceStore());
-		setDescription("Exports plates into *.csv reports according to these rules.");
+		setDescription("Exports plates into *.csv reports.");
 	}
 
 	/**
@@ -41,10 +37,6 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	@Override
 	public void createFieldEditors() {
 
-		addField(new ChannelMappingFieldEditor(PreferenceSupplier.P_CHANNEL_MAPPING, "Channel Mappings:", getFieldEditorParent()));
-		addField(new WellMappingFieldEditor(PreferenceSupplier.P_WELL_MAPPING, "Well Mappings:", getFieldEditorParent()));
-		addField(new VirtualChannelFieldEditor(PreferenceSupplier.P_VIRTUAL_CHANNELS, "Virtual Channels:", getFieldEditorParent()));
-		addField(new LabelFieldEditor("*.csv Options", getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_DELIMITER, "Delimiter Character: ", Delimiter.getOptions(), getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_DECIMAL_SEPARATOR, "Decimal Separator: ", DecimalSeparator.getOptions(), getFieldEditorParent()));
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/csv/ui/preferences/VirtualChannelsPreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/csv/ui/preferences/VirtualChannelsPreferencePage.java
@@ -9,22 +9,22 @@
  *
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
-package org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.preferences;
+package org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui.preferences;
 
-import org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.preferences.PreferenceSupplier;
-import org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.Activator;
+import org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.preferences.PreferenceSupplier;
+import org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui.Activator;
+import org.eclipse.chemclipse.pcr.report.supplier.tabular.ui.editors.VirtualChannelFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
-import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
-public class PreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+public class VirtualChannelsPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
 
-	public PreferencePage() {
+	public VirtualChannelsPreferencePage() {
 
 		super(GRID);
 		setPreferenceStore(Activator.getDefault().getPreferenceStore());
-		setDescription("Exports plates into *.xlsx reports.");
+		setDescription("Adds extra channels by combining existing ones according to these rules.");
 	}
 
 	/**
@@ -35,7 +35,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	@Override
 	public void createFieldEditors() {
 
-		addField(new StringFieldEditor(PreferenceSupplier.P_ANALYSIS_SEPARATOR, "Sample Analysis Separator:", getFieldEditorParent()));
+		addField(new VirtualChannelFieldEditor(PreferenceSupplier.P_VIRTUAL_CHANNELS, "", getFieldEditorParent()));
 	}
 
 	/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/csv/ui/preferences/WellMappingPreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/csv/ui/preferences/WellMappingPreferencePage.java
@@ -9,22 +9,22 @@
  *
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
-package org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.preferences;
+package org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui.preferences;
 
-import org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.preferences.PreferenceSupplier;
-import org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.Activator;
+import org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.preferences.PreferenceSupplier;
+import org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui.Activator;
+import org.eclipse.chemclipse.pcr.report.supplier.tabular.ui.editors.WellMappingFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
-import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
-public class PreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+public class WellMappingPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
 
-	public PreferencePage() {
+	public WellMappingPreferencePage() {
 
 		super(GRID);
 		setPreferenceStore(Activator.getDefault().getPreferenceStore());
-		setDescription("Exports plates into *.xlsx reports.");
+		setDescription("Decides how the end result is reported based on Ct values.");
 	}
 
 	/**
@@ -35,7 +35,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	@Override
 	public void createFieldEditors() {
 
-		addField(new StringFieldEditor(PreferenceSupplier.P_ANALYSIS_SEPARATOR, "Sample Analysis Separator:", getFieldEditorParent()));
+		addField(new WellMappingFieldEditor(PreferenceSupplier.P_WELL_MAPPING, "", getFieldEditorParent()));
 	}
 
 	/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui/plugin.xml
@@ -9,6 +9,18 @@
             id="org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.preferences.converterPreferencePage"
             name="Excel PCR Export Converter">
       </page>
+      <page
+            category="org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.preferences.converterPreferencePage"
+            class="org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.preferences.IgnoredSubsetPreferencePage"
+            id="org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.preferences.converterPreferencePageIgnoredSubsets"
+            name="Ignored PCR Subsets">
+      </page>
+      <page
+            category="org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.preferences.converterPreferencePage"
+            class="org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.preferences.ChannelMappingPreferencePage"
+            id="org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.preferences.converterPreferencePageIgnoredSubsets"
+            name="PCR Channel Mappings">
+      </page>
    </extension>
    <extension
          point="org.eclipse.chemclipse.xxd.process.ui.menu.icon">

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/ui/preferences/ChannelMappingPreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/ui/preferences/ChannelMappingPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Lablicate GmbH.
+ * Copyright (c) 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,18 +13,18 @@ package org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.preferences;
 
 import org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.Activator;
+import org.eclipse.chemclipse.pcr.report.supplier.tabular.ui.editors.ChannelMappingFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
-import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
-public class PreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+public class ChannelMappingPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
 
-	public PreferencePage() {
+	public ChannelMappingPreferencePage() {
 
 		super(GRID);
 		setPreferenceStore(Activator.getDefault().getPreferenceStore());
-		setDescription("Exports plates into *.xlsx reports.");
+		setDescription("Exports plates into *.xlsx reports according to these rules.");
 	}
 
 	/**
@@ -35,7 +35,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	@Override
 	public void createFieldEditors() {
 
-		addField(new StringFieldEditor(PreferenceSupplier.P_ANALYSIS_SEPARATOR, "Sample Analysis Separator:", getFieldEditorParent()));
+		addField(new ChannelMappingFieldEditor(PreferenceSupplier.P_CHANNEL_MAPPING, "", getFieldEditorParent()));
 	}
 
 	/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/ui/preferences/IgnoredSubsetPreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/ui/preferences/IgnoredSubsetPreferencePage.java
@@ -14,17 +14,16 @@ package org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.preferences;
 import org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.Activator;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
-import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
-public class PreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+public class IgnoredSubsetPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
 
-	public PreferencePage() {
+	public IgnoredSubsetPreferencePage() {
 
 		super(GRID);
 		setPreferenceStore(Activator.getDefault().getPreferenceStore());
-		setDescription("Exports plates into *.xlsx reports.");
+		setDescription("These subsets will never get reported.");
 	}
 
 	/**
@@ -35,7 +34,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	@Override
 	public void createFieldEditors() {
 
-		addField(new StringFieldEditor(PreferenceSupplier.P_ANALYSIS_SEPARATOR, "Sample Analysis Separator:", getFieldEditorParent()));
+		addField(new StringListFieldEditor(PreferenceSupplier.P_IGNORE_SUBSETS, "", getFieldEditorParent()));
 	}
 
 	/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/ui/preferences/PreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/ui/preferences/PreferencePage.java
@@ -13,6 +13,7 @@ package org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.preferences;
 
 import org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui.Activator;
+import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.ui.IWorkbench;
@@ -36,6 +37,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	public void createFieldEditors() {
 
 		addField(new StringFieldEditor(PreferenceSupplier.P_ANALYSIS_SEPARATOR, "Sample Analysis Separator:", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_OPEN_REPORT, "Open report after generation.", getFieldEditorParent()));
 	}
 
 	/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/core/PCRExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/core/PCRExportConverter.java
@@ -295,9 +295,7 @@ public class PCRExportConverter extends AbstractPlateExportConverter implements 
 				}
 			}
 		}
-		for(int c = 0; c < maxColumn; c++) {
-			sheet.setColumnWidth(c, sheet.getColumnWidth(c + 1));
-		}
+		sheet.autoSizeColumn(columnToDelete);
 	}
 
 	private void cloneCell(Cell newCell, Cell oldCell) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/core/PCRExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/core/PCRExportConverter.java
@@ -48,6 +48,7 @@ import org.eclipse.chemclipse.pcr.report.supplier.tabular.model.ChannelMappings;
 import org.eclipse.chemclipse.pcr.report.supplier.tabular.model.WellComparator;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
+import org.eclipse.chemclipse.support.editor.SystemEditor;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 public class PCRExportConverter extends AbstractPlateExportConverter implements IPlateExportConverter {
@@ -106,8 +107,9 @@ public class PCRExportConverter extends AbstractPlateExportConverter implements 
 			processingInfo.addErrorMessage(DESCRIPTION, "Input/Output problem.");
 			logger.warn(e);
 		}
+		if(PreferenceSupplier.isOpenReport()) {
+			SystemEditor.open(file);
 		}
-		//
 		return processingInfo;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/core/PCRExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/core/PCRExportConverter.java
@@ -98,15 +98,14 @@ public class PCRExportConverter extends AbstractPlateExportConverter implements 
 				} catch(FileNotFoundException e) {
 					logger.warn(e);
 					processingInfo.addErrorMessage(DESCRIPTION, "File not found.");
-				} catch(IOException e) {
-					processingInfo.addErrorMessage(DESCRIPTION, "Input/Output problem.");
-					logger.warn(e);
 				}
 			} else {
 				processingInfo.addErrorMessage(DESCRIPTION, "The PCR plate is not available.");
 			}
-		} catch(IOException e1) {
-			logger.warn(e1);
+		} catch(IOException e) {
+			processingInfo.addErrorMessage(DESCRIPTION, "Input/Output problem.");
+			logger.warn(e);
+		}
 		}
 		//
 		return processingInfo;

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/preferences/PreferenceSupplier.java
@@ -120,13 +120,11 @@ public class PreferenceSupplier implements IPreferenceSupplier {
 
 	public static Boolean isOpenReport() {
 
-		IEclipsePreferences preferences = INSTANCE().getPreferences();
-		return preferences.getBoolean(P_OPEN_REPORT, DEF_OPEN_REPORT);
+		return INSTANCE().getBoolean(P_OPEN_REPORT, DEF_OPEN_REPORT);
 	}
 
 	private static String getFilterPath(String key, String def) {
 
-		IEclipsePreferences preferences = INSTANCE().getPreferences();
-		return preferences.get(key, def);
+		return INSTANCE().get(key, def);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/preferences/PreferenceSupplier.java
@@ -90,9 +90,9 @@ public class PreferenceSupplier implements IPreferenceSupplier {
 	public static Set<String> getIgnoredSubsets() {
 
 		IEclipsePreferences preferences = INSTANCE().getPreferences();
-		Set<String> subsets = new HashSet<String>();
+		Set<String> subsets = new HashSet<>();
 		String preferenceEntry = preferences.get(P_IGNORE_SUBSETS, DEF_IGNORE_SUBSETS);
-		if(preferenceEntry != "") {
+		if(!"".equals(preferenceEntry)) {
 			String[] items = StringUtils.parseString(preferenceEntry);
 			if(items.length > 0) {
 				for(String item : items) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/preferences/PreferenceSupplier.java
@@ -36,6 +36,8 @@ public class PreferenceSupplier implements IPreferenceSupplier {
 	public static final String DEF_LIST_PATH_EXPORT = "";
 	public static final String P_ANALYSIS_SEPARATOR = "xlsx-pcr-analysis-separator";
 	public static final String DEF_ANALYSIS_SEPARATOR = "_";
+	public static final String P_OPEN_REPORT = "xlsx-pcr-open-report";
+	public static final boolean DEF_OPEN_REPORT = true;
 	//
 	private static IPreferenceSupplier preferenceSupplier;
 
@@ -66,6 +68,7 @@ public class PreferenceSupplier implements IPreferenceSupplier {
 		defaultValues.put(P_CHANNEL_MAPPING, DEF_CHANNEL_MAPPING);
 		defaultValues.put(P_IGNORE_SUBSETS, DEF_IGNORE_SUBSETS);
 		defaultValues.put(P_ANALYSIS_SEPARATOR, DEF_ANALYSIS_SEPARATOR);
+		defaultValues.put(P_OPEN_REPORT, Boolean.toString(DEF_OPEN_REPORT));
 		return defaultValues;
 	}
 
@@ -113,6 +116,12 @@ public class PreferenceSupplier implements IPreferenceSupplier {
 	public static String getListPathExport() {
 
 		return getFilterPath(P_LIST_PATH_EXPORT, DEF_LIST_PATH_EXPORT);
+	}
+
+	public static Boolean isOpenReport() {
+
+		IEclipsePreferences preferences = INSTANCE().getPreferences();
+		return preferences.getBoolean(P_OPEN_REPORT, DEF_OPEN_REPORT);
 	}
 
 	private static String getFilterPath(String key, String def) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/preferences/PreferenceSupplier.java
@@ -16,7 +16,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.pcr.report.supplier.tabular.Activator;
 import org.eclipse.chemclipse.pcr.report.supplier.tabular.model.ChannelMappings;
 import org.eclipse.chemclipse.pcr.report.supplier.tabular.preferences.StringUtils;
@@ -24,12 +23,9 @@ import org.eclipse.chemclipse.support.preferences.IPreferenceSupplier;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.eclipse.core.runtime.preferences.InstanceScope;
-import org.osgi.service.prefs.BackingStoreException;
 
 public class PreferenceSupplier implements IPreferenceSupplier {
 
-	private static final Logger logger = Logger.getLogger(PreferenceSupplier.class);
-	//
 	public static final String P_IGNORE_SUBSETS = "ignore-subsets";
 	public static final String DEF_IGNORE_SUBSETS = "New Subset";
 	public static final String P_CHANNEL_MAPPING = "channel-mapping-xlsx";
@@ -114,35 +110,14 @@ public class PreferenceSupplier implements IPreferenceSupplier {
 		return getFilterPath(P_LIST_PATH_IMPORT, DEF_LIST_PATH_IMPORT);
 	}
 
-	public static void setListPathImport(String filterPath) {
-
-		setFilterPath(P_LIST_PATH_IMPORT, filterPath);
-	}
-
 	public static String getListPathExport() {
 
 		return getFilterPath(P_LIST_PATH_EXPORT, DEF_LIST_PATH_EXPORT);
-	}
-
-	public static void setListPathExport(String filterPath) {
-
-		setFilterPath(P_LIST_PATH_EXPORT, filterPath);
 	}
 
 	private static String getFilterPath(String key, String def) {
 
 		IEclipsePreferences preferences = INSTANCE().getPreferences();
 		return preferences.get(key, def);
-	}
-
-	private static void setFilterPath(String key, String filterPath) {
-
-		try {
-			IEclipsePreferences preferences = INSTANCE().getPreferences();
-			preferences.put(key, filterPath);
-			preferences.flush();
-		} catch(BackingStoreException e) {
-			logger.warn(e);
-		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/editors/ChannelMappingFieldEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/editors/ChannelMappingFieldEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -55,6 +55,7 @@ public class ChannelMappingFieldEditor extends FieldEditor {
 		editor = new ChannelMappingTable(parent, SWT.NONE);
 		GridData gridData = new GridData(GridData.FILL_BOTH);
 		gridData.minimumHeight = 150;
+		gridData.widthHint = 500;
 		editor.setLayoutData(gridData);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/editors/VirtualChannelFieldEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/editors/VirtualChannelFieldEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -55,6 +55,7 @@ public class VirtualChannelFieldEditor extends FieldEditor {
 		editor = new VirtualChannelTable(parent, SWT.NONE);
 		GridData gridData = new GridData(GridData.FILL_BOTH);
 		gridData.minimumHeight = 150;
+		gridData.widthHint = 600;
 		editor.setLayoutData(gridData);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/editors/WellMappingFieldEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/editors/WellMappingFieldEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -55,6 +55,7 @@ public class WellMappingFieldEditor extends FieldEditor {
 		editor = new WellMappingTable(parent, SWT.NONE);
 		GridData gridData = new GridData(GridData.FILL_BOTH);
 		gridData.minimumHeight = 150;
+		gridData.widthHint = 1000;
 		editor.setLayoutData(gridData);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/internal/provider/ChannelMappingLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/internal/provider/ChannelMappingLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -45,8 +45,7 @@ public class ChannelMappingLabelProvider extends AbstractChemClipseLabelProvider
 	public String getColumnText(Object element, int columnIndex) {
 
 		String text = "";
-		if(element instanceof ChannelMapping) {
-			ChannelMapping channelMapping = (ChannelMapping)element;
+		if(element instanceof ChannelMapping channelMapping) {
 			switch(columnIndex) {
 				case 0:
 					text = channelMapping.getSubset();

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/internal/provider/VirtualChannelLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/internal/provider/VirtualChannelLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -47,8 +47,7 @@ public class VirtualChannelLabelProvider extends AbstractChemClipseLabelProvider
 	public String getColumnText(Object element, int columnIndex) {
 
 		String text = "";
-		if(element instanceof VirtualChannel) {
-			VirtualChannel virtualChannel = (VirtualChannel)element;
+		if(element instanceof VirtualChannel virtualChannel) {
 			switch(columnIndex) {
 				case 0:
 					text = virtualChannel.getSubset();

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/internal/provider/WellMappingLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/internal/provider/WellMappingLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -51,8 +51,7 @@ public class WellMappingLabelProvider extends AbstractChemClipseLabelProvider {
 	public String getColumnText(Object element, int columnIndex) {
 
 		String text = "";
-		if(element instanceof WellMapping) {
-			WellMapping wellMapping = (WellMapping)element;
+		if(element instanceof WellMapping wellMapping) {
 			switch(columnIndex) {
 				case 0:
 					text = wellMapping.getSubset();

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/plugin.xml
@@ -21,7 +21,12 @@
             class="org.eclipse.chemclipse.rcp.app.ui.preferences.PreferencePage"
             id="org.eclipse.chemclipse.rcp.app.ui.preferences.preferencePage"
             name="Chromatography/Spectrometry">
-      </page>   
+      </page>
+      <page
+            class="org.eclipse.chemclipse.rcp.app.ui.preferences.PreferencePage"
+            id="org.eclipse.chemclipse.rcp.app.ui.preferences.preferencePageMolecularBiology"
+            name="Molecular Biology">
+      </page>
       <page
             category="org.eclipse.chemclipse.rcp.app.ui.preferences.preferencePage"
             class="org.eclipse.chemclipse.rcp.app.ui.preferences.DevicesPreferencePage"


### PR DESCRIPTION
This improves usability on top of #1086 and #1493. The settings were hard to find and navigate. My idea of having all tables in one page also turned out to be a disaster for layouting so I split them and added some descriptions. There was also an annoying bug where the resulting column width was wrong for reports which got empty columns removed. As a goody you can now automatically open the human readable spreadsheet report inspired by #1476.