### PR TITLE
Update contributor documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,6 @@ Information regarding source code management, builds, coding standards, and
 more.
 
 * https://github.com/eclipse/chemclipse/wiki/Chemclipse-Developer-Manual
-* 
 
 The project maintains the following source code repositories
 
@@ -35,11 +34,7 @@ Be sure to search for existing bugs before you create another one. Remember that
 contributions are always welcome!
 
 ### Building the source
-+ A Java 8 JDK is required as well as JavaFX support, you have several options for this:
-    + You can download a JDK8 from Oracle https://www.oracle.com/java/technologies/javase-jdk8-downloads.html it already includes JavaFX
-    + You can download OpenJDK/OpenFX, for example [Zulu Community(TM)](https://www.azul.com/downloads/zulu-community/?&version=java-8-lts&architecture=x86-64-bit&package=jdk-fx) offer pre-build packages that already combine OpenJDK/FX, or you can even build one of your own
-    + Install via the package manager of your system, make sure to install OpenJDK+OpenFX as these are often seperate packages!
-+ You will need maven as a build tool, but be aware that Maven 3.6.1 and 3.6.2 do not work with tycho (a plugin that we use for building Eclipse projects), so either downgrade to 3.6.0 or use the latest 3.6.3!
++ An OpenJDK is required. We recommend the [Eclipse Temurin](https://adoptium.net/temurin/) distribution.
 + Clone the repository: `git clone -b develop git@github.com:eclipse/chemclipse.git`
 + Build: mvn `mvn -f chemclipse/chemclipse/releng/org.eclipse.chemclipse.aggregator/pom.xml install`
 + Find the compiled product in `chemclipse/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/target/products`


### PR DESCRIPTION
We switched to Temurin https://github.com/eclipse/chemclipse/pull/688 and removed JavaFX https://github.com/eclipse/chemclipse/issues/8 a while ago.