### PR TITLE
PCA, reinstate dblclick in loading plot, add focus in table

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedFeatureListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedFeatureListUI.java
@@ -100,6 +100,7 @@ public class ExtendedFeatureListUI extends Composite implements IExtendedPartUI 
 									}
 									if(features.size() > 0) {
 										listControl.get().setSelection(new StructuredSelection(features));
+										listControl.get().reveal(features.get(0));
 									}
 								}
 							}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedLoadingsPlot.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedLoadingsPlot.java
@@ -14,6 +14,8 @@ package org.eclipse.chemclipse.xxd.process.supplier.pca.ui.swt;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -29,6 +31,7 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.swt.IExtendedPartUI;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ISettingsHandler;
 import org.eclipse.chemclipse.xxd.process.supplier.pca.model.EvaluationPCA;
 import org.eclipse.chemclipse.xxd.process.supplier.pca.model.Feature;
+import org.eclipse.chemclipse.xxd.process.supplier.pca.model.FeatureDelta;
 import org.eclipse.chemclipse.xxd.process.supplier.pca.model.IAnalysisSettings;
 import org.eclipse.chemclipse.xxd.process.supplier.pca.model.IResultPCA;
 import org.eclipse.chemclipse.xxd.process.supplier.pca.model.IResultsPCA;
@@ -287,6 +290,76 @@ public class ExtendedLoadingsPlot extends Composite implements IExtendedPartUI {
 					 */
 					userSelection.reset();
 					userSelection.setSingleClick(false);
+				}
+			}
+		});
+		chartSettings.addHandledEventProcessor(new IHandledEventProcessor() {
+
+			@Override
+			public int getEvent() {
+
+				return IMouseSupport.EVENT_MOUSE_DOUBLE_CLICK;
+			}
+
+			@Override
+			public int getButton() {
+
+				return IMouseSupport.MOUSE_BUTTON_LEFT;
+			}
+
+			@Override
+			public int getStateMask() {
+
+				return SWT.NONE;
+			}
+
+			@Override
+			public void handleEvent(BaseChart baseChart, Event event) {
+
+				if(evaluationPCA != null) {
+					/*
+					 * Determine the x|y coordinates.
+					 */
+					Rectangle rectangle = baseChart.getPlotArea().getBounds();
+					int x = event.x;
+					int y = event.y;
+					int width = rectangle.width;
+					int height = rectangle.height;
+					/*
+					 * Calculate the selected point.
+					 */
+					Range rangeX = baseChart.getAxisSet().getXAxis(BaseChart.ID_PRIMARY_X_AXIS).getRange();
+					Range rangeY = baseChart.getAxisSet().getYAxis(BaseChart.ID_PRIMARY_Y_AXIS).getRange();
+					double pX = rangeX.lower + (rangeX.upper - rangeX.lower) * ((1.0d / width) * x);
+					double pY = rangeY.lower + (rangeY.upper - rangeY.lower) * ((1.0d / height) * y);
+					/*
+					 * Map the result deltas.
+					 */
+					PrincipalComponentUI principalComponentUI = principalComponentControl.get();
+					int pcX = principalComponentUI.getPCX();
+					int pcY = principalComponentUI.getPCY();
+					IResultsPCA<? extends IResultPCA, ? extends IVariable> resultsPCA = evaluationPCA.getResults();
+					List<FeatureDelta> featureDeltas = new ArrayList<>();
+					//
+					// Here need to prepare a result object with loading vectors per variable
+					//
+					for(int i = 0; i < resultsPCA.getExtractedVariables().size(); i++) {
+						double[] variableLoading = getVariableLoading(resultsPCA, i);
+						IPoint pointResult = getPoint(variableLoading, pcX, pcY, i);
+						double deltaX = Math.abs(pointResult.getX() - pX);
+						double deltaY = Math.abs(pointResult.getY() + pY);
+						featureDeltas.add(new FeatureDelta(evaluationPCA.getFeatureDataMatrix().getFeatures().get(i), deltaX, deltaY));
+					}
+					/*
+					 * Get the closest result.
+					 */
+					if(!featureDeltas.isEmpty()) {
+						Collections.sort(featureDeltas, Comparator.comparing(FeatureDelta::getDeltaX).thenComparing(FeatureDelta::getDeltaY));
+						FeatureDelta featureDelta = featureDeltas.get(0);
+						List<Feature> featureList = new ArrayList<>();
+						featureList.add(featureDelta.getFeature());
+						UpdateNotifierUI.update(event.display, IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_VARIABLE, featureList.toArray());
+					}
 				}
 			}
 		});


### PR DESCRIPTION
Reinstate the double click in the loading plot. This will highlight the selected Feature/Variable and at the same time jump/scroll the feature table/list to the highlighted entry. This allows the user to inspect in a quick way which Peaks/Compounds (if identified) are driving the separation.