### PR TITLE
PCA, improve dbl click variable selection

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/model/FeatureDelta.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/model/FeatureDelta.java
@@ -18,12 +18,14 @@ public class FeatureDelta {
 	private Feature feature = null;
 	private double deltaX = 0;
 	private double deltaY = 0;
+	private double distance = 0;
 
 	public FeatureDelta(Feature feature, double deltaX, double deltaY) {
 
 		this.feature = feature;
-		this.deltaX = deltaX;
-		this.deltaY = deltaY;
+		this.deltaX = Math.abs(deltaX);
+		this.deltaY = Math.abs(deltaY);
+		this.distance = Math.sqrt(Math.pow(this.deltaX, 2) + Math.pow(this.deltaY, 2));
 	}
 
 	public Feature getFeature() {
@@ -39,6 +41,11 @@ public class FeatureDelta {
 	public double getDeltaY() {
 
 		return deltaY;
+	}
+
+	public double getDistance() {
+
+		return distance;
 	}
 
 	@Override
@@ -63,6 +70,6 @@ public class FeatureDelta {
 	@Override
 	public String toString() {
 
-		return "FeatureDelta [featurePCA=" + feature + ", deltaX=" + deltaX + ", deltaY=" + deltaY + "]";
+		return "FeatureDelta [featurePCA=" + feature + ", deltaX=" + deltaX + ", deltaY=" + deltaY + ", distance=" + distance + "]";
 	}
 }


### PR DESCRIPTION
- so far nearest feature to dbl click was determined by sequential sort of delta X/Y, this does not result in every case in the closest geometric distance. Hence distance was added to FeatureDelta class.
- x/y delta calculation did not work correct when the axis was limited to only positive or only negative values which resulted in wrong results specifically when zoomed in. 