### PR TITLE
Add literature references to baseline detectors

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/META-INF/MANIFEST.MF
@@ -12,7 +12,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.csd.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.wsd.model;bundle-version="0.8.0",
- com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.9.9"
+ com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.9.9",
+ org.eclipse.chemclipse.support;bundle-version="0.9.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.core,

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Lablicate GmbH.
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -121,6 +121,7 @@ public class BaselineDetector {
 				try {
 					IBaselineDetectorSettings instance = (IBaselineDetectorSettings)element.createExecutableExtension(DETECTOR_SETTINGS);
 					supplier.setSettingsClass(instance.getClass());
+					supplier.getLiteratureReferences().addAll(instance.getLiteratureReferences());
 				} catch(CoreException e) {
 					logger.warn(e);
 					// settings class is optional, set null instead

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorProcessTypeSupplier.java
@@ -60,6 +60,7 @@ public class BaselineDetectorProcessTypeSupplier implements IProcessTypeSupplier
 		public BaselineDetectorProcessorSupplier(IBaselineDetectorSupplier supplier, IProcessTypeSupplier parent) {
 
 			super(supplier.getId(), supplier.getDetectorName(), supplier.getDescription(), (Class<IBaselineDetectorSettings>)supplier.getSettingsClass(), parent, DataType.MSD, DataType.CSD, DataType.WSD, DataType.VSD);
+			getLiteratureReferences().addAll(supplier.getLiteratureReferences());
 		}
 
 		@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,7 +11,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.core;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.settings.IBaselineDetectorSettings;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
 public class BaselineDetectorSupplier implements IBaselineDetectorSupplier {
 
@@ -19,6 +23,7 @@ public class BaselineDetectorSupplier implements IBaselineDetectorSupplier {
 	private String description = "";
 	private String detectorName = "";
 	private Class<? extends IBaselineDetectorSettings> settingsClass;
+	private List<LiteratureReference> literatureReference = new ArrayList<>();
 
 	@Override
 	public String getId() {
@@ -84,6 +89,12 @@ public class BaselineDetectorSupplier implements IBaselineDetectorSupplier {
 	protected void setSettingsClass(Class<? extends IBaselineDetectorSettings> settingsClass) {
 
 		this.settingsClass = settingsClass;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		return literatureReference;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/IBaselineDetectorSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/IBaselineDetectorSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,7 +11,10 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.core;
 
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.settings.IBaselineDetectorSettings;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
 public interface IBaselineDetectorSupplier {
 
@@ -43,4 +46,6 @@ public interface IBaselineDetectorSupplier {
 	 * @return
 	 */
 	Class<? extends IBaselineDetectorSettings> getSettingsClass();
+
+	List<LiteratureReference> getLiteratureReferences();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
  org.eclipse.chemclipse.numeric;bundle-version="0.8.0",
  org.eclipse.chemclipse.chromatogram.filter;bundle-version="0.8.0",
- com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.7.1"
+ com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.7.1",
+ org.eclipse.chemclipse.logging;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip.calculator,

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/src/org/eclipse/chemclipse/chromatogram/xxd/edit/supplier/snip/settings/0168583X88900638.ris
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/src/org/eclipse/chemclipse/chromatogram/xxd/edit/supplier/snip/settings/0168583X88900638.ris
@@ -1,0 +1,19 @@
+TY  - JOUR
+T1  - SNIP, a statistics-sensitive background treatment for the quantitative analysis of PIXE spectra in geoscience applications
+AU  - Ryan, C.G.
+AU  - Clayton, E.
+AU  - Griffin, W.L.
+AU  - Sie, S.H.
+AU  - Cousens, D.R.
+JO  - Nuclear Instruments and Methods in Physics Research Section B: Beam Interactions with Materials and Atoms
+VL  - 34
+IS  - 3
+SP  - 396
+EP  - 402
+PY  - 1988
+DA  - 1988/09/01/
+SN  - 0168-583X
+DO  - https://doi.org/10.1016/0168-583X(88)90063-8
+UR  - https://www.sciencedirect.com/science/article/pii/0168583X88900638
+AB  - Statistical fluctuations in X-ray spectra must be treated properly for reliable quantitative PIXE analysis. A background approximation that provides reliable treatment of fluctuations, the Statistics-sensitive Non-linear Iterative Peak-clipping (SNIP) algorithm, is described. Monte Carlo simulation demonstrates the stability of this background approximation, and hence the deduced trace element concentrations, over a wide range of counting statistics.
+ER  - 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/src/org/eclipse/chemclipse/chromatogram/xxd/edit/supplier/snip/settings/BaselineDetectorSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/src/org/eclipse/chemclipse/chromatogram/xxd/edit/supplier/snip/settings/BaselineDetectorSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 Lablicate GmbH.
+ * Copyright (c) 2013, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,8 +12,13 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip.settings;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.settings.AbstractBaselineDetectorSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip.preferences.PreferenceSupplier;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 import org.eclipse.chemclipse.support.settings.IntSettingsProperty;
 import org.eclipse.chemclipse.support.settings.IntSettingsProperty.Validation;
 import org.eclipse.chemclipse.support.settings.serialization.WindowSizeDeserializer;
@@ -24,6 +29,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 public class BaselineDetectorSettings extends AbstractBaselineDetectorSettings {
 
+	private static final Logger logger = Logger.getLogger(BaselineDetectorSettings.class);
+	//
 	@JsonProperty(value = "Number of Iterations", defaultValue = "100")
 	@JsonPropertyDescription(value = "The number of iterations to apply the SNIP filter.")
 	@IntSettingsProperty(minValue = PreferenceSupplier.MIN_ITERATIONS, maxValue = PreferenceSupplier.MAX_ITERATIONS)
@@ -52,5 +59,25 @@ public class BaselineDetectorSettings extends AbstractBaselineDetectorSettings {
 	public void setIterations(int iterations) {
 
 		this.iterations = iterations;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		List<LiteratureReference> literatureReferences = new ArrayList<>();
+		literatureReferences.add(createLiteratureReference("0168583X88900638.ris", "10.1016/0168-583X(88)90063-8"));
+		return literatureReferences;
+	}
+
+	private static LiteratureReference createLiteratureReference(String file, String doi) {
+
+		String content;
+		try {
+			content = new String(BaselineDetectorSettings.class.getResourceAsStream(file).readAllBytes());
+		} catch(Exception e) {
+			content = doi;
+			logger.warn(e);
+		}
+		return new LiteratureReference(content);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/LiteratureUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/LiteratureUI.java
@@ -91,7 +91,7 @@ public class LiteratureUI extends StyledText {
 		String[] lines = formattedRIS.split(LiteratureSupport.LINE_DELIMITER);
 		int offset = 0;
 		for(String line : lines) {
-			String[] entries = line.split(LiteratureSupport.ENTTRY_DELIMITER);
+			String[] entries = line.split(LiteratureSupport.ENTRY_DELIMITER);
 			if(entries.length == 2) {
 				String identifier = entries[0].trim();
 				if(!LiteratureSupport.isEndOfReferenceRIS(identifier)) {


### PR DESCRIPTION
Same as https://github.com/eclipse/chemclipse/pull/1925 but for baseline detectors. Also fixed the RIS reader which had trouble with `/` or `-` in titles and might even crash when it can't find a matching group, so I avoid regular expression entirely as this can potentially bring down the whole editor.