### PR TITLE
Fixed a crash in mzXML MALDI-TOF MS data

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion20.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion20.java
@@ -76,7 +76,7 @@ public class MassSpectrumReaderVersion20 extends AbstractMassSpectraReader imple
 			massSpectrum.setFile(file);
 			massSpectrum.setIdentifier(file.getName());
 			for(DataProcessing dataProcessing : msrun.getDataProcessing()) {
-				if(dataProcessing.isCentroided()) {
+				if(Boolean.TRUE.equals(dataProcessing.isCentroided())) {
 					massSpectrum.setMassSpectrumType(MassSpectrumType.CENTROID);
 				} else {
 					massSpectrum.setMassSpectrumType(MassSpectrumType.PROFILE);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion21.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion21.java
@@ -76,7 +76,7 @@ public class MassSpectrumReaderVersion21 extends AbstractMassSpectraReader imple
 			massSpectrum.setFile(file);
 			massSpectrum.setIdentifier(file.getName());
 			for(DataProcessing dataProcessing : msrun.getDataProcessing()) {
-				if(dataProcessing.isCentroided()) {
+				if(Boolean.TRUE.equals(dataProcessing.isCentroided())) {
 					massSpectrum.setMassSpectrumType(MassSpectrumType.CENTROID);
 				} else {
 					massSpectrum.setMassSpectrumType(MassSpectrumType.PROFILE);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion22.java
@@ -76,7 +76,7 @@ public class MassSpectrumReaderVersion22 extends AbstractMassSpectraReader imple
 			massSpectrum.setFile(file);
 			massSpectrum.setIdentifier(file.getName());
 			for(DataProcessing dataProcessing : msrun.getDataProcessing()) {
-				if(dataProcessing.isCentroided()) {
+				if(Boolean.TRUE.equals(dataProcessing.isCentroided())) {
 					massSpectrum.setMassSpectrumType(MassSpectrumType.CENTROID);
 				} else {
 					massSpectrum.setMassSpectrumType(MassSpectrumType.PROFILE);


### PR DESCRIPTION
from http://t2d.lab.gy/ to be specific, which creates a very minimal mzXML. Also fixes [S5411](https://rules.sonarsource.com/java/type/Code%20Smell/RSPEC-5411/).