### PR TITLE
Add literature references to peak detectors

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector/src/org/eclipse/chemclipse/chromatogram/csd/peak/detector/core/PeakDetectorCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector/src/org/eclipse/chemclipse/chromatogram/csd/peak/detector/core/PeakDetectorCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 Lablicate GmbH.
+ * Copyright (c) 2014, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -109,6 +109,7 @@ public class PeakDetectorCSD {
 				try {
 					IPeakDetectorSettingsCSD instance = (IPeakDetectorSettingsCSD)element.createExecutableExtension(PEAK_DETECTOR_SETTINGS);
 					supplier.setSettingsClass(instance.getClass());
+					supplier.getLiteratureReferences().addAll(instance.getLiteratureReferences());
 				} catch(CoreException e) {
 					logger.error(e);
 					// settings class is optional, set null instead

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector/src/org/eclipse/chemclipse/chromatogram/csd/peak/detector/core/PeakDetectorCSDProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector/src/org/eclipse/chemclipse/chromatogram/csd/peak/detector/core/PeakDetectorCSDProcessTypeSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -66,6 +66,7 @@ public class PeakDetectorCSDProcessTypeSupplier implements IProcessTypeSupplier 
 		public PeakDetectorProcessorSupplier(IPeakDetectorSupplier supplier, IProcessTypeSupplier parent) {
 
 			super("PeakDetectorCSD." + supplier.getId(), supplier.getPeakDetectorName(), supplier.getDescription(), (Class<IPeakDetectorSettingsCSD>)supplier.getSettingsClass(), parent, DataType.CSD); //$NON-NLS-1$
+			getLiteratureReferences().addAll(supplier.getLiteratureReferences());
 			this.supplier = supplier;
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/core/PeakDetectorMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/core/PeakDetectorMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Lablicate GmbH.
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -131,6 +131,7 @@ public class PeakDetectorMSD {
 				try {
 					IPeakDetectorSettingsMSD instance = (IPeakDetectorSettingsMSD)element.createExecutableExtension(PEAK_DETECTOR_SETTINGS);
 					supplier.setSettingsClass(instance.getClass());
+					supplier.getLiteratureReferences().addAll(instance.getLiteratureReferences());
 				} catch(CoreException e) {
 					logger.error(e);
 					// settings class is optional, set null instead

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/core/PeakDetectorMSDProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/core/PeakDetectorMSDProcessTypeSupplier.java
@@ -65,6 +65,7 @@ public class PeakDetectorMSDProcessTypeSupplier implements IProcessTypeSupplier 
 		public PeakDetectorProcessorSupplier(IPeakDetectorSupplier supplier, IProcessTypeSupplier parent) {
 
 			super("PeakDetectorMSD." + supplier.getId(), supplier.getPeakDetectorName(), supplier.getDescription(), (Class<IPeakDetectorSettingsMSD>)supplier.getSettingsClass(), parent, DataType.MSD);
+			getLiteratureReferences().addAll(supplier.getLiteratureReferences());
 			this.supplier = supplier;
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/core/AbstractPeakDetectorSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/core/AbstractPeakDetectorSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,7 +12,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.peak.detector.core;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.peak.detector.settings.IPeakDetectorSettings;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
 public abstract class AbstractPeakDetectorSupplier<S extends IPeakDetectorSettings> implements IPeakDetectorSupplier {
 
@@ -20,8 +24,10 @@ public abstract class AbstractPeakDetectorSupplier<S extends IPeakDetectorSettin
 	private String description = "";
 	private String peakDetectorName = "";
 	private Class<? extends S> settingsClass;
+	private List<LiteratureReference> literatureReference = new ArrayList<>();
 
 	public AbstractPeakDetectorSupplier(String id, String description, String peakDetectorName) {
+
 		setId(id);
 		setDescription(description);
 		setPeakDetectorName(peakDetectorName);
@@ -82,6 +88,7 @@ public abstract class AbstractPeakDetectorSupplier<S extends IPeakDetectorSettin
 		}
 	}
 
+	@Override
 	public Class<? extends S> getSettingsClass() {
 
 		return this.settingsClass;
@@ -90,6 +97,12 @@ public abstract class AbstractPeakDetectorSupplier<S extends IPeakDetectorSettin
 	public void setSettingsClass(Class<? extends S> settingsClass) {
 
 		this.settingsClass = settingsClass;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		return literatureReference;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/core/IPeakDetectorSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/core/IPeakDetectorSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,7 +11,10 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.peak.detector.core;
 
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.peak.detector.settings.IPeakDetectorSettings;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
 public interface IPeakDetectorSupplier {
 
@@ -43,4 +46,6 @@ public interface IPeakDetectorSupplier {
 	 * @return
 	 */
 	Class<? extends IPeakDetectorSettings> getSettingsClass();
+
+	List<LiteratureReference> getLiteratureReferences();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/core/PeakDetectorWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/core/PeakDetectorWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 Lablicate GmbH.
+ * Copyright (c) 2018, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -111,6 +111,7 @@ public class PeakDetectorWSD {
 				try {
 					IPeakDetectorSettingsWSD instance = (IPeakDetectorSettingsWSD)element.createExecutableExtension(PEAK_DETECTOR_SETTINGS);
 					supplier.setSettingsClass(instance.getClass());
+					supplier.getLiteratureReferences().addAll(instance.getLiteratureReferences());
 				} catch(CoreException e) {
 					logger.error(e);
 					// settings class is optional, set null instead

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/core/PeakDetectorWSDProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/core/PeakDetectorWSDProcessTypeSupplier.java
@@ -64,6 +64,7 @@ public class PeakDetectorWSDProcessTypeSupplier implements IProcessTypeSupplier 
 		public PeakDetectorProcessorSupplier(IPeakDetectorSupplier supplier, IProcessTypeSupplier parent) {
 
 			super("PeakDetectorWSD." + supplier.getId(), supplier.getPeakDetectorName(), supplier.getDescription(), (Class<IPeakDetectorSettingsWSD>)supplier.getSettingsClass(), parent, DataType.WSD);
+			getLiteratureReferences().addAll(supplier.getLiteratureReferences());
 			this.supplier = supplier;
 		}
 


### PR DESCRIPTION
Same as https://github.com/eclipse/chemclipse/pull/1925 but for peak detectors, though I couldn't find a good reference for the first derivative used here.