### PR TITLE
Fix inconsistent MS interface naming and hierarchy

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/converter/model/VendorMassSpectra.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/converter/model/VendorMassSpectra.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 Lablicate GmbH.
+ * Copyright (c) 2013, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -13,7 +13,7 @@ package org.eclipse.chemclipse.msd.converter.supplier.mmass.converter.model;
 
 import org.eclipse.chemclipse.msd.model.core.AbstractMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 
 public class VendorMassSpectra extends AbstractMassSpectra implements IVendorMassSpectra {
 
@@ -21,8 +21,8 @@ public class VendorMassSpectra extends AbstractMassSpectra implements IVendorMas
 	public String getName() {
 
 		IScanMSD scanMSD = this.getMassSpectrum(1);
-		if(scanMSD instanceof IVendorStandaloneMassSpectrum vendorStandaloneMassSpectrum) {
-			return vendorStandaloneMassSpectrum.getName();
+		if(scanMSD instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
+			return standaloneMassSpectrum.getName();
 		} else {
 			return super.getName();
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/internal/io/MassSpectrumReaderVersion20.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/internal/io/MassSpectrumReaderVersion20.java
@@ -43,9 +43,8 @@ import org.eclipse.chemclipse.msd.converter.supplier.mmass.converter.model.IVend
 import org.eclipse.chemclipse.msd.converter.supplier.mmass.converter.model.VendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.mmass.converter.model.VendorMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
-import org.eclipse.chemclipse.msd.model.core.IVendorMassSpectrum;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
-import org.eclipse.chemclipse.msd.model.implementation.VendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
@@ -62,9 +61,9 @@ public class MassSpectrumReaderVersion20 extends AbstractMassSpectraReader imple
 	@Override
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
-		IVendorStandaloneMassSpectrum massSpectrum = null;
+		IStandaloneMassSpectrum massSpectrum = null;
 		try {
-			massSpectrum = new VendorStandaloneMassSpectrum();
+			massSpectrum = new StandaloneMassSpectrum();
 			massSpectrum.setFile(file);
 			massSpectrum.setIdentifier(file.getName());
 			massSpectrum.setMassSpectrumType((short)1); // profile
@@ -104,7 +103,7 @@ public class MassSpectrumReaderVersion20 extends AbstractMassSpectraReader imple
 		return document.getElementsByTagName("mSD");
 	}
 
-	private void readDescription(Element element, IVendorStandaloneMassSpectrum massSpectrum) {
+	private void readDescription(Element element, IStandaloneMassSpectrum massSpectrum) {
 
 		NodeList descriptionList = element.getElementsByTagName("description");
 		for(int i = 0; i < descriptionList.getLength(); i++) {
@@ -129,7 +128,7 @@ public class MassSpectrumReaderVersion20 extends AbstractMassSpectraReader imple
 		}
 	}
 
-	private void readSpectrum(Element element, IVendorMassSpectrum massSpectrum, IProgressMonitor monitor) throws DOMException, DataFormatException {
+	private void readSpectrum(Element element, IStandaloneMassSpectrum massSpectrum, IProgressMonitor monitor) throws DOMException, DataFormatException {
 
 		int points = 0;
 		float[] mzs = null;
@@ -160,7 +159,7 @@ public class MassSpectrumReaderVersion20 extends AbstractMassSpectraReader imple
 		}
 	}
 
-	private void readPeakList(Element element, IVendorStandaloneMassSpectrum massSpectrum) throws DOMException {
+	private void readPeakList(Element element, IStandaloneMassSpectrum massSpectrum) throws DOMException {
 
 		NodeList peakList = element.getElementsByTagName("peaklist");
 		for(int i = 0; i < peakList.getLength(); i++) {
@@ -182,7 +181,7 @@ public class MassSpectrumReaderVersion20 extends AbstractMassSpectraReader imple
 		}
 	}
 
-	private void readAnnotations(Element element, IVendorStandaloneMassSpectrum massSpectrum) throws DOMException {
+	private void readAnnotations(Element element, IStandaloneMassSpectrum massSpectrum) throws DOMException {
 
 		NodeList annotationsList = element.getElementsByTagName("annotations");
 		for(int i = 0; i < annotationsList.getLength(); i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/internal/io/MassSpectrumReaderVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/internal/io/MassSpectrumReaderVersion22.java
@@ -43,9 +43,8 @@ import org.eclipse.chemclipse.msd.converter.supplier.mmass.converter.model.IVend
 import org.eclipse.chemclipse.msd.converter.supplier.mmass.converter.model.VendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.mmass.converter.model.VendorMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
-import org.eclipse.chemclipse.msd.model.core.IVendorMassSpectrum;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
-import org.eclipse.chemclipse.msd.model.implementation.VendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
@@ -62,9 +61,9 @@ public class MassSpectrumReaderVersion22 extends AbstractMassSpectraReader imple
 	@Override
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
-		IVendorStandaloneMassSpectrum massSpectrum = null;
+		IStandaloneMassSpectrum massSpectrum = null;
 		try {
-			massSpectrum = new VendorStandaloneMassSpectrum();
+			massSpectrum = new StandaloneMassSpectrum();
 			massSpectrum.setFile(file);
 			massSpectrum.setIdentifier(file.getName());
 			massSpectrum.setMassSpectrumType((short)1); // profile
@@ -104,7 +103,7 @@ public class MassSpectrumReaderVersion22 extends AbstractMassSpectraReader imple
 		return document.getElementsByTagName("mSD");
 	}
 
-	private void readDescription(Element element, IVendorStandaloneMassSpectrum massSpectrum) {
+	private void readDescription(Element element, IStandaloneMassSpectrum massSpectrum) {
 
 		NodeList descriptionList = element.getElementsByTagName("description");
 		for(int i = 0; i < descriptionList.getLength(); i++) {
@@ -129,7 +128,7 @@ public class MassSpectrumReaderVersion22 extends AbstractMassSpectraReader imple
 		}
 	}
 
-	private void readSpectrum(Element element, IVendorMassSpectrum massSpectrum, IProgressMonitor monitor) throws DOMException, DataFormatException {
+	private void readSpectrum(Element element, IStandaloneMassSpectrum massSpectrum, IProgressMonitor monitor) throws DOMException, DataFormatException {
 
 		int points = 0;
 		float[] mzs = null;
@@ -160,7 +159,7 @@ public class MassSpectrumReaderVersion22 extends AbstractMassSpectraReader imple
 		}
 	}
 
-	private void readPeakList(Element element, IVendorStandaloneMassSpectrum massSpectrum) throws DOMException {
+	private void readPeakList(Element element, IStandaloneMassSpectrum massSpectrum) throws DOMException {
 
 		NodeList peakList = element.getElementsByTagName("peaklist");
 		for(int i = 0; i < peakList.getLength(); i++) {
@@ -182,7 +181,7 @@ public class MassSpectrumReaderVersion22 extends AbstractMassSpectraReader imple
 		}
 	}
 
-	private void readAnnotations(Element element, IVendorStandaloneMassSpectrum massSpectrum) throws DOMException {
+	private void readAnnotations(Element element, IStandaloneMassSpectrum massSpectrum) throws DOMException {
 
 		NodeList annotationsList = element.getElementsByTagName("annotations");
 		for(int i = 0; i < annotationsList.getLength(); i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMaldiAxima_ITest.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMaldiAxima_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -16,8 +16,8 @@ import java.io.File;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
-import org.eclipse.chemclipse.msd.model.implementation.VendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Test;
@@ -26,7 +26,7 @@ import junit.framework.TestCase;
 
 public class ChromatogramImportConverterMaldiAxima_ITest extends TestCase {
 
-	private IVendorStandaloneMassSpectrum standaloneMassSpectrum;
+	private IStandaloneMassSpectrum standaloneMassSpectrum;
 
 	@Override
 	protected void setUp() throws Exception {
@@ -36,7 +36,7 @@ public class ChromatogramImportConverterMaldiAxima_ITest extends TestCase {
 		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		VendorMassSpectra massSpectra = (VendorMassSpectra)processingInfo.getProcessingResult();
-		standaloneMassSpectrum = (VendorStandaloneMassSpectrum)massSpectra.getMassSpectrum(1);
+		standaloneMassSpectrum = (StandaloneMassSpectrum)massSpectra.getMassSpectrum(1);
 	}
 
 	@Test

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMyoDta104_ITest.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMyoDta104_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -17,7 +17,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzdata.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorChromatogram;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
-import org.eclipse.chemclipse.msd.model.core.IVendorMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Test;
@@ -86,7 +86,7 @@ public class ChromatogramImportConverterMyoDta104_ITest extends TestCase {
 	@Test
 	public void testFirstScan() {
 
-		IVendorMassSpectrum massSpectrum = (IVendorMassSpectrum)chromatogram.getScan(1);
+		IScanMSD massSpectrum = (IScanMSD)chromatogram.getScan(1);
 		assertEquals("Ions", 331, massSpectrum.getNumberOfIons());
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMyoDta105_ITest.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMyoDta105_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -17,7 +17,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzdata.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorChromatogram;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
-import org.eclipse.chemclipse.msd.model.core.IVendorMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Test;
@@ -86,7 +86,7 @@ public class ChromatogramImportConverterMyoDta105_ITest extends TestCase {
 	@Test
 	public void testFirstScan() {
 
-		IVendorMassSpectrum massSpectrum = (IVendorMassSpectrum)chromatogram.getScan(1);
+		IScanMSD massSpectrum = (IScanMSD)chromatogram.getScan(1);
 		assertEquals("Ions", 331, massSpectrum.getNumberOfIons());
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/MassSpectrumReaderVersion105.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/MassSpectrumReaderVersion105.java
@@ -31,8 +31,8 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorMassSpe
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
-import org.eclipse.chemclipse.msd.model.implementation.VendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -51,7 +51,7 @@ public class MassSpectrumReaderVersion105 extends AbstractMassSpectraReader impl
 	@Override
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
-		IVendorStandaloneMassSpectrum massSpectrum = null;
+		IStandaloneMassSpectrum massSpectrum = null;
 		//
 		try {
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
@@ -63,7 +63,7 @@ public class MassSpectrumReaderVersion105 extends AbstractMassSpectraReader impl
 			Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
 			MzData mzData = (MzData)unmarshaller.unmarshal(nodeList.item(0));
 			//
-			massSpectrum = new VendorStandaloneMassSpectrum();
+			massSpectrum = new StandaloneMassSpectrum();
 			massSpectrum.setSampleName(mzData.getDescription().getAdmin().getSampleName());
 			for(PersonType contact : mzData.getDescription().getAdmin().getContact()) {
 				String contactDetails = "";

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/model/IVendorScan.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/model/IVendorScan.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 Lablicate GmbH.
+ * Copyright (c) 2014, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.converter.supplier.mzdata.model;
 
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 
-public interface IVendorScan extends IVendorStandaloneMassSpectrum {
+public interface IVendorScan extends IScanMSD {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/model/VendorMassSpectra.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/model/VendorMassSpectra.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 Lablicate GmbH.
+ * Copyright (c) 2013, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -13,7 +13,7 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzdata.model;
 
 import org.eclipse.chemclipse.msd.model.core.AbstractMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 
 public class VendorMassSpectra extends AbstractMassSpectra implements IVendorMassSpectra {
 
@@ -21,7 +21,7 @@ public class VendorMassSpectra extends AbstractMassSpectra implements IVendorMas
 	public String getName() {
 
 		IScanMSD scanMSD = this.getMassSpectrum(1);
-		if(scanMSD instanceof IVendorStandaloneMassSpectrum standaloneMassSpectrum) {
+		if(scanMSD instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
 			return standaloneMassSpectrum.getName();
 		} else {
 			return super.getName();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/model/VendorScan.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/model/VendorScan.java
@@ -11,38 +11,16 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.converter.supplier.mzdata.model;
 
-import org.eclipse.chemclipse.msd.model.core.AbstractVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.AbstractScanMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 
-public class VendorScan extends AbstractVendorStandaloneMassSpectrum implements IVendorScan {
+public class VendorScan extends AbstractScanMSD implements IVendorScan {
 
 	private static final long serialVersionUID = -3291852423110935802L;
-	//
-	public static final int MAX_MASSFRAGMENTS = 65535;
-	public static final int MIN_RETENTION_TIME = 0;
-	public static final int MAX_RETENTION_TIME = Integer.MAX_VALUE;
 
 	public VendorScan() {
 
 		super();
-	}
-
-	@Override
-	public int getMaxPossibleIons() {
-
-		return MAX_MASSFRAGMENTS;
-	}
-
-	@Override
-	public int getMinPossibleRetentionTime() {
-
-		return MIN_RETENTION_TIME;
-	}
-
-	@Override
-	public int getMaxPossibleRetentionTime() {
-
-		return MAX_RETENTION_TIME;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/IVendorScan.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/IVendorScan.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 Lablicate GmbH.
+ * Copyright (c) 2013, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model;
 
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 
-public interface IVendorScan extends IVendorStandaloneMassSpectrum {
+public interface IVendorScan extends IScanMSD {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/VendorMassSpectra.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/VendorMassSpectra.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 Lablicate GmbH.
+ * Copyright (c) 2013, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -13,7 +13,7 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model;
 
 import org.eclipse.chemclipse.msd.model.core.AbstractMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 
 public class VendorMassSpectra extends AbstractMassSpectra implements IVendorMassSpectra {
 
@@ -21,8 +21,8 @@ public class VendorMassSpectra extends AbstractMassSpectra implements IVendorMas
 	public String getName() {
 
 		IScanMSD scanMSD = this.getMassSpectrum(1);
-		if(scanMSD instanceof IVendorStandaloneMassSpectrum vendorStandaloneMassSpectrum) {
-			return vendorStandaloneMassSpectrum.getName();
+		if(scanMSD instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
+			return standaloneMassSpectrum.getName();
 		} else {
 			return super.getName();
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/VendorScan.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/VendorScan.java
@@ -11,10 +11,10 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model;
 
-import org.eclipse.chemclipse.msd.model.core.AbstractVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.AbstractScanMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 
-public class VendorScan extends AbstractVendorStandaloneMassSpectrum implements IVendorScan {
+public class VendorScan extends AbstractScanMSD implements IVendorScan {
 
 	private static final long serialVersionUID = -2545043408685013930L;
 	//
@@ -25,24 +25,6 @@ public class VendorScan extends AbstractVendorStandaloneMassSpectrum implements 
 	public VendorScan() {
 
 		super();
-	}
-
-	@Override
-	public int getMaxPossibleIons() {
-
-		return MAX_MASSFRAGMENTS;
-	}
-
-	@Override
-	public int getMinPossibleRetentionTime() {
-
-		return MIN_RETENTION_TIME;
-	}
-
-	@Override
-	public int getMaxPossibleRetentionTime() {
-
-		return MAX_RETENTION_TIME;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/converter/XmlReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/converter/XmlReader.java
@@ -15,7 +15,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendo
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IIon;
-import org.eclipse.chemclipse.msd.model.core.IVendorMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 
 public class XmlReader {
 
@@ -37,7 +37,7 @@ public class XmlReader {
 		}
 	}
 
-	public static void addIons(double[] intensities, double[] mzs, IVendorMassSpectrum massSpectrum) {
+	public static void addIons(double[] intensities, double[] mzs, IScanMSD massSpectrum) {
 
 		int ions = Math.min(mzs.length, intensities.length);
 		for(int i = 0; i < ions; i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/io/ChromatogramReaderVersion10.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/io/ChromatogramReaderVersion10.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Lablicate GmbH.
+ * Copyright (c) 2021, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -46,7 +46,7 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionGroup;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
-import org.eclipse.chemclipse.msd.model.core.IVendorMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransition;
 import org.eclipse.chemclipse.msd.model.implementation.VendorMassSpectrum;
 import org.eclipse.chemclipse.support.history.EditInformation;
@@ -144,7 +144,7 @@ public class ChromatogramReaderVersion10 extends AbstractChromatogramReader impl
 			}
 			RunType run = mzML.getRun();
 			for(SpectrumType spectrum : run.getSpectrumList().getSpectrum()) {
-				IVendorMassSpectrum massSpectrum = new VendorMassSpectrum();
+				IStandaloneMassSpectrum massSpectrum = new VendorMassSpectrum();
 				for(CVParamType cvParam : spectrum.getCvParam()) {
 					if(cvParam.getAccession().equals("MS:1000127") && cvParam.getName().equals("centroid spectrum")) {
 						massSpectrum.setMassSpectrumType((short)0);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/io/MassSpectrumReaderVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/internal/io/MassSpectrumReaderVersion110.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Lablicate GmbH.
+ * Copyright (c) 2021, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -34,7 +34,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzml.internal.v110.model.Pa
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.internal.v110.model.RunType;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.internal.v110.model.SpectrumType;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.msd.model.implementation.VendorMassSpectrum;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.xml.sax.SAXException;
@@ -48,7 +48,7 @@ public class MassSpectrumReaderVersion110 extends AbstractMassSpectraReader impl
 	@Override
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
-		IVendorStandaloneMassSpectrum massSpectrum = null;
+		IStandaloneMassSpectrum massSpectrum = null;
 		//
 		try {
 			//

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion32.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion32.java
@@ -113,7 +113,7 @@ public class ChromatogramReaderVersion32 extends AbstractChromatogramReaderVersi
 				long retentionTime = scan.getRetentionTime().getTimeInMillis(new Date());
 				// MS, MS/MS
 				short msLevel = scan.getMsLevel().shortValue();
-				massSpectrum.setMassSpectrometer(msLevel);
+				// massSpectrum.setMassSpectrometer(msLevel);
 				// float collisionEnergy = 0.0f;
 				// double filter1Ion = 0.0d;
 				//

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion20.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion20.java
@@ -37,7 +37,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorMassSpec
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.msd.model.implementation.VendorMassSpectrum;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
@@ -57,7 +57,7 @@ public class MassSpectrumReaderVersion20 extends AbstractMassSpectraReader imple
 	@Override
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
-		IVendorStandaloneMassSpectrum massSpectrum = null;
+		IStandaloneMassSpectrum massSpectrum = null;
 		//
 		try {
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion21.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion21.java
@@ -37,7 +37,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorMassSpec
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.msd.model.implementation.VendorMassSpectrum;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
@@ -57,7 +57,7 @@ public class MassSpectrumReaderVersion21 extends AbstractMassSpectraReader imple
 	@Override
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
-		IVendorStandaloneMassSpectrum massSpectrum = null;
+		IStandaloneMassSpectrum massSpectrum = null;
 		//
 		try {
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion22.java
@@ -37,7 +37,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorMassSpec
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.msd.model.implementation.VendorMassSpectrum;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
@@ -57,7 +57,7 @@ public class MassSpectrumReaderVersion22 extends AbstractMassSpectraReader imple
 	@Override
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
-		IVendorStandaloneMassSpectrum massSpectrum = null;
+		IStandaloneMassSpectrum massSpectrum = null;
 		//
 		try {
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/model/IVendorScan.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/model/IVendorScan.java
@@ -11,10 +11,10 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.converter.supplier.mzxml.model;
 
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 
-public interface IVendorScan extends IVendorStandaloneMassSpectrum {
+public interface IVendorScan extends IScanMSD {
 
 	Polarity getPolarity();
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/model/VendorMassSpectra.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/model/VendorMassSpectra.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 Lablicate GmbH.
+ * Copyright (c) 2013, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -13,7 +13,7 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzxml.model;
 
 import org.eclipse.chemclipse.msd.model.core.AbstractMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 
 public class VendorMassSpectra extends AbstractMassSpectra implements IVendorMassSpectra {
 
@@ -21,8 +21,8 @@ public class VendorMassSpectra extends AbstractMassSpectra implements IVendorMas
 	public String getName() {
 
 		IScanMSD scanMSD = this.getMassSpectrum(1);
-		if(scanMSD instanceof IVendorStandaloneMassSpectrum vendorStandaloneMassSpectrum) {
-			return vendorStandaloneMassSpectrum.getName();
+		if(scanMSD instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
+			return standaloneMassSpectrum.getName();
 		} else {
 			return super.getName();
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/model/VendorScan.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/model/VendorScan.java
@@ -11,37 +11,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.converter.supplier.mzxml.model;
 
-import org.eclipse.chemclipse.msd.model.core.AbstractVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.AbstractScanMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 
-public class VendorScan extends AbstractVendorStandaloneMassSpectrum implements IVendorScan {
+public class VendorScan extends AbstractScanMSD implements IVendorScan {
 
 	private static final long serialVersionUID = -6772709008581956403L;
 	//
-	public static final int MAX_IONS = 65535;
-	public static final int MIN_RETENTION_TIME = 0;
-	public static final int MAX_RETENTION_TIME = Integer.MAX_VALUE;
-	//
 	private Polarity polarity;
-
-	@Override
-	public int getMaxPossibleIons() {
-
-		return MAX_IONS;
-	}
-
-	@Override
-	public int getMaxPossibleRetentionTime() {
-
-		return MAX_RETENTION_TIME;
-	}
-
-	@Override
-	public int getMinPossibleRetentionTime() {
-
-		return MIN_RETENTION_TIME;
-	}
 
 	@Override
 	public Polarity getPolarity() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogramMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogramMSD.java
@@ -57,7 +57,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
  */
 public abstract class AbstractChromatogramMSD extends AbstractChromatogram<IChromatogramPeakMSD> implements IChromatogramMSD {
 
-	private static final long serialVersionUID = 6481555040060687480L;
+	private static final long serialVersionUID = 6481555040060687481L;
 	//
 	public static final int DEFAULT_SEGMENT_WIDTH = 10;
 	private final IIonTransitionSettings ionTransitionSettings;
@@ -65,7 +65,7 @@ public abstract class AbstractChromatogramMSD extends AbstractChromatogram<IChro
 	private ImmutableZeroIon immutableZeroIon;
 	private IScanMSD combinedMassSpectrum;
 
-	public AbstractChromatogramMSD() {
+	protected AbstractChromatogramMSD() {
 
 		ionTransitionSettings = new IonTransitionSettings();
 		immutableZeroIon = new ImmutableZeroIon();
@@ -105,8 +105,8 @@ public abstract class AbstractChromatogramMSD extends AbstractChromatogram<IChro
 
 		int amount = 0;
 		for(IScan scan : getScans()) {
-			if(scan instanceof IVendorMassSpectrum ms) {
-				amount += ms.getNumberOfIons();
+			if(scan instanceof IScanMSD scanMSD) {
+				amount += scanMSD.getNumberOfIons();
 			}
 		}
 		return amount;
@@ -116,8 +116,8 @@ public abstract class AbstractChromatogramMSD extends AbstractChromatogram<IChro
 	public void enforceLoadScanProxies(IProgressMonitor monitor) {
 
 		for(IScan scan : getScans()) {
-			if(scan instanceof IVendorMassSpectrum ms && !isUnloaded()) {
-				ms.enforceLoadScanProxy();
+			if(scan instanceof IScanMSD scanMSD && !isUnloaded()) {
+				scanMSD.enforceLoadScanProxy();
 			}
 		}
 	}
@@ -166,8 +166,8 @@ public abstract class AbstractChromatogramMSD extends AbstractChromatogram<IChro
 		IIon ion;
 		float minAbundance = Float.MAX_VALUE;
 		for(IScan scan : getScans()) {
-			if(scan instanceof IVendorMassSpectrum ms) {
-				ion = ms.getLowestAbundance();
+			if(scan instanceof IScanMSD scanMSD) {
+				ion = scanMSD.getLowestAbundance();
 				if(!isZeroImmutableIon(ion)) {
 					if(ion.getAbundance() < minAbundance) {
 						minAbundance = ion.getAbundance();
@@ -184,8 +184,8 @@ public abstract class AbstractChromatogramMSD extends AbstractChromatogram<IChro
 		IIon ion;
 		float maxAbundance = Float.MIN_VALUE;
 		for(IScan scan : getScans()) {
-			if(scan instanceof IVendorMassSpectrum ms) {
-				ion = ms.getHighestAbundance();
+			if(scan instanceof IScanMSD scanMSD) {
+				ion = scanMSD.getHighestAbundance();
 				if(!isZeroImmutableIon(ion)) {
 					if(ion.getAbundance() > maxAbundance) {
 						maxAbundance = ion.getAbundance();
@@ -211,8 +211,8 @@ public abstract class AbstractChromatogramMSD extends AbstractChromatogram<IChro
 		 * Check all scans.
 		 */
 		for(IScan scan : getScans()) {
-			if(scan instanceof IVendorMassSpectrum ms) {
-				IIon ion = ms.getLowestIon();
+			if(scan instanceof IScanMSD scanMSD) {
+				IIon ion = scanMSD.getLowestIon();
 				if(!isZeroImmutableIon(ion)) {
 					actualIon = ion.getIon();
 					if(actualIon < lowestIon) {
@@ -239,8 +239,8 @@ public abstract class AbstractChromatogramMSD extends AbstractChromatogram<IChro
 		 * Check all scans.
 		 */
 		for(IScan scan : getScans()) {
-			if(scan instanceof IVendorMassSpectrum ms) {
-				IIon ion = ms.getHighestIon();
+			if(scan instanceof IScanMSD scanMSD) {
+				IIon ion = scanMSD.getHighestIon();
 				if(!isZeroImmutableIon(ion)) {
 					actualIon = ion.getIon();
 					if(actualIon > highestIon) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractStandaloneMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractStandaloneMassSpectrum.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 import org.eclipse.chemclipse.model.core.IMassSpectrumPeak;
 
-public abstract class AbstractVendorStandaloneMassSpectrum extends AbstractVendorMassSpectrum implements IVendorStandaloneMassSpectrum {
+public abstract class AbstractStandaloneMassSpectrum extends AbstractRegularMassSpectrum implements IStandaloneMassSpectrum {
 
 	/**
 	 * Renew the serialVersionUID any time you have changed some fields or

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IStandaloneMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IStandaloneMassSpectrum.java
@@ -22,7 +22,7 @@ import org.eclipse.chemclipse.model.core.IMassSpectrumPeak;
  * 
  * @author Matthias Mailänder
  */
-public interface IVendorStandaloneMassSpectrum extends IVendorMassSpectrum {
+public interface IStandaloneMassSpectrum extends IRegularMassSpectrum {
 
 	/**
 	 * Returns the file, see setFile().
@@ -47,7 +47,6 @@ public interface IVendorStandaloneMassSpectrum extends IVendorMassSpectrum {
 	 */
 	String getName();
 
-	//
 	String getSampleName();
 
 	void setSampleName(String name);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/StandaloneMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/StandaloneMassSpectrum.java
@@ -11,37 +11,18 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.implementation;
 
-import org.eclipse.chemclipse.msd.model.core.AbstractVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.AbstractStandaloneMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IVendorMassSpectrum;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
 
-public class VendorStandaloneMassSpectrum extends AbstractVendorStandaloneMassSpectrum implements IVendorStandaloneMassSpectrum {
+public class StandaloneMassSpectrum extends AbstractStandaloneMassSpectrum implements IStandaloneMassSpectrum {
 
 	/**
 	 * Renew the serialVersionUID any time you have changed some fields or
 	 * methods.
 	 */
-	private static final long serialVersionUID = 7540947309609765367L;
-	public static final int MAX_IONS = Integer.MAX_VALUE;
-
-	@Override
-	public int getMaxPossibleIons() {
-
-		return MAX_IONS;
-	}
-
-	@Override
-	public int getMaxPossibleRetentionTime() {
-
-		return 0; // TODO: this should move away
-	}
-
-	@Override
-	public int getMinPossibleRetentionTime() {
-
-		return 0; // TODO: this should move away
-	}
+	private static final long serialVersionUID = 7540947309609765368L;
 
 	/**
 	 * Keep in mind, it is a covariant return.<br/>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/VendorMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/VendorMassSpectrum.java
@@ -11,12 +11,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.implementation;
 
-import org.eclipse.chemclipse.msd.model.core.AbstractVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.AbstractStandaloneMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IVendorMassSpectrum;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
 
-public class VendorMassSpectrum extends AbstractVendorStandaloneMassSpectrum implements IVendorStandaloneMassSpectrum {
+public class VendorMassSpectrum extends AbstractStandaloneMassSpectrum implements IVendorMassSpectrum {
 
 	private static final long serialVersionUID = 9103911623007941476L;
 	//

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/ExtendedMassSpectrumPeakListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/ExtendedMassSpectrumPeakListUI.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.swt.ui.components.massspectrum;
 
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -26,7 +26,7 @@ public class ExtendedMassSpectrumPeakListUI extends Composite {
 		createControl();
 	}
 
-	public void update(IVendorStandaloneMassSpectrum standaloneMassSpectrum) {
+	public void update(IStandaloneMassSpectrum standaloneMassSpectrum) {
 
 		massSpectrumPeaksListUI.update(standaloneMassSpectrum);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/MassSpectrumPeakListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/MassSpectrumPeakListUI.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.swt.ui.components.massspectrum;
 
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.msd.swt.ui.internal.provider.MassSpectrumPeakLabelProvider;
 import org.eclipse.chemclipse.support.ui.provider.ListContentProvider;
 import org.eclipse.chemclipse.support.ui.swt.ExtendedTableViewer;
@@ -35,7 +35,7 @@ public class MassSpectrumPeakListUI extends ExtendedTableViewer {
 		createColumns();
 	}
 
-	public void update(IVendorStandaloneMassSpectrum standaloneMassSpectrum) {
+	public void update(IStandaloneMassSpectrum standaloneMassSpectrum) {
 
 		if(standaloneMassSpectrum != null) {
 			setContentProviders();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/MassSpectrumEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/MassSpectrumEditor.java
@@ -30,7 +30,7 @@ import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IRegularLibraryMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.msd.swt.ui.support.DatabaseFileSupport;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.exceptions.TypeCastException;
@@ -299,8 +299,8 @@ public class MassSpectrumEditor implements IMassSpectrumEditor {
 		String name = ("".equals(massSpectra.getName())) ? "NoName" : massSpectra.getName();
 		massSpectrum = massSpectra.getMassSpectrum(1);
 		massSpectrum.setDirty(false);
-		if(massSpectrum instanceof IVendorStandaloneMassSpectrum vendorStandaloneMassSpectrum) {
-			name = vendorStandaloneMassSpectrum.getName();
+		if(massSpectrum instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
+			name = standaloneMassSpectrum.getName();
 		} else if(massSpectrum instanceof IRegularLibraryMassSpectrum regularLibraryMassSpectrum) {
 			ILibraryInformation libraryInformation = regularLibraryMassSpectrum.getLibraryInformation();
 			if(libraryInformation != null) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
@@ -29,7 +29,7 @@ import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.model.notifier.UpdateNotifier;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.processing.core.ICategories;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
@@ -99,7 +99,7 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 			ISeriesData seriesData = getMassSpectrum(massSpectrum);
 			ILineSeriesData lineSeriesData = new LineSeriesData(seriesData);
 			lineSeriesDataList.add(lineSeriesData);
-			if(massSpectrum instanceof IVendorStandaloneMassSpectrum standaloneMassSpectrum) {
+			if(massSpectrum instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
 				LineSeriesData peakLineSeriesData = getPeaks(standaloneMassSpectrum);
 				lineSeriesDataList.add(peakLineSeriesData);
 				createAnnotations(standaloneMassSpectrum);
@@ -254,7 +254,7 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 		return new SeriesData(xSeries, ySeries, "Mass Spectrum");
 	}
 
-	private LineSeriesData getPeaks(IVendorStandaloneMassSpectrum massSpectrum) {
+	private LineSeriesData getPeaks(IStandaloneMassSpectrum massSpectrum) {
 
 		ISeriesData peakSeriesData = createPeakSeries("Peaks", massSpectrum, 0, 0);
 		LineSeriesData peakSeries = new LineSeriesData(peakSeriesData);
@@ -273,7 +273,7 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 		return peakSeries;
 	}
 
-	public static ISeriesData createPeakSeries(String id, IVendorStandaloneMassSpectrum massSpectrum, double yOffset, double xOffset) {
+	public static ISeriesData createPeakSeries(String id, IStandaloneMassSpectrum massSpectrum, double yOffset, double xOffset) {
 
 		List<IMassSpectrumPeak> peaks = massSpectrum.getPeaks();
 		int size = peaks.size();
@@ -288,7 +288,7 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 		return new SeriesData(xSeries, ySeries, id);
 	}
 
-	private void createAnnotations(IVendorStandaloneMassSpectrum massSpectrum) {
+	private void createAnnotations(IStandaloneMassSpectrum massSpectrum) {
 
 		IPlotArea plotarea = getBaseChart().getPlotArea();
 		LabelMarker labelMarker = new LabelMarker(getBaseChart());

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/MassSpectrumPeakListPart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/MassSpectrumPeakListPart.java
@@ -14,7 +14,7 @@ package org.eclipse.chemclipse.ux.extension.xxd.ui.parts;
 
 import java.util.List;
 
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.msd.swt.ui.components.massspectrum.ExtendedMassSpectrumPeakListUI;
 import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.swt.SWT;
@@ -43,8 +43,8 @@ public class MassSpectrumPeakListPart extends AbstractPart<ExtendedMassSpectrumP
 
 		if(objects.size() == 1) {
 			Object object = objects.get(0);
-			if(object instanceof IVendorStandaloneMassSpectrum vendorStandaloneMassSpectrum) {
-				getControl().update(vendorStandaloneMassSpectrum);
+			if(object instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
+				getControl().update(standaloneMassSpectrum);
 				return true;
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedMassSpectrumHeaderUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedMassSpectrumHeaderUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,7 +12,7 @@
 package org.eclipse.chemclipse.ux.extension.xxd.ui.swt;
 
 import org.eclipse.chemclipse.msd.model.core.IVendorMassSpectrum;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.support.text.ValueFormat;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
@@ -36,7 +36,7 @@ public class ExtendedMassSpectrumHeaderUI extends Composite {
 			addHeaderLine(builder, "Data", massSpectrum.getMassSpectrumTypeDescription());
 			addHeaderLine(builder, "Technique", "MS" + massSpectrum.getMassSpectrometer());
 			addHeaderLine(builder, "Ions", Integer.toString(massSpectrum.getNumberOfIons()));
-			if(massSpectrum instanceof IVendorStandaloneMassSpectrum standaloneMassSpectrum) {
+			if(massSpectrum instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
 				addHeaderLine(builder, "Name", standaloneMassSpectrum.getName());
 				addHeaderLine(builder, "File", standaloneMassSpectrum.getFile().getName());
 				addHeaderLine(builder, "Sample", standaloneMassSpectrum.getSampleName());

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedMassSpectrumOverlayUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedMassSpectrumOverlayUI.java
@@ -21,7 +21,7 @@ import jakarta.inject.Inject;
 
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
 import org.eclipse.chemclipse.swt.ui.support.Colors;
@@ -264,7 +264,7 @@ public class ExtendedMassSpectrumOverlayUI extends Composite implements IExtende
 
 	private ILineSeriesData getLineSeriesData(IScanMSD scanMSD) {
 
-		if(scanMSD instanceof IVendorStandaloneMassSpectrum massSpectrum) {
+		if(scanMSD instanceof IStandaloneMassSpectrum massSpectrum) {
 			ILineSeriesData lineSeriesData = new LineSeriesData(getSeriesDataProcessed(scanMSD, massSpectrum.getName()));
 			ILineSeriesSettings lineSeriesSettings = lineSeriesData.getSettings();
 			lineSeriesSettings.setLineColor(Colors.RED);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mmass.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/converter/ProteinIdentification_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mmass.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/converter/ProteinIdentification_ITest.java
@@ -19,7 +19,7 @@ import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.msd.converter.supplier.mmass.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
-import org.eclipse.chemclipse.msd.model.core.IVendorStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Test;
@@ -28,7 +28,7 @@ import junit.framework.TestCase;
 
 public class ProteinIdentification_ITest extends TestCase {
 
-	private IVendorStandaloneMassSpectrum massSpectrum;
+	private IStandaloneMassSpectrum massSpectrum;
 
 	@Override
 	protected void setUp() throws Exception {
@@ -37,7 +37,7 @@ public class ProteinIdentification_ITest extends TestCase {
 		File importFile = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_PROTEIN_IDENTIFICATION));
 		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(importFile, new NullProgressMonitor());
-		massSpectrum = (IVendorStandaloneMassSpectrum)processingInfo.getProcessingResult().getMassSpectrum(1);
+		massSpectrum = (IStandaloneMassSpectrum)processingInfo.getProcessingResult().getMassSpectrum(1);
 	}
 
 	@Test


### PR DESCRIPTION
`IVendorStandaloneMassSpectrum` → `IStandaloneMassSpectrum` because as far as I see it, the vendor prefix is for specific file formats, not for model code. I didn't know what I was doing when proposing this initially. There is still one MS interface with that prefix, but I didn't touch it yet, even though I think that is what confused me initially.

Also changed the inheritance, so I could remove some of the `Max/MinPossibleSomething` implementation that had no meaning in that context when we are talking about vendor neutral XML file formats.