### PR TITLE
Show the Peak List by default

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/support/PartSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/support/PartSupport.java
@@ -72,7 +72,6 @@ public class PartSupport {
 	public static final String PARTDESCRIPTOR_PEAK_DETAILS = "org.eclipse.chemclipse.ux.extension.xxd.ui.part.peakDetailsPartDescriptor";
 	public static final String PARTDESCRIPTOR_PEAK_DETECTOR = "org.eclipse.chemclipse.ux.extension.xxd.ui.part.peakDetectorPartDescriptor";
 	public static final String PARTDESCRIPTOR_PEAK_TRACES = "org.eclipse.chemclipse.ux.extension.xxd.ui.part.peakTracesPartDescriptor";
-	public static final String PARTDESCRIPTOR_PEAK_SCAN_LIST = "org.eclipse.chemclipse.ux.extension.xxd.ui.part.peakScanListPartDescriptor";
 	public static final String PARTDESCRIPTOR_PEAK_QUANTITATION_LIST = "org.eclipse.chemclipse.ux.extension.xxd.ui.partdescriptor.peakQuantitationListPartDescriptor";
 	public static final String PARTDESCRIPTOR_SUBTRACT_SCAN = "org.eclipse.chemclipse.ux.extension.xxd.ui.part.subtractScanPartDescriptor";
 	public static final String PARTDESCRIPTOR_COMBINED_SCAN = "org.eclipse.chemclipse.ux.extension.xxd.ui.part.combinedScanPartDescriptor";

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/fragment.e4xmi
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/fragment.e4xmi
@@ -30,6 +30,7 @@
               <children xsi:type="advanced:Placeholder" xmi:id="_2Aqc0CskEeakPPc3RJFSAg" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.part.dataexplorer" ref="_qtur4Cf2EeafjOXnfHSw0Q"/>
               <children xsi:type="advanced:Placeholder" xmi:id="_lrDDgCyIEeakko_bfjza1A" elementId="org.eclipse.ui.navigator.ProjectExplorer" ref="_SUu-YK2iEeuuJ_UXBFJQCQ"/>
               <children xsi:type="advanced:Placeholder" xmi:id="_-51qwI8wEeiO3oL5WUkZBQ" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.part.sequenceexplorer" ref="_pWhTQI8wEeiO3oL5WUkZBQ"/>
+              <children xsi:type="advanced:Placeholder" xmi:id="_TEAWcKKVEe-Jq4Ox9k12rA" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.part.peakScanListPartDescriptor" ref="_dXp1AC5uEeiL24_JU7_FGA"/>
             </children>
             <children xsi:type="basic:PartStack" xmi:id="_T6wpUCs2Eea9JYQkIDiHKQ" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.partstack.left.center" visible="false" containerData="3500"/>
           </children>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
@@ -153,7 +153,6 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 				updateChromatogramSelection(chromatogramSelection);
 			}
 		}
-		//
 		updateLabel();
 		return true;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/toolbar/GroupHandlerPeaks.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/toolbar/GroupHandlerPeaks.java
@@ -43,7 +43,6 @@ public class GroupHandlerPeaks extends AbstractGroupHandler {
 		partHandler.add(new PartHandler("Peak Chart", PartSupport.PARTDESCRIPTOR_PEAK_CHART, PreferenceSupplier.P_STACK_POSITION_PEAK_CHART));
 		partHandler.add(new PartHandler("Peak Details", PartSupport.PARTDESCRIPTOR_PEAK_DETAILS, PreferenceSupplier.P_STACK_POSITION_PEAK_DETAILS));
 		partHandler.add(new PartHandler("Peak Detector", PartSupport.PARTDESCRIPTOR_PEAK_DETECTOR, PreferenceSupplier.P_STACK_POSITION_PEAK_DETECTOR));
-		partHandler.add(new PartHandler("Peak List", PartSupport.PARTDESCRIPTOR_PEAK_SCAN_LIST, PreferenceSupplier.P_STACK_POSITION_PEAK_SCAN_LIST));
 		partHandler.add(new PartHandler("Peak Traces", PartSupport.PARTDESCRIPTOR_PEAK_TRACES, PreferenceSupplier.P_STACK_POSITION_PEAK_TRACES));
 		partHandler.add(new PartHandler("Peak Scan Comparison", PartSupport.PARTDESCRIPTOR_COMPARISON_SCAN, PreferenceSupplier.P_STACK_POSITION_COMPARISON_SCAN_CHART));
 		partHandler.add(new PartHandler("Molecule", PartSupport.PARTDESCRIPTOR_MOLECULE, PreferenceSupplier.P_STACK_POSITION_MOLECULE));

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/toolbar/GroupHandlerScans.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/toolbar/GroupHandlerScans.java
@@ -59,7 +59,6 @@ public class GroupHandlerScans extends AbstractGroupHandler {
 		partHandler.add(new PartHandler("Flavor Marker", PartSupport.PARTDESCRIPTOR_FLAVOR_MARKER, PreferenceSupplier.P_STACK_POSITION_FLAVOR_MARKER));
 		partHandler.add(new PartHandler("Literature", PartSupport.PARTDESCRIPTOR_LITERATURE, PreferenceSupplier.P_STACK_POSITION_LITERATURE));
 		partHandler.add(new PartHandler("CAS Numbers", PartSupport.PARTDESCRIPTOR_CAS_NUMBERS, PreferenceSupplier.P_STACK_POSITION_CAS_NUMBERS));
-		partHandler.add(new PartHandler("Scan List", PartSupport.PARTDESCRIPTOR_PEAK_SCAN_LIST, PreferenceSupplier.P_STACK_POSITION_PEAK_SCAN_LIST));
 		partHandler.add(new PartHandler("Scan Subtract", PartSupport.PARTDESCRIPTOR_SUBTRACT_SCAN, PreferenceSupplier.P_STACK_POSITION_SUBTRACT_SCAN_PART));
 		partHandler.add(new PartHandler("Scan Combined", PartSupport.PARTDESCRIPTOR_COMBINED_SCAN, PreferenceSupplier.P_STACK_POSITION_COMBINED_SCAN_PART));
 		partHandler.add(new PartHandler("Scan Comparison", PartSupport.PARTDESCRIPTOR_COMPARISON_SCAN, PreferenceSupplier.P_STACK_POSITION_COMPARISON_SCAN_CHART));


### PR DESCRIPTION
but focus the Data Explorer because people need to open their files first. The rationale is that the Peak List is far too important to hide in the most crowded toolbar menu. Since https://github.com/eclipse/chemclipse/pull/1549 we have more vertical space to allow for a fourth tab.