### PR TITLE
Remove mass spectra FileWriter API

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/AbstractMassSpectraWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/AbstractMassSpectraWriter.java
@@ -20,14 +20,13 @@ import java.util.List;
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
 import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.msd.converter.io.IMassSpectraWriter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.implementation.MassSpectra;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public abstract class AbstractMassSpectraWriter extends AbstractWriter implements IMassSpectraWriter {
+public abstract class AbstractMassSpectraWriter extends AbstractWriter implements IMassSpectraFileWriter {
 
 	private static final int MAX_SPECTRA_CHUNK = 65535;
 	private static final Logger logger = Logger.getLogger(AbstractMassSpectraWriter.class);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/IMassSpectraFileWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/IMassSpectraFileWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 Lablicate GmbH.
+ * Copyright (c) 2012, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,26 +9,23 @@
  * Contributors:
  * Dr. Philip Wenig - initial API and implementation
  *******************************************************************************/
-package org.eclipse.chemclipse.msd.converter.supplier.massbank.io;
+package org.eclipse.chemclipse.msd.converter.supplier.amdis.io;
 
-import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
 import org.eclipse.chemclipse.msd.converter.io.IMassSpectraWriter;
-import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class MassBankWriter implements IMassSpectraWriter {
+public interface IMassSpectraFileWriter extends IMassSpectraWriter {
 
-	@Override
-	public void write(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
-
-	}
-
-	@Override
-	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
-
-	}
+	/**
+	 * Writes the mass spectrum with the given file writer.
+	 * 
+	 * @param fileWriter
+	 * @param massSpectrum
+	 * @throws IOException
+	 */
+	void writeMassSpectrum(FileWriter fileWriter, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException;
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSLWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSLWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Lablicate GmbH.
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,11 +15,10 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
-import org.eclipse.chemclipse.msd.converter.io.IMassSpectraWriter;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class MSLWriter extends AbstractMassSpectraWriter implements IMassSpectraWriter {
+public class MSLWriter extends AbstractMassSpectraWriter implements IMassSpectraFileWriter {
 
 	@Override
 	public void writeMassSpectrum(FileWriter fileWriter, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPWriter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Lablicate GmbH.
- * 
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
+ *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution,
@@ -15,11 +15,10 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
-import org.eclipse.chemclipse.msd.converter.io.IMassSpectraWriter;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class MSPWriter extends AbstractMassSpectraWriter implements IMassSpectraWriter {
+public class MSPWriter extends AbstractMassSpectraWriter implements IMassSpectraFileWriter {
 
 	@Override
 	public void writeMassSpectrum(FileWriter fileWriter, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.cml/src/org/eclipse/chemclipse/msd/converter/supplier/cml/converter/io/MassSpectraWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.cml/src/org/eclipse/chemclipse/msd/converter/supplier/cml/converter/io/MassSpectraWriter.java
@@ -12,7 +12,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.cml.converter.io;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -67,12 +66,6 @@ public class MassSpectraWriter extends AbstractMassSpectraWriter implements IMas
 	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
 		write(file, massSpectra.getMassSpectrum(1), false, monitor);
-	}
-
-	@Override
-	public void writeMassSpectrum(FileWriter fileWriter, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
-
-		throw new UnsupportedOperationException();
 	}
 
 	private Spectrum createSpectrum(IScanMSD massSpectrum) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/converter/io/MassSpectrumWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/converter/io/MassSpectrumWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,7 +12,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mmass.converter.io;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
@@ -31,12 +30,6 @@ public class MassSpectrumWriter implements IMassSpectraWriter {
 
 	@Override
 	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
-
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void writeMassSpectrum(FileWriter fileWriter, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
 
 		throw new UnsupportedOperationException();
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/io/MassSpectrumWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/io/MassSpectrumWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 Lablicate GmbH.
+ * Copyright (c) 2013, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,7 +12,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mzdata.io;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
@@ -30,11 +29,6 @@ public class MassSpectrumWriter implements IMassSpectraWriter {
 
 	@Override
 	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
-
-	}
-
-	@Override
-	public void writeMassSpectrum(FileWriter fileWriter, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
 
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/io/MassSpectrumWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/io/MassSpectrumWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 Lablicate GmbH.
+ * Copyright (c) 2013, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,7 +12,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.io;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
@@ -31,12 +30,6 @@ public class MassSpectrumWriter implements IMassSpectraWriter {
 
 	@Override
 	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
-
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void writeMassSpectrum(FileWriter fileWriter, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
 
 		throw new UnsupportedOperationException();
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/io/MassSpectrumWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/io/MassSpectrumWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 Lablicate GmbH.
+ * Copyright (c) 2013, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,7 +12,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mzxml.io;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
@@ -30,11 +29,6 @@ public class MassSpectrumWriter implements IMassSpectraWriter {
 
 	@Override
 	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
-
-	}
-
-	@Override
-	public void writeMassSpectrum(FileWriter fileWriter, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
 
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/src/org/eclipse/chemclipse/msd/converter/supplier/sirius/io/SiriusWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/src/org/eclipse/chemclipse/msd/converter/supplier/sirius/io/SiriusWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Lablicate GmbH.
+ * Copyright (c) 2021, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,7 +12,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.sirius.io;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
@@ -30,11 +29,6 @@ public class SiriusWriter implements IMassSpectraWriter {
 
 	@Override
 	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
-
-	}
-
-	@Override
-	public void writeMassSpectrum(FileWriter fileWriter, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
 
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/io/IMassSpectraWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/io/IMassSpectraWriter.java
@@ -12,8 +12,6 @@
 package org.eclipse.chemclipse.msd.converter.io;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileWriter;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
@@ -29,7 +27,6 @@ public interface IMassSpectraWriter {
 	 * @param file
 	 * @param massSpectrum
 	 * @param append
-	 * @throws FileNotFoundException
 	 * @throws FileIsNotWriteableException
 	 * @throws IOException
 	 */
@@ -41,18 +38,8 @@ public interface IMassSpectraWriter {
 	 * @param file
 	 * @param massSpectra
 	 * @param append
-	 * @throws FileNotFoundException
 	 * @throws FileIsNotWriteableException
 	 * @throws IOException
 	 */
 	void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException;
-
-	/**
-	 * Writes the mass spectrum with the given file writer.
-	 * 
-	 * @param fileWriter
-	 * @param massSpectrum
-	 * @throws IOException
-	 */
-	void writeMassSpectrum(FileWriter fileWriter, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException;
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/io/MassSpectraWriterAdapter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/io/MassSpectraWriterAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Lablicate GmbH.
+ * Copyright (c) 2015, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,8 +12,6 @@
 package org.eclipse.chemclipse.msd.converter.io;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileWriter;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
@@ -25,17 +23,12 @@ import org.eclipse.core.runtime.IProgressMonitor;
 public class MassSpectraWriterAdapter extends AbstractFileHelper implements IMassSpectraWriter {
 
 	@Override
-	public void write(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotWriteableException, IOException {
+	public void write(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
 	}
 
 	@Override
-	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotWriteableException, IOException {
-
-	}
-
-	@Override
-	public void writeMassSpectrum(FileWriter fileWriter, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ascii/src/org/eclipse/chemclipse/msd/converter/supplier/ascii/io/MassSpectraWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ascii/src/org/eclipse/chemclipse/msd/converter/supplier/ascii/io/MassSpectraWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Lablicate GmbH.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,8 +12,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.ascii.io;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileWriter;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
@@ -25,17 +23,12 @@ import org.eclipse.core.runtime.IProgressMonitor;
 public class MassSpectraWriter implements IMassSpectraWriter {
 
 	@Override
-	public void write(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotWriteableException, IOException {
+	public void write(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
 	}
 
 	@Override
-	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotWriteableException, IOException {
-
-	}
-
-	@Override
-	public void writeMassSpectrum(FileWriter fileWriter, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/core/MassSpectrumExtendedWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/core/MassSpectrumExtendedWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2024 Matthias Mailänder.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -13,7 +13,6 @@
 package org.eclipse.chemclipse.xxd.converter.supplier.csv.io.core;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.text.DecimalFormat;
@@ -47,31 +46,22 @@ public class MassSpectrumExtendedWriter implements IMassSpectraWriter {
 	private DecimalFormat decimalFormat = ValueFormat.getDecimalFormatEnglish();
 
 	@Override
-	public void writeMassSpectrum(FileWriter fileWriter, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	public void write(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
 		MassSpectra massSpectra = new MassSpectra();
 		massSpectra.addMassSpectrum(massSpectrum);
-		writeMassSpectrumToCsv(massSpectra, fileWriter);
+		writeMassSpectrumToCsv(massSpectra, file, append);
 	}
 
 	@Override
-	public void write(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotWriteableException, IOException {
+	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
-		FileWriter fileWriter = new FileWriter(file, append);
-		MassSpectra massSpectra = new MassSpectra();
-		massSpectra.addMassSpectrum(massSpectrum);
-		writeMassSpectrumToCsv(massSpectra, fileWriter);
+		writeMassSpectrumToCsv(massSpectra, file, append);
 	}
 
-	@Override
-	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotWriteableException, IOException {
+	private void writeMassSpectrumToCsv(IMassSpectra massSpectra, File file, boolean append) throws IOException {
 
 		FileWriter fileWriter = new FileWriter(file, append);
-		writeMassSpectrumToCsv(massSpectra, fileWriter);
-	}
-
-	private void writeMassSpectrumToCsv(IMassSpectra massSpectra, FileWriter fileWriter) throws IOException {
-
 		if(massSpectra != null) {
 			try (CSVPrinter csvFilePrinter = new CSVPrinter(fileWriter, CSVFormat.EXCEL);) {
 				/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/core/MassSpectrumWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/core/MassSpectrumWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2024 Matthias Mailänder.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,7 +12,6 @@
 package org.eclipse.chemclipse.xxd.converter.supplier.csv.io.core;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.text.DecimalFormat;
@@ -42,34 +41,24 @@ public class MassSpectrumWriter implements IMassSpectraWriter {
 	private DecimalFormat decimalFormat = ValueFormat.getDecimalFormatEnglish();
 
 	@Override
-	public void writeMassSpectrum(FileWriter fileWriter, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	public void write(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
 		MassSpectra massSpectra = new MassSpectra();
 		massSpectra.addMassSpectrum(massSpectrum);
-		writeMassSpectrumToCsv(massSpectra, fileWriter);
+		writeMassSpectrumToCsv(massSpectra, file, append);
 	}
 
 	@Override
-	public void write(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotWriteableException, IOException {
+	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
-		FileWriter fileWriter = new FileWriter(file, append);
-		MassSpectra massSpectra = new MassSpectra();
-		massSpectra.addMassSpectrum(massSpectrum);
-		writeMassSpectrumToCsv(massSpectra, fileWriter);
+		writeMassSpectrumToCsv(massSpectra, file, append);
 	}
 
-	@Override
-	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotWriteableException, IOException {
-
-		FileWriter fileWriter = new FileWriter(file, append);
-		writeMassSpectrumToCsv(massSpectra, fileWriter);
-	}
-
-	private void writeMassSpectrumToCsv(IMassSpectra massSpectra, FileWriter fileWriter) throws IOException {
+	private void writeMassSpectrumToCsv(IMassSpectra massSpectra, File file, boolean append) throws IOException {
 
 		if(massSpectra != null) {
 			CSVPrinter csvFilePrinter = null;
-			try {
+			try (FileWriter fileWriter = new FileWriter(file, append)) {
 				csvFilePrinter = new CSVPrinter(fileWriter, CSVFormat.EXCEL);
 				//
 				for(IScanMSD massSpectrum : massSpectra.getList()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/io/MassSpectraWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/io/MassSpectraWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Lablicate GmbH.
+ * Copyright (c) 2015, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,7 +13,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.jcampdx.io;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileWriter;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
@@ -31,11 +30,6 @@ public class MassSpectraWriter implements IMassSpectraWriter {
 
 	@Override
 	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotWriteableException, IOException {
-
-	}
-
-	@Override
-	public void writeMassSpectrum(FileWriter fileWriter, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
 
 	}
 }


### PR DESCRIPTION
as it is an implementation detail of text-based file formats stemming from the AMDIS ones, so move it there.