### PR TITLE
Fix Scan Identifier: Unknown Marker requiring a library file

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/impl/AlkaneIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/impl/AlkaneIdentifier.java
@@ -9,7 +9,7 @@
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Alexander Kerner - Generics
- * Christoph Läubrich - add method to check if target is valid, ad generics
+ * Christoph Läubrich - add method to check if target is valid, add generics
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.impl;
 
@@ -24,7 +24,7 @@ import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.se
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.core.MassSpectrumIdentifierFile;
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.core.PeakIdentifierFile;
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.IFileIdentifierSettings;
-import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.MassSpectrumIdentifierSettings;
+import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.MassSpectrumLibraryIdentifierSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.PeakIdentifierSettings;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.identifier.IPeakIdentificationResults;
@@ -75,7 +75,7 @@ public class AlkaneIdentifier {
 		/*
 		 * Create the file identifier settings.
 		 */
-		MassSpectrumIdentifierSettings fileIdentifierSettings = new MassSpectrumIdentifierSettings();
+		MassSpectrumLibraryIdentifierSettings fileIdentifierSettings = new MassSpectrumLibraryIdentifierSettings();
 		initializeSettings(fileIdentifierSettings);
 		transferAlkaneSettings(fileIdentifierSettings, alkaneSettings);
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/settings/AbstractAlkaneSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/settings/AbstractAlkaneSettings.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Lablicate GmbH.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Philip Wenig - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.settings;
+
+import org.eclipse.chemclipse.model.identifier.AbstractIdentifierSettings;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AbstractAlkaneSettings extends AbstractIdentifierSettings implements IAlkaneSettings {
+
+	@JsonProperty(value = "Number of Targets", defaultValue = "15")
+	private int numberOfTargets = 15;
+	@JsonProperty(value = "Min Match Factor", defaultValue = "80.0")
+	private float minMatchFactor = 80.0f;
+	@JsonProperty(value = "Min Reverse Match Factor", defaultValue = "80.0")
+	private float minReverseMatchFactor = 80.0f;
+
+	@Override
+	public int getNumberOfTargets() {
+
+		return numberOfTargets;
+	}
+
+	@Override
+	public void setNumberOfTargets(int numberOfTargets) {
+
+		this.numberOfTargets = numberOfTargets;
+	}
+
+	@Override
+	public float getMinMatchFactor() {
+
+		return minMatchFactor;
+	}
+
+	@Override
+	public void setMinMatchFactor(float minMatchFactor) {
+
+		this.minMatchFactor = minMatchFactor;
+	}
+
+	@Override
+	public float getMinReverseMatchFactor() {
+
+		return minReverseMatchFactor;
+	}
+
+	@Override
+	public void setMinReverseMatchFactor(float minReverseMatchFactor) {
+
+		this.minReverseMatchFactor = minReverseMatchFactor;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/settings/IAlkaneSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/settings/IAlkaneSettings.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 Lablicate GmbH.
- *
+ * Copyright (c) 2024 Lablicate GmbH.
+ * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,17 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.settings;
 
-import org.eclipse.chemclipse.chromatogram.msd.identifier.settings.IMassSpectrumIdentifierSettings;
+public interface IAlkaneSettings {
 
-public class MassSpectrumIdentifierAlkaneSettings extends AbstractAlkaneSettings implements IMassSpectrumIdentifierSettings {
+	int getNumberOfTargets();
+
+	void setNumberOfTargets(int numberOfTargets);
+
+	float getMinMatchFactor();
+
+	void setMinMatchFactor(float minMatchFactor);
+
+	float getMinReverseMatchFactor();
+
+	void setMinReverseMatchFactor(float minReverseMatchFactor);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/settings/PeakIdentifierAlkaneSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/settings/PeakIdentifierAlkaneSettings.java
@@ -12,46 +12,6 @@
 package org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.settings;
 
 import org.eclipse.chemclipse.chromatogram.msd.identifier.settings.IPeakIdentifierSettingsMSD;
-import org.eclipse.chemclipse.model.identifier.AbstractIdentifierSettings;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-public class PeakIdentifierAlkaneSettings extends AbstractIdentifierSettings implements IPeakIdentifierSettingsMSD {
-
-	@JsonProperty(value = "Number of Targets", defaultValue = "15")
-	private int numberOfTargets = 15;
-	@JsonProperty(value = "Min Match Factor", defaultValue = "80.0")
-	private float minMatchFactor = 80.0f;
-	@JsonProperty(value = "Min Reverse Match Factor", defaultValue = "80.0")
-	private float minReverseMatchFactor = 80.0f;
-
-	public int getNumberOfTargets() {
-
-		return numberOfTargets;
-	}
-
-	public void setNumberOfTargets(int numberOfTargets) {
-
-		this.numberOfTargets = numberOfTargets;
-	}
-
-	public float getMinMatchFactor() {
-
-		return minMatchFactor;
-	}
-
-	public void setMinMatchFactor(float minMatchFactor) {
-
-		this.minMatchFactor = minMatchFactor;
-	}
-
-	public float getMinReverseMatchFactor() {
-
-		return minReverseMatchFactor;
-	}
-
-	public void setMinReverseMatchFactor(float minReverseMatchFactor) {
-
-		this.minReverseMatchFactor = minReverseMatchFactor;
-	}
+public class PeakIdentifierAlkaneSettings extends AbstractAlkaneSettings implements IPeakIdentifierSettingsMSD {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/plugin.xml
@@ -45,7 +45,7 @@
             id="org.eclipse.chemclipse.chromatogram.msd.identifier.supplier.file.massSpectrum"
             identifier="org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.core.MassSpectrumIdentifierFile"
             identifierName="Library File (MS)"
-            identifierSettings="org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.MassSpectrumIdentifierSettings">
+            identifierSettings="org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.MassSpectrumLibraryIdentifierSettings">
       </MassSpectrumIdentificationSupplier>
       <MassSpectrumIdentificationSupplier
             description="This plugin sets a mass spectrum identification using the highest intensity m/z values."

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/core/MassSpectrumIdentifierFile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/core/MassSpectrumIdentifierFile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 Lablicate GmbH.
+ * Copyright (c) 2014, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,7 +19,7 @@ import org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.AbstractM
 import org.eclipse.chemclipse.chromatogram.msd.identifier.settings.IMassSpectrumIdentifierSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.internal.identifier.FileIdentifier;
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.preferences.PreferenceSupplier;
-import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.MassSpectrumIdentifierSettings;
+import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.MassSpectrumLibraryIdentifierSettings;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -34,8 +34,8 @@ public class MassSpectrumIdentifierFile extends AbstractMassSpectrumIdentifier {
 		IProcessingInfo<IMassSpectra> processingInfo = new ProcessingInfo<>();
 		//
 		try {
-			MassSpectrumIdentifierSettings massSpectrumIdentifierSettings;
-			if(identifierSettings instanceof MassSpectrumIdentifierSettings settings) {
+			MassSpectrumLibraryIdentifierSettings massSpectrumIdentifierSettings;
+			if(identifierSettings instanceof MassSpectrumLibraryIdentifierSettings settings) {
 				massSpectrumIdentifierSettings = settings;
 			} else {
 				massSpectrumIdentifierSettings = PreferenceSupplier.getMassSpectrumIdentifierSettings();

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/preferences/PreferenceSupplier.java
@@ -21,7 +21,7 @@ import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.IUnknownSettingsMSD;
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.IUnknownSettingsWSD;
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.IdentifierSettings;
-import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.MassSpectrumIdentifierSettings;
+import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.MassSpectrumLibraryIdentifierSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.MassSpectrumUnknownSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.PeakIdentifierSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.PeakUnknownSettingsCSD;
@@ -182,9 +182,9 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 		putDefault(P_INCLUDE_RETENTION_INDEX_UNKNOWN + postfix, Boolean.toString(DEF_INCLUDE_RETENTION_INDEX_UNKNOWN));
 	}
 
-	public static MassSpectrumIdentifierSettings getMassSpectrumIdentifierSettings() {
+	public static MassSpectrumLibraryIdentifierSettings getMassSpectrumIdentifierSettings() {
 
-		MassSpectrumIdentifierSettings settings = new MassSpectrumIdentifierSettings();
+		MassSpectrumLibraryIdentifierSettings settings = new MassSpectrumLibraryIdentifierSettings();
 		initialize(settings);
 		//
 		return settings;
@@ -244,7 +244,6 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 
 		String postfix = POSTFIX_MSD;
 		MassSpectrumUnknownSettings settings = new MassSpectrumUnknownSettings();
-		settings.setMassSpectrumComparatorId("");
 		initalizeUnknownSettings(settings, postfix);
 		settings.setNumberOfMZ(INSTANCE().getInteger(P_NUMBER_OF_MZ_UNKNOWN + postfix, DEF_NUMBER_OF_MZ_UNKNOWN));
 		//

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/settings/MassSpectrumLibraryIdentifierSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/settings/MassSpectrumLibraryIdentifierSettings.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
-public class MassSpectrumIdentifierSettings extends AbstractMassSpectrumIdentifierSettings implements ILibraryIdentifierSettings {
+public class MassSpectrumLibraryIdentifierSettings extends AbstractMassSpectrumIdentifierSettings implements ILibraryIdentifierSettings {
 
 	@JsonProperty(value = "Library File", defaultValue = "")
 	@JsonPropertyDescription("Select the library file.")

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/settings/MassSpectrumUnknownSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/settings/MassSpectrumUnknownSettings.java
@@ -11,20 +11,17 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings;
 
+import org.eclipse.chemclipse.chromatogram.msd.identifier.settings.IMassSpectrumIdentifierSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.preferences.PreferenceSupplier;
-import org.eclipse.chemclipse.model.identifier.IIdentifierSettings;
+import org.eclipse.chemclipse.model.identifier.AbstractIdentifierSettings;
 import org.eclipse.chemclipse.support.settings.FloatSettingsProperty;
 import org.eclipse.chemclipse.support.settings.IntSettingsProperty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
-public class MassSpectrumUnknownSettings extends MassSpectrumIdentifierSettings implements IUnknownSettingsMSD {
+public class MassSpectrumUnknownSettings extends AbstractIdentifierSettings implements IUnknownSettingsMSD, IMassSpectrumIdentifierSettings {
 
-	@JsonProperty(value = "Limit Match Factor", defaultValue = "80.0")
-	@JsonPropertyDescription(value = "Run an identification if no target exists with a Match Factor >= the given limit.")
-	@FloatSettingsProperty(minValue = IIdentifierSettings.MIN_LIMIT_MATCH_FACTOR, maxValue = IIdentifierSettings.MAX_LIMIT_MATCH_FACTOR)
-	private float limitMatchFactor = 80.0f;
 	@JsonProperty(value = "Target Name", defaultValue = PreferenceSupplier.DEF_TARGET_NAME_UNKNOWN)
 	private String targetName = "Unknown";
 	@JsonProperty(value = "Match Quality", defaultValue = "80.0")
@@ -49,18 +46,6 @@ public class MassSpectrumUnknownSettings extends MassSpectrumIdentifierSettings 
 	private boolean includeRetentionIndex = false;
 
 	@Override
-	public float getLimitMatchFactor() {
-
-		return limitMatchFactor;
-	}
-
-	@Override
-	public void setLimitMatchFactor(float limitMatchFactor) {
-
-		this.limitMatchFactor = limitMatchFactor;
-	}
-
-	@Override
 	public String getTargetName() {
 
 		return targetName;
@@ -82,11 +67,6 @@ public class MassSpectrumUnknownSettings extends MassSpectrumIdentifierSettings 
 	public void setMatchQuality(float matchQuality) {
 
 		this.matchQuality = matchQuality;
-	}
-
-	public int getNumberOfMZ() {
-
-		return numberOfMZ;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak/src/org/eclipse/chemclipse/msd/classifier/supplier/molpeak/identifier/BasePeakIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak/src/org/eclipse/chemclipse/msd/classifier/supplier/molpeak/identifier/BasePeakIdentifier.java
@@ -24,7 +24,7 @@ import org.eclipse.chemclipse.chromatogram.msd.identifier.support.TargetBuilderM
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.core.MassSpectrumIdentifierFile;
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.core.PeakIdentifierFile;
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.IFileIdentifierSettings;
-import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.MassSpectrumIdentifierSettings;
+import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.MassSpectrumLibraryIdentifierSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings.PeakIdentifierSettings;
 import org.eclipse.chemclipse.model.identifier.ComparisonResult;
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
@@ -189,7 +189,7 @@ public class BasePeakIdentifier {
 		/*
 		 * Post identify NOTFOUND peaks.
 		 */
-		MassSpectrumIdentifierSettings massSpectrumIdentifierSettings = new MassSpectrumIdentifierSettings();
+		MassSpectrumLibraryIdentifierSettings massSpectrumIdentifierSettings = new MassSpectrumLibraryIdentifierSettings();
 		setIdentifierSettings(massSpectrumIdentifierSettings);
 		setFileIdentifierSettings(massSpectrumIdentifierSettings);
 		MassSpectrumIdentifierFile massSpectrumIdentifier = new MassSpectrumIdentifierFile();


### PR DESCRIPTION
as the class names and inheritance from https://github.com/eclipse/chemclipse/pull/1981 were a bit unfortunate.