### PR TITLE
Add the CBI repository

### DIFF
--- a/chemclipse/pom.xml
+++ b/chemclipse/pom.xml
@@ -289,4 +289,18 @@
 			</build>
 		</profile>
 	</profiles>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>eclipse</id>
+			<url>https://repo.eclipse.org/content/repositories/cbi/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
 </project>


### PR DESCRIPTION
It seems the `eclipse-jarsigner-plugin` is not available on Maven central. Followup to https://github.com/eclipse/chemclipse/pull/1709.