### PR TITLE
Revert back to modifiable lists

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.ui/src/org/eclipse/chemclipse/chromatogram/msd/process/supplier/peakidentification/ui/internal/wizards/PeakInputFilesWizard.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.ui/src/org/eclipse/chemclipse/chromatogram/msd/process/supplier/peakidentification/ui/internal/wizards/PeakInputFilesWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Lablicate GmbH.
+ * Copyright (c) 2011, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -28,6 +28,7 @@ public class PeakInputFilesWizard extends Wizard {
 	private List<String> selectedPeakFiles;
 
 	public PeakInputFilesWizard() {
+
 		super();
 		setNeedsProgressMonitor(true);
 	}
@@ -37,7 +38,7 @@ public class PeakInputFilesWizard extends Wizard {
 
 		ISelection selection = inputEntriesPage.getSelection();
 		IStructuredSelection structuredSelection = (IStructuredSelection)selection;
-		selectedPeakFiles = new ArrayList<String>();
+		selectedPeakFiles = new ArrayList<>();
 		for(Object element : structuredSelection.toList()) {
 			selectedPeakFiles.add(element.toString());
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.cml/src/org/eclipse/chemclipse/msd/converter/supplier/cml/converter/io/MassSpectraReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.cml/src/org/eclipse/chemclipse/msd/converter/supplier/cml/converter/io/MassSpectraReader.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -104,7 +103,7 @@ public class MassSpectraReader extends AbstractMassSpectraReader implements IMas
 							mzs = Arrays.stream( //
 									StringUtils.split(array.getValue())) //
 									.map(Double::parseDouble) //
-									.collect(Collectors.toList()); //
+									.toList(); //
 						}
 					}
 					Yaxis yAxis = spectrumData.getYaxis();
@@ -116,7 +115,8 @@ public class MassSpectraReader extends AbstractMassSpectraReader implements IMas
 							}
 							abundances = Arrays.stream( //
 									StringUtils.split(array.getValue())) //
-									.map(Double::parseDouble).toList(); //
+									.map(Double::parseDouble)//
+									.toList();
 						}
 					}
 					try {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/matrix/ExtractedMatrix.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/matrix/ExtractedMatrix.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Lablicate GmbH.
- * 
+ * Copyright (c) 2020, 2024 Lablicate GmbH.
+ *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution,
@@ -85,7 +85,7 @@ public class ExtractedMatrix {
 				.filter(s -> s.getScanNumber() >= startScan) //
 				.filter(s -> s.getScanNumber() <= stopScan) //
 				.collect(Collectors.toList()); //
-		return (scans);
+		return scans;
 	}
 
 	private IonRange getMinMaxMz() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/MassSpectrumIonsListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/MassSpectrumIonsListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 Lablicate GmbH.
+ * Copyright (c) 2015, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/FileSettingUtil.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/FileSettingUtil.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -45,7 +46,7 @@ public class FileSettingUtil implements IStringSerialization<File> {
 
 		if(data != null && !data.isEmpty()) {
 			try {
-				return Arrays.stream(objectMapper.readValue(data, String[].class)).map(File::new).toList();
+				return Arrays.stream(objectMapper.readValue(data, String[].class)).map(File::new).collect(Collectors.toList());
 			} catch(IOException e) {
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/TraceSettingUtil.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/TraceSettingUtil.java
@@ -75,7 +75,7 @@ public class TraceSettingUtil implements IStringSerialization<String> {
 		try {
 			if(deserialize != null && !deserialize.isEmpty()) {
 				String[] decodedArray = objectMapper.readValue(deserialize, String[].class);
-				return Arrays.stream(decodedArray).toList();
+				return Arrays.asList(decodedArray);
 			}
 		} catch(IOException e) {
 		}
@@ -101,7 +101,7 @@ public class TraceSettingUtil implements IStringSerialization<String> {
 			 */
 			decodedArray = new String[0];
 		}
-		return Arrays.stream(decodedArray).toList();
+		return Arrays.asList(decodedArray);
 	}
 
 	public int compare(String s1, String s2) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.supplier.cml/src/org/eclipse/chemclipse/vsd/converter/supplier/cml/io/ScanReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.supplier.cml/src/org/eclipse/chemclipse/vsd/converter/supplier/cml/io/ScanReader.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -128,7 +127,7 @@ public class ScanReader {
 								waveNumbers = Arrays.stream( //
 										StringUtils.split(array.getValue())) //
 										.map(Double::parseDouble) //
-										.collect(Collectors.toList()); //
+										.toList(); //
 							}
 						}
 					}
@@ -139,11 +138,13 @@ public class ScanReader {
 							if(array.getUnits().equals("cml:absorbance")) {
 								absorbances = Arrays.stream( //
 										StringUtils.split(array.getValue())) //
-										.map(Double::parseDouble).toList(); //
+										.map(Double::parseDouble) //
+										.toList();
 							} else if(array.getUnits().equals("jcampUnits:transmittance")) {
 								transmittances = Arrays.stream( //
 										StringUtils.split(array.getValue())) //
-										.map(Double::parseDouble).toList(); //
+										.map(Double::parseDouble) //
+										.toList(); //
 							}
 						}
 					}

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.cml/src/org/eclipse/chemclipse/wsd/converter/supplier/cml/io/ScanReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.cml/src/org/eclipse/chemclipse/wsd/converter/supplier/cml/io/ScanReader.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -96,7 +95,7 @@ public class ScanReader {
 								wavelengths = Arrays.stream( //
 										StringUtils.split(array.getValue())) //
 										.map(Double::parseDouble) //
-										.collect(Collectors.toList()); //
+										.toList(); //
 							}
 						}
 					}
@@ -106,7 +105,8 @@ public class ScanReader {
 						if(array != null) {
 							absorbances = Arrays.stream( //
 									StringUtils.split(array.getValue())) //
-									.map(Double::parseDouble).toList(); //
+									.map(Double::parseDouble) //
+									.toList();
 						}
 					}
 					int scans = Math.min(wavelengths.size(), absorbances.size());

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.classification/src/org/eclipse/chemclipse/xxd/classification/model/Reference.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.classification/src/org/eclipse/chemclipse/xxd/classification/model/Reference.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,7 +12,6 @@
 package org.eclipse.chemclipse.xxd.classification.model;
 
 import java.util.Arrays;
-import java.util.stream.Collectors;
 
 import org.eclipse.chemclipse.support.text.ILabel;
 
@@ -42,6 +41,6 @@ public enum Reference implements ILabel {
 
 	public static String[] getItems() {
 
-		return Arrays.stream(Reference.values()).map(Enum::name).collect(Collectors.toList()).toArray(new String[Reference.values().length]);
+		return Arrays.stream(Reference.values()).map(Enum::name).toList().toArray(new String[Reference.values().length]);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/AbstractCentering.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/AbstractCentering.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/AbstractPreprocessing.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/preprocessing/AbstractPreprocessing.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@
 package org.eclipse.chemclipse.xxd.process.supplier.pca.core.preprocessing;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.eclipse.chemclipse.model.statistics.ISample;
 import org.eclipse.chemclipse.model.statistics.ISamples;
@@ -41,6 +42,6 @@ public abstract class AbstractPreprocessing implements IPreprocessing {
 
 	protected <V extends IVariable, S extends ISample> List<S> selectSamples(ISamples<V, S> samples) {
 
-		return samples.getSampleList().stream().filter(s -> s.isSelected() || !onlySelected).toList();
+		return samples.getSampleList().stream().filter(s -> s.isSelected() || !onlySelected).collect(Collectors.toList());
 	}
 }


### PR DESCRIPTION
Closes https://github.com/eclipse/chemclipse/issues/1824.

I was blindly following the java:S6204 rule, as I thought it was a new syntax with more brevity. However, it changes behavior as the list becomes unmodifiable and @sonarlint does not check if they are modified later in the code. This was reported https://sonarsource.atlassian.net/browse/SONARJAVA-4422 and got a WONTFIX, so I disabled this rule and reverted it except for a few instances where I think it is safe.