### PR TITLE
Try to fix Jenkins triggering twice

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,9 +4,6 @@ pipeline {
 			label 'ubuntu-latest'
 		}
 	}
-	triggers {
-		pollSCM('H/5 * * * *')
-	}
 	parameters {
 		booleanParam(name: 'CLEAN_INTEGRATION', defaultValue: false, description: 'Attention: Cleans the integration folder with all branches completely.')
 		booleanParam(name: 'CODESIGN', defaultValue: false, description: 'Sign the artifacts.')


### PR DESCRIPTION
https://ci.eclipse.org/chemclipse/job/chemclipse/job/develop/ always runs twice. My theory is that it gets a notification for every commit, and then we also have this every 5 minute poll git for changes, and this might be the second one. Because there is a fresh Kubernetes runner, it will then do another full rebuild as nothing is cached which is wasteful.