### PR TITLE
Remove contact placeholders

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/plugin.xml
@@ -222,17 +222,6 @@
       </page>
    </extension>
    <extension
-         point="org.eclipse.chemclipse.ux.extension.ui.welcometile">
-      <WelcomeTile
-            Description="Please write us an email if you need help."
-            Section="Help">
-      </WelcomeTile>
-      <WelcomeTile
-            Description="If your data can&apos;t be loaded, please contact us."
-            Section="Data Formats">
-      </WelcomeTile>
-   </extension>
-   <extension
          point="org.eclipse.ui.cheatsheets.cheatSheetContent">
       <category
             name="Basics"


### PR DESCRIPTION
It doesn't tell whom to write an e-Mail to, and it can't because this is a vendor neutral environment. Providing support needs to be solved differently.