### PR TITLE
Drag and Drop for RI and MS Databases

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.ui/src/org/eclipse/chemclipse/chromatogram/msd/process/supplier/peakidentification/ui/editors/BatchProcessEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.ui/src/org/eclipse/chemclipse/chromatogram/msd/process/supplier/peakidentification/ui/editors/BatchProcessEditor.java
@@ -148,7 +148,7 @@ public class BatchProcessEditor extends MultiPageEditorPart {
 				Thread.currentThread().interrupt();
 			}
 		} else {
-			throw new PartInitException("The file could't be loaded.");
+			throw new PartInitException("Unimplemented editor input " + input.getClass());
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/editors/EditorCalibration.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/editors/EditorCalibration.java
@@ -88,7 +88,7 @@ public class EditorCalibration extends MultiPageEditorPart {
 		} else if(input instanceof IURIEditorInput uriEditorInput) {
 			this.file = new File(uriEditorInput.getURI());
 		} else {
-			throw new PartInitException("The file could't be loaded.");
+			throw new PartInitException("Unimplemented editor input " + input.getClass());
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/editors/EditorCalibration.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/editors/EditorCalibration.java
@@ -30,6 +30,7 @@ import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorSite;
 import org.eclipse.ui.IFileEditorInput;
+import org.eclipse.ui.IURIEditorInput;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.part.MultiPageEditorPart;
 import org.osgi.service.event.Event;
@@ -84,6 +85,8 @@ public class EditorCalibration extends MultiPageEditorPart {
 		setPartName(fileName);
 		if(input instanceof IFileEditorInput fileEditorInput) {
 			this.file = fileEditorInput.getFile().getLocation().toFile();
+		} else if(input instanceof IURIEditorInput uriEditorInput) {
+			this.file = new File(uriEditorInput.getURI());
 		} else {
 			throw new PartInitException("The file could't be loaded.");
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/ui/editors/BatchJobEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/ui/editors/BatchJobEditor.java
@@ -156,7 +156,7 @@ public class BatchJobEditor extends EditorPart implements IRunnableWithProgress 
 	@Override
 	public boolean isSaveAsAllowed() {
 
-		return false; // enable once the Date Explorer can open .obj
+		return false; // enable once the Data Explorer can open .obj
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/ui/editors/BatchJobEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/ui/editors/BatchJobEditor.java
@@ -129,12 +129,12 @@ public class BatchJobEditor extends EditorPart implements IRunnableWithProgress 
 				monitor.run(false, false, runnable);
 				batchProcessJob = runnable.getBatchProcessJob();
 			} catch(InvocationTargetException e) {
-				throw new PartInitException("The file could't be loaded.", e.getTargetException());
+				throw new PartInitException("The file couldn't be loaded.", e.getTargetException());
 			} catch(InterruptedException e) {
 				Thread.currentThread().interrupt();
 			}
 		} else {
-			throw new PartInitException("The file could't be loaded.");
+			throw new PartInitException("The file couldn't be loaded.");
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.workflows.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/workflows/ui/editors/EditorSampleQuant.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.workflows.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/workflows/ui/editors/EditorSampleQuant.java
@@ -156,7 +156,7 @@ public class EditorSampleQuant extends MultiPageEditorPart {
 		if(input instanceof IFileEditorInput fileEditorInput) {
 			file = fileEditorInput.getFile().getLocation().toFile();
 		} else {
-			throw new PartInitException("The file could't be loaded.");
+			throw new PartInitException("Unimplemented editor input " + input.getClass());
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis.ui/META-INF/MANIFEST.MF
@@ -17,6 +17,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.chemclipse.msd.model;bundle-version="0.9.0",
  org.eclipse.chemclipse.msd.converter;bundle-version="0.9.0",
  org.eclipse.chemclipse.converter;bundle-version="0.9.0",
- org.eclipse.chemclipse.model;bundle-version="0.9.0"
+ org.eclipse.chemclipse.model;bundle-version="0.9.0",
+ org.eclipse.chemclipse.ux.extension.msd.ui;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis.ui/plugin.xml
@@ -38,4 +38,24 @@
             name="Database Collector (*.msl)">
       </wizard>
    </extension>
+   <extension
+         point="org.eclipse.ui.editors">
+      <editor
+            class="org.eclipse.chemclipse.ux.extension.msd.ui.editors.DatabaseEditor"
+            extensions="msl"
+            icon="platform:/plugin/org.eclipse.chemclipse.rcp.ui.icons/icons/16x16/database.gif"
+            id="org.eclipse.chemclipse.ux.extension.msd.ui.editors.DatabaseEditor.msl"
+            name="Mass Spectra Database">
+      </editor>
+   </extension>
+   <extension
+         point="org.eclipse.ui.editors">
+      <editor
+            class="org.eclipse.chemclipse.ux.extension.msd.ui.editors.DatabaseEditor"
+            extensions="msp"
+            icon="platform:/plugin/org.eclipse.chemclipse.rcp.ui.icons/icons/16x16/database.gif"
+            id="org.eclipse.chemclipse.ux.extension.msd.ui.editors.DatabaseEditor.msp"
+            name="Mass Spectra Database">
+      </editor>
+   </extension>
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/plugin.xml
@@ -15,7 +15,7 @@
             isImportable="true">
       </DatabaseSupplier>
       <DatabaseSupplier
-            description="Reads and writes NIST Text  (MSP) mass spectra."
+            description="Reads and writes NIST Text (MSP) mass spectra."
             exportConverter="org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msp.MSPDatabaseExportConverter"
             fileExtension=".msp"
             filterName="NIST Text (*.msp)"
@@ -50,7 +50,7 @@
             isImportable="false">
       </PeakSupplier>
       <PeakSupplier
-            description="Writes NIST Text  (MSP) mass spectra."
+            description="Writes NIST Text (MSP) mass spectra."
             exportConverter="org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msp.MSPPeakExportConverter"
             fileExtension=".msp"
             filterName="NIST Text (*.msp)"

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/support/DatabaseFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/support/DatabaseFileSupport.java
@@ -124,7 +124,9 @@ public class DatabaseFileSupport {
 	/**
 	 * Opens a file dialog and tries to save the mass spectra
 	 * 
-	 * @param chromatogram
+	 * @param shell
+	 * @param peaks
+	 * @param fileName
 	 * @throws NoConverterAvailableException
 	 */
 	public static void saveMassSpectra(Shell shell, List<IPeakMSD> peaks, String fileName) throws NoConverterAvailableException {
@@ -179,7 +181,9 @@ public class DatabaseFileSupport {
 	/**
 	 * Opens a file dialog and tries to save the mass spectra
 	 * 
+	 * @param shell
 	 * @param massSpectra
+	 * @param fileName
 	 * @throws NoConverterAvailableException
 	 */
 	public static void saveMassSpectra(Shell shell, IMassSpectra massSpectra, String fileName) throws NoConverterAvailableException {
@@ -246,6 +250,7 @@ public class DatabaseFileSupport {
 			logger.warn(e.getCause());
 		} catch(InterruptedException e) {
 			logger.warn(e);
+			Thread.currentThread().interrupt();
 		}
 		File data = runnable.getData();
 		if(data == null) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/META-INF/MANIFEST.MF
@@ -35,7 +35,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.swtchart;bundle-version="0.8.0",
  org.eclipse.swtchart.extensions;bundle-version="0.8.0",
  org.eclipse.chemclipse.xxd.process;bundle-version="0.8.0",
- org.eclipse.swt
+ org.eclipse.ui.ide;bundle-version="3.22.100"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: ChemClipse

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/DatabaseEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/DatabaseEditor.java
@@ -370,7 +370,7 @@ public class DatabaseEditor extends EditorPart {
 			File file = new File(uriEditorInput.getURI());
 			importMassSpectra(file, true);
 		} else {
-			throw new PartInitException("The file could't be loaded.");
+			throw new PartInitException("Unimplemented editor input " + input.getClass());
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/handlers/SaveAsHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/handlers/SaveAsHandler.java
@@ -11,8 +11,6 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.ui.handlers;
 
-import jakarta.inject.Named;
-
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.ux.extension.ui.editors.IChemClipseEditor;
 import org.eclipse.core.commands.ParameterizedCommand;
@@ -23,7 +21,11 @@ import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.services.IServiceConstants;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
+import org.eclipse.ui.internal.e4.compatibility.CompatibilityEditor;
 
+import jakarta.inject.Named;
+
+@SuppressWarnings("restriction")
 public class SaveAsHandler {
 
 	private static final Logger logger = Logger.getLogger(SaveAsHandler.class);
@@ -32,7 +34,7 @@ public class SaveAsHandler {
 	boolean canExecute(@Named(IServiceConstants.ACTIVE_PART) MPart part) {
 
 		if(part != null) {
-			if(part.isDirty() || part.getObject() instanceof IChemClipseEditor) {
+			if (part.getObject() instanceof IChemClipseEditor || part.getObject() instanceof CompatibilityEditor) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Fix save as for 3.x editors and allow for save as even if the file is not changed so you can always save as at another location. Fix drag and drop for `.cal` files and implement for `.msl` and `.msp` files.