### PR TITLE
Add chromatography type to chromatogram

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractChromatogram.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractChromatogram.java
@@ -57,6 +57,7 @@ public abstract class AbstractChromatogram<T extends IPeak> extends AbstractMeas
 	private int scanDelay = 4500;
 	private int scanInterval = 1000; // 1000ms = 1 scan per second
 	private final List<ChromatogramAnalysisSegment> analysisSegments = new ArrayList<>();
+	private ChromatographyType chromatographyType = null;
 	/*
 	 * This flag marks whether the chromatogram has been
 	 * set to unload modus. It is used e.g. when loading
@@ -962,6 +963,12 @@ public abstract class AbstractChromatogram<T extends IPeak> extends AbstractMeas
 	@Override
 	public void updateAnalysisSegment(IAnalysisSegment segment, IScanRange range) {
 
+	}
+
+	@Override
+	public ChromatographyType getChromatographyType() {
+
+		return chromatographyType;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/ChromatographyType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/ChromatographyType.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.model.core;
+
+import org.eclipse.chemclipse.support.text.ILabel;
+
+public enum ChromatographyType implements ILabel {
+
+	GC("Gas Chromatography"), //
+	LC("Liquid Chromatography"), //
+	TLC("Thin Layer Chromatography"), //
+	SEC("Size Exclusion Chromatography"), //
+	IC("Ion Chromatography"), //
+	CE("Capillary Electrophoresis"), //
+	AC("Affinity Chromatography"); //
+
+	private String label;
+
+	private ChromatographyType(String label) {
+
+		this.label = label;
+	}
+
+	@Override
+	public String label() {
+
+		return label;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IChromatogram.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IChromatogram.java
@@ -274,4 +274,6 @@ public interface IChromatogram<T extends IPeak> extends SegmentedMeasurement, IM
 			removeAnalysisSegment(segment);
 		}
 	}
+
+	ChromatographyType getChromatographyType();
 }


### PR DESCRIPTION
We currently differentiate by detector type, but not whether the chromatogram is from an LC or GC. Not all file formats are agnostic in this regard. Also, some types might want their own editor. This is a proposal. I am not sure if this is the right way to do it.