### PR TITLE
Fixed a native crash in SWT TreeViewer labelling on Linux

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/workbench/DisplayUtils.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/workbench/DisplayUtils.java
@@ -73,8 +73,8 @@ public class DisplayUtils {
 	public static Display getDisplay(Widget widget) {
 
 		Display display = null;
-		if(widget instanceof Control) {
-			display = ((Control)widget).getDisplay();
+		if(widget instanceof Control control) {
+			display = control.getDisplay();
 		} else {
 			display = getDisplay();
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/DataExplorerTreeRoot.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/DataExplorerTreeRoot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Lablicate GmbH.
+ * Copyright (c) 2019, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@
 package org.eclipse.chemclipse.ux.extension.ui.swt;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -120,8 +121,9 @@ public enum DataExplorerTreeRoot {
 
 		List<File> rootFiles = new ArrayList<>();
 		for(File root : roots) {
-			if((!PreferenceSupplier.showNetworkShares()) && isWindowsNetworkDriveRoot(root))
+			if((!PreferenceSupplier.showNetworkShares()) && isWindowsNetworkDriveRoot(root)) {
 				continue;
+			}
 			rootFiles.add(root);
 		}
 		return rootFiles.toArray(new File[rootFiles.size()]);
@@ -143,8 +145,11 @@ public enum DataExplorerTreeRoot {
 			process.getOutputStream().close();
 			int exitCode = process.waitFor();
 			return exitCode == 0;
-		} catch(Exception e) {
+		} catch(IOException e) {
 			logger.error("Failed to detect network drive status for " + driveLetter, e);
+		} catch(InterruptedException e) {
+			logger.error(e);
+			Thread.currentThread().interrupt();
 		}
 		return false;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/DataExplorerPart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/DataExplorerPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -17,6 +17,7 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.eclipse.chemclipse.processing.converter.ISupplierFileIdentifier;
+import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.swt.DataExplorerUI;
 import org.eclipse.e4.core.contexts.IEclipseContext;
@@ -36,7 +37,12 @@ public class DataExplorerPart {
 	@PostConstruct
 	public void init(Composite parent, MPart part, IEclipseContext context) {
 
-		dataExplorerUI = new DataExplorerUI(parent, preferenceStore, context, supplierFileIdentifier);
+		// Workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=573090
+		DisplayUtils.getDisplay().asyncExec(() -> {
+			dataExplorerUI = new DataExplorerUI(parent, preferenceStore, context, supplierFileIdentifier);
+			dataExplorerUI.getControl().redraw();
+			dataExplorerUI.getControl().requestLayout();
+		});
 	}
 
 	public DataExplorerUI getDataExplorerUI() {
@@ -47,6 +53,8 @@ public class DataExplorerPart {
 	@Focus
 	public void focus() {
 
-		dataExplorerUI.setFocus();
+		if(dataExplorerUI != null) {
+			dataExplorerUI.setFocus();
+		}
 	}
 }


### PR DESCRIPTION
Closes https://github.com/OpenChrom/openchrom/issues/317 with the workaround proposed in https://github.com/eclipse-platform/eclipse.platform.swt/issues/678#issuecomment-1699915261.