### PR TITLE
Tie to Open Chromatography Binary

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/META-INF/MANIFEST.MF
@@ -30,8 +30,9 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.chemclipse.ux.extension.xxd.ui;bundle-version="0.8.0",
  org.eclipse.e4.core.services;bundle-version="2.0.100",
  org.eclipse.e4.core.contexts;bundle-version="1.5.1",
- com.fasterxml.jackson.core.jackson-databind;bundle-version="2.9.2", 
- org.eclipse.chemclipse.xxd.process.ui;bundle-version="0.8.0"
+ com.fasterxml.jackson.core.jackson-databind;bundle-version="2.9.2",
+ org.eclipse.chemclipse.xxd.process.ui;bundle-version="0.8.0",
+ org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: OSGI-INF/l10n/bundle

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/WizardCreateRetentionIndexFile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/WizardCreateRetentionIndexFile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Lablicate GmbH.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -31,6 +31,7 @@ import org.eclipse.chemclipse.support.ui.wizards.AbstractFileWizard;
 import org.eclipse.chemclipse.support.ui.wizards.ChromatogramWizardElements;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.wizards.InputEntriesWizardPage;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.wizards.InputWizardSettings;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -49,8 +50,6 @@ public class WizardCreateRetentionIndexFile extends AbstractFileWizard {
 	private RetentionIndexWizardElements wizardElements = new RetentionIndexWizardElements();
 	//
 	private static final String CALIBRATION_FILE_EXTENSION = ".cal";
-	private static final String CHROMATOGRAM_FILE_EXTENSION = ".ocb";
-	private static final String CHROMATOGRAM_CONVERTER_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
 	//
 	private PageCalibrationSettings pageCalibrationSettings;
 	private InputEntriesWizardPage pageInputEntriesMSD;
@@ -196,17 +195,17 @@ public class WizardCreateRetentionIndexFile extends AbstractFileWizard {
 			 * Export the chromatogram.
 			 */
 			String path = calibrationFile.getAbsolutePath();
-			File chromatogramFile = new File(path.substring(0, path.length() - CALIBRATION_FILE_EXTENSION.length()) + CHROMATOGRAM_FILE_EXTENSION);
+			File chromatogramFile = new File(path.substring(0, path.length() - CALIBRATION_FILE_EXTENSION.length()) + VersionConstants.FILE_EXTENSION_CHROMATOGRAM);
 			IChromatogramSelection<?, ?> chromatogramSelection = wizardElements.getChromatogramSelection();
 			if(wizardElements.isUseMassSpectrometryData()) {
 				if(chromatogramSelection instanceof IChromatogramSelectionMSD chromatogramSelectionMSD) {
 					IChromatogramMSD chromatogramMSD = chromatogramSelectionMSD.getChromatogram();
-					ChromatogramConverterMSD.getInstance().convert(chromatogramFile, chromatogramMSD, CHROMATOGRAM_CONVERTER_ID, monitor);
+					ChromatogramConverterMSD.getInstance().convert(chromatogramFile, chromatogramMSD, VersionConstants.CONVERTER_ID_CHROMATOGRAM, monitor);
 				}
 			} else {
 				if(chromatogramSelection instanceof IChromatogramSelectionCSD chromatogramSelectionCSD) {
 					IChromatogramCSD chromatogramCSD = chromatogramSelectionCSD.getChromatogram();
-					ChromatogramConverterCSD.getInstance().convert(chromatogramFile, chromatogramCSD, CHROMATOGRAM_CONVERTER_ID, monitor);
+					ChromatogramConverterCSD.getInstance().convert(chromatogramFile, chromatogramCSD, VersionConstants.CONVERTER_ID_CHROMATOGRAM, monitor);
 				}
 			}
 		} catch(Exception e) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.workflows/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.workflows/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.chromatogram.msd.identifier;bundle-version="0.8.0",
  org.apache.commons.math3;bundle-version="3.5.0",
  org.apache.pdfbox;bundle-version="2.0.26",
- org.apache.commons.commons-csv;bundle-version="1.8.0"
+ org.apache.commons.commons-csv;bundle-version="1.8.0",
+ org.eclipse.chemclipse.xxd.converter.supplier.ocx
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.chromatogram.xxd.process.supplier.workflows.converter,

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.workflows/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/workflows/core/SampleQuantProcessor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.workflows/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/workflows/core/SampleQuantProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Lablicate GmbH.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -40,6 +40,7 @@ import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.exceptions.TypeCastException;
 import org.eclipse.chemclipse.support.text.ValueFormat;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 
@@ -51,9 +52,6 @@ public class SampleQuantProcessor {
 	//
 	private static final String EXTENSION_POINT_ID_RTERES = "net.openchrom.msd.converter.supplier.agilent.hp.report.rteres";
 	private static final String EXTENSION_POINT_ID_SUMRPT = "net.openchrom.msd.converter.supplier.agilent.hp.report.sumrpt";
-	//
-	private static final String CHROMATOGRAM_CONVERTER_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
-	private static final String CHROMATOGRAM_FILE_EXTENSION = ".ocb";
 	//
 	private Pattern pattern = Pattern.compile("(\\d+)-(\\d\\d)-(\\d)"); // CAS#
 
@@ -90,8 +88,8 @@ public class SampleQuantProcessor {
 			/*
 			 * Export the chromatogram
 			 */
-			File chromatogramExportFile = new File(sampleQuantReportFile.getAbsolutePath().replace(REPORT_FILE_EXTENSION, CHROMATOGRAM_FILE_EXTENSION));
-			IProcessingInfo<File> processingInfoExport = ChromatogramConverterMSD.getInstance().convert(chromatogramExportFile, chromatogramMSD, CHROMATOGRAM_CONVERTER_ID, monitor);
+			File chromatogramExportFile = new File(sampleQuantReportFile.getAbsolutePath().replace(REPORT_FILE_EXTENSION, VersionConstants.FILE_EXTENSION_CHROMATOGRAM));
+			IProcessingInfo<File> processingInfoExport = ChromatogramConverterMSD.getInstance().convert(chromatogramExportFile, chromatogramMSD, VersionConstants.CONVERTER_ID_CHROMATOGRAM, monitor);
 			sampleQuantReport.setPathChromatogramEdited(processingInfoExport.getProcessingResult().getAbsolutePath());
 			/*
 			 * Write sample quant report

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.ui/META-INF/MANIFEST.MF
@@ -16,6 +16,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.ux.extension.msd.ui;bundle-version="0.8.0",
  org.eclipse.chemclipse.support.ui;bundle-version="0.8.0",
- org.eclipse.chemclipse.converter;bundle-version="0.8.0"
+ org.eclipse.chemclipse.converter;bundle-version="0.8.0",
+ org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.ui/src/org/eclipse/chemclipse/chromatogram/xxd/report/ui/export/wizards/ChromatogramReportExportWizard.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.ui/src/org/eclipse/chemclipse/chromatogram/xxd/report/ui/export/wizards/ChromatogramReportExportWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 Lablicate GmbH.
+ * Copyright (c) 2012, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -27,6 +27,7 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.exceptions.TypeCastException;
 import org.eclipse.chemclipse.ux.extension.msd.ui.wizards.ChromatogramSelectionWizardPage;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
@@ -41,7 +42,6 @@ public class ChromatogramReportExportWizard extends Wizard implements IExportWiz
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReportExportWizard.class);
 	private static final String DESCRIPTION = "Chromatogram Report";
-	private static final String CONVERTER_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
 	private ChromatogramSelectionWizardPage chromatogramSelectionWizardPage;
 	private ReportSupplierSelectionWizardPage reportSupplierSelectionWizardPage;
 
@@ -89,7 +89,7 @@ public class ChromatogramReportExportWizard extends Wizard implements IExportWiz
 							 * Load each chromatogram
 							 */
 							File chromatogramFile = new File(inputFile);
-							IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(chromatogramFile, CONVERTER_ID, monitor);
+							IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(chromatogramFile, VersionConstants.CONVERTER_ID_CHROMATOGRAM, monitor);
 							try {
 								IChromatogramMSD chromatogram = processingInfo.getProcessingResult();
 								if(chromatogram != null) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.ui/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.chemclipse.csd.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.ux.extension.xxd.ui,
- org.eclipse.chemclipse.support.ui;bundle-version="0.9.0"
+ org.eclipse.chemclipse.support.ui;bundle-version="0.9.0",
+ org.eclipse.chemclipse.xxd.converter.supplier.ocx
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: ChemClipse

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.ui/src/org/eclipse/chemclipse/csd/converter/ui/wizards/ImportDirectoryWizardPage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.ui/src/org/eclipse/chemclipse/csd/converter/ui/wizards/ImportDirectoryWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 Lablicate GmbH.
+ * Copyright (c) 2013, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.chemclipse.support.ui.swt.EnhancedCombo;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.wizard.WizardPage;
@@ -32,9 +33,9 @@ import org.eclipse.swt.widgets.Text;
 public class ImportDirectoryWizardPage extends WizardPage {
 
 	private static final String CONVERTER_LABEL_XY = "*.xy";
-	private static final String CONVERTER_LABEL_OCB = "*.ocb";
+	private static final String CONVERTER_LABEL_OCB = VersionConstants.FILE_EXTENSION_CHROMATOGRAM;
 	private static final String CONVERTER_ID_XY = "org.eclipse.chemclipse.csd.converter.supplier.xy";
-	private static final String CONVERTER_ID_OCB = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
+	private static final String CONVERTER_ID_OCB = VersionConstants.CONVERTER_ID_CHROMATOGRAM;
 	//
 	private Map<String, String> converterIds;
 	//
@@ -44,7 +45,7 @@ public class ImportDirectoryWizardPage extends WizardPage {
 	public ImportDirectoryWizardPage(String pageName, String title, ImageDescriptor titleImage) {
 
 		super(pageName, title, titleImage);
-		converterIds = new HashMap<String, String>();
+		converterIds = new HashMap<>();
 		converterIds.put(CONVERTER_LABEL_XY, CONVERTER_ID_XY);
 		converterIds.put(CONVERTER_LABEL_OCB, CONVERTER_ID_OCB);
 	}
@@ -74,7 +75,7 @@ public class ImportDirectoryWizardPage extends WizardPage {
 		gridDataCombo.horizontalSpan = 2;
 		comboConverter = EnhancedCombo.create(container, SWT.NONE);
 		comboConverter.select(1);
-		comboConverter.setItems(new String[]{CONVERTER_LABEL_XY, CONVERTER_LABEL_OCB});
+		comboConverter.setItems(CONVERTER_LABEL_XY, CONVERTER_LABEL_OCB);
 		comboConverter.setLayoutData(gridDataCombo);
 		//
 		GridData gridDataText = new GridData(GridData.FILL_HORIZONTAL);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.ui/META-INF/MANIFEST.MF
@@ -21,9 +21,10 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.chemclipse.xxd.process;bundle-version="0.8.0",
  org.eclipse.chemclipse.converter.ui;bundle-version="0.8.0",
  org.eclipse.chemclipse.ux.extension.xxd.ui,
- org.eclipse.e4.core.contexts,
- org.eclipse.e4.core.di.annotations,
- org.eclipse.chemclipse.swt.ui;bundle-version="0.9.0"
+ org.eclipse.e4.core.contexts;bundle-version="1.12.600",
+ org.eclipse.e4.core.di.annotations;bundle-version="1.8.400",
+ org.eclipse.chemclipse.swt.ui;bundle-version="0.9.0",
+ org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.chemclipse.msd.converter.ui.adapter

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.ui/src/org/eclipse/chemclipse/msd/converter/ui/wizards/ChromatogramImportWizard.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.ui/src/org/eclipse/chemclipse/msd/converter/ui/wizards/ChromatogramImportWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 Lablicate GmbH.
+ * Copyright (c) 2013, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -25,6 +25,7 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.exceptions.TypeCastException;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.wizards.RawFileSelectionWizardPage;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
@@ -38,7 +39,6 @@ public class ChromatogramImportWizard extends Wizard implements IImportWizard {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramImportWizard.class);
 	private static final String DESCRIPTION = "Chromatogram MSD Import";
-	private static final String CONVERTER_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
 	private RawFileSelectionWizardPage rawFileSelectionWizardPage;
 	private ImportDirectoryWizardPage importDirectoryWizardPage;
 
@@ -111,7 +111,7 @@ public class ChromatogramImportWizard extends Wizard implements IImportWizard {
 						 * Export
 						 */
 						File outputFile = new File(directory + chromatogram.getName());
-						ChromatogramConverterMSD.getInstance().convert(outputFile, chromatogram, CONVERTER_ID, monitor);
+						ChromatogramConverterMSD.getInstance().convert(outputFile, chromatogram, VersionConstants.CONVERTER_ID_CHROMATOGRAM, monitor);
 					} catch(TypeCastException e) {
 						logger.warn(e);
 					}

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/ChromatogramImporterTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Lablicate GmbH.
+ * Copyright (c) 2011, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -20,6 +20,7 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Ignore;
 
@@ -28,8 +29,6 @@ import junit.framework.TestCase;
 @Ignore
 public class ChromatogramImporterTestCase extends TestCase {
 
-	private static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
-	//
 	protected IChromatogramMSD chromatogram;
 	protected IChromatogramSelectionMSD chromatogramSelection;
 
@@ -41,7 +40,7 @@ public class ChromatogramImporterTestCase extends TestCase {
 		 * Import
 		 */
 		File fileImport = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1));
-		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, EXTENSION_POINT_ID, new NullProgressMonitor());
+		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/core/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/core/ChromatogramImporterTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Lablicate GmbH.
+ * Copyright (c) 2011, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -20,6 +20,7 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Ignore;
 
@@ -28,7 +29,6 @@ import junit.framework.TestCase;
 @Ignore
 public class ChromatogramImporterTestCase extends TestCase {
 
-	private static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
 	protected IChromatogramMSD chromatogram;
 	protected IChromatogramSelectionMSD chromatogramSelection;
 
@@ -40,7 +40,7 @@ public class ChromatogramImporterTestCase extends TestCase {
 		 * Import
 		 */
 		File fileImport = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2));
-		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, EXTENSION_POINT_ID, new NullProgressMonitor());
+		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/ChromatogramImporterTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2023 Lablicate GmbH.
+ * Copyright (c) 2010, 2024 Lablicate GmbH.
  *
  * All rights reserved. This
  * program and the accompanying materials are made available under the terms of
@@ -21,6 +21,7 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Ignore;
 
@@ -29,7 +30,6 @@ import junit.framework.TestCase;
 @Ignore
 public class ChromatogramImporterTestCase extends TestCase {
 
-	private static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
 	protected IChromatogramMSD chromatogram;
 	protected IChromatogramSelectionMSD chromatogramSelection;
 
@@ -41,7 +41,7 @@ public class ChromatogramImporterTestCase extends TestCase {
 		 * Import
 		 */
 		File fileImport = new File(PathResolver.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1));
-		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, EXTENSION_POINT_ID, new NullProgressMonitor());
+		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/noise/dyson/core/ChromatogramReaderTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/noise/dyson/core/ChromatogramReaderTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 Lablicate GmbH.
+ * Copyright (c) 2014, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,6 +17,7 @@ import java.io.File;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Ignore;
 
@@ -28,14 +29,13 @@ public class ChromatogramReaderTestCase extends TestCase {
 	protected IChromatogramMSD chromatogram;
 	protected String pathImport;
 	protected File fileImport;
-	private static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
 
 	@Override
 	protected void setUp() throws Exception {
 
 		super.setUp();
 		fileImport = new File(this.pathImport);
-		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, EXTENSION_POINT_ID, new NullProgressMonitor());
+		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/noise/stein/core/ChromatogramReaderTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/noise/stein/core/ChromatogramReaderTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 Lablicate GmbH.
+ * Copyright (c) 2014, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,6 +17,7 @@ import java.io.File;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Ignore;
 
@@ -28,14 +29,13 @@ public class ChromatogramReaderTestCase extends TestCase {
 	protected IChromatogramMSD chromatogram;
 	protected String pathImport;
 	protected File fileImport;
-	private static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
 
 	@Override
 	protected void setUp() throws Exception {
 
 		super.setUp();
 		fileImport = new File(this.pathImport);
-		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, EXTENSION_POINT_ID, new NullProgressMonitor());
+		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/meannormalizer/core/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/meannormalizer/core/ChromatogramImporterTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Lablicate GmbH.
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,6 +20,7 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Ignore;
 
@@ -28,8 +29,6 @@ import junit.framework.TestCase;
 @Ignore
 public class ChromatogramImporterTestCase extends TestCase {
 
-	private static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
-	//
 	protected IChromatogramMSD chromatogram;
 	protected IChromatogramSelectionMSD chromatogramSelection;
 
@@ -41,7 +40,7 @@ public class ChromatogramImporterTestCase extends TestCase {
 		 * Import
 		 */
 		File fileImport = new File(PathResolver.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1));
-		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, EXTENSION_POINT_ID, new NullProgressMonitor());
+		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/mediannormalizer/core/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/mediannormalizer/core/ChromatogramImporterTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 Lablicate GmbH.
+ * Copyright (c) 2015, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,6 +20,7 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Ignore;
 
@@ -28,7 +29,6 @@ import junit.framework.TestCase;
 @Ignore
 public class ChromatogramImporterTestCase extends TestCase {
 
-	private static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
 	protected IChromatogramMSD chromatogram;
 	protected IChromatogramSelectionMSD chromatogramSelection;
 
@@ -40,7 +40,7 @@ public class ChromatogramImporterTestCase extends TestCase {
 		 * Import
 		 */
 		File fileImport = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1));
-		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, EXTENSION_POINT_ID, new NullProgressMonitor());
+		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/multiplier/core/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/multiplier/core/ChromatogramImporterTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 Lablicate GmbH.
+ * Copyright (c) 2015, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,6 +20,7 @@ import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMS
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Ignore;
 
@@ -28,8 +29,6 @@ import junit.framework.TestCase;
 @Ignore
 public class ChromatogramImporterTestCase extends TestCase {
 
-	private static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
-	//
 	protected IChromatogramMSD chromatogram;
 	protected IChromatogramSelection<?, ?> chromatogramSelection;
 
@@ -41,7 +40,7 @@ public class ChromatogramImporterTestCase extends TestCase {
 		 * Import
 		 */
 		File fileImport = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1));
-		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, EXTENSION_POINT_ID, new NullProgressMonitor());
+		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/normalizer/core/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/normalizer/core/ChromatogramImporterTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Lablicate GmbH.
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,6 +20,7 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Ignore;
 
@@ -28,8 +29,6 @@ import junit.framework.TestCase;
 @Ignore
 public class ChromatogramImporterTestCase extends TestCase {
 
-	private static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
-	//
 	protected IChromatogramMSD chromatogram;
 	protected IChromatogramSelectionMSD chromatogramSelection;
 
@@ -41,7 +40,7 @@ public class ChromatogramImporterTestCase extends TestCase {
 		 * Import
 		 */
 		File fileImport = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1));
-		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, EXTENSION_POINT_ID, new NullProgressMonitor());
+		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/unitsumnormalizer/core/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/unitsumnormalizer/core/ChromatogramImporterTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 Lablicate GmbH.
+ * Copyright (c) 2015, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,6 +19,7 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Ignore;
 
@@ -27,8 +28,6 @@ import junit.framework.TestCase;
 @Ignore
 public class ChromatogramImporterTestCase extends TestCase {
 
-	private static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
-	//
 	protected IChromatogramMSD chromatogram;
 	protected IChromatogramSelectionMSD chromatogramSelection;
 
@@ -40,7 +39,7 @@ public class ChromatogramImporterTestCase extends TestCase {
 		 * Import
 		 */
 		File fileImport = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1));
-		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, EXTENSION_POINT_ID, new NullProgressMonitor());
+		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/supplier/trapezoid/internal/core/ChromatogramImportOCBTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/supplier/trapezoid/internal/core/ChromatogramImportOCBTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Lablicate GmbH.
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -19,6 +19,7 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Ignore;
 
@@ -30,14 +31,13 @@ public class ChromatogramImportOCBTestCase extends TestCase {
 	private IChromatogramMSD chromatogram;
 	protected IChromatogramSelectionMSD chromatogramSelection;
 	protected String chromatogramRelativePath;
-	private static final String converterId = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
 
 	@Override
 	protected void setUp() throws Exception {
 
 		super.setUp();
 		File fileImport = new File(TestPathHelper.getAbsolutePath(chromatogramRelativePath));
-		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, converterId, new NullProgressMonitor());
+		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/excel/io/ChromatogramReaderTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/excel/io/ChromatogramReaderTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Lablicate GmbH.
+ * Copyright (c) 2011, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -17,6 +17,7 @@ import java.io.File;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Ignore;
 
@@ -28,15 +29,13 @@ public class ChromatogramReaderTestCase extends TestCase {
 	protected IChromatogramMSD chromatogram;
 	protected String pathImport;
 	protected File fileImport;
-	//
-	private static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
 
 	@Override
 	protected void setUp() throws Exception {
 
 		super.setUp();
 		fileImport = new File(this.pathImport);
-		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, EXTENSION_POINT_ID, new NullProgressMonitor());
+		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportExport110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportExport110_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Lablicate GmbH.
+ * Copyright (c) 2011, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -18,6 +18,7 @@ import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMS
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
 
 import junit.framework.TestCase;
@@ -40,7 +41,7 @@ public class ChromatogramImportExport110_ITest extends TestCase {
 		 * Import
 		 */
 		pathImport = TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
-		extensionPointImport = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
+		extensionPointImport = VersionConstants.CONVERTER_ID_CHROMATOGRAM;
 		/*
 		 * Export/Reimport
 		 */

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.csv.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/ChromatogramReaderTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.csv.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/ChromatogramReaderTestCase.java
@@ -17,6 +17,7 @@ import java.io.File;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Ignore;
 
@@ -28,15 +29,13 @@ public class ChromatogramReaderTestCase extends TestCase {
 	protected IChromatogramMSD chromatogram;
 	protected String pathImport;
 	protected File fileImport;
-	//
-	private static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
 
 	@Override
 	protected void setUp() throws Exception {
 
 		super.setUp();
 		fileImport = new File(this.pathImport);
-		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, EXTENSION_POINT_ID, new NullProgressMonitor());
+		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.csv.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/ChromatogramReader_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.csv.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/ChromatogramReader_1_ITest.java
@@ -16,6 +16,7 @@ import java.io.File;
 import org.eclipse.chemclipse.model.settings.Delimiter;
 import org.eclipse.chemclipse.xxd.converter.supplier.csv.TestPathHelper;
 import org.eclipse.chemclipse.xxd.converter.supplier.csv.preferences.PreferenceSupplier;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 
 public class ChromatogramReader_1_ITest extends ChromatogramWriterTestCase {
 
@@ -28,7 +29,7 @@ public class ChromatogramReader_1_ITest extends ChromatogramWriterTestCase {
 		 * Import
 		 */
 		pathImport = TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
-		extensionPointImport = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
+		extensionPointImport = VersionConstants.CONVERTER_ID_CHROMATOGRAM;
 		/*
 		 * Export/Reimport
 		 */

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReaderFIDTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReaderFIDTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 Lablicate GmbH.
+ * Copyright (c) 2014, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -18,6 +18,7 @@ import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCS
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.exceptions.TypeCastException;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Ignore;
 
@@ -29,14 +30,13 @@ public class ChromatogramReaderFIDTestCase extends TestCase {
 	protected IChromatogramCSD chromatogram;
 	protected String pathImport;
 	protected File fileImport;
-	private static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
 
 	@Override
 	protected void setUp() throws Exception {
 
 		super.setUp();
 		fileImport = new File(this.pathImport);
-		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, EXTENSION_POINT_ID, new NullProgressMonitor());
+		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		try {
 			chromatogram = processingInfo.getProcessingResult();
 		} catch(TypeCastException e) {

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReaderMSDTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReaderMSDTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 Lablicate GmbH.
+ * Copyright (c) 2014, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -18,6 +18,7 @@ import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMS
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.exceptions.TypeCastException;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Ignore;
 
@@ -29,14 +30,13 @@ public class ChromatogramReaderMSDTestCase extends TestCase {
 	protected IChromatogramMSD chromatogram;
 	protected String pathImport;
 	protected File fileImport;
-	private static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
 
 	@Override
 	protected void setUp() throws Exception {
 
 		super.setUp();
 		fileImport = new File(this.pathImport);
-		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, EXTENSION_POINT_ID, new NullProgressMonitor());
+		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		try {
 			chromatogram = processingInfo.getProcessingResult();
 		} catch(TypeCastException e) {

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReaderWSDTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReaderWSDTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 Lablicate GmbH.
+ * Copyright (c) 2015, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -18,6 +18,7 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.exceptions.TypeCastException;
 import org.eclipse.chemclipse.wsd.converter.chromatogram.ChromatogramConverterWSD;
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
+import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Ignore;
 
@@ -29,14 +30,13 @@ public class ChromatogramReaderWSDTestCase extends TestCase {
 	protected IChromatogramWSD chromatogram;
 	protected String pathImport;
 	protected File fileImport;
-	private static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.converter.supplier.chemclipse";
 
 	@Override
 	protected void setUp() throws Exception {
 
 		super.setUp();
 		fileImport = new File(this.pathImport);
-		IProcessingInfo<IChromatogramWSD> processingInfo = ChromatogramConverterWSD.getInstance().convert(fileImport, EXTENSION_POINT_ID, new NullProgressMonitor());
+		IProcessingInfo<IChromatogramWSD> processingInfo = ChromatogramConverterWSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		try {
 			chromatogram = processingInfo.getProcessingResult();
 		} catch(TypeCastException e) {


### PR DESCRIPTION
Many unit tests have a runtime dependency on the `ocb` converter. This adds compile time dependencies, so those are not accidentally removed, which can lead to confusing errors.