### PR TITLE
Cleanup feature licenses and copyright

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.peakmax.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.peakmax.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.sumarea.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.sumarea.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.classifier.supplier.durbinwatson.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.classifier.supplier.durbinwatson.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.zeroset.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.zeroset.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.identifier.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.identifier.feature/feature.xml
@@ -4,7 +4,9 @@
       label="Identifier (XXD)"
       version="0.9.0.qualifier"
       provider-name="ChemClipse"
-      plugin="org.eclipse.chemclipse.feature.branding">
+      plugin="org.eclipse.chemclipse.feature.branding"
+      license-feature="org.eclipse.license"
+      license-feature-version="1.0.0.qualifier">
 
    <description url="http://www.chemclipse.net">
       This is a detector independent identifier template.
@@ -14,12 +16,8 @@
       Copyright (c) 2023 Lablicate GmbH.
    </copyright>
 
-   <license url="http://www.eclipse.org/legal/epl-v10.html">
-      Copyright (c) 2023 Lablicate GmbH.
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License
-v1.0 which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
+   <license url="%licenseURL">
+      %license
    </license>
 
    <plugin

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.manual.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.manual.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.manual.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.manual.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.thirdderivative.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.thirdderivative.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.csd.converter.supplier.xy.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.csd.converter.supplier.xy.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.amdis.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.amdis.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.massbank.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.massbank.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzdata.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzdata.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzml.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzml.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzxml.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzxml.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.base.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.base.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.compilation.base.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.compilation.base.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.compilation.core.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.compilation.core.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
@@ -4,7 +4,9 @@
       label="ChemClipse CE"
       version="0.9.0.qualifier"
       provider-name="ChemClipse"
-      plugin="org.eclipse.chemclipse.feature.branding">
+      plugin="org.eclipse.chemclipse.feature.branding"
+      license-feature="org.eclipse.license"
+      license-feature-version="1.0.0.qualifier">
 
    <description url="http://www.chemclipse.net">
       This is the ChemClipse Community Edition.
@@ -14,12 +16,8 @@
       Copyright (c) 2014, 2024 Lablicate GmbH.
    </copyright>
 
-   <license url="http://www.eclipse.org/legal/epl-v10.html">
-      Copyright (c) 2014, 2024 Lablicate GmbH.
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License
-v1.0 which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
+   <license url="%licenseURL">
+      %license
    </license>
 
    <includes

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.connector.supplier.microsoft.office.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.connector.supplier.microsoft.office.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.ux.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.ux.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.ux.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.ux.feature/feature.xml
@@ -3,7 +3,9 @@
       id="org.eclipse.chemclipse.ux.feature"
       label="UX Support"
       version="0.9.0.qualifier"
-      provider-name="ChemClipse" plugin="org.eclipse.chemclipse.feature.branding">
+      provider-name="ChemClipse" plugin="org.eclipse.chemclipse.feature.branding"
+      license-feature="org.eclipse.license"
+      license-feature-version="1.0.0.qualifier">
 
    <description url="http://www.chemclipse.net">
       ChemClipse - UX components
@@ -13,12 +15,8 @@
       Copyright (c) 2014, 2018 Lablicate GmbH.
    </copyright>
 
-   <license url="http://www.eclipse.org/legal/epl-v10.html">
-      Copyright (c) 2014, 2018 Lablicate GmbH.
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License
-v1.0 which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
+   <license url="%licenseURL">
+      %license
    </license>
 
    <requires>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.ocx.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.ocx.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.process.supplier.pca.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.process.supplier.pca.feature/build.properties
@@ -1,12 +1,1 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 bin.includes = feature.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.converter/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.converter/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.batchprocess/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.batchprocess/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.filter.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.filter.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.filter/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.filter/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.method.model/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.method.model/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.peakmax/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.peakmax/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.sumarea/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.sumarea/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.classifier.supplier.durbinwatson/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.classifier.supplier.durbinwatson/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.classifier.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.classifier.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.classifier/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.classifier/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.zeroset.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.zeroset.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.zeroset/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.zeroset/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.manual/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.manual/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.manual.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.manual.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.manual/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.manual/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.thirdderivative/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.thirdderivative/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/,\
            xsd/
 output.. = bin/

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.xy.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.xy.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.xy/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.xy/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.swt.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.swt.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.keystore/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.keystore/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.logging/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.logging/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.massbank/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.model/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.model/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.numeric/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.numeric/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.progress.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.progress.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.progress/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.progress/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.test/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.compilation.community.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.compilation.community.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.connector.supplier.microsoft.office/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.connector.supplier.microsoft.office/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.ui.icons/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.ui.icons/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = .,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.swt.win32/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.swt.win32/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.csd.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.csd.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.wsd.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.wsd.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.swt.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.swt.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.ui/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.ui/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.converter.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.converter.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.model.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.model.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.csd.filter.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.csd.filter.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.identifier.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.identifier.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.quantitation.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.quantitation.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.classifier.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.classifier.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.keystore.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.keystore.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.logging.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.logging.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.massbank.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.massbank.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.swt.ui.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.swt.ui.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.numeric.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.numeric.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.processing.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.processing.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.progress.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.progress.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.rcp.app.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.rcp.app.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.support.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.support.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/build.properties
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/build.properties
@@ -1,14 +1,3 @@
-###############################################################################
-# Copyright (c) 2015, 2017 Lablicate GmbH.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
-#
-# Contributors:
-#     Dr. Philip Wenig - initial API and implementation
-###############################################################################
 source.. = src/,\
            testData/
 output.. = bin/


### PR DESCRIPTION
Followup to https://github.com/eclipse/chemclipse/pull/1445.