### PR TITLE
Add literature references to chromatogram filters

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.filter/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.filter/META-INF/MANIFEST.MF
@@ -11,7 +11,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.logging;bundle-version="0.8.0",
  org.eclipse.chemclipse.processing;bundle-version="0.8.0",
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
- org.eclipse.chemclipse.chromatogram.filter;bundle-version="0.8.0"
+ org.eclipse.chemclipse.chromatogram.filter;bundle-version="0.8.0",
+ org.eclipse.chemclipse.support;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.chemclipse.chromatogram.csd.filter.core.chromatogram,
  org.eclipse.chemclipse.chromatogram.csd.filter.core.peak,

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.filter/src/org/eclipse/chemclipse/chromatogram/csd/filter/core/chromatogram/ChromatogramFilterSupplierCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.filter/src/org/eclipse/chemclipse/chromatogram/csd/filter/core/chromatogram/ChromatogramFilterSupplierCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 Lablicate GmbH.
+ * Copyright (c) 2015, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,7 +11,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.csd.filter.core.chromatogram;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
 public class ChromatogramFilterSupplierCSD implements IChromatogramFilterSupplierCSD {
 
@@ -19,6 +23,7 @@ public class ChromatogramFilterSupplierCSD implements IChromatogramFilterSupplie
 	private String description = ""; //$NON-NLS-1$
 	private String filterName = ""; //$NON-NLS-1$
 	private Class<? extends IChromatogramFilterSettings> settingsClass;
+	private List<LiteratureReference> literatureReference = new ArrayList<>();
 
 	@Override
 	public String getDescription() {
@@ -84,6 +89,12 @@ public class ChromatogramFilterSupplierCSD implements IChromatogramFilterSupplie
 	protected void setFilterSettingsClass(Class<? extends IChromatogramFilterSettings> settingsClass) {
 
 		this.settingsClass = settingsClass;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		return literatureReference;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/ChromatogramFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Lablicate GmbH.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -124,6 +124,7 @@ public class ChromatogramFilter {
 			if(element.getAttribute(FILTER_SETTINGS) != null) {
 				try {
 					IChromatogramFilterSettings instance = (IChromatogramFilterSettings)element.createExecutableExtension(FILTER_SETTINGS);
+					supplier.getLiteratureReferences().addAll(instance.getLiteratureReferences());
 					supplier.setSettingsClass(instance.getClass());
 				} catch(CoreException e) {
 					logger.warn(e);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/ChromatogramFilterSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/ChromatogramFilterSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Lablicate GmbH.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,7 +11,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.filter.core.chromatogram;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
 public class ChromatogramFilterSupplier implements IChromatogramFilterSupplier {
 
@@ -19,6 +23,7 @@ public class ChromatogramFilterSupplier implements IChromatogramFilterSupplier {
 	private String description = ""; //$NON-NLS-1$
 	private String filterName = ""; //$NON-NLS-1$
 	private Class<? extends IChromatogramFilterSettings> settingsClass;
+	private List<LiteratureReference> literatureReference = new ArrayList<>();
 
 	@Override
 	public String getDescription() {
@@ -84,6 +89,12 @@ public class ChromatogramFilterSupplier implements IChromatogramFilterSupplier {
 	protected void setSettingsClass(Class<? extends IChromatogramFilterSettings> settingsClass) {
 
 		this.settingsClass = settingsClass;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		return literatureReference;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/IChromatogramFilterSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/IChromatogramFilterSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Lablicate GmbH.
+ * Copyright (c) 2016, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,7 +11,10 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.filter.core.chromatogram;
 
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
 public interface IChromatogramFilterSupplier {
 
@@ -43,4 +46,6 @@ public interface IChromatogramFilterSupplier {
 	 * @return
 	 */
 	Class<? extends IChromatogramFilterSettings> getSettingsClass();
+
+	List<LiteratureReference> getLiteratureReferences();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/system/FilterIonRounding.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/system/FilterIonRounding.java
@@ -30,7 +30,6 @@ import org.osgi.service.component.annotations.Component;
 public class FilterIonRounding extends AbstractSystemProcessSettings {
 
 	private static final String ID = "org.eclipse.chemclipse.chromatogram.filter.system.ionRounding"; //$NON-NLS-1$
-	private static final String FILE_LITERATURE_RIS = "9294.ris";
 
 	@Override
 	public Collection<IProcessSupplier<?>> getProcessorSuppliers() {
@@ -43,7 +42,7 @@ public class FilterIonRounding extends AbstractSystemProcessSettings {
 		public ProcessSupplier(IProcessTypeSupplier parent) {
 
 			super(ID, Messages.ionRoundMethod, Messages.ionRoundMethodDescription, SettingsIonRounding.class, parent);
-			getLiteratureReferences().add(getLiteratureReference());
+			getLiteratureReferences().add(createLiteratureReference());
 		}
 
 		@Override
@@ -55,11 +54,11 @@ public class FilterIonRounding extends AbstractSystemProcessSettings {
 		}
 	}
 
-	private static LiteratureReference getLiteratureReference() {
+	private static LiteratureReference createLiteratureReference() {
 
 		String content;
 		try {
-			content = new String(FilterIonRounding.class.getResourceAsStream(FILE_LITERATURE_RIS).readAllBytes());
+			content = new String(FilterIonRounding.class.getResourceAsStream("9294.ris").readAllBytes());
 		} catch(IOException e) {
 			content = "https://doi.org/10.1002/rcm.9294";
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/detector/BackfoldingShifter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/detector/BackfoldingShifter.java
@@ -366,7 +366,7 @@ public class BackfoldingShifter implements IBackfoldingShifter {
 		int deltaDistance = 0;
 		int negativeMaximum = 0;
 		int positiveMaximum = 0;
-		List<Integer> peakDistances = new ArrayList<Integer>();
+		List<Integer> peakDistances = new ArrayList<>();
 		/*
 		 * Divide the result by 2.
 		 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/settings/ChromatogramFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/settings/ChromatogramFilterSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Lablicate GmbH.
+ * Copyright (c) 2011, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,14 +11,22 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.settings;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.filter.settings.AbstractChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.preferences.PreferenceSupplier;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 import org.eclipse.chemclipse.support.settings.IntSettingsProperty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ChromatogramFilterSettings extends AbstractChromatogramFilterSettings {
 
+	private static final Logger logger = Logger.getLogger(ChromatogramFilterSettings.class);
+	//
 	@JsonProperty(value = "Backfolding Runs", defaultValue = "3")
 	@IntSettingsProperty(minValue = PreferenceSupplier.MIN_BACKFOLDING_RUNS, maxValue = PreferenceSupplier.MAX_BACKFOLDING_RUNS)
 	private int numberOfBackfoldingRuns = 3;
@@ -44,5 +52,28 @@ public class ChromatogramFilterSettings extends AbstractChromatogramFilterSettin
 	public void setMaximumRetentionTimeShift(int maximumRetentionTimeShift) {
 
 		this.maximumRetentionTimeShift = maximumRetentionTimeShift;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		List<LiteratureReference> literatureReferences = new ArrayList<>();
+		literatureReferences.add(createLiteratureReference("achs_ancham61_73.ris", "10.1021/ac00176a015"));
+		literatureReferences.add(createLiteratureReference("pericles_10969888c31.ris", "10.1002/(SICI)1096-9888(199605)31:5<509::AID-JMS323>3.0.CO;2-B"));
+		literatureReferences.add(createLiteratureReference("pericles_10969888c32.ris", "10.1002/(SICI)1096-9888(199704)32:4<438::AID-JMS499>3.0.CO;2-N"));
+		literatureReferences.add(createLiteratureReference("pericles_10969888c33.ris", "10.1002/(SICI)1096-9888(199711)32:11<1253::AID-JMS593>3.0.CO;2-T"));
+		return literatureReferences;
+	}
+
+	private static LiteratureReference createLiteratureReference(String file, String doi) {
+
+		String content;
+		try {
+			content = new String(ChromatogramFilterSettings.class.getResourceAsStream(file).readAllBytes());
+		} catch(IOException | NullPointerException e) {
+			content = doi;
+			logger.warn(e);
+		}
+		return new LiteratureReference(content);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/settings/achs_ancham61_73.ris
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/settings/achs_ancham61_73.ris
@@ -1,0 +1,25 @@
+
+
+
+
+TY  - JOUR
+T1  - Differential gas chromatographic mass spectrometry
+AU  - Ghosh, Amit.
+AU  - Anderegg, Robert J.
+Y1  - 1989/01/01
+PY  - 1989
+DA  - 1989/01/01
+N1  - doi: 10.1021/ac00176a015
+DO  - 10.1021/ac00176a015
+T2  - Analytical Chemistry
+JF  - Analytical Chemistry
+JO  - Anal. Chem.
+SP  - 73
+EP  - 77
+VL  - 61
+IS  - 1
+PB  - American Chemical Society
+SN  - 0003-2700
+M3  - doi: 10.1021/ac00176a015
+UR  - https://doi.org/10.1021/ac00176a015
+ER  - 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/settings/pericles_10969888c31.ris
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/settings/pericles_10969888c31.ris
@@ -1,0 +1,29 @@
+
+TY  - JOUR
+T1  - Backfolding Applied to Differential Gas Chromatography/Mass Spectrometry as a Mathematical Enhancement of Chromatographic Resolution§
+AU  - Pool, Wim G.
+AU  - de Leeuw, Jan W.
+AU  - van de Graaf, Bastiaan
+Y1  - 1996/05/01
+PY  - 1996
+DA  - 1996/05/01
+DO  - https://doi.org/10.1002/(SICI)1096-9888(199605)31:5<509::AID-JMS323>3.0.CO;2-B
+T2  - Journal of Mass Spectrometry
+JF  - Journal of Mass Spectrometry
+JO  - Journal of Mass Spectrometry
+JA  - J. Mass Spectrom.
+SP  - 509
+EP  - 516
+VL  - 31
+IS  - 5
+KW  - differential gas chromatography/mass spectrometry
+KW  - overlapping components
+KW  - deconvolution
+KW  - resolution enhancement
+KW  - spectrum clean-up
+PB  - John Wiley & Sons, Ltd
+SN  - 1076-5174
+UR  - https://doi.org/10.1002/(SICI)1096-9888(199605)31:5<509::AID-JMS323>3.0.CO;2-B
+Y2  - 2024/10/29
+N2  - Abstract Differential gas chromatography/mass spectrometry (GC/MS) results in both positive and negative differential mass spectra. The method enhances the chromatographic resolution and cleans up spectra. Although the method is effective with respect to slowly changing signals, this is not true for statistical noise which is aggravated by subtracting spectra. To remedy this, the two sets of data are combined, after they have been shifted with respect to each other by the width of the chromatographic peaks at half-height. This process, called backfolding, has the advantage that a conventional GC trace is produced. By repeating the process of differentiation and subsequent backfolding a number of times, the chromatographic resolution can be further improved and the mass spectra resemble library spectra much closer. The method was evaluated using both simulated and real GC/MS data. The sensitivity of the method with respect to applied shift, chromatographic resolution, peak shape and concentration was investigated. Backfolding of differential GC/MS does not require sophisticated mathematics. It is easy to implement and it is not a burden in terms of CPU time. Application of this method allows for a significantly better identification of the components present in the sample to be analysed.
+ER  - 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/settings/pericles_10969888c32.ris
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/settings/pericles_10969888c32.ris
@@ -1,0 +1,28 @@
+
+TY  - JOUR
+T1  - Automated Extraction of Pure Mass Spectra from Gas Chromatographic/Mass Spectrometric Data†
+AU  - Pool, Wim G.
+AU  - de Leeuw, Jan W.
+AU  - van de Graaf, Bastiaan
+Y1  - 1997/04/01
+PY  - 1997
+DA  - 1997/04/01
+DO  - https://doi.org/10.1002/(SICI)1096-9888(199704)32:4<438::AID-JMS499>3.0.CO;2-N
+T2  - Journal of Mass Spectrometry
+JF  - Journal of Mass Spectrometry
+JO  - Journal of Mass Spectrometry
+JA  - J. Mass Spectrom.
+SP  - 438
+EP  - 443
+VL  - 32
+IS  - 4
+KW  - gas chromatography/mass spectrometry
+KW  - deconvolution
+KW  - spectrum clean-up
+KW  - backfolding
+PB  - John Wiley & Sons, Ltd
+SN  - 1076-5174
+UR  - https://doi.org/10.1002/(SICI)1096-9888(199704)32:4<438::AID-JMS499>3.0.CO;2-N
+Y2  - 2024/10/30
+N2  - Abstract An algorithm is described that extracts pure mass spectra from gas chromatographic/mass spectrometric (GC/MS) data. It is based on backfolding, a method described previously to enhance chromatographic resolution in GC/MS data. The ability to extract pure mass spectra was evaluated with both simulated and real GC/MS data and the algorithm was compared with two other methods described recently. It is shown that the algorithm presented gives good results, even when the chromatographic resolution is poor and the spectra are very similar. No a priori knowledge concerning the composition of the data is required. ? 1997 by John Wiley & Sons, Ltd.
+ER  - 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/settings/pericles_10969888c33.ris
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/settings/pericles_10969888c33.ris
@@ -1,0 +1,30 @@
+
+TY  - JOUR
+T1  - Automated processing of GC/MS data: quantification of the signals of individual components
+AU  - Pool, Wim G.
+AU  - Maas, Leo R. M.
+AU  - de Leeuw, Jan W.
+AU  - van de Graaf, Bastiaan
+Y1  - 1997/11/01
+PY  - 1997
+DA  - 1997/11/01
+DO  - https://doi.org/10.1002/(SICI)1096-9888(199711)32:11<1253::AID-JMS593>3.0.CO;2-T
+T2  - Journal of Mass Spectrometry
+JF  - Journal of Mass Spectrometry
+JO  - Journal of Mass Spectrometry
+JA  - J. Mass Spectrom.
+SP  - 1253
+EP  - 1257
+VL  - 32
+IS  - 11
+KW  - deconvolution
+KW  - GC/MS
+KW  - backfolding
+KW  - spectrum clean-up
+KW  - quantification
+PB  - John Wiley & Sons, Ltd
+SN  - 1076-5174
+UR  - https://doi.org/10.1002/(SICI)1096-9888(199711)32:11<1253::AID-JMS593>3.0.CO;2-T
+Y2  - 2024/10/30
+N2  - Abstract An algorithm is described to quantify the signals of components in GC/MS data. It is an extension of the backfolding algorithm described recently. [W. G. Pool, B. van de Graaf and J. W. de Leeuw, J. Mass. Spectrom. 31, 509 (1996); 32, 438 (1997)]. The method is evaluated on both simulated and real GC/MS data. The results indicate that the method performs quite well, even in cases of components with highly similar spectra and with severe coelution. ? 1997 John Wiley & Sons, Ltd.
+ER  - 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/settings/FilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/settings/FilterSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Lablicate GmbH.
+ * Copyright (c) 2011, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,14 +11,22 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.settings;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.filter.settings.AbstractChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.preferences.PreferenceSupplier;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 import org.eclipse.chemclipse.support.settings.FloatSettingsProperty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class FilterSettings extends AbstractChromatogramFilterSettings {
 
+	private static final Logger logger = Logger.getLogger(FilterSettings.class);
+	//
 	@JsonProperty(value = "Coda Threshold", defaultValue = "0.75f")
 	@FloatSettingsProperty(minValue = PreferenceSupplier.CODA_THRESHOLD_MIN_VALUE, maxValue = PreferenceSupplier.CODA_THRESHOLD_MAX_VALUE, step = 0.05f)
 	private float codaThreshold;
@@ -31,5 +39,23 @@ public class FilterSettings extends AbstractChromatogramFilterSettings {
 	public void setCodaThreshold(float codaThreshold) {
 
 		this.codaThreshold = codaThreshold;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		return Collections.singletonList(createLiteratureReference("ac960435y.ris", "10.1021/ac960435y"));
+	}
+
+	private static LiteratureReference createLiteratureReference(String file, String doi) {
+
+		String content;
+		try {
+			content = new String(FilterSettings.class.getResourceAsStream(file).readAllBytes());
+		} catch(IOException | NullPointerException e) {
+			content = doi;
+			logger.warn(e);
+		}
+		return new LiteratureReference(content);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/settings/ac960435y.ris
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/settings/ac960435y.ris
@@ -1,0 +1,26 @@
+
+
+
+
+TY  - JOUR
+T1  - A Noise and Background Reduction Method for Component Detection in Liquid Chromatography/Mass Spectrometry
+AU  - Windig, Willem
+AU  - Phalp, J. Martin
+AU  - Payne, Alan W.
+Y1  - 1996/01/01
+PY  - 1996
+DA  - 1996/01/01
+N1  - doi: 10.1021/ac960435y
+DO  - 10.1021/ac960435y
+T2  - Analytical Chemistry
+JF  - Analytical Chemistry
+JO  - Anal. Chem.
+SP  - 3602
+EP  - 3606
+VL  - 68
+IS  - 20
+PB  - American Chemical Society
+SN  - 0003-2700
+M3  - doi: 10.1021/ac960435y
+UR  - https://doi.org/10.1021/ac960435y
+ER  - 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/xpass/settings/CutOfMassSpectrumFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/xpass/settings/CutOfMassSpectrumFilterSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Lablicate GmbH.
+ * Copyright (c) 2020, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,7 +11,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass.settings;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.msd.filter.settings.IMassSpectrumFilterSettings;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 import org.eclipse.chemclipse.support.settings.IntSettingsProperty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -25,5 +29,11 @@ public class CutOfMassSpectrumFilterSettings implements IMassSpectrumFilterSetti
 	public int getThreshold() {
 
 		return threshold;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		return new ArrayList<>();
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/ChromatogramFilterMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/ChromatogramFilterMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Lablicate GmbH.
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -115,6 +115,7 @@ public class ChromatogramFilterMSD {
 				try {
 					IChromatogramFilterSettings instance = (IChromatogramFilterSettings)element.createExecutableExtension(FILTER_SETTINGS);
 					supplier.setSettingsClass(instance.getClass());
+					supplier.getLiteratureReferences().addAll(instance.getLiteratureReferences());
 				} catch(CoreException e) {
 					logger.error(e);
 					// settings class is optional, set null instead

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/ChromatogramFilterMSDProcessSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/ChromatogramFilterMSDProcessSupplier.java
@@ -65,6 +65,7 @@ public class ChromatogramFilterMSDProcessSupplier implements IProcessTypeSupplie
 
 			super("ChromatogramFilterMSD." + supplier.getId(), supplier.getFilterName(), supplier.getDescription(), (Class<IChromatogramFilterSettings>)supplier.getSettingsClass(), parent, DataType.MSD);
 			this.supplier = supplier;
+			getLiteratureReferences().addAll(supplier.getLiteratureReferences());
 		}
 
 		@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/ChromatogramFilterSupplierMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/ChromatogramFilterSupplierMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,7 +11,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.core.chromatogram;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
 public class ChromatogramFilterSupplierMSD implements IChromatogramFilterSupplierMSD {
 
@@ -19,6 +23,7 @@ public class ChromatogramFilterSupplierMSD implements IChromatogramFilterSupplie
 	private String description = "";
 	private String filterName = "";
 	private Class<? extends IChromatogramFilterSettings> settingsClass;
+	private List<LiteratureReference> literatureReference = new ArrayList<>();
 
 	@Override
 	public String getDescription() {
@@ -84,6 +89,12 @@ public class ChromatogramFilterSupplierMSD implements IChromatogramFilterSupplie
 	protected void setSettingsClass(Class<? extends IChromatogramFilterSettings> settingsClass) {
 
 		this.settingsClass = settingsClass;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		return literatureReference;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.filter/src/org/eclipse/chemclipse/chromatogram/wsd/filter/core/chromatogram/ChromatogramFilterSupplierWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.filter/src/org/eclipse/chemclipse/chromatogram/wsd/filter/core/chromatogram/ChromatogramFilterSupplierWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Lablicate GmbH.
+ * Copyright (c) 2018, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,7 +11,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.wsd.filter.core.chromatogram;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
 public class ChromatogramFilterSupplierWSD implements IChromatogramFilterSupplierWSD {
 
@@ -19,6 +23,7 @@ public class ChromatogramFilterSupplierWSD implements IChromatogramFilterSupplie
 	private String description = "";
 	private String filterName = "";
 	private Class<? extends IChromatogramFilterSettings> settingsClass;
+	private List<LiteratureReference> literatureReference = new ArrayList<>();
 
 	@Override
 	public String getDescription() {
@@ -84,6 +89,12 @@ public class ChromatogramFilterSupplierWSD implements IChromatogramFilterSupplie
 	protected void setFilterSettingsClass(Class<? extends IChromatogramFilterSettings> settingsClass) {
 
 		this.settingsClass = settingsClass;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		return literatureReference;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/settings/NoiseChromatogramClassifierSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/settings/NoiseChromatogramClassifierSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,10 +13,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.calculator.settings;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.core.noise.INoiseCalculator;
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.core.noise.NoiseCalculator;
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.chromatogram.xxd.classifier.settings.IChromatogramClassifierSettings;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 import org.eclipse.chemclipse.support.settings.ComboSettingsProperty;
 import org.eclipse.chemclipse.support.settings.IntSettingsProperty;
 import org.eclipse.chemclipse.support.settings.IntSettingsProperty.Validation;
@@ -71,5 +75,11 @@ public class NoiseChromatogramClassifierSettings implements IChromatogramClassif
 	public INoiseCalculator getNoiseCalculator() {
 
 		return NoiseCalculator.getNoiseCalculator(getNoiseCalculatorId());
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		return new ArrayList<>();
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/settings/ChromatogramFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/settings/ChromatogramFilterSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 Lablicate GmbH.
+ * Copyright (c) 2015, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,8 +13,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.settings;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.filter.settings.AbstractChromatogramFilterSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.preferences.PreferenceSupplier;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 import org.eclipse.chemclipse.support.settings.IntSettingsProperty;
 import org.eclipse.chemclipse.support.settings.IntSettingsProperty.Validation;
 
@@ -24,6 +30,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 public class ChromatogramFilterSettings extends AbstractChromatogramFilterSettings {
 
+	private static final Logger logger = Logger.getLogger(ChromatogramFilterSettings.class);
+	//
 	@JsonProperty(value = "Order", defaultValue = "2")
 	@JsonPropertyDescription(value = "Order p of the polynomial to be fitted: Integer in the range from 2 to 5")
 	@IntSettingsProperty(minValue = PreferenceSupplier.MIN_ORDER, maxValue = PreferenceSupplier.MAX_ORDER)
@@ -63,5 +71,23 @@ public class ChromatogramFilterSettings extends AbstractChromatogramFilterSettin
 	public void setWidth(int width) {
 
 		this.width = width;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		return Collections.singletonList(createLiteratureReference("achs_ancham36_1627.ris", "10.1021/ac60214a047"));
+	}
+
+	private static LiteratureReference createLiteratureReference(String file, String doi) {
+
+		String content;
+		try {
+			content = new String(ChromatogramFilterSettings.class.getResourceAsStream(file).readAllBytes());
+		} catch(IOException | NullPointerException e) {
+			content = doi;
+			logger.warn(e);
+		}
+		return new LiteratureReference(content);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/settings/achs_ancham36_1627.ris
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/settings/achs_ancham36_1627.ris
@@ -1,0 +1,25 @@
+
+
+
+
+TY  - JOUR
+T1  - Smoothing and Differentiation of Data by Simplified Least Squares Procedures.
+AU  - Savitzky, Abraham.
+AU  - Golay, M. J. E.
+Y1  - 1964/07/01
+PY  - 1964
+DA  - 1964/07/01
+N1  - doi: 10.1021/ac60214a047
+DO  - 10.1021/ac60214a047
+T2  - Analytical Chemistry
+JF  - Analytical Chemistry
+JO  - Anal. Chem.
+SP  - 1627
+EP  - 1639
+VL  - 36
+IS  - 8
+PB  - American Chemical Society
+SN  - 0003-2700
+M3  - doi: 10.1021/ac60214a047
+UR  - https://doi.org/10.1021/ac60214a047
+ER  - 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/settings/AbstractProcessSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/settings/AbstractProcessSettings.java
@@ -11,12 +11,19 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.model.settings;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.commons.io.FileSystem;
 import org.eclipse.chemclipse.model.core.IChromatogram;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
 public abstract class AbstractProcessSettings implements IProcessSettings {
 
+	private final List<LiteratureReference> literatureReference = new ArrayList<>();
+
 	@Override
+	@Deprecated
 	public void setSystemSettings() {
 
 	}
@@ -37,6 +44,12 @@ public abstract class AbstractProcessSettings implements IProcessSettings {
 		 * Remove OS specific file system control characters.
 		 */
 		return FileSystem.getCurrent().toLegalFileName(fileName, '-');
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		return literatureReference;
 	}
 
 	/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/settings/IProcessSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/settings/IProcessSettings.java
@@ -11,6 +11,10 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.model.settings;
 
+import java.util.List;
+
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
+
 public interface IProcessSettings {
 
 	public static final String VARIABLE_CHROMATOGRAM_NAME = "{chromatogram_name}";
@@ -31,4 +35,6 @@ public interface IProcessSettings {
 
 		throw new UnsupportedOperationException();
 	}
+
+	List<LiteratureReference> getLiteratureReferences();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/ChromatogramProcedureSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/ChromatogramProcedureSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,7 +12,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.converter.supplier.ocx;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.chemclipse.model.settings.IProcessSettings;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -53,5 +57,11 @@ public class ChromatogramProcedureSettings implements IProcessSettings {
 	public void setName(String name) {
 
 		this.name = name;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		return new ArrayList<>();
 	}
 }


### PR DESCRIPTION
This extends https://github.com/eclipse/chemclipse/issues/1597 to chromatogram filters which already cite literature in the source code. Now it is displayed to users.