### PR TITLE
Improve PCR channel and subset selection

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPlateChartsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPlateChartsUI.java
@@ -205,6 +205,9 @@ public class ExtendedPlateChartsUI extends Composite implements IExtendedPartUI 
 			List<ILineSeriesData> lineSeriesDataList = new ArrayList<>();
 			//
 			for(IWell well : plate.getWells()) {
+				if(!well.isActiveSubset()) {
+					continue;
+				}
 				try {
 					int channelNumber = plate.getActiveChannel();
 					IChannel channel = well.getChannels().get(channelNumber);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPlateChartsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPlateChartsUI.java
@@ -26,7 +26,6 @@ import org.eclipse.chemclipse.pcr.model.core.IWell;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
-import org.eclipse.chemclipse.support.ui.swt.EnhancedCombo;
 import org.eclipse.chemclipse.swt.ui.components.InformationUI;
 import org.eclipse.chemclipse.swt.ui.support.Colors;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
@@ -42,7 +41,6 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
-import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swtchart.extensions.core.IChartSettings;
@@ -58,7 +56,6 @@ public class ExtendedPlateChartsUI extends Composite implements IExtendedPartUI 
 	//
 	private Button buttonToolbarInfo;
 	private AtomicReference<InformationUI> toolbarInfo = new AtomicReference<>();
-	private Combo comboChannels;
 	private AtomicReference<ChartPCR> chartControl = new AtomicReference<>();
 	private IPlate plate = null;
 	//
@@ -76,7 +73,6 @@ public class ExtendedPlateChartsUI extends Composite implements IExtendedPartUI 
 
 		this.plate = plate;
 		updateLabel();
-		updateComboChannels();
 		updateChartData();
 		colorCompensation = !plate.getWells().stream().allMatch(w -> w.getActiveChannel() != null //
 				&& !w.getActiveChannel().getColorCompensatedFluorescence().isEmpty());
@@ -85,17 +81,6 @@ public class ExtendedPlateChartsUI extends Composite implements IExtendedPartUI 
 	private void updateLabel() {
 
 		toolbarInfo.get().setText(plate != null ? plate.getName() : "--");
-	}
-
-	private void updateComboChannels() {
-
-		if(plate != null) {
-			List<String> activeChannels = plate.getActiveChannels();
-			comboChannels.setItems(plate.getActiveChannels().toArray(new String[activeChannels.size()]));
-			comboChannels.select(plate.getActiveChannel());
-		} else {
-			comboChannels.setItems("");
-		}
 	}
 
 	private void updateChartData() {
@@ -131,7 +116,6 @@ public class ExtendedPlateChartsUI extends Composite implements IExtendedPartUI 
 		composite.setLayout(new GridLayout(7, false));
 		//
 		createToolbarInfo(composite);
-		comboChannels = createComboChannels(composite);
 		//
 		buttonToolbarInfo = createButtonToggleToolbar(composite, toolbarInfo, IMAGE_INFO, TOOLTIP_INFO);
 		createButtonToggleChartLegend(composite, chartControl, IMAGE_LEGEND);
@@ -195,22 +179,6 @@ public class ExtendedPlateChartsUI extends Composite implements IExtendedPartUI 
 		toolbarInfo.set(informationUI);
 	}
 
-	private Combo createComboChannels(Composite parent) {
-
-		Combo combo = EnhancedCombo.create(parent, SWT.READ_ONLY);
-		combo.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		combo.addSelectionListener(new SelectionAdapter() {
-
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-
-				updateChart();
-			}
-		});
-		//
-		return combo;
-	}
-
 	private void createChart(Composite parent) {
 
 		ChartPCR chart = new ChartPCR(parent, SWT.NONE);
@@ -238,7 +206,7 @@ public class ExtendedPlateChartsUI extends Composite implements IExtendedPartUI 
 			//
 			for(IWell well : plate.getWells()) {
 				try {
-					int channelNumber = comboChannels.getSelectionIndex();
+					int channelNumber = plate.getActiveChannel();
 					IChannel channel = well.getChannels().get(channelNumber);
 					Color color = getWellColor(well, colorCodes);
 					ILineSeriesData lineSeriesData = getLineSeriesData(plate, well, channel, color);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedPCRPlateUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedPCRPlateUI.java
@@ -97,6 +97,7 @@ public class ExtendedPCRPlateUI extends Composite implements IExtendedPartUI {
 				String activeSubset = combo.getText();
 				if(plate != null) {
 					plate.setActiveSubset(activeSubset);
+					fireUpdate(e.widget.getDisplay(), plate);
 					fireUpdate(e.widget.getDisplay(), pcrPlate.getSelectedWell());
 					pcrPlate.refresh();
 				}


### PR DESCRIPTION
Instead of trying to synchronize two combo boxes that do the same, keep only one authoritative. When a subset of data is selected, also reflect that in the chart to avoid getting overwhelmed. You can still select all subsets for an overview across different analyses. I think this is also way more consistent.