### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<img src="https://science.eclipse.org/images/science/logo.png" height="50" align="right">
-
 # ChemClipse
 
 The Eclipse ChemClipse project offers functionality for data reading and processing in the domain of
@@ -22,12 +20,6 @@ Currently it offers workflows in the following areas:
 
 Thanks to the open and flexible architecture more are possible and we are open for ideas and suggestions see our [contribution guidelines](https://github.com/eclipse/chemclipse/blob/develop/CONTRIBUTING.md).
 
-[ChemClipse](https://projects.eclipse.org/projects/science.chemclipse) is part of the [Eclipse Science](https://science.eclipse.org/) working group and is the basis for [OpenChrom®](https://github.com/Openchrom/openchrom).
+[ChemClipse](https://projects.eclipse.org/projects/science.chemclipse) is the basis for [OpenChrom®](https://github.com/Openchrom/openchrom) by [Lablicate](https://lablicate.com/).
 
 For user- and developer documentation, have a look at our [wiki](https://github.com/eclipse/chemclipse/wiki), if you have questions or need guidelines you can contact contact the project developers via the [project's "dev" list](https://dev.eclipse.org/mailman/listinfo/chemclipse-dev). See [Jenkins](https://ci.eclipse.org/chemclipse/) for continous integration builds.
-
-Continuous Integration:
-https://ci.eclipse.org/chemclipse
-
-Eclipse Page:
-https://projects.eclipse.org/projects/science.chemclipse


### PR DESCRIPTION
The logo was removed by the @eclipse foundation as the [science working group was retired](https://www.eclipse.org/lists/science-iwg/msg02865.html) so clean up all loose ends. Also removed some duplicated links and mention the driving force behind this project.