### PR TITLE
Speed improvements for ZIP files in Data Explorer

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.container.supplier.zip/src/org/eclipse/chemclipse/xxd/converter/supplier/zip/io/ZipContainer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.container.supplier.zip/src/org/eclipse/chemclipse/xxd/converter/supplier/zip/io/ZipContainer.java
@@ -102,4 +102,17 @@ public class ZipContainer implements IFileContentProvider {
 		}
 		return file;
 	}
+
+	@Override
+	public boolean hasContainerContents(File file) {
+
+		try (ZipFile zipFile = new ZipFile(file)) {
+			return zipFile.entries().hasMoreElements();
+		} catch(ZipException e) {
+			logger.warn(e);
+		} catch(IOException e) {
+			logger.warn(e);
+		}
+		return false;
+	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.container/src/org/eclipse/chemclipse/container/definition/IFileContentProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.container/src/org/eclipse/chemclipse/container/definition/IFileContentProvider.java
@@ -15,6 +15,8 @@ import java.io.File;
 
 public interface IFileContentProvider {
 
+	public boolean hasContainerContents(File container);
+
 	public long getContentSize(File container);
 
 	public File[] getContents(File container);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/LazyFileExplorerContentProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/LazyFileExplorerContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -189,7 +189,7 @@ public class LazyFileExplorerContentProvider implements ILazyTreeContentProvider
 	private boolean hasContainerContents(File file) {
 
 		IFileContentProvider fileContentProvider = FileContainerSupport.getCache().getFileContentProvider(file);
-		return fileContentProvider != null && fileContentProvider.getContentSize(file) > 0;
+		return fileContentProvider != null && fileContentProvider.hasContainerContents(file);
 	}
 
 	private File[] getContainerContents(File file) {


### PR DESCRIPTION
Basically adds `isEmpty()` for file containers because extracting everything to calculate size is too expensive. We can and should bail out earlier.