### PR TITLE
Add read support for MS/MS fields from MassBank .msp files

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractRegularLibraryMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractRegularLibraryMassSpectrum.java
@@ -32,6 +32,7 @@ public abstract class AbstractRegularLibraryMassSpectrum extends AbstractRegular
 	//
 	private ILibraryInformation libraryInformation;
 	private String precursorType;
+	private String polarity; // TODO enum?
 	private double neutralMass = 0.0d;
 	private Map<String, String> properties = null; // Initialization on demand
 
@@ -88,6 +89,9 @@ public abstract class AbstractRegularLibraryMassSpectrum extends AbstractRegular
 	@Override
 	public String getPolarity() {
 
+		if(polarity != null) {
+			return polarity;
+		}
 		if(properties != null) {
 			String precursorType = getProperty(PROPERTY_PRECURSOR_TYPE);
 			if(precursorType.contains("]+")) {
@@ -98,6 +102,12 @@ public abstract class AbstractRegularLibraryMassSpectrum extends AbstractRegular
 		}
 		//
 		return "";
+	}
+
+	@Override
+	public void setPolarity(String polarity) {
+
+		this.polarity = polarity;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractRegularMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractRegularMassSpectrum.java
@@ -28,8 +28,8 @@ public abstract class AbstractRegularMassSpectrum extends AbstractScanMSD implem
 
 	private static final long serialVersionUID = 6001414280468244074L;
 	//
-	private short massSpectrometer;
-	private short massSpectrumType;
+	private short massSpectrometer; // TODO: enum?
+	private short massSpectrumType; // TODO: enum?
 	private double precursorIon;
 	private double precursorBasePeak;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IRegularLibraryMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IRegularLibraryMassSpectrum.java
@@ -28,12 +28,18 @@ public interface IRegularLibraryMassSpectrum extends IRegularMassSpectrum, ILibr
 	void setNeutralMass(double neutralMass);
 
 	/**
-	 * Returns the polarity (+) or (-) if the precursor type is set.
+	 * Returns the polarity if set.
+	 * 
+	 * Otherwise returns the polarity (+) or (-)
+	 * if the precursor type is set.
+	 * 
 	 * If none is available "" will be returned.
 	 * 
 	 * @return String
 	 */
 	String getPolarity();
+
+	void setPolarity(String polarity);
 
 	Set<String> getPropertyKeySet();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/TestPathHelper.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/TestPathHelper.java
@@ -46,6 +46,7 @@ public class TestPathHelper extends PathResolver {
 	public static final String TESTFILE_IMPORT_LIB_4_MSP = "testData/files/import/msp/Lib4.MSP";
 	public static final String TESTFILE_IMPORT_SYNONYMS = "testData/files/import/msp/Synonyms.MSP";
 	public static final String TESTFILE_IMPORT_GOLMDB_TEST_MSP = "testData/files/import/msp/GolmDB-Test.MSP";
+	public static final String TESTFILE_IMPORT_MASSBANK_TEST_MSP = "testData/files/import/msp/MassBank.msp";
 	/*
 	 * IMPORT ELU
 	 */

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MassBankMS2ImportConverter_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MassBankMS2ImportConverter_ITest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Lablicate GmbH.
+ * 
+ * All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msp;
+
+import java.io.File;
+
+import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
+import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.ImportConverterMspTestCase;
+import org.eclipse.chemclipse.msd.model.core.IRegularLibraryMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.junit.Test;
+
+public class MassBankMS2ImportConverter_ITest extends ImportConverterMspTestCase {
+
+	@Override
+	protected void setUp() throws Exception {
+
+		importFile = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_MASSBANK_TEST_MSP));
+		super.setUp();
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+
+		super.tearDown();
+	}
+
+	@Test
+	public void testMassSpectra() {
+
+		assertNotNull(massSpectra);
+		assertEquals(1, massSpectra.size());
+	}
+
+	@Test
+	public void testMassSpectrum() {
+
+		IScanMSD massSpectrum = massSpectra.getMassSpectrum(1);
+		assertNotNull(massSpectrum);
+		if(massSpectrum instanceof IRegularLibraryMassSpectrum regularLibraryMassSpectrum) {
+			assertEquals((short)2, regularLibraryMassSpectrum.getMassSpectrometer());
+			assertEquals(288.1225d, regularLibraryMassSpectrum.getPrecursorIon());
+			assertEquals(287.11575d, regularLibraryMassSpectrum.getNeutralMass());
+			assertEquals("30(NCE)", regularLibraryMassSpectrum.getProperty(IRegularLibraryMassSpectrum.PROPERTY_COLLISION_ENERGY));
+			assertEquals("+", regularLibraryMassSpectrum.getPolarity());
+			assertEquals("[M+H]+", regularLibraryMassSpectrum.getProperty(IRegularLibraryMassSpectrum.PROPERTY_PRECURSOR_TYPE));
+			assertEquals("Q-Exactive Orbitrap Thermo Scientific", regularLibraryMassSpectrum.getProperty(IRegularLibraryMassSpectrum.PROPERTY_INSTRUMENT_NAME));
+		}
+	}
+}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/testData/files/import/msp/MassBank.msp
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/testData/files/import/msp/MassBank.msp
@@ -1,0 +1,27 @@
+Name: Pyrophen
+Synon: N-[(1S)-1-(4-methoxy-6-oxopyran-2-yl)-2-phenylethyl]acetamide
+DB#: MSBNK-AAFC-AC000854
+InChIKey: VFMQMACUYWGDOJ-AWEZNQCLSA-N
+InChI: InChI=1S/C16H17NO4/c1-11(18)17-14(8-12-6-4-3-5-7-12)15-9-13(20-2)10-16(19)21-15/h3-7,9-10,14H,8H2,1-2H3,(H,17,18)/t14-/m0/s1
+SMILES: CC(=O)N[C@@H](CC1=CC=CC=C1)C2=CC(=CC(=O)O2)OC
+Precursor_type: [M+H]+
+Spectrum_type: MS2
+PrecursorMZ: 288.1225
+Instrument_type: LC-ESI-ITFT
+Instrument: Q-Exactive Orbitrap Thermo Scientific
+Ion_mode: POSITIVE
+Collision_energy: 30(NCE)
+Formula: C16H17NO4
+MW: 287
+ExactMass: 287.11575
+Comments: Parent=288.1225
+Splash: splash10-004j-1940000000-b1bd14eb30f6afd2739e
+Num Peaks: 8
+91.0542 245
+125.0233 999
+154.0499 80
+155.0577 355
+185.0961 349
+200.107 45
+229.0859 142
+246.1125 734


### PR DESCRIPTION
This parses the new fields from https://github.com/eclipse/chemclipse/issues/1554 using @massbank supplied .msp files.