### PR TITLE
Add literature references to peak identifiers

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.csd.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.processing;bundle-version="0.8.0",
- org.eclipse.chemclipse.logging;bundle-version="0.8.0"
+ org.eclipse.chemclipse.logging;bundle-version="0.8.0",
+ org.eclipse.chemclipse.support;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.chromatogram.csd.identifier.impl,

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/peak/AbstractPeakIdentifierCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/peak/AbstractPeakIdentifierCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Lablicate GmbH.
+ * Copyright (c) 2018, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,11 +12,17 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.csd.identifier.peak;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.csd.identifier.settings.IIdentifierSettingsCSD;
 import org.eclipse.chemclipse.csd.model.core.IPeakCSD;
 import org.eclipse.chemclipse.model.exceptions.ValueMustNotBeNullException;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
 public abstract class AbstractPeakIdentifierCSD<T> implements IPeakIdentifierCSD<T> {
+
+	private List<LiteratureReference> literatureReferences = new ArrayList<>();
 
 	/**
 	 * Validates that the peak is not null.<br/>
@@ -43,5 +49,11 @@ public abstract class AbstractPeakIdentifierCSD<T> implements IPeakIdentifierCSD
 		if(identifierSettings == null) {
 			throw new ValueMustNotBeNullException("The identifier settings must not be null.");
 		}
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		return literatureReferences;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/peak/IPeakIdentifierCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/peak/IPeakIdentifierCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Lablicate GmbH.
+ * Copyright (c) 2018, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -17,6 +17,7 @@ import java.util.List;
 import org.eclipse.chemclipse.chromatogram.csd.identifier.settings.IPeakIdentifierSettingsCSD;
 import org.eclipse.chemclipse.csd.model.core.IPeakCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 public interface IPeakIdentifierCSD<T> {
@@ -30,4 +31,6 @@ public interface IPeakIdentifierCSD<T> {
 	 * @return {@link IProcessingInfo}
 	 */
 	IProcessingInfo<T> identify(List<? extends IPeakCSD> peaks, IPeakIdentifierSettingsCSD peakIdentifierSettings, IProgressMonitor monitor);
+
+	List<LiteratureReference> getLiteratureReferences();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/peak/PeakIdentifierCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/peak/PeakIdentifierCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Lablicate GmbH.
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -125,6 +125,7 @@ public class PeakIdentifierCSD {
 				try {
 					IPeakIdentifierSettingsCSD instance = (IPeakIdentifierSettingsCSD)element.createExecutableExtension(Identifier.IDENTIFIER_SETTINGS);
 					supplier.setIdentifierSettingsClass(instance.getClass());
+					supplier.getLiteratureReferences().addAll(instance.getLiteratureReferences());
 				} catch(CoreException e) {
 					logger.error(e);
 					// settings class is optional, set null instead

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/peak/PeakIdentifierCSDProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/peak/PeakIdentifierCSDProcessTypeSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -64,6 +64,7 @@ public class PeakIdentifierCSDProcessTypeSupplier implements IProcessTypeSupplie
 		public PeakIdentifierProcessorSupplier(IPeakIdentifierSupplierCSD supplier, IProcessTypeSupplier parent) {
 
 			super("PeakIdentifierCSD." + supplier.getId(), supplier.getIdentifierName(), supplier.getDescription(), (Class<IPeakIdentifierSettingsCSD>)supplier.getSettingsClass(), parent, DataType.CSD); //$NON-NLS-1$
+			getLiteratureReferences().addAll(supplier.getLiteratureReferences());
 			this.supplier = supplier;
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/peak/IPeakIdentifierSupplierMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/peak/IPeakIdentifierSupplierMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,11 +12,16 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.identifier.peak;
 
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.msd.identifier.settings.IPeakIdentifierSettingsMSD;
 import org.eclipse.chemclipse.model.identifier.core.ISupplier;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
 public interface IPeakIdentifierSupplierMSD extends ISupplier {
 
 	@Override
 	Class<? extends IPeakIdentifierSettingsMSD> getSettingsClass();
+
+	List<LiteratureReference> getLiteratureReferences();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/peak/PeakIdentifierMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/peak/PeakIdentifierMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Lablicate GmbH.
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -127,6 +127,7 @@ public class PeakIdentifierMSD {
 				try {
 					IPeakIdentifierSettingsMSD instance = (IPeakIdentifierSettingsMSD)element.createExecutableExtension(Identifier.IDENTIFIER_SETTINGS);
 					supplier.setIdentifierSettingsClass(instance.getClass());
+					supplier.getLiteratureReferences().addAll(instance.getLiteratureReferences());
 				} catch(CoreException e) {
 					logger.warn(e);
 					// settings class is optional, set null instead

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/peak/PeakIdentifierMSDProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/peak/PeakIdentifierMSDProcessTypeSupplier.java
@@ -63,6 +63,7 @@ public class PeakIdentifierMSDProcessTypeSupplier implements IProcessTypeSupplie
 		public PeakIdentifierProcessorSupplier(IPeakIdentifierSupplierMSD supplier, IProcessTypeSupplier parent) {
 
 			super("PeakIdentifierMSD." + supplier.getId(), supplier.getIdentifierName(), supplier.getDescription(), (Class<IPeakIdentifierSettingsMSD>)supplier.getSettingsClass(), parent, DataType.MSD);
+			getLiteratureReferences().addAll(supplier.getLiteratureReferences());
 			this.supplier = supplier;
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/peak/AbstractPeakIdentifierWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/peak/AbstractPeakIdentifierWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Lablicate GmbH.
+ * Copyright (c) 2018, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,11 +12,17 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.wsd.identifier.peak;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.settings.IIdentifierSettingsWSD;
 import org.eclipse.chemclipse.model.exceptions.ValueMustNotBeNullException;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 import org.eclipse.chemclipse.wsd.model.core.IPeakWSD;
 
 public abstract class AbstractPeakIdentifierWSD<T> implements IPeakIdentifierWSD<T> {
+
+	private List<LiteratureReference> literatureReferences = new ArrayList<>();
 
 	/**
 	 * Validates that the peak is not null.<br/>
@@ -43,5 +49,11 @@ public abstract class AbstractPeakIdentifierWSD<T> implements IPeakIdentifierWSD
 		if(identifierSettings == null) {
 			throw new ValueMustNotBeNullException("The identifier settings must not be null.");
 		}
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		return literatureReferences;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/peak/IPeakIdentifierWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/peak/IPeakIdentifierWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Lablicate GmbH.
+ * Copyright (c) 2018, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.settings.IPeakIdentifierSettingsWSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 import org.eclipse.chemclipse.wsd.model.core.IPeakWSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
@@ -30,4 +31,6 @@ public interface IPeakIdentifierWSD<T> {
 	 * @return {@link IProcessingInfo}
 	 */
 	IProcessingInfo<T> identify(List<? extends IPeakWSD> peaks, IPeakIdentifierSettingsWSD peakIdentifierSettings, IProgressMonitor monitor);
+
+	List<LiteratureReference> getLiteratureReferences();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/peak/PeakIdentifierWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/peak/PeakIdentifierWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Lablicate GmbH.
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -124,6 +124,7 @@ public class PeakIdentifierWSD {
 				try {
 					IPeakIdentifierSettingsWSD instance = (IPeakIdentifierSettingsWSD)element.createExecutableExtension(Identifier.IDENTIFIER_SETTINGS);
 					supplier.setIdentifierSettingsClass(instance.getClass());
+					supplier.getLiteratureReferences().addAll(instance.getLiteratureReferences());
 				} catch(CoreException e) {
 					logger.error(e);
 					// settings class is optional, set null instead

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/peak/PeakIdentifierWSDProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/peak/PeakIdentifierWSDProcessTypeSupplier.java
@@ -63,6 +63,7 @@ public class PeakIdentifierWSDProcessTypeSupplier implements IProcessTypeSupplie
 		public PeakIdentifierProcessorSupplier(IPeakIdentifierSupplierWSD supplier, IProcessTypeSupplier parent) {
 
 			super("PeakIdentifierWSD." + supplier.getId(), supplier.getIdentifierName(), supplier.getDescription(), (Class<IPeakIdentifierSettingsWSD>)supplier.getSettingsClass(), parent, DataType.WSD);
+			getLiteratureReferences().addAll(supplier.getLiteratureReferences());
 			this.supplier = supplier;
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/core/PeakIdentifierUnknown.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/core/PeakIdentifierUnknown.java
@@ -32,6 +32,7 @@ import org.eclipse.chemclipse.model.targets.TargetUnknownSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 import org.eclipse.chemclipse.wsd.model.core.IPeakWSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
@@ -88,5 +89,11 @@ public class PeakIdentifierUnknown implements IPeakIdentifierMSD<IPeakIdentifica
 		}
 		//
 		return processingInfo;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		return null;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/core/AbstractSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/core/AbstractSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 Lablicate GmbH.
+ * Copyright (c) 2008, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,7 +12,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.model.identifier.core;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.chemclipse.model.identifier.IIdentifierSettings;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
 public abstract class AbstractSupplier<S extends IIdentifierSettings> implements ISupplierSetter {
 
@@ -20,6 +24,7 @@ public abstract class AbstractSupplier<S extends IIdentifierSettings> implements
 	private String id = "";
 	private String identifierName = "";
 	private Class<? extends S> identifierSettingsClass;
+	private List<LiteratureReference> literatureReference = new ArrayList<>();
 
 	@Override
 	public boolean equals(final Object otherObject) {
@@ -93,6 +98,12 @@ public abstract class AbstractSupplier<S extends IIdentifierSettings> implements
 	public void setIdentifierSettingsClass(Class<? extends S> identifierSettingsClass) {
 
 		this.identifierSettingsClass = identifierSettingsClass;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		return literatureReference;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/core/ISupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/core/ISupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Lablicate GmbH.
+ * Copyright (c) 2018, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,7 +11,10 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.model.identifier.core;
 
+import java.util.List;
+
 import org.eclipse.chemclipse.model.identifier.IIdentifierSettings;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
 public interface ISupplier {
 
@@ -43,4 +46,6 @@ public interface ISupplier {
 	 * @return
 	 */
 	Class<? extends IIdentifierSettings> getSettingsClass();
+
+	List<LiteratureReference> getLiteratureReferences();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.pubchem/src/org/eclipse/chemclipse/xxd/identifier/supplier/pubchem/identifier/PubChemExternalTargetIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.pubchem/src/org/eclipse/chemclipse/xxd/identifier/supplier/pubchem/identifier/PubChemExternalTargetIdentifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,6 +21,7 @@ import org.eclipse.chemclipse.chromatogram.xxd.identifier.targets.ITargetIdentif
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.identifier.IIdentifierSettings;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 import org.eclipse.chemclipse.xxd.identifier.supplier.pubchem.rest.PowerUserGateway;
 
 public class PubChemExternalTargetIdentifier implements ITargetIdentifierSupplier {
@@ -69,5 +70,11 @@ public class PubChemExternalTargetIdentifier implements ITargetIdentifierSupplie
 			logger.warn(e);
 		}
 		return url;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		return null;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/identifier/WikidataExternalTargetIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/identifier/WikidataExternalTargetIdentifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,12 +15,14 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.targets.ITargetIdentifierSupplier;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.cas.CasSupport;
 import org.eclipse.chemclipse.model.identifier.IIdentifierSettings;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
 import org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.query.QueryEntity;
 
 public class WikidataExternalTargetIdentifier implements ITargetIdentifierSupplier {
@@ -74,6 +76,12 @@ public class WikidataExternalTargetIdentifier implements ITargetIdentifierSuppli
 				logger.warn(e);
 			}
 		}
+		return null;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
 		return null;
 	}
 }


### PR DESCRIPTION
Same as https://github.com/eclipse/chemclipse/pull/1925 but for peak identifiers. The downstream ones come with a rich set of publications.