### PR TITLE
Remove `Chromatogram` prefix and `Filter` suffix from Chromatogram Filters

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/plugin.xml
@@ -26,14 +26,14 @@
             id="org.eclipse.chemclipse.chromatogram.filter.scanTargetsToReferencesTransfer">
       </ChromatogramFilterSupplier>
       <ChromatogramFilterSupplier
-            description="This filter transforms the chromatogram."
+            description="Changes MSD to CSD and vice versa."
             filter="org.eclipse.chemclipse.chromatogram.filter.impl.ChromatogramFilterTransform"
             filterName="Transform"
             filterSettings="org.eclipse.chemclipse.chromatogram.filter.impl.settings.FilterSettingsTransform"
             id="org.eclipse.chemclipse.chromatogram.filter.transformChromatogramSelection">
       </ChromatogramFilterSupplier>
       <ChromatogramFilterSupplier
-            description="This filter reshapes the chromatogram."
+            description="Cuts a chromatogram into multiple referenced chromatograms."
             filter="org.eclipse.chemclipse.chromatogram.filter.impl.ChromatogramFilterReshape"
             filterName="Reshape"
             filterSettings="org.eclipse.chemclipse.chromatogram.filter.impl.settings.FilterSettingsReshape"

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/plugin.xml
@@ -28,21 +28,21 @@
       <ChromatogramFilterSupplier
             description="This filter transforms the chromatogram."
             filter="org.eclipse.chemclipse.chromatogram.filter.impl.ChromatogramFilterTransform"
-            filterName="Chromatogram Transform"
+            filterName="Transform"
             filterSettings="org.eclipse.chemclipse.chromatogram.filter.impl.settings.FilterSettingsTransform"
             id="org.eclipse.chemclipse.chromatogram.filter.transformChromatogramSelection">
       </ChromatogramFilterSupplier>
       <ChromatogramFilterSupplier
             description="This filter reshapes the chromatogram."
             filter="org.eclipse.chemclipse.chromatogram.filter.impl.ChromatogramFilterReshape"
-            filterName="Chromatogram Reshape"
+            filterName="Reshape"
             filterSettings="org.eclipse.chemclipse.chromatogram.filter.impl.settings.FilterSettingsReshape"
             id="org.eclipse.chemclipse.chromatogram.filter.chromatogramReshape">
       </ChromatogramFilterSupplier>
       <ChromatogramFilterSupplier
             description="This filter transfers header data to the chromatogram references."
             filter="org.eclipse.chemclipse.chromatogram.filter.impl.ChromatogramFilterHeaderTransfer"
-            filterName="Chromatogram Header Transfer"
+            filterName="Header Transfer"
             filterSettings="org.eclipse.chemclipse.chromatogram.filter.impl.settings.FilterSettingsHeaderTransfer"
             id="org.eclipse.chemclipse.chromatogram.filter.chromatogramHeaderTransfer">
       </ChromatogramFilterSupplier>                          

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/plugin.xml
@@ -6,7 +6,7 @@
       <ChromatogramFilterSupplier
             description="This filter applies the backfolding algorithm."
             filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.core.ChromatogramFilter"
-            filterName="Backfolding Filter"
+            filterName="Backfolding"
             filterSettings="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.settings.ChromatogramFilterSettings"
             id="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding">
       </ChromatogramFilterSupplier>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/ChromatogramFilter.java
@@ -22,8 +22,8 @@ import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.prefe
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.settings.ChromatogramFilterSettings;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
-import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.msd.model.xic.IExtractedIonSignals;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/detector/BackfoldingShifter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/detector/BackfoldingShifter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Lablicate GmbH.
+ * Copyright (c) 2011, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -215,7 +215,6 @@ public class BackfoldingShifter implements IBackfoldingShifter {
 		 * extractedIonSignalsShifted will only store absolute positive values.
 		 */
 		int retentionTime = 0;
-		float abundance = 0.0f;
 		/*
 		 * Select the start and stop scan.
 		 */
@@ -244,7 +243,7 @@ public class BackfoldingShifter implements IBackfoldingShifter {
 			 * Add the absolute signal and do not remove previous signals but
 			 * merge them.
 			 */
-			abundance = Math.abs(totalIonSignal.getTotalSignal());
+			float abundance = Math.abs(totalIonSignal.getTotalSignal());
 			extractedIonSignalsShifted.add(ion, abundance, retentionTime, false);
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/plugin.xml
@@ -6,7 +6,7 @@
       <ChromatogramFilterSupplier
             description="This filter applies the CODA background remover algorithm."
             filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.core.ChromatogramFilter"
-            filterName="CODA Filter"
+            filterName="CODA"
             filterSettings="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.settings.FilterSettings"
             id="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda">
       </ChromatogramFilterSupplier>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising/plugin.xml
@@ -6,7 +6,7 @@
       <ChromatogramFilterSupplier
             description="This filter tries to denoise a chromatogram selection."
             filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.core.ChromatogramFilter"
-            filterName="Denoising Filter"
+            filterName="Denoising"
             filterSettings="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.settings.FilterSettings"
             id="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising">
       </ChromatogramFilterSupplier>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/plugin.xml
@@ -7,7 +7,7 @@
             config="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover.settings.MassSpectrumFilterSettings"
             description="This filter removes all specified ions from a mass spectrum."
             filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover.core.MassSpectrumFilter"
-            filterName="Ion Remover Filter"
+            filterName="Ion Remover"
             id="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover.massspectrum">
       </MassSpectrumFilterSupplier>
    </extension>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter/plugin.xml
@@ -6,28 +6,28 @@
       <ChromatogramFilterSupplier
             description="This filter splits a chromatogram into its MS1, MS2, ... reference chromatograms."
             filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.core.ChromatogramFilterMSx"
-            filterName="Chromatogram Splitter (MS1, MS2, ...)"
+            filterName="Splitter (MS1, MS2, ...)"
             filterSettings="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.settings.FilterSettingsMSx"
             id="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.msx">
       </ChromatogramFilterSupplier>
       <ChromatogramFilterSupplier
             description="This filter splits a chromatogram into its SCAN, SIM reference chromatograms."
             filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.core.ChromatogramFilterSIM"
-            filterName="Chromatogram Splitter (SCAN, SIM)"
+            filterName="Splitter (SCAN, SIM)"
             filterSettings="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.settings.FilterSettingsSIM"
             id="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.sim">
       </ChromatogramFilterSupplier>
       <ChromatogramFilterSupplier
             description="This filter splits a chromatogram into its MS/MS reference chromatograms."
             filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.core.ChromatogramFilterTandemMS"
-            filterName="Chromatogram Splitter (MS/MS)"
+            filterName="Splitter (MS/MS)"
             filterSettings="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.settings.FilterSettingsTandemMS"
             id="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.tandemms">
       </ChromatogramFilterSupplier>
       <ChromatogramFilterSupplier
             description="This filter splits a chromatogram into its high resolution reference chromatograms."
             filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.core.ChromatogramFilterHighResMS"
-            filterName="Chromatogram Splitter (High Resolution)"
+            filterName="Splitter (High Resolution)"
             filterSettings="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.settings.FilterSettingsHighResMS"
             id="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.highresms">
       </ChromatogramFilterSupplier>              

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.ui/plugin.xml
@@ -13,7 +13,7 @@
             category="org.eclipse.chemclipse.chromatogram.msd.filter.ui.preferences.filterPreferencePage"
             class="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.ui.preferences.PreferencePage"
             id="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.ui.preferences.preferencePage"
-            name="Subtract Filter">
+            name="Subtract">
       </page> 
    </extension>
    <extension

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/plugin.xml
@@ -6,7 +6,7 @@
       <ChromatogramFilterSupplier
             description="This filter applies the Subtract filter to a chromatogram."
             filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.core.ChromatogramFilter"
-            filterName="Subtract Filter"
+            filterName="Subtract"
             filterSettings="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.settings.ChromatogramFilterSettings"
             id="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.chromatogram">
       </ChromatogramFilterSupplier>
@@ -16,7 +16,7 @@
       <PeakFilterSupplier
             description="This filter applies the Subtract filter to a list of peaks."
             filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.core.PeakFilter"
-            filterName="Subtract Filter"
+            filterName="Subtract"
             filterSettings="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.settings.PeakFilterSettings"
             id="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.peak">
       </PeakFilterSupplier>
@@ -27,7 +27,7 @@
             config="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.settings.MassSpectrumFilterSettings"
             description="This filter applies the Subtract filter to a list of mass spectra."
             filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.core.MassSpectrumFilter"
-            filterName="Subtract Filter"
+            filterName="Subtract"
             id="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.massspectrum">
       </MassSpectrumFilterSupplier>
    </extension>  

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/plugin.xml
@@ -4,7 +4,7 @@
    <extension
          point="org.eclipse.chemclipse.chromatogram.msd.filter.chromatogramFilterSupplier">
       <ChromatogramFilterSupplier
-            description="This filter applies the Subtract filter to a chromatogram."
+            description="Subtract a given mass spectrum from the whole chromatogram."
             filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.core.ChromatogramFilter"
             filterName="Subtract"
             filterSettings="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.settings.ChromatogramFilterSettings"
@@ -14,7 +14,7 @@
    <extension
          point="org.eclipse.chemclipse.chromatogram.msd.filter.peakFilterSupplier">
       <PeakFilterSupplier
-            description="This filter applies the Subtract filter to a list of peaks."
+            description="Substract a given mass spectrum from selected peaks."
             filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.core.PeakFilter"
             filterName="Subtract"
             filterSettings="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.settings.PeakFilterSettings"

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/ChromatogramFilterMSDProcessSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/ChromatogramFilterMSDProcessSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -77,7 +77,7 @@ public class ChromatogramFilterMSDProcessSupplier implements IProcessTypeSupplie
 					messageConsumer.addMessages(ChromatogramFilterMSD.applyFilter(chromatogramSelectionMSD, supplier.getId(), monitor));
 				}
 			} else {
-				messageConsumer.addWarnMessage(getName(), "Only MSD chromatogram supported, skipp processing");
+				messageConsumer.addWarnMessage(getName(), "Only MSD chromatogram supported, skip processing");
 			}
 			return chromatogramSelection;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/peak/PeakIdentifierMSDProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/peak/PeakIdentifierMSDProcessTypeSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -76,7 +76,7 @@ public class PeakIdentifierMSDProcessTypeSupplier implements IProcessTypeSupplie
 					messageConsumer.addMessages(PeakIdentifierMSD.identify(chromatogramSelectionMSD, supplier.getId(), monitor));
 				}
 			} else {
-				messageConsumer.addWarnMessage(getName(), "Only MSD chromatogram supported, skipp processing");
+				messageConsumer.addWarnMessage(getName(), "Only MSD chromatogram supported, skip processing");
 			}
 			return chromatogramSelection;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/core/PeakDetectorMSDProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/core/PeakDetectorMSDProcessTypeSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -78,7 +78,7 @@ public class PeakDetectorMSDProcessTypeSupplier implements IProcessTypeSupplier 
 					messageConsumer.addMessages(PeakDetectorMSD.detect(chromatogramSelectionMSD, supplier.getId(), monitor));
 				}
 			} else {
-				messageConsumer.addWarnMessage(getDescription(), "Only MSD Chromatogram supported, skipp processing");
+				messageConsumer.addWarnMessage(getDescription(), "Only MSD Chromatogram supported, skip processing");
 			}
 			return chromatogramSelection;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.filter/src/org/eclipse/chemclipse/chromatogram/wsd/filter/core/chromatogram/ChromatogramFilterWSDProcessSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.filter/src/org/eclipse/chemclipse/chromatogram/wsd/filter/core/chromatogram/ChromatogramFilterWSDProcessSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -76,7 +76,7 @@ public class ChromatogramFilterWSDProcessSupplier implements IProcessTypeSupplie
 					messageConsumer.addMessages(ChromatogramFilterWSD.applyFilter(chromatogramSelectionWSD, supplier.getId(), monitor));
 				}
 			} else {
-				messageConsumer.addWarnMessage(getName(), "Only WSD chromatogram supported, skipp processing");
+				messageConsumer.addWarnMessage(getName(), "Only WSD chromatogram supported, skip processing");
 			}
 			return chromatogramSelection;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/peak/PeakIdentifierWSDProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/peak/PeakIdentifierWSDProcessTypeSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -76,7 +76,7 @@ public class PeakIdentifierWSDProcessTypeSupplier implements IProcessTypeSupplie
 					messageConsumer.addMessages(PeakIdentifierWSD.identify(chromatogramSelectionWSD, supplier.getId(), monitor));
 				}
 			} else {
-				messageConsumer.addWarnMessage(getName(), "Only WSD chromatogram supported, skipp processing");
+				messageConsumer.addWarnMessage(getName(), "Only WSD chromatogram supported, skip processing");
 			}
 			return chromatogramSelection;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/wavespectrum/WaveSpectrumIdentifierProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/wavespectrum/WaveSpectrumIdentifierProcessTypeSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -75,7 +75,7 @@ public class WaveSpectrumIdentifierProcessTypeSupplier implements IProcessTypeSu
 					messageConsumer.addMessages(WaveSpectrumIdentifier.identify(chromatogramSelectionWSD.getSelectedScan(), supplier.getId(), monitor));
 				}
 			} else {
-				messageConsumer.addWarnMessage(getName(), "Only WSD chromatogram supported, skipp processing");
+				messageConsumer.addWarnMessage(getName(), "Only WSD chromatogram supported, skip processing");
 			}
 			return chromatogramSelection;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/core/PeakDetectorWSDProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/core/PeakDetectorWSDProcessTypeSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -77,7 +77,7 @@ public class PeakDetectorWSDProcessTypeSupplier implements IProcessTypeSupplier 
 					messageConsumer.addMessages(PeakDetectorWSD.detect(chromatogramSelectionWSD, supplier.getId(), monitor));
 				}
 			} else {
-				messageConsumer.addWarnMessage(getDescription(), "Only WSD Chromatogram supported, skipp processing");
+				messageConsumer.addWarnMessage(getDescription(), "Only WSD Chromatogram supported, skip processing");
 			}
 			return chromatogramSelection;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.ui/plugin.xml
@@ -14,7 +14,7 @@
       <ChromatogramFilterSupplier
             description="This filters enables to remove the subtract another chromatogram."
             filter="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.ui.core.ChromatogramFilter"
-            filterName="Chromatogram Subtract Filter (UI)"
+            filterName="Subtract Filter (UI)"
             filterSettings="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.ui.settings.FilterSettings"
             id="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.chromatogramsubtract">
       </ChromatogramFilterSupplier>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/plugin.xml
@@ -6,14 +6,14 @@
       <ChromatogramFilterSupplier
             description="This filters enables to remove the baseline from the chromatogram."
             filter="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.core.ChromatogramFilter"
-            filterName="Chromatogram Baseline Subtract Filter"
+            filterName="Baseline Subtract Filter"
             filterSettings="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.settings.ChromatogramFilterSettings"
             id="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract">
       </ChromatogramFilterSupplier>
       <ChromatogramFilterSupplier
             description="Extracts the Baseline From the Chromatogram"
             filter="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.core.BaselineFilter"
-            filterName="Chromatogram Baseline Extractor"
+            filterName="Baseline Extractor"
             filterSettings="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.settings.BaselineFilterSettings"            
             id="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselineextract">
       </ChromatogramFilterSupplier>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/plugin.xml
@@ -6,7 +6,7 @@
       <ChromatogramFilterSupplier
             description="This filters enables to remove the baseline from the chromatogram."
             filter="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.core.ChromatogramFilter"
-            filterName="Baseline Subtract Filter"
+            filterName="Baseline Subtract"
             filterSettings="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.settings.ChromatogramFilterSettings"
             id="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract">
       </ChromatogramFilterSupplier>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer/plugin.xml
@@ -6,7 +6,7 @@
       <ChromatogramFilterSupplier
             description="This filter median normalizes all signals of a chromatogram."
             filter="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer.core.ChromatogramFilter"
-            filterName="Median Normalizing Filter"
+            filterName="Median Normalizing"
             filterSettings="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer.settings.FilterSettings"
             id="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer">
       </ChromatogramFilterSupplier>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.ui/plugin.xml
@@ -7,7 +7,7 @@
             category="org.eclipse.chemclipse.chromatogram.filter.ui.preferences.filterPreferencePage"
             class="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.ui.preferences.PreferencePage"
             id="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.ui.preferences.preferencePage"
-            name="Multiplier Filter">
+            name="Multiplier">
       </page>
    </extension>
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier/plugin.xml
@@ -6,14 +6,14 @@
       <ChromatogramFilterSupplier
             description="This filter multiplies all signals of a chromatogram."
             filter="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.core.MultiplierChromatogramFilter"
-            filterName="Multiplier Filter"
+            filterName="Multiplier"
             filterSettings="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.settings.MultiplierSettings"
             id="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier">
       </ChromatogramFilterSupplier>
       <ChromatogramFilterSupplier
             description="This filter divides all signals of a chromatogram."
             filter="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.core.DivisorChromatogramFilter"
-            filterName="Divisor Filter"
+            filterName="Divisor"
             filterSettings="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.settings.DivisorSettings"
             id="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.divisor">
       </ChromatogramFilterSupplier>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.ui/plugin.xml
@@ -7,7 +7,7 @@
             category="org.eclipse.chemclipse.chromatogram.filter.ui.preferences.filterPreferencePage"
             class="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.ui.preferences.PreferencePage"
             id="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.ui.preferences.preferencePage"
-            name="Retention Time Filter">
+            name="Retention Time">
       </page>
    </extension>
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/rtshifter/core/internal/support/RetentionTimeShifter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/rtshifter/core/internal/support/RetentionTimeShifter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Lablicate GmbH.
+ * Copyright (c) 2011, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -59,7 +59,7 @@ public class RetentionTimeShifter extends AbstractRetentionTimeModifier {
 		int retentionTimeLeftBorder = getRetentionTimeLeftBorder(chromatogram, startScan);
 		int retentionTimeRightBorder = getRetentionTimeRightBorder(chromatogram, stopScan);
 		//
-		List<Integer> scansToRemove = new ArrayList<Integer>();
+		List<Integer> scansToRemove = new ArrayList<>();
 		/*
 		 * Adjust the retention times.
 		 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/plugin.xml
@@ -37,7 +37,7 @@
             config="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.settings.MassSpectrumFilterSettings"
             description="This is a Savitzky-Golay Mass Spectrum optimization filter."
             filter="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.core.MassSpectrumFilter"
-            filterName="Savitzky-Golay Filter"
+            filterName="Savitzky-Golay Smoothing"
             id="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.savitzkygolay.massspectrum">
       </MassSpectrumFilterSupplier>
    </extension>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/plugin.xml
@@ -20,7 +20,7 @@
       <ChromatogramFilterSupplier
             description="This filters removes empty scans."
             filter="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.core.FilterCleaner"
-            filterName="Scan Cleaner (Remove Empty)"
+            filterName="Remove Empty Scans"
             filterSettings="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.settings.FilterSettingsCleaner"
             id="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.removeemptyscans">
       </ChromatogramFilterSupplier> 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterCleaner.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterCleaner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Lablicate GmbH.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -38,7 +38,6 @@ import org.eclipse.core.runtime.SubMonitor;
  * This filter removes empty scans.
  *
  */
-
 public class FilterCleaner extends AbstractChromatogramFilter {
 
 	@Override
@@ -71,7 +70,7 @@ public class FilterCleaner extends AbstractChromatogramFilter {
 		IChromatogram<?> chromatogram = chromatogramSelection.getChromatogram();
 		int startScan = chromatogram.getScanNumber(chromatogramSelection.getStartRetentionTime());
 		int stopScan = chromatogram.getScanNumber(chromatogramSelection.getStopRetentionTime());
-		List<Integer> scansToRemove = new ArrayList<Integer>();
+		List<Integer> scansToRemove = new ArrayList<>();
 		/*
 		 * Iterate through all selected scans and mark those to be removed.
 		 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/supplier/AbstractProcessSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/supplier/AbstractProcessSupplier.java
@@ -37,7 +37,7 @@ public abstract class AbstractProcessSupplier<SettingsClass> implements IProcess
 	private SettingsClassParser<SettingsClass> classParser;
 	private String category;
 
-	public AbstractProcessSupplier(String id, String name, String description, Class<SettingsClass> settingsClass, IProcessTypeSupplier parent, DataCategory... dataTypes) {
+	protected AbstractProcessSupplier(String id, String name, String description, Class<SettingsClass> settingsClass, IProcessTypeSupplier parent, DataCategory... dataTypes) {
 
 		this.id = id;
 		this.name = name;

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/system/AbstractSystemProcessSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/system/AbstractSystemProcessSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Lablicate GmbH.
+ * Copyright (c) 2021, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,12 +20,12 @@ import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 
 public abstract class AbstractSystemProcessSupplier<S extends ISystemProcessSettings> extends AbstractProcessSupplier<S> implements IProcessExecutor, SystemExecutor {
 
-	public AbstractSystemProcessSupplier(String id, String name, String description, Class<S> settingsClass, IProcessTypeSupplier parent) {
+	protected AbstractSystemProcessSupplier(String id, String name, String description, Class<S> settingsClass, IProcessTypeSupplier parent) {
 
 		super(id, name, description, settingsClass, parent, DataCategory.chromatographyCategories());
 	}
 
-	public AbstractSystemProcessSupplier(String id, String name, String description, Class<S> settingsClass, IProcessTypeSupplier parent, DataCategory... dataTypes) {
+	protected AbstractSystemProcessSupplier(String id, String name, String description, Class<S> settingsClass, IProcessTypeSupplier parent, DataCategory... dataTypes) {
 
 		super(id, name, description, settingsClass, parent, dataTypes);
 	}


### PR DESCRIPTION
It's redundant, makes it harder to read and it doesn't sort alphabetically.