### PR TITLE
Added progress bars to the File Identifier

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/support/DatabasesCache.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/support/DatabasesCache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -240,8 +240,7 @@ public class DatabasesCache {
 		}
 		//
 		for(IScanMSD reference : massSpectraDatabase.getList()) {
-			if(reference instanceof IRegularLibraryMassSpectrum) {
-				IRegularLibraryMassSpectrum libraryMassSpectrum = (IRegularLibraryMassSpectrum)reference;
+			if(reference instanceof IRegularLibraryMassSpectrum libraryMassSpectrum) {
 				ILibraryInformation libraryInformation = libraryMassSpectrum.getLibraryInformation();
 				databaseNames.put(libraryInformation.getName(), reference);
 				databaseCasNumbers.put(libraryInformation.getCasNumber(), reference);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/core/ChromatogramIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/core/ChromatogramIdentifier.java
@@ -40,12 +40,11 @@ public class ChromatogramIdentifier extends AbstractChromatogramIdentifier {
 
 		IProcessingInfo<?> processingInfo = validate(chromatogramSelection, chromatogramIdentifierSettings);
 		if(!processingInfo.hasErrorMessages()) {
-			if(chromatogramIdentifierSettings instanceof IdentifierSettings) {
+			if(chromatogramIdentifierSettings instanceof IdentifierSettings settings) {
 				try {
 					/*
 					 * Settings
 					 */
-					IdentifierSettings settings = (IdentifierSettings)chromatogramIdentifierSettings;
 					boolean useNormalize = settings.isUseNormalizedScan();
 					CalculationType calculationType = settings.getCalculationType();
 					boolean usePeaksInsteadOfScans = settings.isUsePeaksInsteadOfScans();

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/core/MassSpectrumIdentifierFile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/core/MassSpectrumIdentifierFile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -35,8 +35,8 @@ public class MassSpectrumIdentifierFile extends AbstractMassSpectrumIdentifier {
 		//
 		try {
 			MassSpectrumIdentifierSettings massSpectrumIdentifierSettings;
-			if(identifierSettings instanceof MassSpectrumIdentifierSettings) {
-				massSpectrumIdentifierSettings = (MassSpectrumIdentifierSettings)identifierSettings;
+			if(identifierSettings instanceof MassSpectrumIdentifierSettings settings) {
+				massSpectrumIdentifierSettings = settings;
 			} else {
 				massSpectrumIdentifierSettings = PreferenceSupplier.getMassSpectrumIdentifierSettings();
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/internal/identifier/FileIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/internal/identifier/FileIdentifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 Lablicate GmbH.
+ * Copyright (c) 2015, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -259,14 +259,6 @@ public class FileIdentifier {
 		return matched;
 	}
 
-	private static boolean isValidTarget(IComparisonResult comparisonResult, float minMatchFactor, float minReverseMatchFactor) {
-
-		if(comparisonResult.getMatchFactor() >= minMatchFactor && comparisonResult.getReverseMatchFactor() >= minReverseMatchFactor) {
-			return true;
-		}
-		return false;
-	}
-
 	private static final class FindMatchingSpectras extends RecursiveTask<Map<IComparisonResult, IScanMSD>> {
 
 		private static final long serialVersionUID = 1L;
@@ -331,6 +323,14 @@ public class FileIdentifier {
 				}
 			}
 			return results;
+		}
+
+		private static boolean isValidTarget(IComparisonResult comparisonResult, float minMatchFactor, float minReverseMatchFactor) {
+
+			if(comparisonResult.getMatchFactor() >= minMatchFactor && comparisonResult.getReverseMatchFactor() >= minReverseMatchFactor) {
+				return true;
+			}
+			return false;
 		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/internal/identifier/FileIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/internal/identifier/FileIdentifier.java
@@ -66,7 +66,6 @@ public class FileIdentifier {
 
 	public IMassSpectra runIdentification(List<IScanMSD> massSpectraList, ILibraryIdentifierSettings fileIdentifierSettings, IProgressMonitor monitor) throws FileNotFoundException {
 
-		SubMonitor subMonitor = SubMonitor.convert(monitor, "Running mass spectra identification", 100);
 		/*
 		 * Pre-filter the mass spectra to identify.
 		 */
@@ -91,10 +90,9 @@ public class FileIdentifier {
 		 * Load the mass spectra database only if the raw file or its content has changed.
 		 */
 		List<String> files = extractFiles(fileIdentifierSettings.getMassSpectraFiles());
-		Map<String, IMassSpectra> databases = databasesCache.getDatabases(files, subMonitor.split(10));
-		subMonitor.setWorkRemaining(databases.size() * 100);
+		Map<String, IMassSpectra> databases = databasesCache.getDatabases(files, monitor);
 		for(Map.Entry<String, IMassSpectra> database : databases.entrySet()) {
-			compareMassSpectraAgainstDatabase(massSpectra.getList(), database.getValue().getList(), fileIdentifierSettings, identifier, database.getKey(), subMonitor.split(100, SubMonitor.SUPPRESS_NONE));
+			compareMassSpectraAgainstDatabase(massSpectra.getList(), database.getValue().getList(), fileIdentifierSettings, identifier, database.getKey(), monitor);
 		}
 		//
 		return massSpectra;
@@ -112,7 +110,6 @@ public class FileIdentifier {
 	 */
 	public IPeakIdentificationResults runPeakIdentification(List<? extends IPeakMSD> peaks, PeakIdentifierSettings peakIdentifierSettings, IProcessingInfo<?> processingInfo, IProgressMonitor monitor) throws FileNotFoundException {
 
-		SubMonitor subMonitor = SubMonitor.convert(monitor, "Running mass spectra identification", 100);
 		/*
 		 * Pre-filter the mass spectra to identify.
 		 */
@@ -138,10 +135,9 @@ public class FileIdentifier {
 		 * Load the mass spectra database only if the raw file or its content has changed.
 		 */
 		List<String> files = extractFiles(peakIdentifierSettings.getMassSpectraFiles());
-		Map<String, IMassSpectra> databases = databasesCache.getDatabases(files, subMonitor.split(10));
-		subMonitor.setWorkRemaining(databases.size() * 100);
+		Map<String, IMassSpectra> databases = databasesCache.getDatabases(files, monitor);
 		for(Map.Entry<String, IMassSpectra> database : databases.entrySet()) {
-			comparePeaksAgainstDatabase(peaksToIdentify, database.getValue().getList(), peakIdentifierSettings, identifier, database.getKey(), subMonitor.split(100, SubMonitor.SUPPRESS_NONE));
+			comparePeaksAgainstDatabase(peaksToIdentify, database.getValue().getList(), peakIdentifierSettings, identifier, database.getKey(), monitor);
 		}
 		//
 		return identificationResults;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/settings/MassSpectrumIdentifierSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/settings/MassSpectrumIdentifierSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -30,7 +30,7 @@ public class MassSpectrumIdentifierSettings extends AbstractMassSpectrumIdentifi
 
 	@JsonProperty(value = "Library File", defaultValue = "")
 	@JsonPropertyDescription("Select the library file.")
-	@FileSettingProperty(dialogType = DialogType.OPEN_DIALOG, extensionNames = {"AMDIS (*.msl)", "NIST (*.msp)", "MassBank (.zip)"}, validExtensions = {"*.msl;*.MSL", "*.msp;*.MSP", "*.zip;*.ZIP"}, onlyDirectory = false)
+	@FileSettingProperty(dialogType = DialogType.OPEN_DIALOG, extensionNames = {"AMDIS (*.msl)", "NIST (*.msp)"}, validExtensions = {"*.msl;*.MSL", "*.msp;*.MSP"}, onlyDirectory = false)
 	private File libraryFile;
 	@JsonProperty(value = "Pre-Optimization", defaultValue = "false")
 	private boolean usePreOptimization = false;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSLReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSLReader.java
@@ -86,7 +86,7 @@ public class MSLReader extends AbstractMassSpectraReader implements IMassSpectra
 
 		List<String> massSpectraData = getMassSpectraData(file);
 		//
-		IMassSpectra massSpectra = extractMassSpectra(massSpectraData);
+		IMassSpectra massSpectra = extractMassSpectra(massSpectraData, monitor);
 		massSpectra.setConverterId(CONVERTER_ID);
 		massSpectra.setName(file.getName());
 		/*
@@ -300,7 +300,7 @@ public class MSLReader extends AbstractMassSpectraReader implements IMassSpectra
 	 * @param massSpectraData
 	 * @return IMassSpectra
 	 */
-	private IMassSpectra extractMassSpectra(List<String> massSpectraData) {
+	private IMassSpectra extractMassSpectra(List<String> massSpectraData, IProgressMonitor monitor) {
 
 		IMassSpectra massSpectra = new MassSpectra();
 		String referenceIdentifierMarker = org.eclipse.chemclipse.msd.converter.preferences.PreferenceSupplier.getReferenceIdentifierMarker();
@@ -309,8 +309,10 @@ public class MSLReader extends AbstractMassSpectraReader implements IMassSpectra
 		 * Iterates through the saved mass spectrum text data and converts it to
 		 * a mass spectrum.
 		 */
+		monitor.beginTask("Extract mass spectra", massSpectraData.size());
 		for(String massSpectrumData : massSpectraData) {
 			addMassSpectrum(massSpectra, massSpectrumData, referenceIdentifierMarker, referenceIdentifierPrefix);
+			monitor.worked(1);
 		}
 		return massSpectra;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -76,7 +76,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 
 		List<String> massSpectraData = getMassSpectraData(file);
 		//
-		IMassSpectra massSpectra = extractMassSpectra(massSpectraData);
+		IMassSpectra massSpectra = extractMassSpectra(massSpectraData, monitor);
 		massSpectra.setConverterId(CONVERTER_ID);
 		massSpectra.setName(file.getName());
 		/*
@@ -163,7 +163,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 	 * @param massSpectraData
 	 * @return IMassSpectra
 	 */
-	private IMassSpectra extractMassSpectra(List<String> massSpectraData) {
+	private IMassSpectra extractMassSpectra(List<String> massSpectraData, IProgressMonitor monitor) {
 
 		IMassSpectra massSpectra = new MassSpectra();
 		String referenceIdentifierMarker = org.eclipse.chemclipse.msd.converter.preferences.PreferenceSupplier.getReferenceIdentifierMarker();
@@ -174,8 +174,10 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 			 * Iterates through the saved mass spectrum text data and converts it to
 			 * a mass spectrum.
 			 */
+			monitor.beginTask("Extract mass spectra", massSpectraData.size());
 			for(String massSpectrumData : massSpectraData) {
 				addMassSpectrum(massSpectra, massSpectrumData, referenceIdentifierMarker, referenceIdentifierPrefix);
+				monitor.worked(1);
 			}
 		} else if(massSpectraData.size() == 1) {
 			/*


### PR DESCRIPTION
This adds moving progress bars to reading `.msl` and `.msp` files and also shows that when using file-based identifiers, which showed a bar that does not move before. Also removes .ZIP from the dialog, which was removed in https://github.com/eclipse/chemclipse/pull/1439.