### PR TITLE
Retrieve container file size as long

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.container.supplier.zip/src/org/eclipse/chemclipse/xxd/converter/supplier/zip/io/ZipContainer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.container.supplier.zip/src/org/eclipse/chemclipse/xxd/converter/supplier/zip/io/ZipContainer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -32,7 +32,8 @@ public class ZipContainer implements IFileContentProvider {
 	private final int BUFFER = 2048;
 	private static final Logger logger = Logger.getLogger(ZipContainer.class);
 
-	public int getContentSize(File file) {
+	@Override
+	public long getContentSize(File file) {
 
 		try (ZipFile zipFile = new ZipFile(file)) {
 			return zipFile.size();

--- a/chemclipse/plugins/org.eclipse.chemclipse.container/src/org/eclipse/chemclipse/container/definition/IFileContentProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.container/src/org/eclipse/chemclipse/container/definition/IFileContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,7 +15,7 @@ import java.io.File;
 
 public interface IFileContentProvider {
 
-	public int getContentSize(File container);
+	public long getContentSize(File container);
 
 	public File[] getContents(File container);
 }


### PR DESCRIPTION
[File size is long in Java.](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/io/File.html#length()) It is just [int in ZipFile](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/zip/ZipFile.html#size()) so I would like to increase this to cover all cases. Introduced in https://github.com/eclipse/chemclipse/pull/1155.