### PR TITLE
Add missing magic number check

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/MultiDataExplorerTreeUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/MultiDataExplorerTreeUI.java
@@ -374,7 +374,7 @@ public class MultiDataExplorerTreeUI {
 					continue;
 				}
 				for(ISupplierFileIdentifier supplierFileIdentifier : map.keySet()) {
-					if(supplierFileIdentifier.isMatchContent(file)) {
+					if(supplierFileIdentifier.isMatchMagicNumber(file) && supplierFileIdentifier.isMatchContent(file)) {
 						Collection<ISupplier> suppliers = map.get(supplierFileIdentifier);
 						for(ISupplier supplier : suppliers) {
 							if(supplier.isMatchMagicNumber(file) && supplier.isMatchContent(file)) {
@@ -501,6 +501,9 @@ public class MultiDataExplorerTreeUI {
 			//
 			Collection<ISupplierFileIdentifier> identifiers = getIdentifierSupplier().apply(file).keySet();
 			for(ISupplierFileIdentifier identifier : identifiers) {
+				if(!identifier.isMatchMagicNumber(file)) {
+					continue;
+				}
 				if(!identifier.isMatchContent(file)) {
 					continue;
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ChromatogramEditor3x.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ChromatogramEditor3x.java
@@ -245,11 +245,9 @@ public class ChromatogramEditor3x extends EditorPart implements IChromatogramEdi
 	private boolean isMatch(File file, ISupplierFileIdentifier supplierFileIdentifier) {
 
 		boolean isMatch = false;
-		if(supplierFileIdentifier != null && file != null && file.exists()) {
-			if(supplierFileIdentifier.isSupplierFile(file) && supplierFileIdentifier.isMatchMagicNumber(file)) {
-				if(supplierFileIdentifier.isMatchContent(file)) {
-					isMatch = true;
-				}
+		if(supplierFileIdentifier != null && file != null && file.exists() && supplierFileIdentifier.isSupplierFile(file)) {
+			if(supplierFileIdentifier.isMatchMagicNumber(file) && supplierFileIdentifier.isMatchContent(file)) {
+				isMatch = true;
 			}
 		}
 		//


### PR DESCRIPTION
as the file content matcher is assuming the file is valid and of the correct type. It only determines what type of editor to open.