### PR TITLE
Added mzXML standalone mass spectra write support

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.processing;bundle-version="0.8.0",
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
- org.eclipse.chemclipse.support;bundle-version="0.8.0"
+ org.eclipse.chemclipse.support;bundle-version="0.8.0",
+ org.apache.commons.commons-codec;bundle-version="1.16.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.msd.converter.supplier.mzxml.preferences

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/plugin.xml
@@ -19,7 +19,7 @@
    <extension
          point="org.eclipse.chemclipse.msd.converter.massSpectrumSupplier">
       <MassSpectrumSupplier
-            description="Reads mzXML Mass Spectra"
+            description="Reads and writes mzXML Mass Spectra"
             exportConverter="org.eclipse.chemclipse.msd.converter.supplier.mzxml.converter.MassSpectrumExportConverter"
             fileExtension=".mzXML"
             filterName="mzXML Mass Spectra (*.mzXML)"
@@ -30,5 +30,20 @@
             isExportable="false"
             isImportable="true">
       </MassSpectrumSupplier>
+   </extension>
+   <extension
+         point="org.eclipse.chemclipse.msd.converter.databaseSupplier">
+      <DatabaseSupplier
+            description="Reads and writes mzXML Mass Spectra"
+            exportConverter="org.eclipse.chemclipse.msd.converter.supplier.mzxml.converter.DatabaseExportConverter"
+            fileExtension=".mzXML"
+            filterName="mzXML Mass Spectra (*.mzXML)"
+            id="org.eclipse.chemclipse.msd.converter.supplier.mzxml.library"
+            importConverter="org.eclipse.chemclipse.msd.converter.supplier.mzxml.converter.DatabaseImportConverter"
+            importMagicNumberMatcher="org.eclipse.chemclipse.msd.converter.supplier.mzxml.converter.MagicNumberMatcher"
+            importContentMatcher="org.eclipse.chemclipse.msd.converter.supplier.mzxml.converter.MassSpectrumFileContentMatcher"
+            isExportable="true"
+            isImportable="false">
+      </DatabaseSupplier>
    </extension>
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/DatabaseExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/DatabaseExportConverter.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzxml.converter;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
+import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.msd.converter.database.AbstractDatabaseExportConverter;
+import org.eclipse.chemclipse.msd.converter.io.IMassSpectraWriter;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.io.MassSpectrumWriter;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.processing.core.ProcessingInfo;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.osgi.util.NLS;
+
+public class DatabaseExportConverter extends AbstractDatabaseExportConverter {
+
+	private static final Logger logger = Logger.getLogger(DatabaseExportConverter.class);
+	private static String DESCRIPTION = "mzXML Mass Spectrum Export";
+
+	@Override
+	public IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
+
+		IProcessingInfo<File> processingInfo = validate(file, massSpectrum);
+		if(!processingInfo.hasErrorMessages()) {
+			try {
+				IMassSpectraWriter massSpectraWriter = new MassSpectrumWriter();
+				massSpectraWriter.write(file, massSpectrum, append, monitor);
+				processingInfo.setProcessingResult(file);
+			} catch(FileNotFoundException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.fileNotFound, file.getAbsolutePath()));
+			} catch(FileIsNotWriteableException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.fileNotWritable, file.getAbsolutePath()));
+			} catch(IOException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.failedToWriteFile, file.getAbsolutePath()));
+			}
+		}
+		return processingInfo;
+	}
+
+	@Override
+	public IProcessingInfo<File> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
+
+		return convert(file, massSpectra.getMassSpectrum(1), false, monitor);
+	}
+
+	private IProcessingInfo<File> validate(File file, IScanMSD massSpectrum) {
+
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
+		processingInfo.addMessages(super.validate(file));
+		processingInfo.addMessages(super.validate(massSpectrum));
+		return processingInfo;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/DatabaseImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/DatabaseImportConverter.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzxml.converter;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
+import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
+import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.msd.converter.database.AbstractDatabaseImportConverter;
+import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.io.MassSpectrumReader;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.processing.core.ProcessingInfo;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.osgi.util.NLS;
+
+public class DatabaseImportConverter extends AbstractDatabaseImportConverter {
+
+	private static final Logger logger = Logger.getLogger(DatabaseImportConverter.class);
+	private static String DESCRIPTION = "mzXML Mass Spectrum Import";
+
+	@Override
+	public IProcessingInfo<IMassSpectra> convert(File file, IProgressMonitor monitor) {
+
+		IProcessingInfo<IMassSpectra> processingInfo = new ProcessingInfo<>();
+		/*
+		 * Checks if the file is null or empty ...
+		 */
+		IProcessingInfo<IMassSpectra> processingInfoValidate = super.validate(file);
+		if(processingInfoValidate.hasErrorMessages()) {
+			processingInfo.addMessages(processingInfoValidate);
+		} else {
+			try {
+				IMassSpectraReader massSpectraReader = new MassSpectrumReader();
+				IMassSpectra massSpectra = massSpectraReader.read(file, monitor);
+				if(massSpectra != null && !massSpectra.isEmpty()) {
+					processingInfo.setProcessingResult(massSpectra);
+				} else {
+					processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.noMassSpectraStored, file.getAbsolutePath()));
+				}
+			} catch(FileNotFoundException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.fileNotFound, file.getAbsolutePath()));
+			} catch(FileIsNotReadableException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.fileNotReadable, file.getAbsolutePath()));
+			} catch(FileIsEmptyException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.emptyFile, file.getAbsolutePath()));
+			} catch(IOException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.failedToReadFile, file.getAbsolutePath()));
+			}
+		}
+		return processingInfo;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -23,13 +23,10 @@ import org.eclipse.core.runtime.IProgressMonitor;
 
 public class MassSpectrumExportConverter extends AbstractMassSpectrumExportConverter {
 
-	private static final String DESCRIPTION = "mzXML Mass Spectra Export Converter";
-
 	@Override
 	public IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
 
 		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
-		processingInfo.addErrorMessage(DESCRIPTION, "It's not possible to export mass spectrum data as mzXML yet.");
 		return processingInfo;
 	}
 
@@ -37,7 +34,6 @@ public class MassSpectrumExportConverter extends AbstractMassSpectrumExportConve
 	public IProcessingInfo<File> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
 
 		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
-		processingInfo.addErrorMessage(DESCRIPTION, "It's not possible to export mass spectrum data as mzXML yet.");
 		return processingInfo;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramWriterVersion32.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramWriterVersion32.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 Lablicate GmbH.
+ * Copyright (c) 2021, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -46,11 +46,11 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 
-public class ChromatogramWriter32 extends AbstractChromatogramWriter implements IChromatogramMSDWriter {
+public class ChromatogramWriterVersion32 extends AbstractChromatogramWriter implements IChromatogramMSDWriter {
 
 	public static final String VERSION = "mzXML_3.2";
 	//
-	private static final Logger logger = Logger.getLogger(ChromatogramWriter32.class);
+	private static final Logger logger = Logger.getLogger(ChromatogramWriterVersion32.class);
 
 	@Override
 	public void writeChromatogram(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramWriterVersion32.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramWriterVersion32.java
@@ -58,6 +58,7 @@ public class ChromatogramWriterVersion32 extends AbstractChromatogramWriter impl
 		try {
 			JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
 			Marshaller marshaller = jaxbContext.createMarshaller();
+			marshaller.setProperty(Marshaller.JAXB_SCHEMA_LOCATION, "http://sashimi.sourceforge.net/schema_revision/mzXML_3.2");
 			MsRun msRun = new MsRun();
 			for(IScan sourceScan : chromatogram.getScans()) {
 				Scan exportScan = new Scan();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion21.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion21.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 Lablicate GmbH.
+ * Copyright (c) 2015, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -29,11 +29,11 @@ import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
-import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.DataProcessing;
-import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.MsRun;
-import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.ObjectFactory;
-import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.Peaks;
-import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.Scan;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.DataProcessing;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.MsRun;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.ObjectFactory;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.Peaks;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.Scan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorMassSpectra;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorMassSpectra;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion22.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 Lablicate GmbH.
+ * Copyright (c) 2015, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -29,11 +29,11 @@ import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
-import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.DataProcessing;
-import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.MsRun;
-import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.ObjectFactory;
-import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.Peaks;
-import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.Scan;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.DataProcessing;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.MsRun;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.ObjectFactory;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.Peaks;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.Scan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorMassSpectra;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorMassSpectra;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion22.java
@@ -31,6 +31,7 @@ import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.DataProcessing;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.MsRun;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.MzXML;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.ObjectFactory;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.Peaks;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.Scan;
@@ -64,25 +65,27 @@ public class MassSpectrumReaderVersion22 extends AbstractMassSpectraReader imple
 		//
 		try {
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+			documentBuilderFactory.setNamespaceAware(true);
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);
-			NodeList nodeList = document.getElementsByTagName(AbstractChromatogramReaderVersion.NODE_MS_RUN);
+			NodeList nodeList = document.getElementsByTagName(AbstractChromatogramReaderVersion.NODE_MZXML);
 			//
 			JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
 			Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
-			MsRun msrun = (MsRun)unmarshaller.unmarshal(nodeList.item(0));
+			MzXML mzXML = (MzXML)unmarshaller.unmarshal(nodeList.item(0));
 			//
 			massSpectrum = new VendorMassSpectrum();
 			massSpectrum.setFile(file);
 			massSpectrum.setIdentifier(file.getName());
-			for(DataProcessing dataProcessing : msrun.getDataProcessing()) {
+			MsRun msRun = mzXML.getMsRun();
+			for(DataProcessing dataProcessing : msRun.getDataProcessing()) {
 				if(Boolean.TRUE.equals(dataProcessing.isCentroided())) {
 					massSpectrum.setMassSpectrumType(MassSpectrumType.CENTROID);
 				} else {
 					massSpectrum.setMassSpectrumType(MassSpectrumType.PROFILE);
 				}
 			}
-			List<Scan> scans = msrun.getScan();
+			List<Scan> scans = msRun.getScan();
 			monitor.beginTask(ConverterMessages.readScans, scans.size());
 			for(Scan scan : scans) {
 				/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumWriterVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumWriterVersion22.java
@@ -1,0 +1,194 @@
+/*******************************************************************************
+ * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * 
+ * All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
+import java.util.List;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
+import org.eclipse.chemclipse.converter.exceptions.NoConverterAvailableException;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.msd.converter.io.IMassSpectraWriter;
+import org.eclipse.chemclipse.msd.converter.massspectrum.MassSpectrumConverter;
+import org.eclipse.chemclipse.msd.converter.massspectrum.MassSpectrumConverterSupport;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.DataProcessing;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.MsRun;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.MzXML;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.ObjectFactory;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.ParentFile;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.Peaks;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.Scan;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.Software;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.io.MassSpectrumWriter;
+import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
+import org.eclipse.core.runtime.IProduct;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Platform;
+import org.osgi.framework.Version;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+
+public class MassSpectrumWriterVersion22 implements IMassSpectraWriter {
+
+	public static final String VERSION = "mzXML_2.2";
+	//
+	private static final Logger logger = Logger.getLogger(MassSpectrumWriter.class);
+
+	@Override
+	public void write(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
+
+		writeMassSpectrum(file, massSpectrum);
+	}
+
+	@Override
+	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
+
+		writeMassSpectra(file, massSpectra, monitor);
+	}
+
+	private void writeMassSpectra(File file, IMassSpectra massSpectra, IProgressMonitor monitor) throws IOException {
+
+		for(int i = 1; i <= massSpectra.size(); i++) {
+			IScanMSD massSpectrum = massSpectra.getMassSpectrum(i);
+			if(massSpectrum != null && massSpectrum.getNumberOfIons() > 0) {
+				writeMassSpectrum(file, massSpectrum);
+			}
+		}
+	}
+
+	private void writeMassSpectrum(File file, IScanMSD scanMSD) {
+
+		try {
+			writeMzXML(file, scanMSD);
+		} catch(JAXBException e) {
+			logger.warn(e);
+		}
+	}
+
+	private void writeMzXML(File file, IScanMSD scanMSD) throws JAXBException {
+
+		JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
+		Marshaller marshaller = jaxbContext.createMarshaller();
+		MzXML mzXML = new MzXML();
+		mzXML.setMsRun(createMsRun(file, scanMSD));
+		marshaller.marshal(mzXML, file);
+	}
+
+	private MsRun createMsRun(File file, IScanMSD scanMSD) {
+
+		MsRun msRun = new MsRun();
+		if(scanMSD instanceof IRegularMassSpectrum regularMassSpectrum) {
+			msRun.getDataProcessing().add(createDataProcessing(regularMassSpectrum));
+		}
+		msRun.setScanCount(BigInteger.valueOf(1));
+		msRun.getParentFile().add(createParentFile(file));
+		msRun.getScan().add(createScan(scanMSD));
+		return msRun;
+	}
+
+	private DataProcessing createDataProcessing(IRegularMassSpectrum regularMassSpectrum) {
+
+		DataProcessing dataProcessing = new DataProcessing();
+		dataProcessing.setCentroided(regularMassSpectrum.getMassSpectrumType() == MassSpectrumType.CENTROID);
+		dataProcessing.setSoftware(createSoftware());
+		return dataProcessing;
+	}
+
+	private Software createSoftware() {
+
+		Software software = new Software();
+		IProduct product = Platform.getProduct();
+		if(product != null) {
+			software.setName(product.getName());
+			Version version = product.getDefiningBundle().getVersion();
+			software.setVersion(version.getMajor() + "." + version.getMinor() + "." + version.getMicro());
+		}
+		return software;
+	}
+
+	private ParentFile createParentFile(File file) {
+
+		ParentFile parentFile = new ParentFile();
+		parentFile.setFileName(file.getName());
+		MassSpectrumConverterSupport converterSupport = MassSpectrumConverter.getMassSpectrumConverterSupport();
+		try {
+			List<String> availableConverterIds = converterSupport.getAvailableConverterIds(file);
+			if(!availableConverterIds.isEmpty()) {
+				parentFile.setFileType(availableConverterIds.get(0));
+			}
+		} catch(NoConverterAvailableException e) {
+			logger.warn(e);
+		}
+		try {
+			parentFile.setFileSha1(new DigestUtils(DigestUtils.getSha1Digest()).digestAsHex(file));
+		} catch(IOException e) {
+			logger.warn(e);
+		}
+		return parentFile;
+	}
+
+	private Scan createScan(IScanMSD scanMSD) {
+
+		Scan scan = new Scan();
+		scan.setNum(BigInteger.valueOf(1));
+		if(scanMSD instanceof IRegularMassSpectrum regularMassSpectrum) {
+			scan.setMsLevel(BigInteger.valueOf(regularMassSpectrum.getMassSpectrometer()));
+			scan.setCentroided(regularMassSpectrum.getMassSpectrumType() == MassSpectrumType.CENTROID);
+		}
+		scan.setPeaksCount(BigInteger.valueOf(scanMSD.getNumberOfIons()));
+		scan.setPeaks(createPeaks(scanMSD));
+		return scan;
+	}
+
+	private Peaks createPeaks(IScanMSD scanMSD) {
+
+		Peaks peaks = new Peaks();
+		peaks.setPrecision(BigInteger.valueOf(Float.BYTES));
+		peaks.setByteOrder("network");
+		peaks.setValue(encodeFloatArray(createValues(scanMSD)));
+		return peaks;
+	}
+
+	private static float[] createValues(IScanMSD scanMSD) {
+
+		float[] peaksArray = new float[scanMSD.getNumberOfIons() * 2];
+		int i = 0;
+		for(IIon ion : scanMSD.getIons()) {
+			peaksArray[i] = (float)ion.getIon();
+			i++;
+			peaksArray[i] = ion.getAbundance();
+			i++;
+		}
+		return peaksArray;
+	}
+
+	private static byte[] encodeFloatArray(float[] array) {
+
+		FloatBuffer doubleBuffer = FloatBuffer.wrap(array);
+		ByteBuffer byteBuffer = ByteBuffer.allocate(doubleBuffer.capacity() * Float.BYTES);
+		byteBuffer.order(ByteOrder.BIG_ENDIAN);
+		byteBuffer.asFloatBuffer().put(doubleBuffer);
+		return byteBuffer.array();
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumWriterVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumWriterVersion22.java
@@ -90,6 +90,7 @@ public class MassSpectrumWriterVersion22 implements IMassSpectraWriter {
 
 		JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
 		Marshaller marshaller = jaxbContext.createMarshaller();
+		marshaller.setProperty(Marshaller.JAXB_SCHEMA_LOCATION, "http://sashimi.sourceforge.net/schema_revision/mzXML_3.2 http://sashimi.sourceforge.net/schema_revision/mzXML_3.2/mzXML_idx_3.2.xsd");
 		MzXML mzXML = new MzXML();
 		mzXML.setMsRun(createMsRun(file, scanMSD));
 		marshaller.marshal(mzXML, file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v22/model/MzXML.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v22/model/MzXML.java
@@ -21,7 +21,7 @@ import jakarta.xml.bind.annotation.XmlType;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "", propOrder = {"msRun"})
-@XmlRootElement(name = "mzXML", namespace = "http://sashimi.sourceforge.net/schema_revision/mzXML_2.2")
+@XmlRootElement(name = "mzXML")
 public class MzXML implements Serializable {
 
 	private static final long serialVersionUID = 220L;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v22/model/MzXML.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v22/model/MzXML.java
@@ -9,7 +9,7 @@
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
-package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v32.model;
+package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model;
 
 import java.io.Serializable;
 
@@ -21,10 +21,10 @@ import jakarta.xml.bind.annotation.XmlType;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "", propOrder = {"msRun"})
-@XmlRootElement(name = "mzXML", namespace = "http://sashimi.sourceforge.net/schema_revision/mzXML_3.2")
+@XmlRootElement(name = "mzXML", namespace = "http://sashimi.sourceforge.net/schema_revision/mzXML_2.2")
 public class MzXML implements Serializable {
 
-	private static final long serialVersionUID = 320L;
+	private static final long serialVersionUID = 220L;
 	@XmlElement(required = true)
 	private MsRun msRun;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v22/model/ObjectFactory.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v22/model/ObjectFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 Lablicate GmbH.
+ * Copyright (c) 2015, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,10 +11,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model;
 
+import javax.xml.namespace.QName;
+
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.annotation.XmlElementDecl;
 import jakarta.xml.bind.annotation.XmlRegistry;
-import javax.xml.namespace.QName;
 
 @XmlRegistry
 public class ObjectFactory {
@@ -22,6 +23,12 @@ public class ObjectFactory {
 	private static final QName _SeparationTechnique_QNAME = new QName("http://sashimi.sourceforge.net/schema_revision/mzXML_2.2", "separationTechnique");
 
 	public ObjectFactory() {
+
+	}
+
+	public MzXML createMzXML() {
+
+		return new MzXML();
 	}
 
 	public MsRun createMsRun() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v22/model/package-info.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v22/model/package-info.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+@XmlSchema(namespace = "http://sashimi.sourceforge.net/schema_revision/mzXML_2.2", elementFormDefault = XmlNsForm.QUALIFIED, xmlns = {@XmlNs(namespaceURI = "http://sashimi.sourceforge.net/schema_revision/mzXML_2.2", prefix = "")})
+package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model;
+
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v32/model/MzXML.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v32/model/MzXML.java
@@ -21,7 +21,7 @@ import jakarta.xml.bind.annotation.XmlType;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "", propOrder = {"msRun"})
-@XmlRootElement(name = "mzXML", namespace = "http://sashimi.sourceforge.net/schema_revision/mzXML_3.2")
+@XmlRootElement(name = "mzXML")
 public class MzXML implements Serializable {
 
 	private static final long serialVersionUID = 320L;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v32/model/package-info.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v32/model/package-info.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+@XmlSchema(namespace = "http://sashimi.sourceforge.net/schema_revision/mzXML_3.2", elementFormDefault = XmlNsForm.QUALIFIED, xmlns = {@XmlNs(namespaceURI = "http://sashimi.sourceforge.net/schema_revision/mzXML_3.2", prefix = "")})
+package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v32.model;
+
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/io/ChromatogramWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/io/ChromatogramWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -18,7 +18,7 @@ import java.io.IOException;
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
 import org.eclipse.chemclipse.converter.io.AbstractChromatogramWriter;
 import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDWriter;
-import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.ChromatogramWriter32;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.ChromatogramWriterVersion32;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -37,8 +37,8 @@ public class ChromatogramWriter extends AbstractChromatogramWriter implements IC
 	private IChromatogramMSDWriter getChromatogramWriter() {
 
 		String versionSave = PreferenceSupplier.getChromatogramVersionSave();
-		if(versionSave.equals(ChromatogramWriter32.VERSION)) {
-			return new ChromatogramWriter32();
+		if(versionSave.equals(ChromatogramWriterVersion32.VERSION)) {
+			return new ChromatogramWriterVersion32();
 		}
 		return null;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/io/MassSpectrumWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/io/MassSpectrumWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2024 Lablicate GmbH.
+ * Copyright (c) 2013, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,7 +7,7 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
+ * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.converter.supplier.mzxml.io;
 
@@ -16,6 +16,8 @@ import java.io.IOException;
 
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
 import org.eclipse.chemclipse.msd.converter.io.IMassSpectraWriter;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.MassSpectrumWriterVersion22;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -25,10 +27,21 @@ public class MassSpectrumWriter implements IMassSpectraWriter {
 	@Override
 	public void write(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
+		getMassSpectrumWriter().write(file, massSpectrum, append, monitor);
 	}
 
 	@Override
 	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
+		getMassSpectrumWriter().write(file, massSpectra, append, monitor);
+	}
+
+	private IMassSpectraWriter getMassSpectrumWriter() {
+
+		String versionSave = PreferenceSupplier.getMassSpectrumVersionSave();
+		if(versionSave.equals(MassSpectrumWriterVersion22.VERSION)) {
+			return new MassSpectrumWriterVersion22();
+		}
+		return null;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/preferences/PreferenceSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 Lablicate GmbH.
+ * Copyright (c) 2021, 2025 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,17 +13,20 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mzxml.preferences;
 
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.Activator;
-import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.ChromatogramWriter32;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.ChromatogramReaderVersion32;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.ChromatogramWriterVersion32;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.MassSpectrumWriterVersion22;
 import org.eclipse.chemclipse.support.preferences.AbstractPreferenceSupplier;
 import org.eclipse.chemclipse.support.preferences.IPreferenceSupplier;
 
 public class PreferenceSupplier extends AbstractPreferenceSupplier implements IPreferenceSupplier {
 
 	public static final String P_CHROMATOGRAM_VERSION_SAVE = "chromatogramVersionSave";
-	public static final String DEF_CHROMATOGRAM_VERSION_SAVE = ChromatogramWriter32.VERSION;
+	public static final String DEF_CHROMATOGRAM_VERSION_SAVE = ChromatogramWriterVersion32.VERSION;
 	public static final String P_CHROMATOGRAM_SAVE_COMPRESSION = "chromatogramSaveCompression";
 	public static final boolean DEF_CHROMATOGRAM_SAVE_COMPRESSION = true;
+	public static final String P_MASS_SPECTRUM_VERSION_SAVE = "massSpectrumVersionSave";
+	public static final String DEF_MASS_SPECTRUM_VERSION_SAVE = MassSpectrumWriterVersion22.VERSION;
 	private static IPreferenceSupplier preferenceSupplier = null;
 
 	public static IPreferenceSupplier INSTANCE() {
@@ -63,5 +66,10 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static boolean getChromatogramSaveCompression() {
 
 		return INSTANCE().getBoolean(P_CHROMATOGRAM_SAVE_COMPRESSION, DEF_CHROMATOGRAM_SAVE_COMPRESSION);
+	}
+
+	public static String getMassSpectrumVersionSave() {
+
+		return INSTANCE().get(P_MASS_SPECTRUM_VERSION_SAVE, DEF_MASS_SPECTRUM_VERSION_SAVE);
 	}
 }


### PR DESCRIPTION
I went for the 2.2 version for now as that is the only one where I found MALDI-TOF MS example data in the wild. Also removed the weird `ns2:` XML namespace prefix from chromatogram exports.