### PR TITLE
Fixed open with editor not working or opening the same file multiple times

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/Activator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/Activator.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.io.CalibrationFileWriter;
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.support.events.IChemClipseEvents;
@@ -82,7 +83,7 @@ public class Activator extends AbstractActivatorUI {
 		if(eventBroker != null) {
 			registeredEventHandler.add(registerEventHandler(eventBroker, IChemClipseEvents.EVENT_BROKER_DATA, IChemClipseEvents.TOPIC_RI_LIBRARY_ADD_ADD_TO_PROCESS));
 			registeredEventHandler.add(registerEventHandler(eventBroker, IChemClipseEvents.EVENT_BROKER_DATA, IChemClipseEvents.TOPIC_RI_LIBRARY_REMOVE_FROM_PROCESS));
-			registeredEventHandler.add(registerEventHandler(eventBroker, IChemClipseEvents.EVENT_BROKER_DATA, IChemClipseEvents.TOPIC_PROCESSING_FILE_CREATED));
+			registeredEventHandler.add(registerEventHandler(eventBroker, IChemClipseEvents.EVENT_BROKER_DATA, CalibrationFileWriter.TOPIC_PROCESSING_FILE_CREATED));
 		}
 	}
 
@@ -110,10 +111,8 @@ public class Activator extends AbstractActivatorUI {
 								if(libraries.contains(library)) {
 									libraries.remove(library); // REMOVE
 								}
-							} else if(IChemClipseEvents.TOPIC_PROCESSING_FILE_CREATED.equals(topic)) {
-								if(PreferenceSupplier.isOpenReportAfterProcessing()) {
-									SystemEditor.open(file);
-								}
+							} else if(CalibrationFileWriter.TOPIC_PROCESSING_FILE_CREATED.equals(topic)) {
+								SystemEditor.open(file);
 							}
 							PreferenceSupplier.setRetentionIndexFiles(libraries);
 						}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/io/CalibrationFileWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/io/CalibrationFileWriter.java
@@ -29,6 +29,8 @@ import org.eclipse.chemclipse.support.text.ValueFormat;
 
 public class CalibrationFileWriter {
 
+	public static final String TOPIC_PROCESSING_FILE_CREATED = "processing/file/created/amdis/cal"; // $NON-NLS-1$
+	//
 	private static final Logger logger = Logger.getLogger(CalibrationFileWriter.class);
 	private DecimalFormat decimalFormat = ValueFormat.getDecimalFormatEnglish("0.000");
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/io/ChromatogramWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/io/ChromatogramWriter.java
@@ -16,12 +16,12 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.impl.RetentionIndexExtractor;
+import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.settings.IndexExportSettings;
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
 import org.eclipse.chemclipse.model.columns.ISeparationColumnIndices;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.notifier.UpdateNotifier;
-import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 public class ChromatogramWriter {
@@ -40,6 +40,8 @@ public class ChromatogramWriter {
 		ISeparationColumnIndices separationColumnIndices = retentionIndexExtractor.extract(chromatogram, deriveMissingIndices, useCuratedNames);
 		CalibrationFileWriter calibrationFileWriter = new CalibrationFileWriter();
 		calibrationFileWriter.write(file, separationColumnIndices);
-		UpdateNotifier.update(IChemClipseEvents.TOPIC_PROCESSING_FILE_CREATED, file);
+		if(PreferenceSupplier.isOpenReportAfterProcessing()) {
+			UpdateNotifier.update(CalibrationFileWriter.TOPIC_PROCESSING_FILE_CREATED, file);
+		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/ui/Activator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/ui/Activator.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.core.PCRExportConverter;
 import org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.chemclipse.support.ui.activator.AbstractActivatorUI;
@@ -77,7 +78,7 @@ public class Activator extends AbstractActivatorUI {
 
 		IEventBroker eventBroker = getEventBroker(bundleContext);
 		if(eventBroker != null) {
-			registeredEventHandler.add(registerEventHandler(eventBroker, IChemClipseEvents.EVENT_BROKER_DATA, IChemClipseEvents.TOPIC_PROCESSING_FILE_CREATED));
+			registeredEventHandler.add(registerEventHandler(eventBroker, IChemClipseEvents.EVENT_BROKER_DATA, PCRExportConverter.TOPIC_PROCESSING_FILE_CREATED));
 		}
 	}
 
@@ -91,10 +92,8 @@ public class Activator extends AbstractActivatorUI {
 				try {
 					Object object = event.getProperty(property);
 					if(object instanceof File file) {
-						if(IChemClipseEvents.TOPIC_PROCESSING_FILE_CREATED.equals(topic)) {
-							if(PreferenceSupplier.isOpenReport()) {
-								SystemEditor.open(file);
-							}
+						if(PCRExportConverter.TOPIC_PROCESSING_FILE_CREATED.equals(topic)) {
+							SystemEditor.open(file);
 						}
 					}
 				} catch(Exception e) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/META-INF/MANIFEST.MF
@@ -21,4 +21,5 @@ Require-Bundle: org.eclipse.core.runtime,
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.chemclipse.pcr.report.supplier.tabular
-Export-Package: org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.preferences
+Export-Package: org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.core,
+ org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.preferences

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/core/PCRExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/core/PCRExportConverter.java
@@ -49,11 +49,12 @@ import org.eclipse.chemclipse.pcr.report.supplier.tabular.model.ChannelMappings;
 import org.eclipse.chemclipse.pcr.report.supplier.tabular.model.WellComparator;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
-import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 public class PCRExportConverter extends AbstractPlateExportConverter implements IPlateExportConverter {
 
+	public static final String TOPIC_PROCESSING_FILE_CREATED = "processing/file/created/pcr/excel"; // $NON-NLS-1$
+	//
 	private static final Logger logger = Logger.getLogger(PCRExportConverter.class);
 	private static final String DESCRIPTION = "PCR Excel Export";
 
@@ -108,7 +109,9 @@ public class PCRExportConverter extends AbstractPlateExportConverter implements 
 			processingInfo.addErrorMessage(DESCRIPTION, "Input/Output problem.");
 			logger.warn(e);
 		}
-		UpdateNotifier.update(IChemClipseEvents.TOPIC_PROCESSING_FILE_CREATED, file);
+		if(PreferenceSupplier.isOpenReport()) {
+			UpdateNotifier.update(TOPIC_PROCESSING_FILE_CREATED, file);
+		}
 		return processingInfo;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/events/IChemClipseEvents.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/events/IChemClipseEvents.java
@@ -101,7 +101,6 @@ public interface IChemClipseEvents {
 	String TOPIC_LIBRARY_MSD_UPDATE_SELECTION = "library/msd/update/selection";
 	//
 	String TOPIC_PROCESSING_INFO_UPDATE = "processinginfo/update";
-	String TOPIC_PROCESSING_FILE_CREATED = "processing/file/created"; // $NON-NLS-1$
 	String TOPIC_EDIT_HISTORY_UPDATE = "edithistory/update"; // $NON-NLS-1$
 	//
 	String TOPIC_EDITOR_CHROMATOGRAM_UPDATE = "editor/chromatogram/update";


### PR DESCRIPTION
https://github.com/eclipse/chemclipse/pull/1826 has a flaw. It uses one topic for all listeners which causes cross-talk between the plugins. Also, the preferences were not available in the Activator realm, so user settings were ignored. By moving the check back into the writer, we can also use its settings instead of system preferences again.