### PR TITLE
Translate menu entries from system supplied process methods

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/methods/ProcessMethod.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/methods/ProcessMethod.java
@@ -17,8 +17,11 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
 import java.util.Set;
 
+import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
 
@@ -26,6 +29,8 @@ public class ProcessMethod extends ListProcessEntryContainer implements IProcess
 
 	public static final Set<DataCategory> CHROMATOGRAPHY = Collections.unmodifiableSet(Set.of(DataCategory.chromatographyCategories()));
 	public static final Set<DataCategory> NMR = Collections.unmodifiableSet(Set.of(DataCategory.spectroscopyCategories()));
+	//
+	private static final Logger logger = Logger.getLogger(ProcessMethod.class);
 	//
 	private final Map<String, String> metadata = new LinkedHashMap<>();
 	private final Set<DataCategory> catgories;
@@ -37,10 +42,17 @@ public class ProcessMethod extends ListProcessEntryContainer implements IProcess
 	 * Transient
 	 */
 	private File sourceFile = null;
+	private ResourceBundle resourceBundle;
 
 	public ProcessMethod(Set<DataCategory> categories) {
 
 		this.catgories = Collections.unmodifiableSet(categories);
+		try {
+			// TODO: inconsistent API, category and translations are stored in processing and not in model
+			resourceBundle = ResourceBundle.getBundle("org.eclipse.chemclipse.processing.l10n.messages");
+		} catch(MissingResourceException e) {
+			logger.warn(e);
+		}
 	}
 
 	/**
@@ -110,7 +122,15 @@ public class ProcessMethod extends ListProcessEntryContainer implements IProcess
 		if(category == null) {
 			return "";
 		}
-		return category;
+		if(resourceBundle == null) {
+			return category;
+		}
+		try {
+			return resourceBundle.getString(category);
+		} catch(MissingResourceException e) {
+			logger.warn(e);
+			return category;
+		}
 	}
 
 	public void setCategory(String category) throws IllegalStateException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/methods/ProcessMethod.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/methods/ProcessMethod.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 Lablicate GmbH.
+ * Copyright (c) 2018, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -30,7 +30,7 @@ public class ProcessMethod extends ListProcessEntryContainer implements IProcess
 	private final Map<String, String> metadata = new LinkedHashMap<>();
 	private final Set<DataCategory> catgories;
 	//
-	private String UUID = java.util.UUID.randomUUID().toString();
+	private String uuid = java.util.UUID.randomUUID().toString();
 	private String operator = "";
 	private String category = "";
 	/*
@@ -132,12 +132,12 @@ public class ProcessMethod extends ListProcessEntryContainer implements IProcess
 	@Override
 	public String getUUID() {
 
-		return UUID;
+		return uuid;
 	}
 
-	public void setUUID(String UUID) {
+	public void setUUID(String uuid) {
 
-		this.UUID = UUID;
+		this.uuid = uuid;
 	}
 
 	@Override


### PR DESCRIPTION
The category is a free form field in `.ocm` files. This translates the default category names. Otherwise, it splits the menu into a translated and an untranslated one, causing confusion.