### PR TITLE
Fix the .app name on macOS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,9 +77,9 @@ pipeline {
 			steps {
 				sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
 					sh '''
-						scp chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/target/products/org.eclipse.chemclipse.rcp.compilation.community.product.id-win32.win32.x86_64.zip genie.chemclipse@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/chemclipse/integration/${BRANCH_NAME}/downloads/chemclipse-win32.win32.x86_64.zip
-						scp chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/target/products/org.eclipse.chemclipse.rcp.compilation.community.product.id-linux.gtk.x86_64.tar.gz genie.chemclipse@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/chemclipse/integration/${BRANCH_NAME}/downloads/chemclipse-linux.gtk.x86_64.tar.gz
-						scp chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/target/products/org.eclipse.chemclipse.rcp.compilation.community.product.id-macosx.cocoa.x86_64.tar.gz genie.chemclipse@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/chemclipse/integration/${BRANCH_NAME}/downloads/chemclipse-macosx.cocoa.x86_64.tar.gz
+						scp chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/target/products/chemclipse-win32.win32.x86_64.zip genie.chemclipse@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/chemclipse/integration/${BRANCH_NAME}/downloads/chemclipse-win32.win32.x86_64.zip
+						scp chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/target/products/chemclipse-linux.gtk.x86_64.tar.gz genie.chemclipse@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/chemclipse/integration/${BRANCH_NAME}/downloads/chemclipse-linux.gtk.x86_64.tar.gz
+						scp chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/target/products/chemclipse-macosx.cocoa.x86_64.tar.gz genie.chemclipse@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/chemclipse/integration/${BRANCH_NAME}/downloads/chemclipse-macosx.cocoa.x86_64.tar.gz
 					'''
 				}
 			}

--- a/chemclipse/pom.xml
+++ b/chemclipse/pom.xml
@@ -220,14 +220,21 @@
 								<goal>archive-products</goal>
 							</goals>
 							<phase>install</phase>
-							<configuration>
-								<formats>
-									<linux>tar.gz</linux>
-									<macosx>tar.gz</macosx>
-								</formats>
-							</configuration>
 						</execution>
 					</executions>
+					<configuration>
+						<formats>
+							<linux>tar.gz</linux>
+							<macosx>tar.gz</macosx>
+						</formats>
+						<products>
+							<product>
+								<rootFolders>
+									<macosx>ChemClipse.app</macosx>
+								</rootFolders>
+							</product>
+						</products>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>

--- a/chemclipse/pom.xml
+++ b/chemclipse/pom.xml
@@ -232,6 +232,7 @@
 								<rootFolders>
 									<macosx>ChemClipse.app</macosx>
 								</rootFolders>
+								<archiveFileName>chemclipse</archiveFileName>
 							</product>
 						</products>
 					</configuration>


### PR DESCRIPTION
as it defaults to `Eclipse.app`, which is weird as people have to type that when searching with Finder.

I also took the liberty to shorten the archive name as `org.eclipse.chemclipse.rcp.compilation.community.product.id-macosx.cocoa.x86_64.tar.gz` is really long.