### PR TITLE
Lower the default compression level for .ocb files

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/internal/support/Format.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/internal/support/Format.java
@@ -32,7 +32,6 @@ public class Format {
 	/*
 	 * Chromatogram (*.ocb)
 	 */
-	public static final int CHROMATOGRAM_COMPRESSION_LEVEL = 9; // 0 - 9 => 0 no compression
 	public static final int CHROMATOGRAM_COMPRESSION_TYPE = ZipOutputStream.DEFLATED;
 	//
 	public static final String CHROMATOGRAM_VERSION_0701 = "0.7.0.1"; // Version 0.7.0, Release 1 (Nernst)

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/preferences/PreferenceSupplier.java
@@ -30,7 +30,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final String P_CHROMATOGRAM_VERSION_SAVE = "chromatogramVersionSave";
 	public static final String DEF_CHROMATOGRAM_VERSION_SAVE = Format.CHROMATOGRAM_VERSION_LATEST;
 	public static final String P_CHROMATOGRAM_COMPRESSION_LEVEL = "chromatogramCompressionLevel";
-	public static final int DEF_CHROMATOGRAM_COMPRESSION_LEVEL = Format.CHROMATOGRAM_COMPRESSION_LEVEL;
+	public static final int DEF_CHROMATOGRAM_COMPRESSION_LEVEL = 1; // compromise between file size and write speed
 	public static final String P_CHROMATGRAM_EXPORT_REFERENCES_SEPARATELY = "chromatogramExportReferencesSeparately";
 	public static final boolean DEF_CHROMATGRAM_EXPORT_REFERENCES_SEPARATELY = false;
 	public static final String P_CHROMATGRAM_EXPORT_REFERENCES_HEADER_FIELD = "chromatogramExportReferencesHeaderField";


### PR DESCRIPTION
My tests with zlib compression conclude that the first level already achieves a huge magnitude of size reduction. The maximum compression level increases write speed too much and seems not really worth it considering the negligible additional file space saved.

| Byte      | File                                  |
|-----------|---------------------------------------|
| 24247237  | DemoChromatogram Compression 0.ocb    |
| 6177403   | DemoChromatogram Compression 1.ocb    |
| 4216132   | DemoChromatogram Compression 9.ocb    |
