### PR TITLE
Fix invalid parameters for process builder

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/amdis/runtime/LinuxWineSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/amdis/runtime/LinuxWineSupport.java
@@ -7,12 +7,13 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis.runtime;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.chemclipse.support.runtime.AbstractLinuxWineSupport;
@@ -21,9 +22,9 @@ public class LinuxWineSupport extends AbstractLinuxWineSupport implements IExten
 
 	private IAmdisSupport amdisSupport;
 
-	public LinuxWineSupport(String application, String parameter) throws FileNotFoundException {
+	public LinuxWineSupport(String application, List<String> parameters) throws FileNotFoundException {
 
-		super(application, parameter);
+		super(application, parameters);
 		amdisSupport = new AmdisSupport(this);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/amdis/runtime/MacWineSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/amdis/runtime/MacWineSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,11 +7,12 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis.runtime;
 
 import java.io.FileNotFoundException;
+import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.support.runtime.AbstractMacWineSupport;
@@ -20,8 +21,9 @@ public class MacWineSupport extends AbstractMacWineSupport implements IExtendedR
 
 	private IAmdisSupport amdisSupport;
 
-	public MacWineSupport(String application, String parameter) throws FileNotFoundException {
-		super(application, parameter, PreferenceSupplier.getMacWineBinary());
+	public MacWineSupport(String application, List<String> parameters) throws FileNotFoundException {
+
+		super(application, parameters, PreferenceSupplier.getMacWineBinary());
 		amdisSupport = new AmdisSupport(this);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/amdis/runtime/RuntimeSupportFactory.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/amdis/runtime/RuntimeSupportFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,11 +7,13 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis.runtime;
 
 import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.chemclipse.support.settings.OperatingSystemUtils;
 
@@ -20,16 +22,18 @@ public class RuntimeSupportFactory {
 	public static IExtendedRuntimeSupport getRuntimeSupport(String application, String chromatogram) throws FileNotFoundException {
 
 		IExtendedRuntimeSupport runtimeSupport;
-		String parameter = chromatogram + " " + IAmdisSupport.PARAMETER;
+		List<String> parameters = new ArrayList<>();
+		parameters.add(chromatogram);
+		parameters.add(IAmdisSupport.PARAMETER);
 		if(OperatingSystemUtils.isWindows()) {
-			runtimeSupport = new WindowsSupport(application, parameter);
+			runtimeSupport = new WindowsSupport(application, parameters);
 		} else if(OperatingSystemUtils.isMac()) {
-			runtimeSupport = new MacWineSupport(application, parameter);
+			runtimeSupport = new MacWineSupport(application, parameters);
 		} else {
 			/*
 			 * wine AMDIS32\$.exe C:\\tmp\\C2.CDF /S
 			 */
-			runtimeSupport = new LinuxWineSupport(application, parameter);
+			runtimeSupport = new LinuxWineSupport(application, parameters);
 		}
 		return runtimeSupport;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/amdis/runtime/WindowsSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/amdis/runtime/WindowsSupport.java
@@ -7,12 +7,13 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.amdis.runtime;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.List;
 
 import org.eclipse.chemclipse.support.runtime.AbstractWindowsSupport;
 
@@ -20,9 +21,9 @@ public class WindowsSupport extends AbstractWindowsSupport implements IExtendedR
 
 	private IAmdisSupport amdisSupport;
 
-	public WindowsSupport(String application, String parameter) throws FileNotFoundException {
+	public WindowsSupport(String application, List<String> parameters) throws FileNotFoundException {
 
-		super(application, parameter);
+		super(application, parameters);
 		amdisSupport = new AmdisSupport(this);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/IExtendedRuntimeSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/IExtendedRuntimeSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,9 +7,11 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
+
+import java.util.List;
 
 import org.eclipse.chemclipse.support.runtime.IRuntimeSupport;
 
@@ -30,7 +32,7 @@ public interface IExtendedRuntimeSupport extends IRuntimeSupport {
 	 */
 	default boolean isBatchModus() {
 
-		String parameter = getParameter();
+		List<String> parameter = getParameters();
 		if(parameter != null) {
 			return parameter.contains(INistSupport.PAR2);
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/INistSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/INistSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,7 +7,7 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
 
@@ -27,8 +27,6 @@ public interface INistSupport {
 	 */
 	String PAR2 = "/PAR=2";
 	String INSTRUMENT = "/INSTRUMENT";
-	String PARAMETER_BACKGROUND = INSTRUMENT + " " + PAR2;
-	String PARAMETER_FOREGROUND = INSTRUMENT;
 	/*
 	 * The path is NIST library specific.
 	 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport.java
@@ -7,7 +7,7 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  * Christoph Läubrich - using a path instead of a string
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
@@ -15,6 +15,7 @@ package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.preferences.PreferenceSupplier;
@@ -24,9 +25,9 @@ public class LinuxWineSupport extends AbstractLinuxWineSupport implements IExten
 
 	private final INistSupport nistSupport;
 
-	public LinuxWineSupport(File applicationFolder, String parameter) throws FileNotFoundException {
+	public LinuxWineSupport(File applicationFolder, List<String> parameters) throws FileNotFoundException {
 
-		super(PreferenceSupplier.getNistExecutable(applicationFolder).getAbsolutePath(), parameter);
+		super(PreferenceSupplier.getNistExecutable(applicationFolder).getAbsolutePath(), parameters);
 		nistSupport = new NistSupport(this);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Lablicate GmbH.
+ * Copyright (c) 2011, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,13 +7,14 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  * Christoph Läubrich - using a path instead of a string
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.util.List;
 
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.support.runtime.AbstractMacWineSupport;
@@ -22,8 +23,9 @@ public class MacWineSupport extends AbstractMacWineSupport implements IExtendedR
 
 	private final INistSupport nistSupport;
 
-	public MacWineSupport(File applicationFolder, String parameter) throws FileNotFoundException {
-		super(PreferenceSupplier.getNistExecutable(applicationFolder).getAbsolutePath(), parameter, PreferenceSupplier.getMacWineBinary());
+	public MacWineSupport(File applicationFolder, List<String> parameters) throws FileNotFoundException {
+
+		super(PreferenceSupplier.getNistExecutable(applicationFolder).getAbsolutePath(), parameters, PreferenceSupplier.getMacWineBinary());
 		nistSupport = new NistSupport(this);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/RuntimeSupportFactory.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/RuntimeSupportFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Lablicate GmbH.
+ * Copyright (c) 2012, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,13 +7,15 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  * Christoph Läubrich - using a path instead of a string
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.chemclipse.support.settings.OperatingSystemUtils;
 
@@ -43,14 +45,17 @@ public class RuntimeSupportFactory {
 	public static IExtendedRuntimeSupport getRuntimeSupport(File applicationFolder, boolean batchModus) throws FileNotFoundException {
 
 		IExtendedRuntimeSupport runtimeSupport;
-		String parameter = batchModus ? INistSupport.PARAMETER_BACKGROUND : INistSupport.PARAMETER_FOREGROUND;
-		//
+		List<String> parameters = new ArrayList<>();
+		parameters.add(INistSupport.INSTRUMENT);
+		if(batchModus) {
+			parameters.add(INistSupport.PAR2);
+		}
 		if(OperatingSystemUtils.isWindows()) {
-			runtimeSupport = new WindowsSupport(applicationFolder, parameter);
+			runtimeSupport = new WindowsSupport(applicationFolder, parameters);
 		} else if(OperatingSystemUtils.isMac()) {
-			runtimeSupport = new MacWineSupport(applicationFolder, parameter);
+			runtimeSupport = new MacWineSupport(applicationFolder, parameters);
 		} else {
-			runtimeSupport = new LinuxWineSupport(applicationFolder, parameter);
+			runtimeSupport = new LinuxWineSupport(applicationFolder, parameters);
 		}
 		return runtimeSupport;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/WindowsSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/WindowsSupport.java
@@ -7,7 +7,7 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  * Christoph Läubrich - using a path instead of a string
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
@@ -15,6 +15,7 @@ package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.List;
 
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.support.runtime.AbstractWindowsSupport;
@@ -23,9 +24,9 @@ public class WindowsSupport extends AbstractWindowsSupport implements IExtendedR
 
 	private final INistSupport nistSupport;
 
-	public WindowsSupport(File applicationFolder, String parameter) throws FileNotFoundException {
+	public WindowsSupport(File applicationFolder, List<String> parameters) throws FileNotFoundException {
 
-		super(PreferenceSupplier.getNistExecutable(applicationFolder).getAbsolutePath(), parameter);
+		super(PreferenceSupplier.getNistExecutable(applicationFolder).getAbsolutePath(), parameters);
 		nistSupport = new NistSupport(this);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/AbstractLinuxWineSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/AbstractLinuxWineSupport.java
@@ -7,12 +7,14 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.support.runtime;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public abstract class AbstractLinuxWineSupport extends AbstractWineRuntimeSupport implements IWineRuntimeSupport {
@@ -24,7 +26,7 @@ public abstract class AbstractLinuxWineSupport extends AbstractWineRuntimeSuppor
 	 * @param application
 	 * @param parameter
 	 */
-	protected AbstractLinuxWineSupport(String application, String parameter) throws FileNotFoundException {
+	protected AbstractLinuxWineSupport(String application, List<String> parameter) throws FileNotFoundException {
 
 		super(application, parameter);
 	}
@@ -40,7 +42,12 @@ public abstract class AbstractLinuxWineSupport extends AbstractWineRuntimeSuppor
 		/*
 		 * "env WINEPREFIX=/home/chemclipse/.wine wine start C:\\programme\\nist\\MSSEARCH\\nistms$.exe /INSTRUMENT /PAR=2"
 		 */
-		ProcessBuilder processBuilder = new ProcessBuilder("wine", "start", getWineApplication(), getParameter());
+		List<String> commands = new ArrayList<>();
+		commands.add("wine");
+		commands.add("start");
+		commands.add(getWineApplication());
+		commands.addAll(getParameters());
+		ProcessBuilder processBuilder = new ProcessBuilder(commands);
 		Map<String, String> environment = processBuilder.environment();
 		environment.put("WINEPREFIX", getWineEnvironment());
 		return processBuilder;

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/AbstractMacWineSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/AbstractMacWineSupport.java
@@ -7,12 +7,13 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.support.runtime;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.List;
 
 public abstract class AbstractMacWineSupport extends AbstractWineRuntimeSupport implements IWineRuntimeSupport {
 
@@ -27,9 +28,9 @@ public abstract class AbstractMacWineSupport extends AbstractWineRuntimeSupport 
 	 * @param macWineBinary
 	 *            (e.g. "/Applications/Wine.app")
 	 */
-	protected AbstractMacWineSupport(String application, String parameter, String macWineBinary) throws FileNotFoundException {
+	protected AbstractMacWineSupport(String application, List<String> parameters, String macWineBinary) throws FileNotFoundException {
 
-		super(application, parameter);
+		super(application, parameters);
 		this.macWineBinary = macWineBinary;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/AbstractRuntimeSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/AbstractRuntimeSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -7,21 +7,23 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.support.runtime;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.util.List;
 
 public abstract class AbstractRuntimeSupport implements IRuntimeSupport {
 
 	private String application = "";
 	private String path = "";
 	private String executable = "";
-	private String parameter = "";
+	private List<String> parameters = null;
 
-	public AbstractRuntimeSupport(String application, String parameter) throws FileNotFoundException {
+	protected AbstractRuntimeSupport(String application, List<String> parameters) throws FileNotFoundException {
+
 		/*
 		 * Application
 		 */
@@ -40,9 +42,16 @@ public abstract class AbstractRuntimeSupport implements IRuntimeSupport {
 		/*
 		 * Parameter
 		 */
-		if(parameter != null) {
-			this.parameter = parameter;
+		if(parameters != null) {
+			this.parameters = parameters;
 		}
+	}
+
+	public List<String> getCommand() {
+
+		List<String> command = parameters;
+		command.add(0, getApplication());
+		return command;
 	}
 
 	@Override
@@ -52,9 +61,9 @@ public abstract class AbstractRuntimeSupport implements IRuntimeSupport {
 	}
 
 	@Override
-	public String getParameter() {
+	public List<String> getParameters() {
 
-		return parameter;
+		return parameters;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/AbstractWindowsSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/AbstractWindowsSupport.java
@@ -7,12 +7,13 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.support.runtime;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.List;
 
 public abstract class AbstractWindowsSupport extends AbstractRuntimeSupport implements IRuntimeSupport {
 
@@ -22,9 +23,9 @@ public abstract class AbstractWindowsSupport extends AbstractRuntimeSupport impl
 	 * @param application
 	 * @param parameter
 	 */
-	protected AbstractWindowsSupport(String application, String parameter) throws FileNotFoundException {
+	protected AbstractWindowsSupport(String application, List<String> parameters) throws FileNotFoundException {
 
-		super(application, parameter);
+		super(application, parameters);
 	}
 
 	@Override
@@ -38,6 +39,6 @@ public abstract class AbstractWindowsSupport extends AbstractRuntimeSupport impl
 		/*
 		 * Returns e.g.: "C:\Programs\NIST\MSSEARCH\nistms$.exe /INSTRUMENT /PAR=2
 		 */
-		return new ProcessBuilder(getApplication(), getParameter());
+		return new ProcessBuilder().command(getCommand());
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/AbstractWineRuntimeSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/AbstractWineRuntimeSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -7,20 +7,22 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.support.runtime;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.util.List;
 
 public abstract class AbstractWineRuntimeSupport extends AbstractRuntimeSupport implements IWineRuntimeSupport {
 
 	private String wineEnvironment = "";
 	private String wineApplication = "";
 
-	public AbstractWineRuntimeSupport(String application, String parameter) throws FileNotFoundException {
-		super(application, parameter);
+	public AbstractWineRuntimeSupport(String application, List<String> parameters) throws FileNotFoundException {
+
+		super(application, parameters);
 		extractValues();
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/IRuntimeSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/IRuntimeSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 Lablicate GmbH.
+ * Copyright (c) 2014, 2023 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -7,11 +7,12 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.support.runtime;
 
 import java.io.IOException;
+import java.util.List;
 
 public interface IRuntimeSupport {
 
@@ -52,9 +53,9 @@ public interface IRuntimeSupport {
 	 * Returns the parameter.
 	 * E.g. /INSTRUMENT /PAR=2
 	 * 
-	 * @return String
+	 * @return List<String>
 	 */
-	String getParameter();
+	List<String> getParameters();
 
 	/**
 	 * Return the path of the application exe.<br/>
@@ -64,6 +65,8 @@ public interface IRuntimeSupport {
 	 * @return
 	 */
 	String getApplicationPath();
+
+	List<String> getCommand();
 
 	/**
 	 * "nistms$.exe"

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/AbstractBackgroundTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/AbstractBackgroundTestCase.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import junit.framework.TestCase;
+
+public class AbstractBackgroundTestCase extends TestCase {
+
+	List<String> parameterBackground = new ArrayList<>();
+
+	@Override
+	protected void setUp() throws Exception {
+
+		parameterBackground.add(INistSupport.INSTRUMENT);
+		parameterBackground.add(INistSupport.PAR2);
+	}
+}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport_DOSDEVICES_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport_DOSDEVICES_1_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,7 +7,7 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
 
@@ -15,9 +15,7 @@ import java.io.File;
 
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 
-import junit.framework.TestCase;
-
-public class LinuxWineSupport_DOSDEVICES_1_ITest extends TestCase {
+public class LinuxWineSupport_DOSDEVICES_1_ITest extends AbstractBackgroundTestCase {
 
 	private IExtendedRuntimeSupport runtimeSupport;
 	private String nistApplication;
@@ -31,7 +29,7 @@ public class LinuxWineSupport_DOSDEVICES_1_ITest extends TestCase {
 		nistApplication = TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_WINE_DOSDEVICES_NIST_APPLICATION);
 		testfileNistApplication = new File(nistApplication);
 		nistApplicationPath = testfileNistApplication.getParent();
-		runtimeSupport = new LinuxWineSupport(testfileNistApplication.getParentFile(), INistSupport.PARAMETER_BACKGROUND);
+		runtimeSupport = new LinuxWineSupport(testfileNistApplication.getParentFile(), parameterBackground);
 	}
 
 	@Override

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport_DOSDEVICES_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport_DOSDEVICES_2_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,7 +7,7 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
 
@@ -16,9 +16,7 @@ import java.io.FileNotFoundException;
 
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 
-import junit.framework.TestCase;
-
-public class LinuxWineSupport_DOSDEVICES_2_ITest extends TestCase {
+public class LinuxWineSupport_DOSDEVICES_2_ITest extends AbstractBackgroundTestCase {
 
 	private IExtendedRuntimeSupport runtimeSupport;
 
@@ -38,7 +36,7 @@ public class LinuxWineSupport_DOSDEVICES_2_ITest extends TestCase {
 
 		String nistApp = TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_WINE_DOSDEVICES_NIST_APPLICATION);
 		try {
-			runtimeSupport = new LinuxWineSupport(new File(nistApp).getParentFile(), INistSupport.PARAMETER_BACKGROUND);
+			runtimeSupport = new LinuxWineSupport(new File(nistApp).getParentFile(), parameterBackground);
 			assertNotNull(runtimeSupport);
 		} catch(FileNotFoundException e) {
 			assertTrue("A file not found exception should not occur here.", false);
@@ -49,7 +47,7 @@ public class LinuxWineSupport_DOSDEVICES_2_ITest extends TestCase {
 
 		String nistApp = "";
 		try {
-			runtimeSupport = new LinuxWineSupport(new File(nistApp).getParentFile(), INistSupport.PARAMETER_BACKGROUND);
+			runtimeSupport = new LinuxWineSupport(new File(nistApp).getParentFile(), parameterBackground);
 			assertNull(runtimeSupport);
 		} catch(FileNotFoundException e) {
 			assertTrue("A file not found exception should not occur here.", true);
@@ -59,7 +57,7 @@ public class LinuxWineSupport_DOSDEVICES_2_ITest extends TestCase {
 	public void testConstruct_3() {
 
 		try {
-			runtimeSupport = new LinuxWineSupport(null, INistSupport.PARAMETER_BACKGROUND);
+			runtimeSupport = new LinuxWineSupport(null, parameterBackground);
 			assertNull(runtimeSupport);
 		} catch(FileNotFoundException e) {
 			assertTrue("A file not found exception should not occur here.", true);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport_DRIVE_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport_DRIVE_1_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,7 +7,7 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
 
@@ -15,9 +15,7 @@ import java.io.File;
 
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 
-import junit.framework.TestCase;
-
-public class LinuxWineSupport_DRIVE_1_ITest extends TestCase {
+public class LinuxWineSupport_DRIVE_1_ITest extends AbstractBackgroundTestCase {
 
 	private IExtendedRuntimeSupport runtimeSupport;
 	private String nistApplicationPath;
@@ -31,7 +29,7 @@ public class LinuxWineSupport_DRIVE_1_ITest extends TestCase {
 		nistApplication = TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_WINE_DRIVE_NIST_APPLICATION);
 		testfileNistApplication = new File(nistApplication);
 		nistApplicationPath = testfileNistApplication.getParent();
-		runtimeSupport = new LinuxWineSupport(testfileNistApplication.getParentFile(), INistSupport.PARAMETER_BACKGROUND);
+		runtimeSupport = new LinuxWineSupport(testfileNistApplication.getParentFile(), parameterBackground);
 	}
 
 	@Override

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport_DRIVE_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport_DRIVE_2_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,7 +7,7 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
 
@@ -16,9 +16,7 @@ import java.io.FileNotFoundException;
 
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 
-import junit.framework.TestCase;
-
-public class LinuxWineSupport_DRIVE_2_ITest extends TestCase {
+public class LinuxWineSupport_DRIVE_2_ITest extends AbstractBackgroundTestCase {
 
 	private IExtendedRuntimeSupport runtimeSupport;
 
@@ -38,7 +36,7 @@ public class LinuxWineSupport_DRIVE_2_ITest extends TestCase {
 
 		String nistApp = TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_WINE_DRIVE_NIST_APPLICATION);
 		try {
-			runtimeSupport = new LinuxWineSupport(new File(nistApp).getParentFile(), INistSupport.PARAMETER_BACKGROUND);
+			runtimeSupport = new LinuxWineSupport(new File(nistApp).getParentFile(), parameterBackground);
 			assertNotNull(runtimeSupport);
 		} catch(FileNotFoundException e) {
 			assertTrue("A file not found exception should not occur here.", false);
@@ -49,7 +47,7 @@ public class LinuxWineSupport_DRIVE_2_ITest extends TestCase {
 
 		String nistApp = "";
 		try {
-			runtimeSupport = new LinuxWineSupport(new File(nistApp).getParentFile(), INistSupport.PARAMETER_BACKGROUND);
+			runtimeSupport = new LinuxWineSupport(new File(nistApp).getParentFile(), parameterBackground);
 			assertNull(runtimeSupport);
 		} catch(FileNotFoundException e) {
 			assertTrue("A file not found exception should not occur here.", true);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport_DOSDEVICES_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport_DOSDEVICES_1_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Lablicate GmbH.
+ * Copyright (c) 2011, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,7 +7,7 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
 
@@ -15,9 +15,7 @@ import java.io.File;
 
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 
-import junit.framework.TestCase;
-
-public class MacWineSupport_DOSDEVICES_1_ITest extends TestCase {
+public class MacWineSupport_DOSDEVICES_1_ITest extends AbstractBackgroundTestCase {
 
 	private IExtendedRuntimeSupport runtimeSupport;
 	private String nistApplication;
@@ -31,7 +29,7 @@ public class MacWineSupport_DOSDEVICES_1_ITest extends TestCase {
 		nistApplication = TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_WINE_DOSDEVICES_NIST_APPLICATION);
 		testfileNistApplication = new File(nistApplication);
 		nistApplicationPath = testfileNistApplication.getParent();
-		runtimeSupport = new MacWineSupport(testfileNistApplication.getParentFile(), INistSupport.PARAMETER_BACKGROUND);
+		runtimeSupport = new MacWineSupport(testfileNistApplication.getParentFile(), parameterBackground);
 	}
 
 	@Override

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport_DOSDEVICES_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport_DOSDEVICES_2_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Lablicate GmbH.
+ * Copyright (c) 2011, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,7 +7,7 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
 
@@ -16,9 +16,7 @@ import java.io.FileNotFoundException;
 
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 
-import junit.framework.TestCase;
-
-public class MacWineSupport_DOSDEVICES_2_ITest extends TestCase {
+public class MacWineSupport_DOSDEVICES_2_ITest extends AbstractBackgroundTestCase {
 
 	private IExtendedRuntimeSupport runtimeSupport;
 
@@ -38,7 +36,7 @@ public class MacWineSupport_DOSDEVICES_2_ITest extends TestCase {
 
 		String nistApp = TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_WINE_DOSDEVICES_NIST_APPLICATION);
 		try {
-			runtimeSupport = new MacWineSupport(new File(nistApp).getParentFile(), INistSupport.PARAMETER_BACKGROUND);
+			runtimeSupport = new MacWineSupport(new File(nistApp).getParentFile(), parameterBackground);
 			assertNotNull(runtimeSupport);
 		} catch(FileNotFoundException e) {
 			assertTrue("A file not found exception should not occur here.", false);
@@ -49,7 +47,7 @@ public class MacWineSupport_DOSDEVICES_2_ITest extends TestCase {
 
 		String nistApp = "";
 		try {
-			runtimeSupport = new MacWineSupport(new File(nistApp).getParentFile(), INistSupport.PARAMETER_BACKGROUND);
+			runtimeSupport = new MacWineSupport(new File(nistApp).getParentFile(), parameterBackground);
 			assertNull(runtimeSupport);
 		} catch(FileNotFoundException e) {
 			assertTrue("A file not found exception should not occur here.", true);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport_DRIVE_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport_DRIVE_1_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Lablicate GmbH.
+ * Copyright (c) 2011, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,7 +7,7 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
 
@@ -15,9 +15,7 @@ import java.io.File;
 
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 
-import junit.framework.TestCase;
-
-public class MacWineSupport_DRIVE_1_ITest extends TestCase {
+public class MacWineSupport_DRIVE_1_ITest extends AbstractBackgroundTestCase {
 
 	private IExtendedRuntimeSupport runtimeSupport;
 	private String nistApplicationPath;
@@ -31,7 +29,7 @@ public class MacWineSupport_DRIVE_1_ITest extends TestCase {
 		nistApplication = TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_WINE_DRIVE_NIST_APPLICATION);
 		testfileNistApplication = new File(nistApplication);
 		nistApplicationPath = testfileNistApplication.getParent();
-		runtimeSupport = new MacWineSupport(testfileNistApplication.getParentFile(), INistSupport.PARAMETER_BACKGROUND);
+		runtimeSupport = new MacWineSupport(testfileNistApplication.getParentFile(), parameterBackground);
 	}
 
 	@Override

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport_DRIVE_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport_DRIVE_2_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Lablicate GmbH.
+ * Copyright (c) 2011, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,7 +7,7 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
 
@@ -16,9 +16,7 @@ import java.io.FileNotFoundException;
 
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 
-import junit.framework.TestCase;
-
-public class MacWineSupport_DRIVE_2_ITest extends TestCase {
+public class MacWineSupport_DRIVE_2_ITest extends AbstractBackgroundTestCase {
 
 	private IExtendedRuntimeSupport runtimeSupport;
 
@@ -38,7 +36,7 @@ public class MacWineSupport_DRIVE_2_ITest extends TestCase {
 
 		String nistApp = TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_WINE_DRIVE_NIST_APPLICATION);
 		try {
-			runtimeSupport = new MacWineSupport(new File(nistApp).getParentFile(), INistSupport.PARAMETER_BACKGROUND);
+			runtimeSupport = new MacWineSupport(new File(nistApp).getParentFile(), parameterBackground);
 			assertNotNull(runtimeSupport);
 		} catch(FileNotFoundException e) {
 			assertTrue("A file not found exception should not occur here.", false);
@@ -49,7 +47,7 @@ public class MacWineSupport_DRIVE_2_ITest extends TestCase {
 
 		String nistApp = "";
 		try {
-			runtimeSupport = new MacWineSupport(new File(nistApp).getParentFile(), INistSupport.PARAMETER_BACKGROUND);
+			runtimeSupport = new MacWineSupport(new File(nistApp).getParentFile(), parameterBackground);
 			assertNull(runtimeSupport);
 		} catch(FileNotFoundException e) {
 			assertTrue("A file not found exception should not occur here.", true);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/WindowsSupport_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/WindowsSupport_1_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,7 +7,7 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
 
@@ -16,9 +16,7 @@ import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 
-import junit.framework.TestCase;
-
-public class WindowsSupport_1_ITest extends TestCase {
+public class WindowsSupport_1_ITest extends AbstractBackgroundTestCase {
 
 	private IExtendedRuntimeSupport runtimeSupport;
 	private String nistApplication;
@@ -32,7 +30,7 @@ public class WindowsSupport_1_ITest extends TestCase {
 		nistApplication = TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_WINDOWS_NIST_APPLICATION);
 		testfileNistApplication = new File(nistApplication);
 		nistApplicationPath = testfileNistApplication.getParent();
-		runtimeSupport = new WindowsSupport(testfileNistApplication.getParentFile(), INistSupport.PARAMETER_BACKGROUND);
+		runtimeSupport = new WindowsSupport(testfileNistApplication.getParentFile(), parameterBackground);
 	}
 
 	@Override

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/WindowsSupport_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/WindowsSupport_2_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 Lablicate GmbH.
+ * Copyright (c) 2008, 2023 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,7 +7,7 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.identifier.supplier.nist.runtime;
 
@@ -16,9 +16,7 @@ import java.io.FileNotFoundException;
 
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 
-import junit.framework.TestCase;
-
-public class WindowsSupport_2_ITest extends TestCase {
+public class WindowsSupport_2_ITest extends AbstractBackgroundTestCase {
 
 	private IExtendedRuntimeSupport runtimeSupport;
 
@@ -38,7 +36,7 @@ public class WindowsSupport_2_ITest extends TestCase {
 
 		String nistApp = TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_WINDOWS_NIST_APPLICATION);
 		try {
-			runtimeSupport = new WindowsSupport(new File(nistApp).getParentFile(), INistSupport.PARAMETER_BACKGROUND);
+			runtimeSupport = new WindowsSupport(new File(nistApp).getParentFile(), parameterBackground);
 			assertNotNull(runtimeSupport);
 		} catch(FileNotFoundException e) {
 			assertTrue("A file not found exception should not occur here.", false);
@@ -49,7 +47,7 @@ public class WindowsSupport_2_ITest extends TestCase {
 
 		String nistApp = "";
 		try {
-			runtimeSupport = new WindowsSupport(new File(nistApp).getParentFile(), INistSupport.PARAMETER_BACKGROUND);
+			runtimeSupport = new WindowsSupport(new File(nistApp).getParentFile(), parameterBackground);
 			assertNull(runtimeSupport);
 		} catch(FileNotFoundException e) {
 			assertTrue("A file not found exception should not occur here.", true);


### PR DESCRIPTION
I introduced a problem in https://github.com/eclipse/chemclipse/pull/1578 where the process builder would not execute for NIST MSSEARCH/AMDIS because the parameters were not correctly separated.