### PR TITLE
Trim Equinox SDK from update site

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
@@ -41,14 +41,6 @@
          version="0.0.0"/>
 
    <includes
-         id="org.eclipse.equinox.p2.rcp.feature"
-         version="0.0.0"/>
-
-   <includes
-         id="org.eclipse.equinox.p2.user.ui"
-         version="0.0.0"/>
-
-   <includes
          id="org.eclipse.help"
          version="0.0.0"/>
 
@@ -342,22 +334,6 @@
 
    <plugin
          id="org.eclipse.equinox.p2.transport.ecf"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.ui"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.ui.sdk"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.ui.sdk.scheduler"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.updatechecker"
          version="0.0.0"/>
 
    <plugin

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
@@ -28,10 +28,6 @@
          id="org.eclipse.license"
          version="0.0.0"/>
 
-   <includes
-         id="org.eclipse.platform"
-         version="0.0.0"/>
-
    <plugin
          id="org.eclipse.chemclipse.rcp.compilation.community.ui"
          version="0.0.0"/>
@@ -386,6 +382,14 @@
 
    <plugin
          id="org.slf4j.api"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.ltk.core.refactoring"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.ltk.ui.refactoring"
          version="0.0.0"/>
 
 </feature>

--- a/chemclipse/sites/chemclipse/category.xml
+++ b/chemclipse/sites/chemclipse/category.xml
@@ -6,21 +6,9 @@
    <feature url="features/org.eclipse.chemclipse.rcp.compilation.community.feature_0.9.0.qualifier.jar" id="org.eclipse.chemclipse.rcp.compilation.community.feature" version="0.9.0.qualifier">
       <category name="org.eclipse.chemclipse.chemclipse"/>
    </feature>
-   <feature id="org.eclipse.equinox.sdk">
-      <category name="org.eclipse.chemclipse.chemclipse.libraries"/>
-   </feature>
-   <feature id="org.eclipse.equinox.executable">
-      <category name="org.eclipse.chemclipse.chemclipse.libraries"/>
-   </feature>
-   <category-def name="org.eclipse.chemclipse.chemclipse" label="Chemclipse">
+   <category-def name="org.eclipse.chemclipse.chemclipse" label="ChemClipse">
       <description>
-         The parts of ChemClipse
-      </description>
-   </category-def>
-   <category-def name="org.eclipse.chemclipse.chemclipse.libraries" label="Libraries">
-      <description>
-         Contains libraries useful for projects that like to enhance ChemClipse.
-To make sure that all extensions are consistent and we do not end up with several versions we provide here these so extension developers can use one unique update site.
+         Update site for derivative products.
       </description>
    </category-def>
 </site>

--- a/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/implementation/Chromatogram_6_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/implementation/Chromatogram_6_Test.java
@@ -40,7 +40,7 @@ public class Chromatogram_6_Test extends TestCase {
 
 	public void test_2() {
 
-		assertEquals(15, chromatogram.getHeaderDataMap().size());
+		assertEquals(16, chromatogram.getHeaderDataMap().size());
 	}
 
 	public void test_3() {


### PR DESCRIPTION
https://download.eclipse.org/chemclipse/integration/develop/repository/ is very slow. Derivative products should get the Eclipse SDK from other mirrored sites to speed up the build and to lessen the burden on the @eclipse download server.