### PR TITLE
Standardize sample name in measurement API

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractMeasurementInfo.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractMeasurementInfo.java
@@ -27,7 +27,7 @@ import org.eclipse.chemclipse.support.text.ValueFormat;
 
 public abstract class AbstractMeasurementInfo implements IMeasurementInfo {
 
-	private static final long serialVersionUID = 4247159773898302230L;
+	private static final long serialVersionUID = 4247159773898302231L;
 	private static final Logger logger = Logger.getLogger(AbstractMeasurementInfo.class);
 	//
 	private static final String OPERATOR = "Operator";
@@ -36,6 +36,7 @@ public abstract class AbstractMeasurementInfo implements IMeasurementInfo {
 	private static final String MISC_INFO_SEPARATED = "Misc Info Separated";
 	private static final String SHORT_INFO = "Short Info";
 	private static final String DETAILED_INFO = "Detailed Info";
+	private static final String SAMPLE_NAME = "Sample Name";
 	private static final String SAMPLE_GROUP = "Sample Group";
 	private static final String BARCODE = "Barcode";
 	private static final String BARCODE_TYPE = "Barcode Type";
@@ -56,6 +57,7 @@ public abstract class AbstractMeasurementInfo implements IMeasurementInfo {
 		headerMap.put(MISC_INFO_SEPARATED, "");
 		headerMap.put(SHORT_INFO, "");
 		headerMap.put(DETAILED_INFO, "");
+		headerMap.put(SAMPLE_NAME, "");
 		headerMap.put(SAMPLE_GROUP, "");
 		headerMap.put(BARCODE, "");
 		headerMap.put(BARCODE_TYPE, "");
@@ -228,6 +230,22 @@ public abstract class AbstractMeasurementInfo implements IMeasurementInfo {
 			putHeaderData(DETAILED_INFO, detailedInfo);
 		} else {
 			putHeaderData(DETAILED_INFO, "");
+		}
+	}
+
+	@Override
+	public String getSampleName() {
+
+		return getHeaderData(SAMPLE_NAME);
+	}
+
+	@Override
+	public void setSampleName(String sampleName) {
+
+		if(sampleName != null) {
+			putHeaderData(SAMPLE_NAME, sampleName);
+		} else {
+			putHeaderData(SAMPLE_NAME, "");
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/FilteredMeasurement.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/FilteredMeasurement.java
@@ -56,6 +56,7 @@ public class FilteredMeasurement<FilteredType extends IMeasurement, ConfigType> 
 	private String sampleWeightUnit;
 	private String barcodeType;
 	private String barcode;
+	private String sampleName;
 	private String sampleGroup;
 	private String shortInfo;
 	private String miscInfoSeparated;
@@ -294,6 +295,21 @@ public class FilteredMeasurement<FilteredType extends IMeasurement, ConfigType> 
 	public void setDetailedInfo(String detailedInfo) {
 
 		this.detailedInfo = detailedInfo;
+	}
+
+	@Override
+	public String getSampleName() {
+
+		if(sampleName != null) {
+			return sampleName;
+		}
+		return measurement.getSampleName();
+	}
+
+	@Override
+	public void setSampleName(String sampleName) {
+
+		this.sampleName = sampleName;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IMeasurementInfo.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IMeasurementInfo.java
@@ -74,6 +74,10 @@ public interface IMeasurementInfo extends Serializable {
 
 	void setDetailedInfo(String detailedInfo);
 
+	String getSampleName();
+
+	void setSampleName(String sampleName);
+
 	String getSampleGroup();
 
 	void setSampleGroup(String sampleGroup);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMyoDta104_ITest.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMyoDta104_ITest.java
@@ -41,7 +41,7 @@ public class ChromatogramImportConverterMyoDta104_ITest extends TestCase {
 	@Test
 	public void testSample() {
 
-		assertEquals("Horse Myoglobin", chromatogram.getDataName());
+		assertEquals("Horse Myoglobin", chromatogram.getSampleName());
 	}
 
 	@Test

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMyoDta105_ITest.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMyoDta105_ITest.java
@@ -41,7 +41,7 @@ public class ChromatogramImportConverterMyoDta105_ITest extends TestCase {
 	@Test
 	public void testSample() {
 
-		assertEquals("myo 7/22 1/50", chromatogram.getDataName());
+		assertEquals("myo 7/22 1/50", chromatogram.getSampleName());
 	}
 
 	@Test

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion104.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion104.java
@@ -72,7 +72,7 @@ public class ChromatogramReaderVersion104 extends AbstractChromatogramReader imp
 			chromatogram = new VendorChromatogram();
 			//
 			AdminType admin = mzData.getDescription().getAdmin();
-			chromatogram.setDataName(admin.getSampleName());
+			chromatogram.setSampleName(admin.getSampleName());
 			for(PersonType contact : admin.getContact()) {
 				String contactDetails = String.join(", ", contact.getName(), contact.getInstitution(), contact.getContactInfo());
 				if(chromatogram.getOperator().isEmpty()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion105.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion105.java
@@ -73,7 +73,7 @@ public class ChromatogramReaderVersion105 extends AbstractChromatogramReader imp
 			chromatogram = new VendorChromatogram();
 			//
 			AdminType admin = mzData.getDescription().getAdmin();
-			chromatogram.setDataName(admin.getSampleName());
+			chromatogram.setSampleName(admin.getSampleName());
 			for(PersonType contact : admin.getContact()) {
 				String contactDetails = String.join(", ", contact.getName(), contact.getInstitution(), contact.getContactInfo());
 				if(chromatogram.getOperator().isEmpty()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ReaderVersion104.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ReaderVersion104.java
@@ -20,8 +20,8 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.v104.model.
 
 public class ReaderVersion104 {
 
-	public final static String NODE_MZ_DATA = "mzData";
-	public final static String NODE_SPECTRUM_LIST = "spectrumList";
+	public static final String NODE_MZ_DATA = "mzData";
+	public static final String NODE_SPECTRUM_LIST = "spectrumList";
 
 	private ReaderVersion104() {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ReaderVersion105.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ReaderVersion105.java
@@ -20,8 +20,8 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.v105.model.
 
 public class ReaderVersion105 {
 
-	public final static String NODE_MZ_DATA = "mzData";
-	public final static String NODE_SPECTRUM_LIST = "spectrumList";
+	public static final String NODE_MZ_DATA = "mzData";
+	public static final String NODE_SPECTRUM_LIST = "spectrumList";
 
 	private ReaderVersion105() {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/io/ChromatogramReaderVersion10.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/io/ChromatogramReaderVersion10.java
@@ -122,7 +122,7 @@ public class ChromatogramReaderVersion10 extends AbstractChromatogramReader impl
 			SampleListType sampleList = mzML.getSampleList();
 			if(sampleList != null) {
 				for(SampleType sample : sampleList.getSample()) {
-					chromatogram.setDataName(sample.getName());
+					chromatogram.setSampleName(sample.getName());
 				}
 			}
 			for(InstrumentConfigurationType instrument : mzML.getInstrumentConfigurationList().getInstrumentConfiguration()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/io/ChromatogramReaderVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/io/ChromatogramReaderVersion110.java
@@ -122,7 +122,7 @@ public class ChromatogramReaderVersion110 extends AbstractChromatogramReader imp
 			SampleListType sampleList = mzML.getSampleList();
 			if(sampleList != null) {
 				for(SampleType sample : sampleList.getSample()) {
-					chromatogram.setDataName(sample.getName());
+					chromatogram.setSampleName(sample.getName());
 				}
 			}
 			for(InstrumentConfigurationType instrument : mzML.getInstrumentConfigurationList().getInstrumentConfiguration()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdes/src/org/eclipse/chemclipse/pcr/converter/supplier/rdes/io/PCRWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdes/src/org/eclipse/chemclipse/pcr/converter/supplier/rdes/io/PCRWriter.java
@@ -75,7 +75,7 @@ public class PCRWriter {
 		for(IWell well : plate.getWells()) {
 			printWriter.print(well.getPosition().toString());
 			printWriter.print(DELIMITER);
-			printWriter.print(well.getSampleId());
+			printWriter.print(well.getSampleName());
 			printWriter.print(DELIMITER);
 			printWriter.print(writeSampleType(well.getSampleType()));
 			printWriter.print(DELIMITER);

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdml/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/io/PCRReaderVersion11.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdml/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/io/PCRReaderVersion11.java
@@ -96,7 +96,7 @@ public class PCRReaderVersion11 implements IPCRReader {
 					IdReferencesType sample = react.getSample();
 					IWell well = new Well();
 					well.setPosition(calculateCoordinate(w + 1, pcrFormatType));
-					well.putHeaderData(IWell.SAMPLE_ID, sample.getId());
+					well.setSampleName(sample.getId());
 					Channel channel = createChannel(rdml);
 					for(DataType data : react.getData()) {
 						for(DpAmpCurveType adp : data.getAdp()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdml/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/io/PCRReaderVersion12.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdml/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/io/PCRReaderVersion12.java
@@ -96,7 +96,7 @@ public class PCRReaderVersion12 implements IPCRReader {
 					IdReferencesType sample = react.getSample();
 					IWell well = new Well();
 					well.setPosition(calculateCoordinate(w + 1, pcrFormatType));
-					well.putHeaderData(IWell.SAMPLE_ID, sample.getId());
+					well.setSampleName(sample.getId());
 					Channel channel = createChannel(rdml);
 					for(DataType data : react.getData()) {
 						for(DpAmpCurveType adp : data.getAdp()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdml/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/io/PCRReaderVersion13.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdml/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/io/PCRReaderVersion13.java
@@ -96,7 +96,7 @@ public class PCRReaderVersion13 implements IPCRReader {
 					IdReferencesType sample = react.getSample();
 					IWell well = new Well();
 					well.setPosition(calculateCoordinate(w + 1, pcrFormatType));
-					well.putHeaderData(IWell.SAMPLE_ID, sample.getId());
+					well.setSampleName(sample.getId());
 					Channel channel = createChannel(rdml);
 					for(DataType data : react.getData()) {
 						for(DpAmpCurveType adp : data.getAdp()) {
@@ -104,7 +104,7 @@ public class PCRReaderVersion13 implements IPCRReader {
 						}
 					}
 					well.getChannels().put(0, channel);
-					well.putHeaderData(IWell.SAMPLE_SUBSET, "Default");
+					well.putHeaderData(IWell.SAMPLE_SUBSET, "Default"); // TODO: should be optional
 					vendorPlate.getWells().add(well);
 					w++;
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.model/src/org/eclipse/chemclipse/pcr/model/core/IWell.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.model/src/org/eclipse/chemclipse/pcr/model/core/IWell.java
@@ -17,7 +17,6 @@ import org.eclipse.chemclipse.model.core.IMeasurement;
 
 public interface IWell extends Comparable<IWell>, IMeasurement {
 
-	String SAMPLE_ID = "Sample ID";
 	String TARGET_NAME = "Target Name";
 	String TARGET_TYPE = "Target Type";
 	String SAMPLE_SUBSET = "Sample Subset";
@@ -52,8 +51,6 @@ public interface IWell extends Comparable<IWell>, IMeasurement {
 	void setPosition(Position position);
 
 	Map<Integer, IChannel> getChannels();
-
-	String getSampleId();
 
 	String getSampleSubset();
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.model/src/org/eclipse/chemclipse/pcr/model/core/Well.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.model/src/org/eclipse/chemclipse/pcr/model/core/Well.java
@@ -34,7 +34,6 @@ public class Well extends AbstractMeasurement implements IWell {
 
 	public Well() {
 
-		addProtectedKey(SAMPLE_ID);
 		addProtectedKey(TARGET_NAME);
 		addProtectedKey(SAMPLE_SUBSET);
 		addProtectedKey(SAMPLE_TYPE);
@@ -46,7 +45,7 @@ public class Well extends AbstractMeasurement implements IWell {
 		if(isEmptyMeasurement()) {
 			return getPosition().toString();
 		} else {
-			return getPosition().toString() + ": " + getSampleId();
+			return getPosition().toString() + ": " + getSampleName();
 		}
 	}
 
@@ -121,12 +120,6 @@ public class Well extends AbstractMeasurement implements IWell {
 	}
 
 	@Override
-	public String getSampleId() {
-
-		return getHeaderDataOrDefault(SAMPLE_ID, "").trim();
-	}
-
-	@Override
 	public String getSampleSubset() {
 
 		return getHeaderDataOrDefault(SAMPLE_SUBSET, "").trim();
@@ -173,7 +166,7 @@ public class Well extends AbstractMeasurement implements IWell {
 	@Override
 	public boolean isEmptyMeasurement() {
 
-		return ("".equals(getSampleId().trim()) || "_".equals(getSampleId().trim()));
+		return ("".equals(getSampleName().trim()) || "_".equals(getSampleName().trim()));
 	}
 
 	@Override
@@ -236,7 +229,6 @@ public class Well extends AbstractMeasurement implements IWell {
 		for(Entry<Integer, IChannel> set : channels.entrySet()) {
 			well.getChannels().put(set.getKey(), set.getValue().makeDeepCopy());
 		}
-		well.putHeaderData(SAMPLE_ID, getSampleId());
 		well.putHeaderData(TARGET_NAME, getTargetName());
 		well.putHeaderData(SAMPLE_SUBSET, getSampleSubset());
 		well.putHeaderData(SAMPLE_TYPE, getSampleType().toString());

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/csv/core/PCRExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/csv/core/PCRExportConverter.java
@@ -143,7 +143,7 @@ public class PCRExportConverter extends AbstractPlateExportConverter implements 
 					continue;
 				}
 				Pattern pattern = Pattern.compile(virtualChannel.getSample(), Pattern.CASE_INSENSITIVE);
-				Matcher matcher = pattern.matcher(well.getSampleId());
+				Matcher matcher = pattern.matcher(well.getSampleName());
 				if(!matcher.find()) {
 					continue;
 				}
@@ -176,7 +176,7 @@ public class PCRExportConverter extends AbstractPlateExportConverter implements 
 							continue;
 						}
 						Pattern pattern = Pattern.compile(wellMapping.getSample(), Pattern.CASE_INSENSITIVE);
-						Matcher matcher = pattern.matcher(well.getSampleId());
+						Matcher matcher = pattern.matcher(well.getSampleName());
 						if(!matcher.find()) {
 							continue;
 						}
@@ -202,7 +202,7 @@ public class PCRExportConverter extends AbstractPlateExportConverter implements 
 							targetChannel.setCrossingPoint(virtualCrossingPoint);
 						}
 						if(well.getChannels().containsKey(target - 1)) {
-							logger.warn("Channel " + target + " for " + well.getSampleId() + " is already defined. Skipping.");
+							logger.warn("Channel " + target + " for " + well.getSampleName() + " is already defined. Skipping.");
 						}
 						well.getChannels().putIfAbsent(target - 1, targetChannel);
 					}
@@ -224,7 +224,7 @@ public class PCRExportConverter extends AbstractPlateExportConverter implements 
 						continue;
 					}
 					Pattern pattern = Pattern.compile(wellMapping.getSample(), Pattern.CASE_INSENSITIVE);
-					Matcher matcher = pattern.matcher(well.getSampleId());
+					Matcher matcher = pattern.matcher(well.getSampleName());
 					if(!matcher.find()) {
 						continue;
 					}

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/core/PCRExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/core/PCRExportConverter.java
@@ -173,11 +173,11 @@ public class PCRExportConverter extends AbstractPlateExportConverter implements 
 				String sampleSubset = dataMap.getOrDefault(IWell.SAMPLE_SUBSET, "");
 				if(isSubsetMatch(sampleSubset, targetSubset)) {
 					XSSFRow data = sheet.createRow(sheet.getLastRowNum() + 1);
-					String sampleNumber = dataMap.getOrDefault(IWell.SAMPLE_ID, "");
+					String sampleName = well.getSampleName();
 					String request = "";
 					if(separator != null && !separator.isEmpty()) {
-						String[] sampleSplit = sampleNumber.split(separator);
-						sampleNumber = sampleSplit[0];
+						String[] sampleSplit = sampleName.split(separator);
+						sampleName = sampleSplit[0];
 						if(sampleSplit.length > 1) {
 							request = sampleSplit[1];
 						}
@@ -186,7 +186,7 @@ public class PCRExportConverter extends AbstractPlateExportConverter implements 
 					positionCell.setCellValue(position.getRow() + position.getColumn());
 					positionCell.setCellStyle(style);
 					XSSFCell sampleNumberCell = data.createCell(1);
-					sampleNumberCell.setCellValue(sampleNumber);
+					sampleNumberCell.setCellValue(sampleName);
 					sampleNumberCell.setCellStyle(style);
 					XSSFCell requestCell = data.createCell(2);
 					requestCell.setCellValue(request);

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/model/WellComparator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/model/WellComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Lablicate GmbH.
+ * Copyright (c) 2021, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,9 +20,9 @@ public class WellComparator implements Comparator<IWell> {
 	@Override
 	public int compare(IWell firstWell, IWell secondWell) {
 
-		if(firstWell.getSampleId().equals(secondWell.getSampleId())) {
+		if(firstWell.getSampleName().equals(secondWell.getSampleName())) {
 			return firstWell.getPosition().compareTo(secondWell.getPosition());
 		}
-		return firstWell.getSampleId().compareTo(secondWell.getSampleId());
+		return firstWell.getSampleName().compareTo(secondWell.getSampleName());
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.txt/src/org/eclipse/chemclipse/pcr/report/supplier/txt/core/PCRExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.txt/src/org/eclipse/chemclipse/pcr/report/supplier/txt/core/PCRExportConverter.java
@@ -140,7 +140,7 @@ public class PCRExportConverter extends AbstractPlateExportConverter implements 
 				if(isSubsetMatch(sampleSubset, targetSubset)) {
 					printWriter.print(position.getRow() + position.getColumn());
 					printWriter.print(TAB);
-					printWriter.print(well.getSampleId());
+					printWriter.print(well.getSampleName());
 					printWriter.print(TAB);
 					printWriter.print(well.getSampleSubset());
 					printWriter.print(TAB);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PCRPlate.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PCRPlate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Lablicate GmbH.
+ * Copyright (c) 2019, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -197,7 +197,7 @@ public class PCRPlate extends Composite {
 				StringBuilder builder = new StringBuilder();
 				String sampleSubset = well.getSampleSubset();
 				String targetName = well.getTargetName();
-				builder.append(well.getSampleId());
+				builder.append(well.getSampleName());
 				if(!well.isEmptyMeasurement()) {
 					builder.append(" | ");
 					builder.append(sampleSubset.equals("") ? "--" : sampleSubset);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PCRWell.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PCRWell.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Lablicate GmbH.
+ * Copyright (c) 2019, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -190,7 +190,7 @@ public class PCRWell extends Composite {
 			} else {
 				if(well.isActiveSubset()) {
 					StringBuilder builder = new StringBuilder();
-					builder.append(well.getSampleId());
+					builder.append(well.getSampleName());
 					appendHeaderInfo(well, builder);
 					appendCrossingPointInfo(well, builder);
 					text = builder.toString();

--- a/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/implementation/Chromatogram_6_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/implementation/Chromatogram_6_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Lablicate GmbH.
+ * Copyright (c) 2016, 2023 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -40,7 +40,7 @@ public class Chromatogram_6_Test extends TestCase {
 
 	public void test_2() {
 
-		assertEquals(12, chromatogram.getHeaderDataMap().size());
+		assertEquals(13, chromatogram.getHeaderDataMap().size());
 	}
 
 	public void test_3() {

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverterTinyProteoWizard10_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverterTinyProteoWizard10_ITest.java
@@ -49,7 +49,7 @@ public class ChromatogramImportConverterTinyProteoWizard10_ITest extends TestCas
 	@Test
 	public void testSample() {
 
-		assertEquals("Sample1", chromatogram.getDataName());
+		assertEquals("Sample1", chromatogram.getSampleName());
 	}
 
 	@Test

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverterTinyProteoWizard110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverterTinyProteoWizard110_ITest.java
@@ -49,7 +49,7 @@ public class ChromatogramImportConverterTinyProteoWizard110_ITest extends TestCa
 	@Test
 	public void testSample() {
 
-		assertEquals("Sample 1", chromatogram.getDataName());
+		assertEquals("Sample 1", chromatogram.getSampleName());
 	}
 
 	@Test


### PR DESCRIPTION
To me, the sample name is the most important field in any lab software. It seems it is not just me because the XML-based file formats also have this field often required. We had it in standalone mass spectra and the PCA model. I now added it to the generic measurement, so chromatograms and PCR plates share the same field.