### PR TITLE
Remove LTK and PDE/JDT JUnit runtime

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
@@ -157,10 +157,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.jdt.core"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.chemclipse.swt.win32"
          version="0.0.0"/>
 

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
@@ -141,14 +141,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.ltk.core.refactoring"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.ltk.ui.refactoring"
-         version="0.0.0"/>
-
-   <plugin
          id="org.apache.httpcomponents.client5.httpclient5"
          version="0.0.0"/>
 

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.testing.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.testing.feature/feature.xml
@@ -47,18 +47,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="org.eclipse.jdt.junit.runtime"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.pde.junit.runtime"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
 </feature>


### PR DESCRIPTION
I can run unit tests without them and [LTK](https://wiki.eclipse.org/FAQ_What_is_LTK%3F) is unused IDE functionality. I am not sure why I added it 2 years ago https://github.com/eclipse/chemclipse/pull/1144 but those are not required anymore. JDT is also not needed for the HTML help anymore. https://github.com/eclipse/chemclipse/pull/1215