### PR TITLE
Reuse Apache dependencies from Eclipse repository

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
@@ -181,14 +181,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="wrapped.org.apache.httpcomponents.httpclient"
-         version="0.0.0"/>
-
-   <plugin
-         id="wrapped.org.apache.httpcomponents.httpcore"
-         version="0.0.0"/>
-
-   <plugin
          id="org.apache.commons.commons-io"
          version="0.0.0"/>
 
@@ -222,10 +214,6 @@
 
    <plugin
          id="org.apache.commons.commons-collections4"
-         version="0.0.0"/>
-
-   <plugin
-         id="wrapped.org.apache.httpcomponents.httpclient-cache"
          version="0.0.0"/>
 
    <plugin
@@ -382,6 +370,14 @@
 
    <plugin
          id="com.sun.xml.bind.jaxb-osgi"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.httpcomponents.httpclient"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.httpcomponents.httpcore"
          version="0.0.0"/>
 
 </feature>

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/AbstractPeakModelCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/AbstractPeakModelCSD.java
@@ -20,7 +20,7 @@ public abstract class AbstractPeakModelCSD extends PeakModel implements IPeakMod
 
 	private static final long serialVersionUID = 1580595192753292038L;
 
-	public AbstractPeakModelCSD(IScan peakMaximum, IPeakIntensityValues peakIntensityValues, float startBackgroundAbundance, float stopBackgroundAbundance) throws IllegalArgumentException, PeakException {
+	protected AbstractPeakModelCSD(IScan peakMaximum, IPeakIntensityValues peakIntensityValues, float startBackgroundAbundance, float stopBackgroundAbundance) throws IllegalArgumentException, PeakException {
 
 		super(peakMaximum, peakIntensityValues, startBackgroundAbundance, stopBackgroundAbundance);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeakModel.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeakModel.java
@@ -215,7 +215,7 @@ public abstract class AbstractPeakModel extends AbstractPeakModelStrict implemen
 		if(strictModel) {
 			return calucalteTailingByInflectionPoints(percentageHeightBaseline);
 		} else {
-			return calucalteTailingByIntensityValues();
+			return calculateTailingByIntensityValues();
 		}
 	}
 
@@ -357,7 +357,7 @@ public abstract class AbstractPeakModel extends AbstractPeakModelStrict implemen
 		validateStrictModel();
 	}
 
-	private float calucalteTailingByIntensityValues() {
+	private float calculateTailingByIntensityValues() {
 
 		float tailing = 0.0f;
 		List<Integer> retentionTimes = peakIntensityValues.getRetentionTimes();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/META-INF/MANIFEST.MF
@@ -20,12 +20,11 @@ Require-Bundle: org.eclipse.core.runtime,
  org.apache.commons.lang3;bundle-version="3.12.0",
  org.apache.thrift;bundle-version="0.12.0",
  org.apache.commons.commons-compress;bundle-version="1.22.0",
- wrapped.org.apache.httpcomponents.httpclient;bundle-version="4.5.14",
- wrapped.org.apache.httpcomponents.httpcore;bundle-version="4.4.16",
  org.slf4j.api;bundle-version="1.7.30",
- wrapped.org.apache.httpcomponents.httpclient-cache;bundle-version="4.5.14",
  org.eclipse.chemclipse.logging;bundle-version="0.9.0",
  org.eclipse.chemclipse.model;bundle-version="0.9.0",
- org.eclipse.chemclipse.chromatogram.xxd.identifier;bundle-version="0.9.0"
+ org.eclipse.chemclipse.chromatogram.xxd.identifier;bundle-version="0.9.0",
+ org.apache.httpcomponents.httpclient;bundle-version="4.5.14",
+ org.apache.httpcomponents.httpcore;bundle-version="4.4.16"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -15,6 +15,12 @@
 	<unit id="org.glassfish.hk2.osgi-resource-locator" version="0.0.0"/>
 	<unit id="com.sun.xml.bind.jaxb-osgi" version="0.0.0"/>
 	<unit id="jakarta.xml.bind-api" version="0.0.0"/>
+	<unit id="org.apache.commons.codec" version="0.0.0"/>
+	<unit id="org.apache.commons.commons-collections4" version="0.0.0"/>
+	<unit id="org.apache.commons.commons-compress" version="0.0.0"/>
+	<unit id="org.apache.commons.lang3" version="0.0.0"/>
+	<unit id="org.apache.httpcomponents.httpclient" version="0.0.0"/>
+	<unit id="org.apache.httpcomponents.httpcore" version="0.0.0"/>
 	<repository location="https://download.eclipse.org/releases/2024-09/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -47,33 +53,9 @@
 				<type>jar</type>
 			</dependency>
 			<dependency>
-				<groupId>commons-codec</groupId>
-				<artifactId>commons-codec</artifactId>
-				<version>1.16.0</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-collections4</artifactId>
-				<version>4.4</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-compress</artifactId>
-				<version>1.24.0</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-csv</artifactId>
 				<version>1.10.0</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-lang3</artifactId>
-				<version>3.13.0</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
@@ -224,28 +206,6 @@
 				<groupId>org.apache.poi</groupId>
 				<artifactId>poi</artifactId>
 				<version>4.1.1</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
-	</location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="org.apache.httpcomponents" missingManifest="generate" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>org.apache.httpcomponents</groupId>
-				<artifactId>httpclient-cache</artifactId>
-				<version>4.5.14</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.httpcomponents</groupId>
-				<artifactId>httpclient</artifactId>
-				<version>4.5.14</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.httpcomponents</groupId>
-				<artifactId>httpcore</artifactId>
-				<version>4.4.16</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
There is no point in wrapping them with @eclipse-m2e when they are already packaged.