### PR TITLE
Don't directly put the WINEPREFIX

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/AbstractLinuxWineSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/AbstractLinuxWineSupport.java
@@ -15,6 +15,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public abstract class AbstractLinuxWineSupport extends AbstractWineRuntimeSupport implements IWineRuntimeSupport {
 
@@ -47,7 +48,8 @@ public abstract class AbstractLinuxWineSupport extends AbstractWineRuntimeSuppor
 		commands.add(getWineApplication());
 		commands.addAll(getParameters());
 		ProcessBuilder processBuilder = new ProcessBuilder(commands);
-		processBuilder.environment().put("WINEPREFIX", getWineEnvironment());
+		Map<String, String> environment = processBuilder.environment();
+		environment.put("WINEPREFIX", getWineEnvironment());
 		return processBuilder;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/AbstractWineRuntimeSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/AbstractWineRuntimeSupport.java
@@ -20,7 +20,7 @@ public abstract class AbstractWineRuntimeSupport extends AbstractRuntimeSupport 
 	private String wineEnvironment = "";
 	private String wineApplication = "";
 
-	public AbstractWineRuntimeSupport(String application, List<String> parameters) throws FileNotFoundException {
+	protected AbstractWineRuntimeSupport(String application, List<String> parameters) throws FileNotFoundException {
 
 		super(application, parameters);
 		extractValues();


### PR DESCRIPTION
as this causes problems on some machines

| Type | Description | Message | Date | 
|---|---|---|---|
| :x: ERROR | AMDIS Identifier | Can't execute AMDIS: Cannot run program "env": error=13, Permission denied | Sun Apr 21 06:56:26 UTC 2024 |	

I thought the syntax was equivalent. See also the [ProcessBuilder](https://docs.oracle.com/javase/8/docs/api/java/lang/ProcessBuilder.html) example code.