### PR TITLE
Drop unused Javax API

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
@@ -581,10 +581,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="javax.activation"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.osgi.util"
          version="0.0.0"/>
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/META-INF/MANIFEST.MF
@@ -15,10 +15,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
- javax.activation;bundle-version="1.1.0",
  org.eclipse.chemclipse.vsd.model;bundle-version="0.9.0",
  org.eclipse.chemclipse.vsd.converter;bundle-version="0.9.0",
- jakarta.activation-api;bundle-version="2.1.0",
  org.apache.commons.math3;bundle-version="3.6.1",
  org.eclipse.chemclipse.wsd.model;bundle-version="0.9.0",
  org.eclipse.chemclipse.wsd.converter;bundle-version="0.9.0"
@@ -28,3 +26,4 @@ Bundle-Vendor: ChemClipse
 Export-Package: org.eclipse.chemclipse.csd.converter.supplier.jcampdx.io,
  org.eclipse.chemclipse.msd.converter.supplier.jcampdx.io,
  org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.io
+Import-Package: jakarta.activation;version="2.1.3"

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -5,7 +5,6 @@
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
 	<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-	<unit id="javax.activation" version="0.0.0"/>
 	<unit id="ch.qos.logback.classic" version="0.0.0"/>
 	<unit id="ch.qos.logback.core" version="0.0.0"/>
 	<unit id="com.fasterxml.jackson.core.jackson-annotations" version="0.0.0"/>


### PR DESCRIPTION
It has been replaced with https://jakarta.ee/specifications/activation/ already.