### PR TITLE
Allow saving chromatogram exports and reports into the current directory

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/src/org/eclipse/chemclipse/chromatogram/xxd/report/core/ChromatogramReportsProcessSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/src/org/eclipse/chemclipse/chromatogram/xxd/report/core/ChromatogramReportsProcessSupplier.java
@@ -81,7 +81,7 @@ public class ChromatogramReportsProcessSupplier implements IProcessTypeSupplier 
 			}
 			File exportFolder = settings.getExportFolder();
 			if(exportFolder == null) {
-				messageConsumer.addErrorMessage(getName(), "No outputfolder specified and no default configured");
+				messageConsumer.addErrorMessage(getName(), "No output folder specified and no default configured.");
 				return chromatogramSelection;
 			}
 			String extension = supplier.getFileExtension();
@@ -92,7 +92,7 @@ public class ChromatogramReportsProcessSupplier implements IProcessTypeSupplier 
 				messageConsumer.addMessages(info);
 				messageConsumer.addInfoMessage(getName(), "Report written to " + file.getAbsolutePath());
 			} else {
-				messageConsumer.addErrorMessage(getName(), "The specified outputfolder does not exits and can't be created");
+				messageConsumer.addErrorMessage(getName(), "The specified output folder does not exist and can't be created.");
 			}
 			return chromatogramSelection;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/src/org/eclipse/chemclipse/chromatogram/xxd/report/core/ChromatogramReportsProcessSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/src/org/eclipse/chemclipse/chromatogram/xxd/report/core/ChromatogramReportsProcessSupplier.java
@@ -87,7 +87,7 @@ public class ChromatogramReportsProcessSupplier implements IProcessTypeSupplier 
 			String extension = supplier.getFileExtension();
 			if(exportFolder.exists() || exportFolder.mkdirs()) {
 				IChromatogram<? extends IPeak> chromatogram = chromatogramSelection.getChromatogram();
-				File file = new File(exportFolder, settings.getFileNamePattern().replace(IChromatogramReportSettings.VARIABLE_CHROMATOGRAM_NAME, chromatogram.getName()).replace(IChromatogramReportSettings.VARIABLE_EXTENSION, extension));
+				File file = new File(exportFolder, settings.getFileNamePattern().replace(IProcessSettings.VARIABLE_CHROMATOGRAM_NAME, chromatogram.getName()).replace(IProcessSettings.VARIABLE_EXTENSION, extension));
 				IProcessingInfo<?> info = ChromatogramReports.generate(file, settings.isAppend(), chromatogram, settings, getId(), monitor);
 				messageConsumer.addMessages(info);
 				messageConsumer.addInfoMessage(getName(), "Report written to " + file.getAbsolutePath());

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/src/org/eclipse/chemclipse/chromatogram/xxd/report/core/ChromatogramReportsProcessSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/src/org/eclipse/chemclipse/chromatogram/xxd/report/core/ChromatogramReportsProcessSupplier.java
@@ -24,6 +24,8 @@ import org.eclipse.chemclipse.chromatogram.xxd.report.settings.IChromatogramRepo
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
+import org.eclipse.chemclipse.model.settings.AbstractProcessSettings;
+import org.eclipse.chemclipse.model.settings.IProcessSettings;
 import org.eclipse.chemclipse.model.supplier.ChromatogramSelectionProcessorSupplier;
 import org.eclipse.chemclipse.model.types.DataType;
 import org.eclipse.chemclipse.processing.core.ICategories;
@@ -83,6 +85,10 @@ public class ChromatogramReportsProcessSupplier implements IProcessTypeSupplier 
 			if(exportFolder == null) {
 				messageConsumer.addErrorMessage(getName(), "No output folder specified and no default configured.");
 				return chromatogramSelection;
+			}
+			if(exportFolder.getAbsolutePath().contains(IProcessSettings.VARIABLE_CURRENT_DIRECTORY)) {
+				String exportPath = AbstractProcessSettings.getCleanedFileValue(exportFolder.getAbsolutePath());
+				exportFolder = new File(exportPath.replace(IProcessSettings.VARIABLE_CURRENT_DIRECTORY, chromatogramSelection.getChromatogram().getFile().getParent()));
 			}
 			String extension = supplier.getFileExtension();
 			if(exportFolder.exists() || exportFolder.mkdirs()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/src/org/eclipse/chemclipse/chromatogram/xxd/report/settings/AbstractChromatogramReportSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/src/org/eclipse/chemclipse/chromatogram/xxd/report/settings/AbstractChromatogramReportSettings.java
@@ -25,6 +25,10 @@ public abstract class AbstractChromatogramReportSettings extends AbstractProcess
 
 	@JsonProperty(value = "Export Folder", defaultValue = "", required = true)
 	@FileSettingProperty(onlyDirectory = true, dialogType = DialogType.SAVE_DIALOG)
+	@JsonPropertyDescription("Set a specific folder or use the placeholder.\n" + //
+			"Variables:\n" + //
+			VARIABLE_CURRENT_DIRECTORY //
+	)
 	private File exportFolder;
 	@JsonProperty(value = "Append", defaultValue = "false")
 	private boolean append = false;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/src/org/eclipse/chemclipse/chromatogram/xxd/report/settings/AbstractChromatogramReportSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/src/org/eclipse/chemclipse/chromatogram/xxd/report/settings/AbstractChromatogramReportSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2023 Lablicate GmbH.
+ * Copyright (c) 2012, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import java.io.File;
 
 import org.eclipse.chemclipse.model.settings.AbstractProcessSettings;
 import org.eclipse.chemclipse.support.settings.FileSettingProperty;
+import org.eclipse.chemclipse.support.settings.FileSettingProperty.DialogType;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -23,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 public abstract class AbstractChromatogramReportSettings extends AbstractProcessSettings implements IChromatogramReportSettings {
 
 	@JsonProperty(value = "Export Folder", defaultValue = "", required = true)
-	@FileSettingProperty(onlyDirectory = true)
+	@FileSettingProperty(onlyDirectory = true, dialogType = DialogType.SAVE_DIALOG)
 	private File exportFolder;
 	@JsonProperty(value = "Append", defaultValue = "false")
 	private boolean append = false;

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/chromatogram/ChromatogramExportSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/chromatogram/ChromatogramExportSettings.java
@@ -32,6 +32,10 @@ public class ChromatogramExportSettings extends AbstractProcessSettings implemen
 
 	@JsonProperty(value = "Export Folder", defaultValue = "")
 	@FileSettingProperty(onlyDirectory = true, dialogType = DialogType.SAVE_DIALOG)
+	@JsonPropertyDescription("Set an absolute folder or use the variables.\n" + //
+			"Variables:\n" + //
+			VARIABLE_CURRENT_DIRECTORY //
+	)
 	private File exportFolder;
 	@JsonProperty(value = "File Name", defaultValue = VARIABLE_CHROMATOGRAM_NAME + VARIABLE_EXTENSION)
 	@JsonPropertyDescription("Set a specific name or use the variables or a combination.\n" + //
@@ -68,7 +72,6 @@ public class ChromatogramExportSettings extends AbstractProcessSettings implemen
 		if(filenamePattern == null) {
 			return VARIABLE_CHROMATOGRAM_NAME + VARIABLE_EXTENSION;
 		}
-		//
 		return filenamePattern;
 	}
 
@@ -95,8 +98,18 @@ public class ChromatogramExportSettings extends AbstractProcessSettings implemen
 	@JsonIgnore
 	public File getExportFile(String extension, IChromatogram<?> chromatogram) {
 
-		File exportFolder = getExportFolder();
+		String exportPath = resolvedFolders(chromatogram);
 		String fileName = getFileName(chromatogram, getFileNamePattern(), extension);
-		return new File(exportFolder, fileName);
+		return new File(exportPath, fileName);
+	}
+
+	private String resolvedFolders(IChromatogram<?> chromatogram) {
+
+		String exportPath = getExportFolder().getAbsolutePath();
+		if(exportPath.contains(IProcessSettings.VARIABLE_CURRENT_DIRECTORY)) {
+			exportPath = getCleanedFileValue(exportPath);
+			exportPath = exportPath.replace(IProcessSettings.VARIABLE_CURRENT_DIRECTORY, chromatogram.getFile().getParent());
+		}
+		return exportPath;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/chromatogram/ChromatogramExportSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/chromatogram/ChromatogramExportSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,6 +19,7 @@ import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.settings.AbstractProcessSettings;
 import org.eclipse.chemclipse.model.settings.IProcessSettings;
 import org.eclipse.chemclipse.support.settings.FileSettingProperty;
+import org.eclipse.chemclipse.support.settings.FileSettingProperty.DialogType;
 import org.eclipse.chemclipse.support.settings.SystemSettings;
 import org.eclipse.chemclipse.support.settings.SystemSettingsStrategy;
 
@@ -30,7 +31,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 public class ChromatogramExportSettings extends AbstractProcessSettings implements IProcessSettings {
 
 	@JsonProperty(value = "Export Folder", defaultValue = "")
-	@FileSettingProperty(onlyDirectory = true)
+	@FileSettingProperty(onlyDirectory = true, dialogType = DialogType.SAVE_DIALOG)
 	private File exportFolder;
 	@JsonProperty(value = "File Name", defaultValue = VARIABLE_CHROMATOGRAM_NAME + VARIABLE_EXTENSION)
 	@JsonPropertyDescription("Set a specific name or use the variables or a combination.\n" + //

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter/src/org/eclipse/chemclipse/csd/converter/chromatogram/ChromatogramConverterCSDProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter/src/org/eclipse/chemclipse/csd/converter/chromatogram/ChromatogramConverterCSDProcessTypeSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -70,7 +70,7 @@ public class ChromatogramConverterCSDProcessTypeSupplier implements IProcessType
 			}
 			File exportFolder = processSettings.getExportFolder();
 			if(exportFolder == null) {
-				messageConsumer.addErrorMessage(getName(), "No outputfolder specified and no default configured");
+				messageConsumer.addErrorMessage(getName(), "No output folder specified and no default configured.");
 				return chromatogramSelection;
 			}
 			if(exportFolder.exists() || exportFolder.mkdirs()) {
@@ -84,10 +84,10 @@ public class ChromatogramConverterCSDProcessTypeSupplier implements IProcessType
 						messageConsumer.addInfoMessage(getName(), "Exported data to " + result.getAbsolutePath());
 					}
 				} else {
-					messageConsumer.addWarnMessage(getName(), "Only CSD Chromatograms supported, skipp processing");
+					messageConsumer.addWarnMessage(getName(), "Only CSD chromatograms supported, skip processing.");
 				}
 			} else {
-				messageConsumer.addErrorMessage(getName(), "The specified outputfolder (" + exportFolder.getAbsolutePath() + ") does not exits and can't be created");
+				messageConsumer.addErrorMessage(getName(), "The specified output folder (" + exportFolder.getAbsolutePath() + ") does not exist and can't be created.");
 			}
 			return chromatogramSelection;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/settings/AbstractProcessSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/settings/AbstractProcessSettings.java
@@ -39,6 +39,20 @@ public abstract class AbstractProcessSettings implements IProcessSettings {
 		return FileSystem.getCurrent().toLegalFileName(fileName, '-');
 	}
 
+	/*
+	 * Jackson serializes File.getAbsolutePath()
+	 * which mistakes the placeholder for a relative path and prepends the working directory
+	 * so we remove it again.
+	 */
+	public static String getCleanedFileValue(String value) {
+
+		int startIndex = value.indexOf(IProcessSettings.VARIABLE_CURRENT_DIRECTORY);
+		if(startIndex != -1) {
+			return value.substring(startIndex);
+		}
+		return value;
+	}
+
 	private String replaceFileName(IChromatogram<?> chromatogram, String fileNamePattern) {
 
 		String fileName = fileNamePattern;

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/settings/AbstractProcessSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/settings/AbstractProcessSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -36,7 +36,7 @@ public abstract class AbstractProcessSettings implements IProcessSettings {
 		/*
 		 * Remove OS specific file system control characters.
 		 */
-		return FileSystem.getCurrent().toLegalFileName(fileName, (char)'-');
+		return FileSystem.getCurrent().toLegalFileName(fileName, '-');
 	}
 
 	private String replaceFileName(IChromatogram<?> chromatogram, String fileNamePattern) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/settings/IProcessSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/settings/IProcessSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -18,6 +18,8 @@ public interface IProcessSettings {
 	public static final String VARIABLE_CHROMATOGRAM_SAMPLEGROUP = "{chromatogram_samplegroup}";
 	public static final String VARIABLE_CHROMATOGRAM_SHORTINFO = "{chromatogram_shortinfo}";
 	public static final String VARIABLE_EXTENSION = "{extension}";
+	//
+	public static final String VARIABLE_CURRENT_DIRECTORY = "{current_directory}";
 
 	/**
 	 * Use this method to set specific system settings.

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/chromatogram/ChromatogramConverterMSDProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/chromatogram/ChromatogramConverterMSDProcessTypeSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -71,7 +71,7 @@ public class ChromatogramConverterMSDProcessTypeSupplier implements IProcessType
 			}
 			File exportFolder = processSettings.getExportFolder();
 			if(exportFolder == null) {
-				messageConsumer.addErrorMessage(getName(), "No outputfolder specified and no default configured");
+				messageConsumer.addErrorMessage(getName(), "No output folder specified and no default configured.");
 				return chromatogramSelection;
 			}
 			if(exportFolder.exists() || exportFolder.mkdirs()) {
@@ -85,10 +85,10 @@ public class ChromatogramConverterMSDProcessTypeSupplier implements IProcessType
 						messageConsumer.addInfoMessage(getName(), "Exported data to " + result.getAbsolutePath());
 					}
 				} else {
-					messageConsumer.addWarnMessage(getName(), "Only MSD Chromatograms supported, skipp processing");
+					messageConsumer.addWarnMessage(getName(), "Only MSD chromatograms supported, skip processing.");
 				}
 			} else {
-				messageConsumer.addErrorMessage(getName(), "The specified outputfolder (" + exportFolder.getAbsolutePath() + ") does not exits and can't be created");
+				messageConsumer.addErrorMessage(getName(), "The specified output folder (" + exportFolder.getAbsolutePath() + ") does not exist and can't be created");
 			}
 			return chromatogramSelection;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/peak/PeakExportSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/peak/PeakExportSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,6 +19,7 @@ import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.settings.AbstractProcessSettings;
 import org.eclipse.chemclipse.model.settings.IProcessSettings;
 import org.eclipse.chemclipse.support.settings.FileSettingProperty;
+import org.eclipse.chemclipse.support.settings.FileSettingProperty.DialogType;
 import org.eclipse.chemclipse.support.settings.SystemSettings;
 import org.eclipse.chemclipse.support.settings.SystemSettingsStrategy;
 
@@ -30,7 +31,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 public class PeakExportSettings extends AbstractProcessSettings implements IProcessSettings {
 
 	@JsonProperty(value = "Export Folder", defaultValue = "")
-	@FileSettingProperty(onlyDirectory = true)
+	@FileSettingProperty(onlyDirectory = true, dialogType = DialogType.SAVE_DIALOG)
 	private File exportFolder;
 	@JsonProperty(value = "File Name", defaultValue = VARIABLE_CHROMATOGRAM_NAME + VARIABLE_EXTENSION)
 	@JsonPropertyDescription("Set a specific name or use the variables or a combination. Variables: " + //

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/DilutionListUtil.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/DilutionListUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Lablicate GmbH.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,6 +12,7 @@
 package org.eclipse.chemclipse.support.util;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -43,14 +44,10 @@ public class DilutionListUtil {
 
 	public List<String> getDilutions(String preferenceEntry) {
 
-		List<String> dilutions = new ArrayList<String>();
-		if(preferenceEntry != "") {
+		List<String> dilutions = new ArrayList<>();
+		if(!"".equals(preferenceEntry)) {
 			String[] items = parseString(preferenceEntry);
-			if(items.length > 0) {
-				for(String item : items) {
-					dilutions.add(item);
-				}
-			}
+			dilutions = Arrays.asList(items);
 		}
 		Collections.sort(dilutions);
 		return dilutions;
@@ -58,12 +55,9 @@ public class DilutionListUtil {
 
 	private List<String> getDilutions(String[] items) {
 
-		List<String> dilutions = new ArrayList<String>();
+		List<String> dilutions = new ArrayList<>();
 		if(items != null) {
-			int size = items.length;
-			for(int i = 0; i < size; i++) {
-				dilutions.add(items[i]);
-			}
+			dilutions = Arrays.asList(items);
 		}
 		return dilutions;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/FileListUtil.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/FileListUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Lablicate GmbH.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -44,8 +44,8 @@ public class FileListUtil {
 
 	public List<String> getFiles(String preferenceEntry) {
 
-		List<String> files = new ArrayList<String>();
-		if(preferenceEntry != "") {
+		List<String> files = new ArrayList<>();
+		if(!"".equals(preferenceEntry)) {
 			String[] items = parseString(preferenceEntry);
 			if(items.length > 0) {
 				for(String item : items) {
@@ -62,7 +62,7 @@ public class FileListUtil {
 
 	private List<String> getFileList(String[] items) {
 
-		List<String> files = new ArrayList<String>();
+		List<String> files = new ArrayList<>();
 		if(items != null) {
 			int size = items.length;
 			for(int i = 0; i < size; i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/FileSettingUtil.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/FileSettingUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 Lablicate GmbH.
+ * Copyright (c) 2013, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -46,7 +45,7 @@ public class FileSettingUtil implements IStringSerialization<File> {
 
 		if(data != null && !data.isEmpty()) {
 			try {
-				return Arrays.stream(objectMapper.readValue(data, String[].class)).map(value -> new File(value)).collect(Collectors.toList());
+				return Arrays.stream(objectMapper.readValue(data, String[].class)).map(File::new).toList();
 			} catch(IOException e) {
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/FileUtil.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/FileUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 Lablicate GmbH.
+ * Copyright (c) 2013, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,6 +19,7 @@ public class FileUtil {
 	 * Use only static methods.
 	 */
 	private FileUtil() {
+
 	}
 
 	/**
@@ -35,7 +36,7 @@ public class FileUtil {
 		 */
 		if(file != null) {
 			String fileName = file.getName();
-			if(fileName != null && fileName != "") {
+			if(fileName != null && !"".equals(fileName)) {
 				/*
 				 * Extract the file name.
 				 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/StringSettingUtil.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/StringSettingUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 Lablicate GmbH.
+ * Copyright (c) 2013, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -45,7 +45,7 @@ public class StringSettingUtil implements IStringSerialization<String[]> {
 		List<String[]> deserialize = new ArrayList<>();
 		if(data != null && !data.isEmpty()) {
 			try {
-				Arrays.stream(objectMapper.readValue(data, String[][].class)).forEach(value -> deserialize.add(value));
+				Arrays.stream(objectMapper.readValue(data, String[][].class)).forEach(deserialize::add);
 			} catch(IOException e) {
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/TraceSettingUtil.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/TraceSettingUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.StringTokenizer;
-import java.util.stream.Collectors;
 
 import org.eclipse.chemclipse.support.model.RangesInteger;
 
@@ -76,7 +75,7 @@ public class TraceSettingUtil implements IStringSerialization<String> {
 		try {
 			if(deserialize != null && !deserialize.isEmpty()) {
 				String[] decodedArray = objectMapper.readValue(deserialize, String[].class);
-				return Arrays.stream(decodedArray).collect(Collectors.toList());
+				return Arrays.stream(decodedArray).toList();
 			}
 		} catch(IOException e) {
 		}
@@ -102,7 +101,7 @@ public class TraceSettingUtil implements IStringSerialization<String> {
 			 */
 			decodedArray = new String[0];
 		}
-		return Arrays.stream(decodedArray).collect(Collectors.toList());
+		return Arrays.stream(decodedArray).toList();
 	}
 
 	public int compare(String s1, String s2) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/methods/WidgetItem.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/methods/WidgetItem.java
@@ -15,6 +15,7 @@ package org.eclipse.chemclipse.ux.extension.xxd.ui.methods;
 
 import java.io.File;
 
+import org.eclipse.chemclipse.model.settings.AbstractProcessSettings;
 import org.eclipse.chemclipse.support.settings.ComboSettingsProperty.ComboSupplier;
 import org.eclipse.chemclipse.support.settings.FileSettingProperty;
 import org.eclipse.chemclipse.support.settings.FileSettingProperty.DialogType;
@@ -36,7 +37,8 @@ import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.custom.CLabel;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.GridData;
@@ -374,18 +376,22 @@ public class WidgetItem {
 		layout.verticalSpacing = 0;
 		composite.setLayout(layout);
 		//
-		CLabel label = new CLabel(composite, SWT.NONE);
-		label.setForeground(parent.getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY));
-		String value = getValueAsString();
-		if(value == null || value.isEmpty()) {
-			label.setText(ExtensionMessages.chooseLocation);
-		} else {
-			label.setText(value);
-		}
-		label.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, true));
+		Text text = new Text(composite, SWT.BORDER);
+		text.setToolTipText(inputValue.getDescription());
+		text.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, true));
+		text.setText(AbstractProcessSettings.getCleanedFileValue(getValueAsString()));
+		text.addModifyListener(new ModifyListener() {
+
+			@Override
+			public void modifyText(ModifyEvent e) {
+
+				currentSelection = new File(text.getText());
+			}
+		});
 		//
 		Button button = new Button(composite, SWT.PUSH);
 		button.setText(" ... ");
+		button.setToolTipText(ExtensionMessages.chooseLocation);
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -418,14 +424,14 @@ public class WidgetItem {
 					}
 					String open = dialog.open();
 					if(open != null) {
-						label.setText(open);
+						text.setText(open);
 						currentSelection = new File(open);
 					}
 				} else {
 					DirectoryDialog dialog = new DirectoryDialog(button.getShell(), style);
 					String open = dialog.open();
 					if(open != null) {
-						label.setText(open);
+						text.setText(open);
 						currentSelection = new File(open);
 					}
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/src/org/eclipse/chemclipse/wsd/converter/chromatogram/ChromatogramConverterWSDProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/src/org/eclipse/chemclipse/wsd/converter/chromatogram/ChromatogramConverterWSDProcessTypeSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -71,7 +71,7 @@ public class ChromatogramConverterWSDProcessTypeSupplier implements IProcessType
 			}
 			File exportFolder = processSettings.getExportFolder();
 			if(exportFolder == null) {
-				messageConsumer.addErrorMessage(getName(), "No outputfolder specified and no default configured");
+				messageConsumer.addErrorMessage(getName(), "No output folder specified and no default configured.");
 				return chromatogramSelection;
 			}
 			if(exportFolder.exists() || exportFolder.mkdirs()) {
@@ -85,10 +85,10 @@ public class ChromatogramConverterWSDProcessTypeSupplier implements IProcessType
 						messageConsumer.addInfoMessage(getName(), "Exported data to " + result.getAbsolutePath());
 					}
 				} else {
-					messageConsumer.addWarnMessage(getName(), "Only WSD Chromatograms supported, skipp processing");
+					messageConsumer.addWarnMessage(getName(), "Only WSD chromatograms supported, skip processing.");
 				}
 			} else {
-				messageConsumer.addErrorMessage(getName(), "The specified outputfolder (" + exportFolder.getAbsolutePath() + ") does not exits and can't be created");
+				messageConsumer.addErrorMessage(getName(), "The specified output folder (" + exportFolder.getAbsolutePath() + ") does not exist and can't be created.");
 			}
 			return chromatogramSelection;
 		}


### PR DESCRIPTION
This adds support for placeholder when saving into folders and adds `{current_directory}` which is helpful during batch processing if you want to reuse the directory structure around your raw data files.