### PR TITLE
Polish the Savitzky-Golay filter message

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/calculator/operations/SavitzkyGolayPerIonOperation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/calculator/operations/SavitzkyGolayPerIonOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.calculator.operations;
 
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -77,7 +78,7 @@ public class SavitzkyGolayPerIonOperation extends AbstractOperation implements I
 			double[][] matrix = extractedMatrix.getMatrix();
 			SavitzkyGolayProcessor.apply(matrix, filterSettings);
 			extractedMatrix.updateSignal();
-			chromatogramFilterResult = new ChromatogramFilterResult(ResultStatus.OK, "The Savitzky-Golay filter has been applied successfully.");
+			chromatogramFilterResult = new ChromatogramFilterResult(ResultStatus.OK, MessageFormat.format("Smoothed {0} scans.", extractedMatrix.getScanNumbers().length));
 			updateChromatogramSelection();
 		} catch(IllegalArgumentException e) {
 			chromatogramFilterResult = new ChromatogramFilterResult(ResultStatus.EXCEPTION, "High Resolution Data is not supported.");

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/calculator/operations/SavitzkyGolayTotalScanSignalOperation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/calculator/operations/SavitzkyGolayTotalScanSignalOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -98,7 +98,7 @@ public class SavitzkyGolayTotalScanSignalOperation extends AbstractOperation imp
 
 		IChromatogramMSD chromatogramMSD = chromatogramSelection.getChromatogram();
 		updateSignal(totalScanSignals, chromatogramMSD);
-		chromatogramFilterResult = new ChromatogramFilterResult(ResultStatus.OK, "The Savitzky-Golay filter has been re-applied successfully.");
+		chromatogramFilterResult = new ChromatogramFilterResult(ResultStatus.OK, "The Savitzky-Golay filter has been re-applied.");
 		updateChromatogramSelection();
 		return Status.OK_STATUS;
 	}
@@ -108,7 +108,7 @@ public class SavitzkyGolayTotalScanSignalOperation extends AbstractOperation imp
 
 		IChromatogramMSD chromatogramMSD = chromatogramSelection.getChromatogram();
 		updateSignal(previousTotalScanSignals, chromatogramMSD);
-		chromatogramFilterResult = new ChromatogramFilterResult(ResultStatus.OK, "The Savitzky-Golay filter has been reverted successfully.");
+		chromatogramFilterResult = new ChromatogramFilterResult(ResultStatus.OK, "The Savitzky-Golay filter has been reverted.");
 		updateChromatogramSelection();
 		return Status.OK_STATUS;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/core/ChromatogramFilterMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/core/ChromatogramFilterMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -34,6 +34,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 public class ChromatogramFilterMSD extends AbstractChromatogramFilterMSD {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramFilterMSD.class);
+	private static final String DESCRIPTION = "Savitzky-Golay Smoothing";
 
 	private IChromatogramFilterResult process(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings filterSettings, IProgressMonitor monitor) {
 
@@ -63,7 +64,7 @@ public class ChromatogramFilterMSD extends AbstractChromatogramFilterMSD {
 			processingInfo.addErrorMessage(processingInfo.getProcessingResult().getResultStatus().name(), processingInfo.getProcessingResult().getDescription(), proposedString.toString());
 		}
 		if(processingInfo.getProcessingResult().getResultStatus().equals(ResultStatus.OK)) {
-			processingInfo.addInfoMessage(processingInfo.getProcessingResult().getResultStatus().name(), processingInfo.getProcessingResult().getDescription());
+			processingInfo.addInfoMessage(DESCRIPTION, processingInfo.getProcessingResult().getDescription());
 		}
 		return processingInfo;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/processor/SavitzkyGolayProcessor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/processor/SavitzkyGolayProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 Lablicate GmbH.
+ * Copyright (c) 2015, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,6 +11,8 @@
  * Lorenz Gerber - Ion-wise msd chromatogram filter
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.processor;
+
+import java.text.MessageFormat;
 
 import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
@@ -61,9 +63,9 @@ public class SavitzkyGolayProcessor {
 			}
 			//
 			chromatogram.setDirty(true);
-			chromatogramFilterResult = new ChromatogramFilterResult(ResultStatus.OK, "The Savitzky-Golay filter has been applied successfully.");
+			chromatogramFilterResult = new ChromatogramFilterResult(ResultStatus.OK, MessageFormat.format("Smoothed {0} scans.", totalScanSignals.getTotalScanSignals().size()));
 		} catch(ChromatogramIsNullException e) {
-			chromatogramFilterResult = new ChromatogramFilterResult(ResultStatus.EXCEPTION, "Something has gone wrong to apply the Savitzky-Golay filter.");
+			chromatogramFilterResult = new ChromatogramFilterResult(ResultStatus.EXCEPTION, "Can't apply Savitzky-Golay filter on empty chromatogram.");
 		}
 		return chromatogramFilterResult;
 	}
@@ -113,7 +115,7 @@ public class SavitzkyGolayProcessor {
 		for(ITotalScanSignal signal : totalSignals.getTotalScanSignals()) {
 			signal.setTotalSignal((float)sgTic[i++]);
 		}
-		return new ChromatogramFilterResult(ResultStatus.OK, "The Savitzky-Golay filter has been applied successfully.");
+		return new ChromatogramFilterResult(ResultStatus.OK, MessageFormat.format("Smoothed {0} signals.", totalSignals.getTotalScanSignals().size()));
 	}
 
 	public static void apply(double[][] matrix, ChromatogramFilterSettings filterSettings) {


### PR DESCRIPTION
This fixes a minor annoyance in the feedback tab where it displays

Type | Description | Message |
--- | --- | ---
✅ INFO | OK | The Savitzky-Golay filter has been applied successfully.


while every other plugins adds more helpful messages.

Type | Description | Message |
--- | --- | ---
✅ INFO | First Derivative Peak Detector | 42 peaks detected.

The API and header labelling is a bit unclear but remains untouched for now.