### PR TITLE
PCA, add 'Peak Number' type for file data

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/statistics/IPeakNumber.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/statistics/IPeakNumber.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Lorenz Gerber - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.model.statistics;
+
+public interface IPeakNumber extends IVariable {
+
+	String TYPE = "Peak Number";
+
+	int getPeakNumber();
+
+	void setPeakNumber(int peakNumber);
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/statistics/PeakNumber.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/statistics/PeakNumber.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Lorenz Gerber - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.model.statistics;
+
+import java.text.DecimalFormat;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.chemclipse.support.text.ValueFormat;
+
+public class PeakNumber extends AbstractVariable implements IPeakNumber {
+
+	private DecimalFormat decimalFormat = ValueFormat.getDecimalFormatEnglish("0");
+	private int peakNumber = 0;
+
+	public PeakNumber(Integer peakNumber) {
+
+		super();
+		this.peakNumber = peakNumber;
+		setValue(convertValue());
+		setType(IPeakNumber.TYPE);
+		setSelected(true);
+	}
+
+	public static Set<PeakNumber> create(List<Integer> peakNumbers) {
+
+		Set<PeakNumber> peakNumberSet = new TreeSet<>();
+		for(int i = 0; i < peakNumbers.size(); i++) {
+			peakNumberSet.add(new PeakNumber(peakNumbers.get(i)));
+		}
+		return peakNumberSet;
+	}
+
+	private String convertValue() {
+
+		return decimalFormat.format(getPeakNumber());
+	}
+
+	@Override
+	public int compareTo(IVariable o) {
+
+		if(o instanceof IPeakNumber peakNumber) {
+			return Integer.compare(getPeakNumber(), peakNumber.getPeakNumber());
+		}
+		return 0;
+	}
+
+	@Override
+	public int getPeakNumber() {
+
+		return peakNumber;
+	}
+
+	@Override
+	public void setPeakNumber(int peakNumber) {
+
+		this.peakNumber = peakNumber;
+		setValue(convertValue());
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/PcaExtractionFileBinary.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/PcaExtractionFileBinary.java
@@ -21,9 +21,11 @@ import java.util.List;
 
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
+import org.eclipse.chemclipse.model.statistics.IPeakNumber;
 import org.eclipse.chemclipse.model.statistics.IRetentionIndex;
 import org.eclipse.chemclipse.model.statistics.IRetentionTime;
 import org.eclipse.chemclipse.model.statistics.IVariable;
+import org.eclipse.chemclipse.model.statistics.PeakNumber;
 import org.eclipse.chemclipse.model.statistics.RetentionIndex;
 import org.eclipse.chemclipse.model.statistics.RetentionTime;
 import org.eclipse.chemclipse.xxd.process.supplier.pca.model.PeakSampleData;
@@ -146,6 +148,9 @@ public class PcaExtractionFileBinary implements IExtractionData {
 					} else if(type.equals(IRetentionIndex.TYPE)) {
 						int retentionIndex = (int)Math.round(Double.parseDouble(value));
 						variable = new RetentionIndex(retentionIndex);
+					} else if(type.equals(IPeakNumber.TYPE)) {
+						int peakNumber = (int)Math.round(Double.parseDouble(value));
+						variable = new PeakNumber(peakNumber);
 					}
 					//
 					if(variable != null) {


### PR DESCRIPTION
"PeakNumber", a new PCA data type that is convenient to use with batch MCR-AR results. 