### PR TITLE
PCA, prepare for combining double click and box selection

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/events/IChemClipseEvents.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/events/IChemClipseEvents.java
@@ -78,7 +78,8 @@ public interface IChemClipseEvents {
 	String TOPIC_PCA_UPDATE_LABELS = "pca/update/labels";
 	String TOPIC_PCA_UPDATE_RESULT = "pca/update/result";
 	String TOPIC_PCA_UPDATE_HIGHLIGHT_SAMPLE = "pca/update/highlight/sample";
-	String TOPIC_PCA_UPDATE_HIGHLIGHT_VARIABLE = "pca/update/highlight/variable";
+	String TOPIC_PCA_UPDATE_HIGHLIGHT_LIST_VARIABLE = "pca/update/highlight/variable";
+	String TOPIC_PCA_UPDATE_HIGHLIGHT_PLOT_VARIABLE = "pca/update/highlight/plot/variable";
 	//
 	String TOPIC_METHOD_SELECTED = "methods/select";
 	String TOPIC_METHOD_CREATED = "methods/create";

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/parts/AbstractPartPCA.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/parts/AbstractPartPCA.java
@@ -37,7 +37,8 @@ public abstract class AbstractPartPCA<T extends Composite> extends AbstractPart<
 		subscribeAdditionalTopic(IChemClipseEvents.TOPIC_PCA_UPDATE_RESULT, IChemClipseEvents.EVENT_BROKER_DATA);
 		subscribeAdditionalTopic(IChemClipseEvents.TOPIC_EDITOR_PCA_CLOSE, IChemClipseEvents.EVENT_BROKER_DATA);
 		subscribeAdditionalTopic(IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_SAMPLE, IChemClipseEvents.EVENT_BROKER_DATA);
-		subscribeAdditionalTopic(IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_VARIABLE, IChemClipseEvents.EVENT_BROKER_DATA);
+		subscribeAdditionalTopic(IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_LIST_VARIABLE, IChemClipseEvents.EVENT_BROKER_DATA);
+		subscribeAdditionalTopic(IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_PLOT_VARIABLE, IChemClipseEvents.EVENT_BROKER_DATA);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedFeatureListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedFeatureListUI.java
@@ -79,7 +79,8 @@ public class ExtendedFeatureListUI extends Composite implements IExtendedPartUI 
 		//
 		DataUpdateSupport dataUpdateSupport = new DataUpdateSupport(Activator.getDefault().getEventBroker());
 		dataUpdateSupport.subscribe(IChemClipseEvents.TOPIC_PCA_UPDATE_RESULT, IChemClipseEvents.EVENT_BROKER_DATA);
-		dataUpdateSupport.subscribe(IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_VARIABLE, IChemClipseEvents.EVENT_BROKER_DATA);
+		dataUpdateSupport.subscribe(IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_LIST_VARIABLE, IChemClipseEvents.EVENT_BROKER_DATA);
+		dataUpdateSupport.subscribe(IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_PLOT_VARIABLE, IChemClipseEvents.EVENT_BROKER_DATA);
 		dataUpdateSupport.add(new IDataUpdateListener() {
 
 			@Override
@@ -87,7 +88,7 @@ public class ExtendedFeatureListUI extends Composite implements IExtendedPartUI 
 
 				if(evaluationPCA != null) {
 					if(DataUpdateSupport.isVisible(control)) {
-						if(IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_VARIABLE.equals(topic)) {
+						if(IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_LIST_VARIABLE.equals(topic) || IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_PLOT_VARIABLE.equals(topic)) {
 							if(objects.size() == 1) {
 								Object object = objects.get(0);
 								ArrayList<Feature> features = new ArrayList<>();
@@ -98,7 +99,7 @@ public class ExtendedFeatureListUI extends Composite implements IExtendedPartUI 
 											features.add(feature);
 										}
 									}
-									if(features.size() > 0) {
+									if(features.size() >= 0) {
 										listControl.get().setSelection(new StructuredSelection(features));
 										listControl.get().reveal(features.get(0));
 									}
@@ -241,7 +242,7 @@ public class ExtendedFeatureListUI extends Composite implements IExtendedPartUI 
 	private void handleRowSelection(List<Object> selectedElements) {
 
 		if(selectedElements.isEmpty()) {
-			UpdateNotifierUI.update(getDisplay(), IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_VARIABLE, selectedElements.toArray());
+			UpdateNotifierUI.update(getDisplay(), IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_LIST_VARIABLE, selectedElements.toArray());
 		} else if(Feature.class.isInstance(selectedElements.get(0))) {
 			ArrayList<Feature> features = new ArrayList<>();
 			for(Object element : selectedElements) {
@@ -249,7 +250,7 @@ public class ExtendedFeatureListUI extends Composite implements IExtendedPartUI 
 					features.add((Feature)element);
 				}
 			}
-			UpdateNotifierUI.update(getDisplay(), IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_VARIABLE, selectedElements.toArray());
+			UpdateNotifierUI.update(getDisplay(), IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_LIST_VARIABLE, selectedElements.toArray());
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedLoadingsPlot.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedLoadingsPlot.java
@@ -77,7 +77,8 @@ public class ExtendedLoadingsPlot extends Composite implements IExtendedPartUI {
 		createControl();
 		DataUpdateSupport dataUpdateSupport = new DataUpdateSupport(Activator.getDefault().getEventBroker());
 		dataUpdateSupport.subscribe(IChemClipseEvents.TOPIC_PCA_UPDATE_RESULT, IChemClipseEvents.EVENT_BROKER_DATA);
-		dataUpdateSupport.subscribe(IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_VARIABLE, IChemClipseEvents.EVENT_BROKER_DATA);
+		dataUpdateSupport.subscribe(IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_LIST_VARIABLE, IChemClipseEvents.EVENT_BROKER_DATA);
+		dataUpdateSupport.subscribe(IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_PLOT_VARIABLE, IChemClipseEvents.EVENT_BROKER_DATA);
 		dataUpdateSupport.add(new IDataUpdateListener() {
 
 			@Override
@@ -85,7 +86,7 @@ public class ExtendedLoadingsPlot extends Composite implements IExtendedPartUI {
 
 				if(evaluationPCA != null) {
 					if(DataUpdateSupport.isVisible(control)) {
-						if(IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_VARIABLE.equals(topic)) {
+						if(IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_LIST_VARIABLE.equals(topic) || IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_PLOT_VARIABLE.equals(topic)) {
 							if(objects.size() == 1) {
 								Object object = objects.get(0);
 								ArrayList<IVariable> selectedVariables = new ArrayList<>();
@@ -285,7 +286,7 @@ public class ExtendedLoadingsPlot extends Composite implements IExtendedPartUI {
 					 * Get the closest result.
 					 */
 					if(!featureSelected.isEmpty()) {
-						UpdateNotifierUI.update(event.display, IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_VARIABLE, featureSelected.toArray());
+						UpdateNotifierUI.update(event.display, IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_PLOT_VARIABLE, featureSelected.toArray());
 					}
 					/*
 					 * Finish User Selection Process
@@ -370,7 +371,7 @@ public class ExtendedLoadingsPlot extends Composite implements IExtendedPartUI {
 						FeatureDelta featureDelta = featureDeltas.get(0);
 						List<Feature> featureList = new ArrayList<>();
 						featureList.add(featureDelta.getFeature());
-						UpdateNotifierUI.update(event.display, IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_VARIABLE, featureList.toArray());
+						UpdateNotifierUI.update(event.display, IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_PLOT_VARIABLE, featureList.toArray());
 						doubleClicked = true;
 					}
 				}


### PR DESCRIPTION
Prepare for combined double click and box selection: eg. initial selection by box, modifying selection by double click on individual samples. Changing the group of selected variables shall work seamless from the list and the plot. This commit introduce directional events (plot to list, list to plot) to better manage and synchronize the state (current selection in both list and plot shall appear as one uniform state to the user). 