### PR TITLE
Fetch more dependencies from Eclipse

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
@@ -209,14 +209,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="com.sun.xml.bind.jaxb-core"
-         version="0.0.0"/>
-
-   <plugin
-         id="com.sun.xml.bind.jaxb-impl"
-         version="0.0.0"/>
-
-   <plugin
          id="org.apache.commons.commons-csv"
          version="0.0.0"/>
 
@@ -390,6 +382,10 @@
 
    <plugin
          id="org.eclipse.ltk.ui.refactoring"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.sun.xml.bind.jaxb-osgi"
          version="0.0.0"/>
 
 </feature>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/META-INF/MANIFEST.MF
@@ -9,6 +9,5 @@ Fragment-Host: org.eclipse.chemclipse.msd.converter.supplier.mzdata;bundle-versi
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.11.0",
  org.eclipse.chemclipse.rcp.app.test;bundle-version="0.9.0",
- com.sun.xml.bind.jaxb-core;bundle-version="4.0.1",
- com.sun.xml.bind.jaxb-impl;bundle-version="4.0.1",
- org.glassfish.hk2.osgi-resource-locator;bundle-version="1.0.3"
+ org.glassfish.hk2.osgi-resource-locator;bundle-version="1.0.3",
+ com.sun.xml.bind.jaxb-osgi;bundle-version="4.0.5"

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/META-INF/MANIFEST.MF
@@ -9,6 +9,5 @@ Fragment-Host: org.eclipse.chemclipse.msd.converter.supplier.mzxml;bundle-versio
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.11.0",
  org.eclipse.chemclipse.rcp.app.test;bundle-version="0.9.0",
- com.sun.xml.bind.jaxb-core;bundle-version="4.0.1",
- com.sun.xml.bind.jaxb-impl;bundle-version="4.0.1",
- org.glassfish.hk2.osgi-resource-locator;bundle-version="1.0.3"
+ org.glassfish.hk2.osgi-resource-locator;bundle-version="1.0.3",
+ com.sun.xml.bind.jaxb-osgi;bundle-version="4.0.5"

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -8,6 +8,14 @@
 	<unit id="javax.activation" version="0.0.0"/>
 	<unit id="ch.qos.logback.classic" version="0.0.0"/>
 	<unit id="ch.qos.logback.core" version="0.0.0"/>
+	<unit id="com.fasterxml.jackson.core.jackson-annotations" version="0.0.0"/>
+	<unit id="com.fasterxml.jackson.core.jackson-core" version="0.0.0"/>
+	<unit id="com.fasterxml.jackson.core.jackson-databind" version="0.0.0"/>
+	<unit id="com.google.guava" version="0.0.0"/>
+	<unit id="com.google.guava.failureaccess" version="0.0.0"/>
+	<unit id="org.glassfish.hk2.osgi-resource-locator" version="0.0.0"/>
+	<unit id="com.sun.xml.bind.jaxb-osgi" version="0.0.0"/>
+	<unit id="jakarta.xml.bind-api" version="0.0.0"/>
 	<repository location="https://download.eclipse.org/releases/2024-09/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -155,32 +163,6 @@
 			</dependency>
 		</dependencies>
 	</location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>org.glassfish.hk2</groupId>
-				<artifactId>osgi-resource-locator</artifactId>
-				<version>1.0.3</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
-	</location>
-	<location includeDependencyDepth="direct" includeDependencyScopes="compile,runtime" includeSource="true" label="xml.bind" missingManifest="generate" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>com.sun.xml.bind</groupId>
-				<artifactId>jaxb-impl</artifactId>
-				<version>4.0.3</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>jakarta.xml.bind</groupId>
-				<artifactId>jakarta.xml.bind-api</artifactId>
-				<version>4.0.0</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
-	</location>
 	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="org.apache.jena" missingManifest="generate" type="Maven">
 		<dependencies>
 			<dependency>
@@ -265,44 +247,6 @@
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpcore</artifactId>
 				<version>4.4.16</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
-	</location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="com.google.guava" missingManifest="generate" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>com.google.guava</groupId>
-				<artifactId>failureaccess</artifactId>
-				<version>1.0.1</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>com.google.guava</groupId>
-				<artifactId>guava</artifactId>
-				<version>31.1-jre</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
-	</location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="com.fasterxml.jackson.core" missingManifest="generate" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-annotations</artifactId>
-				<version>2.13.5</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-core</artifactId>
-				<version>2.13.5</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-databind</artifactId>
-				<version>2.13.5</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.cml.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.cml.fragment.test/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Fragment-Host: org.eclipse.chemclipse.msd.converter.supplier.cml;bundle-version=
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.11.0",
  org.eclipse.chemclipse.rcp.app.test;bundle-version="0.9.0",
- com.sun.xml.bind.jaxb-core;bundle-version="4.0.1",
- com.sun.xml.bind.jaxb-impl;bundle-version="4.0.1",
  org.glassfish.hk2.osgi-resource-locator;bundle-version="1.0.3",
+ com.sun.xml.bind.jaxb-osgi;bundle-version="4.0.5",
  org.apache.commons.commons-codec;bundle-version="1.15.0"

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/META-INF/MANIFEST.MF
@@ -9,8 +9,7 @@ Fragment-Host: org.eclipse.chemclipse.msd.converter.supplier.mzml;bundle-version
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.11.0",
  org.eclipse.chemclipse.rcp.app.test;bundle-version="0.9.0",
- com.sun.xml.bind.jaxb-core;bundle-version="4.0.1",
- com.sun.xml.bind.jaxb-impl;bundle-version="4.0.1",
  org.glassfish.hk2.osgi-resource-locator;bundle-version="1.0.3",
  org.apache.commons.commons-codec;bundle-version="1.15.0",
- org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0"
+ org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0",
+ com.sun.xml.bind.jaxb-osgi;bundle-version="4.0.5"

--- a/chemclipse/tests/org.eclipse.chemclipse.pcr.converter.supplier.rdml.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.pcr.converter.supplier.rdml.fragment.test/META-INF/MANIFEST.MF
@@ -10,6 +10,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.chemclipse.rcp.app.test;bundle-version="0.9.0",
  org.eclipse.chemclipse.pcr.model;bundle-version="0.9.0",
- com.sun.xml.bind.jaxb-core;bundle-version="4.0.1",
- com.sun.xml.bind.jaxb-impl;bundle-version="4.0.1",
- org.glassfish.hk2.osgi-resource-locator;bundle-version="1.0.3"
+ org.glassfish.hk2.osgi-resource-locator;bundle-version="1.0.3",
+ com.sun.xml.bind.jaxb-osgi;bundle-version="4.0.5"

--- a/chemclipse/tests/org.eclipse.chemclipse.vsd.converter.supplier.cml.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.vsd.converter.supplier.cml.test/META-INF/MANIFEST.MF
@@ -9,6 +9,5 @@ Fragment-Host: org.eclipse.chemclipse.vsd.converter.supplier.cml;bundle-version=
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.11.0",
  org.eclipse.chemclipse.rcp.app.test;bundle-version="0.8.0",
- com.sun.xml.bind.jaxb-core;bundle-version="4.0.1",
- com.sun.xml.bind.jaxb-impl;bundle-version="4.0.1",
- org.glassfish.hk2.osgi-resource-locator;bundle-version="1.0.3"
+ org.glassfish.hk2.osgi-resource-locator;bundle-version="1.0.3",
+ com.sun.xml.bind.jaxb-osgi;bundle-version="4.0.5"

--- a/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.cml.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.cml.test/META-INF/MANIFEST.MF
@@ -9,6 +9,5 @@ Fragment-Host: org.eclipse.chemclipse.wsd.converter.supplier.cml;bundle-version=
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.11.0",
  org.eclipse.chemclipse.rcp.app.test;bundle-version="0.8.0",
- com.sun.xml.bind.jaxb-core;bundle-version="4.0.1",
- com.sun.xml.bind.jaxb-impl;bundle-version="4.0.1",
- org.glassfish.hk2.osgi-resource-locator;bundle-version="1.0.3"
+ org.glassfish.hk2.osgi-resource-locator;bundle-version="1.0.3",
+ com.sun.xml.bind.jaxb-osgi;bundle-version="4.0.5"

--- a/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.mzml.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.mzml.fragment.test/META-INF/MANIFEST.MF
@@ -9,6 +9,5 @@ Fragment-Host: org.eclipse.chemclipse.wsd.converter.supplier.mzml;bundle-version
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.11.0",
  org.eclipse.chemclipse.rcp.app.test;bundle-version="0.9.0",
- com.sun.xml.bind.jaxb-core;bundle-version="4.0.1",
- com.sun.xml.bind.jaxb-impl;bundle-version="4.0.1",
- org.glassfish.hk2.osgi-resource-locator;bundle-version="1.0.3"
+ org.glassfish.hk2.osgi-resource-locator;bundle-version="1.0.3",
+ com.sun.xml.bind.jaxb-osgi;bundle-version="4.0.5"

--- a/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.spectroml.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.spectroml.test/META-INF/MANIFEST.MF
@@ -9,6 +9,5 @@ Fragment-Host: org.eclipse.chemclipse.wsd.converter.supplier.spectroml;bundle-ve
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.11.0",
  org.eclipse.chemclipse.rcp.app.test;bundle-version="0.8.0",
- com.sun.xml.bind.jaxb-core;bundle-version="4.0.1",
- com.sun.xml.bind.jaxb-impl;bundle-version="4.0.1",
- org.glassfish.hk2.osgi-resource-locator;bundle-version="1.0.3"
+ org.glassfish.hk2.osgi-resource-locator;bundle-version="1.0.3",
+ com.sun.xml.bind.jaxb-osgi;bundle-version="4.0.5"


### PR DESCRIPTION
I found some dependencies that we used to fetch via Maven on https://download.eclipse.org/staging/2024-09/buildInfo/archive/download.eclipse.org/staging/2024-09/ so I use that instead. In practice this means a small version bump.