### PR TITLE
Fixed a native crash on Linux when opening the file browser tree for the first time

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/DataExplorerTreeUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/DataExplorerTreeUI.java
@@ -20,6 +20,7 @@ import java.util.function.Function;
 
 import org.eclipse.chemclipse.processing.converter.ISupplier;
 import org.eclipse.chemclipse.processing.converter.ISupplierFileIdentifier;
+import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
 import org.eclipse.chemclipse.ux.extension.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.ui.l10n.Messages;
 import org.eclipse.chemclipse.ux.extension.ui.listener.DataExplorerDragListener;
@@ -153,7 +154,8 @@ public class DataExplorerTreeUI {
 
 	private void setInput(TreeViewer treeViewer) {
 
-		treeViewer.setInput(dataExplorerTreeRoot.getRootContent());
+		// Workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=573090
+		DisplayUtils.getDisplay().asyncExec(() -> treeViewer.setInput(dataExplorerTreeRoot.getRootContent()));
 	}
 
 	private int getNumberOfChildDirectories(File directory) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/DataExplorerPart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/DataExplorerPart.java
@@ -17,7 +17,6 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.eclipse.chemclipse.processing.converter.ISupplierFileIdentifier;
-import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.swt.DataExplorerUI;
 import org.eclipse.e4.core.contexts.IEclipseContext;
@@ -37,12 +36,7 @@ public class DataExplorerPart {
 	@PostConstruct
 	public void init(Composite parent, MPart part, IEclipseContext context) {
 
-		// Workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=573090
-		DisplayUtils.getDisplay().asyncExec(() -> {
-			dataExplorerUI = new DataExplorerUI(parent, preferenceStore, context, supplierFileIdentifier);
-			dataExplorerUI.getControl().redraw();
-			dataExplorerUI.getControl().requestLayout();
-		});
+		dataExplorerUI = new DataExplorerUI(parent, preferenceStore, context, supplierFileIdentifier);
 	}
 
 	public DataExplorerUI getDataExplorerUI() {
@@ -53,8 +47,6 @@ public class DataExplorerPart {
 	@Focus
 	public void focus() {
 
-		if(dataExplorerUI != null) {
-			dataExplorerUI.setFocus();
-		}
+		dataExplorerUI.setFocus();
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/DataListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/DataListUI.java
@@ -296,8 +296,8 @@ public class DataListUI implements ConfigurableUI<DataListUIConfig> {
 			@Override
 			public String getText(Object element) {
 
-				if(element instanceof File) {
-					return getName((File)element);
+				if(element instanceof File file) {
+					return getName(file);
 				}
 				return "-";
 			}
@@ -314,8 +314,8 @@ public class DataListUI implements ConfigurableUI<DataListUIConfig> {
 			@Override
 			public String getText(Object element) {
 
-				if(element instanceof File) {
-					return getPath((File)element);
+				if(element instanceof File file) {
+					return getPath(file);
 				}
 				return "-";
 			}


### PR DESCRIPTION
This reverts https://github.com/eclipse/chemclipse/pull/1541 as it was not the right spot for https://github.com/eclipse-platform/eclipse.platform.swt/issues/678#issuecomment-1699915261.

Closes https://github.com/OpenChrom/openchrom/issues/317.