### PR TITLE
Allow cancel for MS database import operations

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/support/DatabasesCache.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/support/DatabasesCache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Lablicate GmbH.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -98,6 +98,10 @@ public class DatabasesCache {
 					 */
 					if(massSpectraDatabases.get(databaseName) == null) {
 						loadMassSpectraFromFile(file, monitor);
+						if(monitor.isCanceled()) {
+							resetCache();
+							return massSpectraDatabases;
+						}
 					} else {
 						/*
 						 * Has the content been edited?

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/io/StandardsReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/io/StandardsReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Lablicate GmbH.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -31,9 +31,8 @@ public class StandardsReader {
 	public IMassSpectra getStandardsMassSpectra() {
 
 		File file = new File(PathResolver.getAbsolutePath(PathResolver.ALKANES));
-		IProcessingInfo<?> processingInfo = DatabaseConverter.convert(file, new NullProgressMonitor());
-		IMassSpectra massSpectra = (IMassSpectra)processingInfo.getProcessingResult();
-		return massSpectra;
+		IProcessingInfo<IMassSpectra> processingInfo = DatabaseConverter.convert(file, new NullProgressMonitor());
+		return processingInfo.getProcessingResult();
 	}
 
 	public List<IRetentionIndexEntry> getStandardsList() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/supplier/ChromatogramSelectionProcessorSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/supplier/ChromatogramSelectionProcessorSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -25,12 +25,12 @@ import org.eclipse.core.runtime.IProgressMonitor;
 
 public abstract class ChromatogramSelectionProcessorSupplier<SettingsClass> extends AbstractProcessSupplier<SettingsClass> implements IChromatogramSelectionProcessSupplier<SettingsClass> {
 
-	public ChromatogramSelectionProcessorSupplier(String id, String name, String description, Class<SettingsClass> settingsClass, IProcessTypeSupplier parent, DataType... dataTypes) {
+	protected ChromatogramSelectionProcessorSupplier(String id, String name, String description, Class<SettingsClass> settingsClass, IProcessTypeSupplier parent, DataType... dataTypes) {
 
 		super(id, name, description, settingsClass, parent, convert(dataTypes));
 	}
 
-	public ChromatogramSelectionProcessorSupplier(String id, String name, String description, Class<SettingsClass> settingsClass, IProcessTypeSupplier parent, int b, DataCategory... dataTypes) {
+	protected ChromatogramSelectionProcessorSupplier(String id, String name, String description, Class<SettingsClass> settingsClass, IProcessTypeSupplier parent, int b, DataCategory... dataTypes) {
 
 		super(id, name, description, settingsClass, parent, dataTypes);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/supplier/IChromatogramSelectionProcessSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/supplier/IChromatogramSelectionProcessSupplier.java
@@ -45,7 +45,7 @@ public interface IChromatogramSelectionProcessSupplier<SettingType> extends IPro
 		//
 		return new IProcessExecutionConsumer<IChromatogramSelection<?, ?>>() {
 
-			AtomicReference<IChromatogramSelection<?, ?>> result = new AtomicReference<IChromatogramSelection<?, ?>>(chromatogramSelection);
+			AtomicReference<IChromatogramSelection<?, ?>> result = new AtomicReference<>(chromatogramSelection);
 
 			@Override
 			public <X> void execute(IProcessorPreferences<X> preferences, ProcessExecutionContext context) throws Exception {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak/src/org/eclipse/chemclipse/msd/classifier/supplier/molpeak/identifier/BasePeakIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak/src/org/eclipse/chemclipse/msd/classifier/supplier/molpeak/identifier/BasePeakIdentifier.java
@@ -288,8 +288,7 @@ public class BasePeakIdentifier {
 
 		File file = new File(PathResolver.getAbsolutePath(PathResolver.REFERENCES));
 		IProcessingInfo<IMassSpectra> processingInfo = DatabaseConverter.convert(file, new NullProgressMonitor());
-		IMassSpectra massSpectra = processingInfo.getProcessingResult();
-		return massSpectra;
+		return processingInfo.getProcessingResult();
 	}
 
 	private void setLibraryInformationFields(ILibraryInformation libraryInformation, String name) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSLReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSLReader.java
@@ -309,6 +309,9 @@ public class MSLReader extends AbstractMassSpectraReader implements IMassSpectra
 		 */
 		monitor.beginTask("Extract mass spectra", massSpectraData.size());
 		for(String massSpectrumData : massSpectraData) {
+			if(monitor.isCanceled()) {
+				return massSpectra;
+			}
 			addMassSpectrum(massSpectra, massSpectrumData, referenceIdentifierMarker, referenceIdentifierPrefix);
 			monitor.worked(1);
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader.java
@@ -184,6 +184,9 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 			 */
 			monitor.beginTask("Extract mass spectra", massSpectraData.size());
 			for(String massSpectrumData : massSpectraData) {
+				if(monitor.isCanceled()) {
+					return massSpectra;
+				}
 				addMassSpectrum(massSpectra, massSpectrumData, referenceIdentifierMarker, referenceIdentifierPrefix);
 				monitor.worked(1);
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/DatabaseEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/DatabaseEditor.java
@@ -283,7 +283,7 @@ public class DatabaseEditor extends EditorPart {
 			 * No fork, otherwise it might crash when loading the data takes too long.
 			 */
 			boolean fork = !batch;
-			dialog.run(fork, false, runnable);
+			dialog.run(fork, true, runnable);
 		} catch(InvocationTargetException e) {
 			logger.warn(e);
 			logger.warn(e.getCause());

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/BatchJobUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/BatchJobUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 Lablicate GmbH.
+ * Copyright (c) 2018, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -206,12 +206,11 @@ public class BatchJobUI {
 					processingInfo.addErrorMessage("BatchJob", "Execution of the job failed", e.getCause());
 					ProcessingInfoPartSupport.getInstance().update(processingInfo);
 				} catch(InterruptedException e) {
-					// canceled
-					return;
+					Thread.currentThread().interrupt();
+					// cancelled
 				}
 			}
 		});
-		//
 		return toolItem;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/targets/TargetsSettingsEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/targets/TargetsSettingsEditor.java
@@ -359,7 +359,7 @@ public class TargetsSettingsEditor implements SettingsUIProvider.SettingsUIContr
 						ProgressMonitorDialog dialog = new ProgressMonitorDialog(e.display.getActiveShell());
 						DatabaseImportRunnable databaseImportRunnable = new DatabaseImportRunnable(file);
 						try {
-							dialog.run(false, false, databaseImportRunnable);
+							dialog.run(false, true, databaseImportRunnable);
 							IMassSpectra massSpectra = databaseImportRunnable.getMassSpectra();
 							if(massSpectra.size() > WARN_NUMBER_IMPORT_ENTRIES) {
 								if(MessageDialog.openQuestion(e.display.getActiveShell(), "Import", "Do you really want to import " + massSpectra.size() + " target entries?")) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/io/MassSpectraReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/io/MassSpectraReader.java
@@ -76,12 +76,12 @@ public class MassSpectraReader extends AbstractMassSpectraReader implements IMas
 
 		if(isValidFileFormat(file)) {
 			boolean isNameMarkerAvailable = isNameMarkerAvailable(file);
-			return extractMassSpectra(file, isNameMarkerAvailable);
+			return extractMassSpectra(file, isNameMarkerAvailable, monitor);
 		}
 		return null;
 	}
 
-	private IMassSpectra extractMassSpectra(File file, boolean isNameMarkerAvailable) throws IOException {
+	private IMassSpectra extractMassSpectra(File file, boolean isNameMarkerAvailable, IProgressMonitor monitor) throws IOException {
 
 		String referenceIdentifierMarker = PreferenceSupplier.getReferenceIdentifierMarker();
 		String referenceIdentifierPrefix = PreferenceSupplier.getReferenceIdentifierPrefix();
@@ -99,6 +99,9 @@ public class MassSpectraReader extends AbstractMassSpectraReader implements IMas
 				 * Parse each line
 				 */
 				while((line = bufferedReader.readLine()) != null) {
+					if(monitor.isCanceled()) {
+						return massSpectra;
+					}
 					/*
 					 * Strip line comments
 					 */


### PR DESCRIPTION
which take a while so not having this was annoying. This effects the database editor, file identifier and batch process.