### PR TITLE
Improved Data Explorer file type detection performance

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.ascii.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.ascii.feature/feature.xml
@@ -9,7 +9,7 @@
       license-feature-version="1.0.0.qualifier">
 
    <description url="http://www.chemclipse.net">
-      This is a JSON chromatogram converter.
+      This is a text based chromatogram converter.
    </description>
 
    <copyright url="http://www.chemclipse.net">

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractFileContentMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,4 +12,6 @@
 package org.eclipse.chemclipse.converter.core;
 
 public abstract class AbstractFileContentMatcher implements IFileContentMatcher {
+
+	public static final long HUNDRED_MB = 100l * 1024l * 1024l;
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramFileContentMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Lablicate GmbH.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -29,6 +29,9 @@ public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher i
 	@Override
 	public boolean checkFileFormat(File file) {
 
+		if(file.length() > HUNDRED_MB) {
+			return true;
+		}
 		boolean isValidFormat = false;
 		try {
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/MassSpectrumFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/MassSpectrumFileContentMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Lablicate GmbH.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -29,6 +29,9 @@ public class MassSpectrumFileContentMatcher extends AbstractFileContentMatcher i
 	@Override
 	public boolean checkFileFormat(File file) {
 
+		if(file.length() > HUNDRED_MB) {
+			return true;
+		}
 		boolean isValidFormat = false;
 		try {
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramFileContentMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Lablicate GmbH.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -27,6 +27,9 @@ public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher i
 	@Override
 	public boolean checkFileFormat(File file) {
 
+		if(file.length() > HUNDRED_MB) {
+			return true;
+		}
 		boolean isValidFormat = false;
 		try {
 			XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumFileContentMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Lablicate GmbH.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -27,6 +27,9 @@ public class MassSpectrumFileContentMatcher extends AbstractFileContentMatcher i
 	@Override
 	public boolean checkFileFormat(File file) {
 
+		if(file.length() > HUNDRED_MB) {
+			return true;
+		}
 		boolean isValidFormat = false;
 		try {
 			XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
@@ -42,6 +45,7 @@ public class MassSpectrumFileContentMatcher extends AbstractFileContentMatcher i
 						hasRootElement = true;
 					} else if(elementName.equals("chromatogramList")) {
 						hasChromatogramList = true;
+						break;
 					} else if(elementName.equals("spectrumList")) {
 						hasSpectrumList = true;
 					}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramFileContentMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Lablicate GmbH.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -28,6 +28,9 @@ public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher i
 	@Override
 	public boolean checkFileFormat(File file) {
 
+		if(file.length() > HUNDRED_MB) {
+			return true;
+		}
 		boolean isValidFormat = false;
 		try {
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumFileContentMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Lablicate GmbH.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -28,6 +28,9 @@ public class MassSpectrumFileContentMatcher extends AbstractFileContentMatcher i
 	@Override
 	public boolean checkFileFormat(File file) {
 
+		if(file.length() > HUNDRED_MB) {
+			return true;
+		}
 		boolean isValidFormat = false;
 		try {
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/converter/AbstractSupplierFileIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/converter/AbstractSupplierFileIdentifier.java
@@ -13,19 +13,13 @@
 package org.eclipse.chemclipse.processing.converter;
 
 import java.io.File;
-import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.support.text.ValueFormat;
-
 public abstract class AbstractSupplierFileIdentifier implements ISupplierFileIdentifier {
 
-	private static final Logger logger = Logger.getLogger(AbstractSupplierFileIdentifier.class);
 	private final List<ISupplier> suppliers;
-	private final NumberFormat timeFormat = ValueFormat.getDecimalFormatEnglish("0.000");
 
 	public AbstractSupplierFileIdentifier(List<ISupplier> suppliers) {
 
@@ -159,18 +153,10 @@ public abstract class AbstractSupplierFileIdentifier implements ISupplierFileIde
 	public boolean isMatchMagicNumber(File file) {
 
 		for(ISupplier supplier : getSupplier()) {
-			long start = System.currentTimeMillis();
-			boolean matched = supplier.isMatchMagicNumber(file);
-			long end = System.currentTimeMillis();
-			long spent = end - start;
-			if(spent > 10) {
-				logger.info("Magic number check of " + file.getName() + " by " + supplier.getFilterName() + " took " + timeFormat.format(spent / 1000.0d) + " seconds.");
-			}
-			if(matched) {
+			if(supplier.isMatchMagicNumber(file)) {
 				return true;
 			}
 		}
-		//
 		return false;
 	}
 
@@ -178,18 +164,10 @@ public abstract class AbstractSupplierFileIdentifier implements ISupplierFileIde
 	public boolean isMatchContent(File file) {
 
 		for(ISupplier supplier : getSupplier()) {
-			long start = System.currentTimeMillis();
-			boolean matched = supplier.isMatchContent(file);
-			long end = System.currentTimeMillis();
-			long spent = end - start;
-			if(spent > 100) {
-				logger.info("File content check of " + file.getName() + " by " + supplier.getFilterName() + " took " + timeFormat.format(spent / 1000.0d) + " seconds.");
-			}
 			if(supplier.isMatchMagicNumber(file) && supplier.isMatchContent(file)) {
 				return true;
 			}
 		}
-		//
 		return false;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/converter/AbstractSupplierFileIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/converter/AbstractSupplierFileIdentifier.java
@@ -185,7 +185,7 @@ public abstract class AbstractSupplierFileIdentifier implements ISupplierFileIde
 			if(spent > 100) {
 				logger.info("File content check of " + file.getName() + " by " + supplier.getFilterName() + " took " + timeFormat.format(spent / 1000.0d) + " seconds.");
 			}
-			if(matched) {
+			if(supplier.isMatchMagicNumber(file) && supplier.isMatchContent(file)) {
 				return true;
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/MultiDataExplorerTreeUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/MultiDataExplorerTreeUI.java
@@ -374,7 +374,7 @@ public class MultiDataExplorerTreeUI {
 					continue;
 				}
 				for(ISupplierFileIdentifier supplierFileIdentifier : map.keySet()) {
-					if(supplierFileIdentifier.isMatchMagicNumber(file) && supplierFileIdentifier.isMatchContent(file)) {
+					if(supplierFileIdentifier.isMatchContent(file)) {
 						Collection<ISupplier> suppliers = map.get(supplierFileIdentifier);
 						for(ISupplier supplier : suppliers) {
 							if(supplier.isMatchMagicNumber(file) && supplier.isMatchContent(file)) {
@@ -501,10 +501,7 @@ public class MultiDataExplorerTreeUI {
 			//
 			Collection<ISupplierFileIdentifier> identifiers = getIdentifierSupplier().apply(file).keySet();
 			for(ISupplierFileIdentifier identifier : identifiers) {
-				if(!identifier.isMatchMagicNumber(file)) {
-					continue;
-				}
-				if(!identifier.isMatchContent(file)) {
+				if(!identifier.isMatchMagicNumber(file) || !identifier.isMatchContent(file)) {
 					continue;
 				}
 				if(identifier instanceof ISupplierFileEditorSupport fileEditorSupport) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ascii/src/org/eclipse/chemclipse/msd/converter/supplier/ascii/io/MassSpectraReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ascii/src/org/eclipse/chemclipse/msd/converter/supplier/ascii/io/MassSpectraReader.java
@@ -13,12 +13,9 @@ package org.eclipse.chemclipse.msd.converter.supplier.ascii.io;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
@@ -34,7 +31,7 @@ public class MassSpectraReader extends AbstractMassSpectraReader implements IMas
 	private static final Logger logger = Logger.getLogger(MassSpectraReader.class);
 
 	@Override
-	public IMassSpectra read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
 		IMassSpectra massSpectra = new MassSpectra();
 		IScanMSD massSpectrum = new ScanMSD();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/src/org/eclipse/chemclipse/xxd/process/support/ChromatogramTypeSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/src/org/eclipse/chemclipse/xxd/process/support/ChromatogramTypeSupport.java
@@ -142,7 +142,9 @@ public class ChromatogramTypeSupport {
 
 	public boolean isSupplierFile(ISupplierFileIdentifier supplierFileIdentifier, File file) {
 
-		if(supplierFileIdentifier.isSupplierFile(file) && supplierFileIdentifier.isMatchMagicNumber(file) && supplierFileIdentifier.isMatchContent(file)) {
+		if(supplierFileIdentifier.isSupplierFile(file) //
+				&& supplierFileIdentifier.isMatchMagicNumber(file) //
+				&& supplierFileIdentifier.isMatchContent(file)) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
https://github.com/eclipse/chemclipse/pull/1802 addresses the problem, but didn't quite solve it. This completely removes all file content checks running on all files by enforcing a successful magic byte check first.

I also removed the benchmarking. As we learned, not one individual check, but a sum of many minor checks cause performance problems. Measuring the performance in the loop also has performance implications as well. Really slow content checks are also quite easy to spot by right-clicking on individual files.