### PR TITLE
Fixed progress reporting when running process methods

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/io/JobReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/io/JobReader.java
@@ -14,7 +14,6 @@ package org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.io
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -30,8 +29,6 @@ import javax.xml.stream.events.XMLEvent;
 import org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.internal.filter.BatchProcessJobEventFilter;
 import org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.internal.support.JobTags;
 import org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.model.BatchProcessJob;
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.converter.model.ChromatogramInputEntry;
 import org.eclipse.chemclipse.converter.model.IChromatogramInputEntry;
 import org.eclipse.chemclipse.logging.core.Logger;
@@ -44,7 +41,7 @@ public class JobReader {
 
 	private static final Logger logger = Logger.getLogger(JobReader.class);
 
-	public BatchProcessJob read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public BatchProcessJob read(File file, IProgressMonitor monitor) throws IOException {
 
 		ProcessMethod processMethod = new ProcessMethod(ProcessMethod.CHROMATOGRAPHY);
 		BatchProcessJob batchProcessJob = new BatchProcessJob(processMethod);
@@ -120,7 +117,7 @@ public class JobReader {
 		/*
 		 * Use event filters.
 		 */
-		List<String> acceptedElements = new ArrayList<String>();
+		List<String> acceptedElements = new ArrayList<>();
 		acceptedElements.add(JobTags.DATA_TYPE_ENTRY);
 		EventFilter eventFilter = new BatchProcessJobEventFilter(acceptedElements);
 		XMLEventReader filteredEventReader = inputFactory.createFilteredReader(eventReader, eventFilter);
@@ -167,7 +164,7 @@ public class JobReader {
 		/*
 		 * Use event filters.
 		 */
-		List<String> acceptedElements = new ArrayList<String>();
+		List<String> acceptedElements = new ArrayList<>();
 		acceptedElements.add(JobTags.CHROMATOGRAM_INPUT_ENTRY);
 		EventFilter eventFilter = new BatchProcessJobEventFilter(acceptedElements);
 		XMLEventReader filteredEventReader = inputFactory.createFilteredReader(eventReader, eventFilter);
@@ -207,7 +204,7 @@ public class JobReader {
 		/*
 		 * Use event filters.
 		 */
-		List<String> acceptedElements = new ArrayList<String>();
+		List<String> acceptedElements = new ArrayList<>();
 		acceptedElements.add(JobTags.CHROMATOGRAM_PROCESS_ENTRY);
 		EventFilter eventFilter = new BatchProcessJobEventFilter(acceptedElements);
 		XMLEventReader filteredEventReader = inputFactory.createFilteredReader(eventReader, eventFilter);

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/ProcessEntryContainer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/ProcessEntryContainer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,10 +17,10 @@ import java.util.Set;
 import java.util.function.BiFunction;
 
 import org.eclipse.chemclipse.processing.methods.SubProcessExecutionConsumer.SubProcess;
-import org.eclipse.chemclipse.processing.supplier.IProcessSupplier;
 import org.eclipse.chemclipse.processing.supplier.IProcessExecutionConsumer;
-import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
+import org.eclipse.chemclipse.processing.supplier.IProcessSupplier;
 import org.eclipse.chemclipse.processing.supplier.IProcessorPreferences;
+import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 
 /**
  * A {@link ProcessEntryContainer} holds some {@link IProcessEntry}s
@@ -140,7 +140,6 @@ public interface ProcessEntryContainer extends Iterable<IProcessEntry> {
 	static <X, T> T applyProcessEntries(ProcessEntryContainer container, ProcessExecutionContext context, BiFunction<IProcessEntry, IProcessSupplier<X>, IProcessorPreferences<X>> preferenceSupplier, IProcessExecutionConsumer<T> consumer) {
 
 		int resumeIndex = container.isSupportResume() ? container.getResumeIndex() : DEFAULT_RESUME_INDEX;
-		context.setWorkRemaining(container.getNumberOfEntries());
 		//
 		int index = -1;
 		for(IProcessEntry processEntry : container) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/SubProcessExecutionConsumer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/SubProcessExecutionConsumer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,8 +12,8 @@
 package org.eclipse.chemclipse.processing.methods;
 
 import org.eclipse.chemclipse.processing.supplier.IProcessExecutionConsumer;
-import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 import org.eclipse.chemclipse.processing.supplier.IProcessorPreferences;
+import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 
 public final class SubProcessExecutionConsumer<T> implements IProcessExecutionConsumer<T> {
 
@@ -21,6 +21,7 @@ public final class SubProcessExecutionConsumer<T> implements IProcessExecutionCo
 	private final SubProcess<T> subprocess;
 
 	public SubProcessExecutionConsumer(IProcessExecutionConsumer<T> parent, SubProcess<T> subprocess) {
+
 		this.intercepted = parent;
 		this.subprocess = subprocess;
 	}
@@ -30,7 +31,6 @@ public final class SubProcessExecutionConsumer<T> implements IProcessExecutionCo
 
 		ProcessExecutionContext ctx2;
 		if(intercepted.canExecute(preferences)) {
-			context.setWorkRemaining(2);
 			ProcessExecutionContext ctx1 = context.split();
 			ctx1.setContextObject(IProcessExecutionConsumer.class, intercepted);
 			intercepted.execute(preferences, ctx1);

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/supplier/IProcessSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/supplier/IProcessSupplier.java
@@ -139,9 +139,6 @@ public interface IProcessSupplier<SettingType> {
 				numberOfCalls++;
 			}
 			boolean mustSplit = numberOfCalls > 1;
-			if(mustSplit) {
-				context.setWorkRemaining(numberOfCalls);
-			}
 			context.setContextObject(IProcessSupplier.class, supplier);
 			context.setContextObject(IProcessorPreferences.class, processorPreferences);
 			if(transformer != null) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/supplier/ProcessExecutionContext.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/supplier/ProcessExecutionContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,13 +21,10 @@ import java.util.function.Predicate;
 import org.eclipse.chemclipse.processing.core.IMessageConsumer;
 import org.eclipse.chemclipse.processing.core.MessageType;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.SubMonitor;
 
 public class ProcessExecutionContext implements IProcessSupplierContext, IMessageConsumer {
 
-	private static final int WORK_UNIT = 100;
-	//
-	private final SubMonitor subMonitor;
+	private final IProgressMonitor monitor;
 	private final IProcessSupplierContext context;
 	private final IMessageConsumer consumer;
 	private ProcessExecutionContext parent;
@@ -44,13 +41,12 @@ public class ProcessExecutionContext implements IProcessSupplierContext, IMessag
 		this.consumer = rootConsumer;
 		this.context = rootContext;
 		this.parent = parent;
-		//
-		subMonitor = SubMonitor.convert(monitor, WORK_UNIT);
+		this.monitor = monitor;
 	}
 
 	public IProgressMonitor getProgressMonitor() {
 
-		return subMonitor;
+		return monitor;
 	}
 
 	public ProcessExecutionContext getParent() {
@@ -96,11 +92,6 @@ public class ProcessExecutionContext implements IProcessSupplierContext, IMessag
 		}
 	}
 
-	public void setWorkRemaining(int workRemaining) {
-
-		subMonitor.setWorkRemaining(workRemaining * WORK_UNIT);
-	}
-
 	public ProcessExecutionContext split() {
 
 		return split(context);
@@ -108,7 +99,7 @@ public class ProcessExecutionContext implements IProcessSupplierContext, IMessag
 
 	public ProcessExecutionContext split(IProcessSupplierContext childContext) {
 
-		return new ProcessExecutionContext(subMonitor.split(WORK_UNIT), consumer, childContext, this);
+		return new ProcessExecutionContext(monitor, consumer, childContext, this);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/src/org/eclipse/chemclipse/xxd/process/support/ProcessTypeSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/src/org/eclipse/chemclipse/xxd/process/support/ProcessTypeSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Lablicate GmbH.
+ * Copyright (c) 2011, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -143,7 +143,6 @@ public class ProcessTypeSupport implements IProcessSupplierContext {
 
 		ProcessingInfo<T> processingInfo = new ProcessingInfo<>();
 		ProcessExecutionContext executionContext = new ProcessExecutionContext(monitor, processingInfo, this);
-		executionContext.setWorkRemaining(chromatogramSelections.size());
 		for(IChromatogramSelection<?, ?> selection : chromatogramSelections) {
 			ProcessEntryContainer.applyProcessEntries(processMethod, executionContext.split(), IChromatogramSelectionProcessSupplier.createConsumer(selection));
 		}


### PR DESCRIPTION
There was an annoying bug where the progress monitor would not show titles (only "operation in progress") or not update after a previous process entry was finished, despite the plugins doing their monitors and sub monitors properly and working fine when applied manually.

This will now always show the task and subtask name. The progress bar is not divided anymore by task size, which can lead to a quick task where you can't even read the task name finishing and then taking up half the progress bar as completed while endlessly working on a long-running task with a barely moving progress bar.