### PR TITLE
Show detailed feedback about MS database converter errors

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/META-INF/MANIFEST.MF
@@ -19,7 +19,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.processing;bundle-version="0.8.0",
  org.eclipse.nebula.visualization.xygraph;bundle-version="1.0.0",
  org.eclipse.chemclipse.support.ui;bundle-version="0.8.0",
- org.eclipse.e4.core.services;bundle-version="2.0.0"
+ org.eclipse.e4.core.services;bundle-version="2.0.0",
+ org.eclipse.chemclipse.processing.ui;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.chemclipse.msd.swt.ui.components,
  org.eclipse.chemclipse.msd.swt.ui.components.identification,

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/support/DatabaseExportRunnable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/support/DatabaseExportRunnable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 Lablicate GmbH.
+ * Copyright (c) 2013, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -19,6 +19,7 @@ import org.eclipse.chemclipse.msd.converter.database.DatabaseConverter;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.processing.converter.ISupplier;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.processing.ui.support.ProcessingInfoPartSupport;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 
@@ -37,7 +38,7 @@ public class DatabaseExportRunnable implements IRunnableWithProgress {
 	}
 
 	/**
-	 * Returns the written chromatogram file or null.
+	 * Returns the written database file or null.
 	 */
 	public File getData() {
 
@@ -50,6 +51,7 @@ public class DatabaseExportRunnable implements IRunnableWithProgress {
 		try {
 			monitor.beginTask("Export Mass Spectra", IProgressMonitor.UNKNOWN);
 			IProcessingInfo<File> processingInfo = DatabaseConverter.convert(file, massSpectra, false, supplier.getId(), monitor);
+			ProcessingInfoPartSupport.getInstance().update(processingInfo);
 			data = processingInfo.getProcessingResult();
 		} finally {
 			monitor.done();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/support/DatabaseFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/support/DatabaseFileSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 Lablicate GmbH.
+ * Copyright (c) 2015, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -251,10 +251,6 @@ public class DatabaseFileSupport {
 		} catch(InterruptedException e) {
 			logger.warn(e);
 			Thread.currentThread().interrupt();
-		}
-		File data = runnable.getData();
-		if(data == null) {
-			MessageDialog.openInformation(shell, "Save Database / Mass Spectra", "There is not suitable database / mass spectra converter available.");
 		}
 	}
 


### PR DESCRIPTION
I forgot about it at https://github.com/eclipse-chemclipse/chemclipse/pull/1866. This removes a generic error message with awkward wording into a detailed feedback about what went wrong in the converter. Also avoids two pop-up windows.