### PR TITLE
Fixed a memory leak in Database Editor

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/LibraryModifySupportUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/LibraryModifySupportUI.java
@@ -441,4 +441,11 @@ public class LibraryModifySupportUI extends Composite {
 		buttonSelectLibrary.setEnabled(enabled);
 		buttonMergeLibrary.setEnabled(enabled);
 	}
+
+	@Override
+	public void dispose() {
+
+		massSpectra = null;
+		massSpectrumListUI.dispose();
+	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/MassSpectrumListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/MassSpectrumListUI.java
@@ -276,4 +276,9 @@ public class MassSpectrumListUI extends ExtendedTableViewer {
 
 		return ((getTable().getStyle() & SWT.VIRTUAL) == SWT.VIRTUAL);
 	}
+
+	public void dispose() {
+
+		massSpectra = null;
+	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/DatabaseEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/DatabaseEditor.java
@@ -180,10 +180,9 @@ public class DatabaseEditor implements IChemClipseEditor {
 
 		if(objects.size() == 1) {
 			Object object = objects.get(0);
-			if(object instanceof IMassSpectra) {
+			if(object instanceof IMassSpectra newMassSpectra) {
 				if(object == massSpectra) {
-					IMassSpectra massSpectra = (IMassSpectra)object;
-					dirtyable.setDirty(massSpectra.isDirty());
+					dirtyable.setDirty(newMassSpectra.isDirty());
 				}
 			}
 		}
@@ -238,7 +237,7 @@ public class DatabaseEditor implements IChemClipseEditor {
 			/*
 			 * No fork, otherwise it might crash when loading the data takes too long.
 			 */
-			boolean fork = (batch) ? false : true;
+			boolean fork = !batch;
 			dialog.run(fork, false, runnable);
 		} catch(InvocationTargetException e) {
 			logger.warn(e);
@@ -275,11 +274,11 @@ public class DatabaseEditor implements IChemClipseEditor {
 				File file = new File((String)map.get(EditorSupport.MAP_FILE));
 				boolean batch = (boolean)map.get(EditorSupport.MAP_BATCH);
 				importMassSpectra(file, batch);
-			} else if(object instanceof String) {
+			} else if(object instanceof String text) {
 				/*
 				 * Legacy ... Deprecated
 				 */
-				File file = new File((String)object);
+				File file = new File(text);
 				importMassSpectra(file, true);
 			}
 		} catch(Exception e) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/DatabaseEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/DatabaseEditor.java
@@ -289,6 +289,8 @@ public class DatabaseEditor implements IChemClipseEditor {
 	@PreDestroy
 	private void preDestroy() {
 
+		massSpectrumLibraryUI.dispose();
+		UpdateNotifierUI.update(Display.getDefault(), IChemClipseEvents.TOPIC_LIBRARY_MSD_UPDATE_SELECTION, null);
 		/*
 		 * Remove the editor from the listed parts.
 		 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/DatabaseEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/DatabaseEditor.java
@@ -303,10 +303,6 @@ public class DatabaseEditor implements IChemClipseEditor {
 			part.setVisible(false);
 			partStack.getChildren().remove(part);
 		}
-		/*
-		 * Run the garbage collector.
-		 */
-		System.gc();
 	}
 
 	private EventHandler registerEventHandler(IEventBroker eventBroker, String topic, String[] properties) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumLibraryUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumLibraryUI.java
@@ -390,4 +390,12 @@ public class MassSpectrumLibraryUI extends Composite {
 
 		updateLabel();
 	}
+
+	@Override
+	public void dispose() {
+
+		libraryModifySupportUI.dispose();
+		massSpectrumListUI.dispose();
+		libraryModifySupportUI.dispose();
+	}
 }


### PR DESCRIPTION
Closed mass spectra databases still clogged up, including all their ions.

![image](https://github.com/eclipse/chemclipse/assets/756669/3f7a8f5f-8a83-4f6a-86a8-feba3e173578)
