### PR TITLE
Fix a Jenkins warning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
 	agent {
 		kubernetes {
-			label 'ubuntu-latest'
+			inheritFrom 'ubuntu-latest'
 		}
 	}
 	triggers {


### PR DESCRIPTION
https://plugins.jenkins.io/kubernetes/#plugin-content-warning-label-option-is-deprecated