### PR TITLE
Add Eclipse platform as dependency

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
@@ -30,6 +30,10 @@ http://www.eclipse.org/legal/epl-v10.html
          id="org.eclipse.license"
          version="0.0.0"/>
 
+   <includes
+         id="org.eclipse.platform"
+         version="0.0.0"/>
+
    <plugin
          id="org.eclipse.chemclipse.rcp.compilation.community.ui"
          version="0.0.0"/>


### PR DESCRIPTION
This seems to be required to enable https://github.com/eclipse/chemclipse/commit/d59266d156cc0cbbe159f39c42660c4a2b4d122b.