### PR TITLE
Remove pointless generics from PeakDetector

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.firstderivative/src/org/eclipse/chemclipse/chromatogram/csd/peak/detector/supplier/firstderivative/core/PeakDetectorCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.firstderivative/src/org/eclipse/chemclipse/chromatogram/csd/peak/detector/supplier/firstderivative/core/PeakDetectorCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 Lablicate GmbH.
+ * Copyright (c) 2014, 2025 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -37,8 +37,6 @@ import org.eclipse.chemclipse.csd.model.core.IChromatogramPeakCSD;
 import org.eclipse.chemclipse.csd.model.core.selection.IChromatogramSelectionCSD;
 import org.eclipse.chemclipse.csd.model.core.support.PeakBuilderCSD;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.core.PeakType;
 import org.eclipse.chemclipse.model.exceptions.PeakException;
@@ -60,17 +58,17 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.e4.core.services.translation.TranslationService;
 
-public class PeakDetectorCSD<P extends IPeak, C extends IChromatogram<P>, R> extends BasePeakDetector<P, C, R> implements IPeakDetectorCSD<P, C, R> {
+public class PeakDetectorCSD extends BasePeakDetector implements IPeakDetectorCSD {
 
 	private static final Logger logger = Logger.getLogger(PeakDetectorCSD.class);
 
 	@Override
-	public IProcessingInfo<R> detect(IChromatogramSelectionCSD chromatogramSelection, IPeakDetectorSettingsCSD detectorSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<?> detect(IChromatogramSelectionCSD chromatogramSelection, IPeakDetectorSettingsCSD detectorSettings, IProgressMonitor monitor) {
 
 		/*
 		 * Check whether the chromatogram selection is null or not.
 		 */
-		IProcessingInfo<R> processingInfo = validate(chromatogramSelection, detectorSettings, monitor);
+		IProcessingInfo<?> processingInfo = validate(chromatogramSelection, detectorSettings, monitor);
 		if(!processingInfo.hasErrorMessages()) {
 			if(detectorSettings instanceof PeakDetectorSettingsCSD peakDetectorSettings) {
 				SubMonitor subMonitor = SubMonitor.convert(monitor, 100);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector/src/org/eclipse/chemclipse/chromatogram/csd/peak/detector/core/AbstractPeakDetectorCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector/src/org/eclipse/chemclipse/chromatogram/csd/peak/detector/core/AbstractPeakDetectorCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 Lablicate GmbH.
+ * Copyright (c) 2014, 2025 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,8 +12,6 @@
 package org.eclipse.chemclipse.chromatogram.csd.peak.detector.core;
 
 import org.eclipse.chemclipse.chromatogram.peak.detector.core.AbstractPeakDetector;
-import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IPeak;
 
-public abstract class AbstractPeakDetectorCSD<P extends IPeak, C extends IChromatogram<P>, R> extends AbstractPeakDetector<P, C, R> implements IPeakDetectorCSD<P, C, R> {
+public abstract class AbstractPeakDetectorCSD extends AbstractPeakDetector implements IPeakDetectorCSD {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector/src/org/eclipse/chemclipse/chromatogram/csd/peak/detector/core/IPeakDetectorCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector/src/org/eclipse/chemclipse/chromatogram/csd/peak/detector/core/IPeakDetectorCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 Lablicate GmbH.
+ * Copyright (c) 2014, 2025 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,12 +15,10 @@ import org.eclipse.chemclipse.chromatogram.csd.peak.detector.settings.IPeakDetec
 import org.eclipse.chemclipse.chromatogram.peak.detector.core.IPeakDetector;
 import org.eclipse.chemclipse.chromatogram.peak.detector.exceptions.ValueMustNotBeNullException;
 import org.eclipse.chemclipse.csd.model.core.selection.IChromatogramSelectionCSD;
-import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public interface IPeakDetectorCSD<P extends IPeak, C extends IChromatogram<P>, R> extends IPeakDetector<P, C, R> {
+public interface IPeakDetectorCSD extends IPeakDetector {
 
 	/**
 	 * All peak detector plugins must implement this class.

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector/src/org/eclipse/chemclipse/chromatogram/csd/peak/detector/core/PeakDetectorCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector/src/org/eclipse/chemclipse/chromatogram/csd/peak/detector/core/PeakDetectorCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 Lablicate GmbH.
+ * Copyright (c) 2014, 2025 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -58,7 +58,7 @@ public class PeakDetectorCSD {
 	public static IProcessingInfo<?> detect(IChromatogramSelectionCSD chromatogramSelection, IPeakDetectorSettingsCSD peakDetectorSettings, String peakDetectorId, IProgressMonitor monitor) {
 
 		IProcessingInfo<?> processingInfo;
-		IPeakDetectorCSD<?, ?, ?> peakDetector = getPeakDetector(peakDetectorId);
+		IPeakDetectorCSD peakDetector = getPeakDetector(peakDetectorId);
 		if(peakDetector != null) {
 			processingInfo = peakDetector.detect(chromatogramSelection, peakDetectorSettings, monitor);
 			chromatogramSelection.getChromatogram().setDirty(true);
@@ -80,7 +80,7 @@ public class PeakDetectorCSD {
 	public static IProcessingInfo<?> detect(IChromatogramSelectionCSD chromatogramSelection, String peakDetectorId, IProgressMonitor monitor) {
 
 		IProcessingInfo<?> processingInfo;
-		IPeakDetectorCSD<?, ?, ?> peakDetector = getPeakDetector(peakDetectorId);
+		IPeakDetectorCSD peakDetector = getPeakDetector(peakDetectorId);
 		if(peakDetector != null) {
 			processingInfo = peakDetector.detect(chromatogramSelection, monitor);
 			chromatogramSelection.getChromatogram().setDirty(true);
@@ -121,14 +121,14 @@ public class PeakDetectorCSD {
 		return peakDetectorSupport;
 	}
 
-	private static IPeakDetectorCSD<?, ?, ?> getPeakDetector(final String peakDetectorId) {
+	private static IPeakDetectorCSD getPeakDetector(final String peakDetectorId) {
 
 		IConfigurationElement element;
 		element = getConfigurationElement(peakDetectorId);
-		IPeakDetectorCSD<?, ?, ?> instance = null;
+		IPeakDetectorCSD instance = null;
 		if(element != null) {
 			try {
-				instance = (IPeakDetectorCSD<?, ?, ?>)element.createExecutableExtension(PEAK_DETECTOR);
+				instance = (IPeakDetectorCSD)element.createExecutableExtension(PEAK_DETECTOR);
 			} catch(CoreException e) {
 				logger.warn(e);
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/firstderivative/core/PeakDetectorMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/firstderivative/core/PeakDetectorMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -38,8 +38,6 @@ import org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderiv
 import org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.support.IFirstDerivativeDetectorSlope;
 import org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.support.IFirstDerivativeDetectorSlopes;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.core.MarkedTraceModus;
 import org.eclipse.chemclipse.model.core.PeakType;
@@ -70,14 +68,14 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.e4.core.services.translation.TranslationService;
 
-public class PeakDetectorMSD<P extends IPeak, C extends IChromatogram<P>, R> extends BasePeakDetector<P, C, R> implements IPeakDetectorMSD<P, C, R> {
+public class PeakDetectorMSD extends BasePeakDetector implements IPeakDetectorMSD {
 
 	private static final Logger logger = Logger.getLogger(PeakDetectorMSD.class);
 
 	@Override
-	public IProcessingInfo<R> detect(IChromatogramSelectionMSD chromatogramSelection, IPeakDetectorSettingsMSD detectorSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<?> detect(IChromatogramSelectionMSD chromatogramSelection, IPeakDetectorSettingsMSD detectorSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo<R> processingInfo = validate(chromatogramSelection, detectorSettings, monitor);
+		IProcessingInfo<?> processingInfo = validate(chromatogramSelection, detectorSettings, monitor);
 		if(!processingInfo.hasErrorMessages()) {
 			if(detectorSettings instanceof PeakDetectorSettingsMSD peakDetectorSettings) {
 				SubMonitor subMonitor = SubMonitor.convert(monitor, 100);
@@ -115,7 +113,7 @@ public class PeakDetectorMSD<P extends IPeak, C extends IChromatogram<P>, R> ext
 	}
 
 	@Override
-	public IProcessingInfo<R> detect(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<?> detect(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
 
 		if(peakDetectorSettings == null) {
 			peakDetectorSettings = PreferenceSupplier.getPeakDetectorSettingsMSD();

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/core/AbstractPeakDetectorMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/core/AbstractPeakDetectorMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,11 +12,9 @@
 package org.eclipse.chemclipse.chromatogram.msd.peak.detector.core;
 
 import org.eclipse.chemclipse.chromatogram.peak.detector.core.AbstractPeakDetector;
-import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IPeak;
 
 /**
  * Extend this class to implement a valid peak detector.r
  */
-public abstract class AbstractPeakDetectorMSD<P extends IPeak, C extends IChromatogram<P>, R> extends AbstractPeakDetector<P, C, R> implements IPeakDetectorMSD<P, C, R> {
+public abstract class AbstractPeakDetectorMSD extends AbstractPeakDetector implements IPeakDetectorMSD {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/core/IPeakDetectorMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/core/IPeakDetectorMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -14,13 +14,11 @@ package org.eclipse.chemclipse.chromatogram.msd.peak.detector.core;
 import org.eclipse.chemclipse.chromatogram.msd.peak.detector.settings.IPeakDetectorSettingsMSD;
 import org.eclipse.chemclipse.chromatogram.peak.detector.core.IPeakDetector;
 import org.eclipse.chemclipse.chromatogram.peak.detector.exceptions.ValueMustNotBeNullException;
-import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public interface IPeakDetectorMSD<P extends IPeak, C extends IChromatogram<P>, R> extends IPeakDetector<P, C, R> {
+public interface IPeakDetectorMSD extends IPeakDetector {
 
 	/**
 	 * All peak detector plugins must implement this class.
@@ -30,7 +28,7 @@ public interface IPeakDetectorMSD<P extends IPeak, C extends IChromatogram<P>, R
 	 * @param monitor
 	 * @throws ValueMustNotBeNullException
 	 */
-	IProcessingInfo<R> detect(IChromatogramSelectionMSD chromatogramSelection, IPeakDetectorSettingsMSD peakDetectorSettings, IProgressMonitor monitor);
+	IProcessingInfo<?> detect(IChromatogramSelectionMSD chromatogramSelection, IPeakDetectorSettingsMSD peakDetectorSettings, IProgressMonitor monitor);
 
 	/**
 	 * The same as the other method but without settings.
@@ -39,5 +37,5 @@ public interface IPeakDetectorMSD<P extends IPeak, C extends IChromatogram<P>, R
 	 * @param monitor
 	 * @throws ValueMustNotBeNullException
 	 */
-	IProcessingInfo<R> detect(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor);
+	IProcessingInfo<?> detect(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/core/PeakDetectorMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/core/PeakDetectorMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -75,7 +75,7 @@ public class PeakDetectorMSD {
 	public static IProcessingInfo<?> detect(IChromatogramSelectionMSD chromatogramSelection, IPeakDetectorSettingsMSD peakDetectorSettings, String peakDetectorId, IProgressMonitor monitor) {
 
 		IProcessingInfo<?> processingInfo;
-		IPeakDetectorMSD<?, ?, ?> peakDetector = getPeakDetector(peakDetectorId);
+		IPeakDetectorMSD peakDetector = getPeakDetector(peakDetectorId);
 		if(peakDetector != null) {
 			processingInfo = peakDetector.detect(chromatogramSelection, peakDetectorSettings, monitor);
 			chromatogramSelection.getChromatogram().setDirty(true);
@@ -100,7 +100,7 @@ public class PeakDetectorMSD {
 		return detect(chromatogramSelection, getPeakDetector(peakDetectorId), monitor);
 	}
 
-	public static IProcessingInfo<?> detect(IChromatogramSelectionMSD chromatogramSelection, IPeakDetectorMSD<?, ?, ?> peakDetector, IProgressMonitor monitor) {
+	public static IProcessingInfo<?> detect(IChromatogramSelectionMSD chromatogramSelection, IPeakDetectorMSD peakDetector, IProgressMonitor monitor) {
 
 		IProcessingInfo<?> processingInfo;
 		if(peakDetector != null) {
@@ -143,14 +143,14 @@ public class PeakDetectorMSD {
 		return peakDetectorSupport;
 	}
 
-	private static IPeakDetectorMSD<?, ?, ?> getPeakDetector(final String peakDetectorId) {
+	private static IPeakDetectorMSD getPeakDetector(final String peakDetectorId) {
 
 		IConfigurationElement element;
 		element = getConfigurationElement(peakDetectorId);
-		IPeakDetectorMSD<?, ?, ?> instance = null;
+		IPeakDetectorMSD instance = null;
 		if(element != null) {
 			try {
-				instance = (IPeakDetectorMSD<?, ?, ?>)element.createExecutableExtension(PEAK_DETECTOR);
+				instance = (IPeakDetectorMSD)element.createExecutableExtension(PEAK_DETECTOR);
 			} catch(CoreException e) {
 				logger.error(e);
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/core/AbstractPeakDetector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/core/AbstractPeakDetector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 Lablicate GmbH.
+ * Copyright (c) 2014, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,24 +8,21 @@
  *
  * Contributors:
  * Dr. Philip Wenig - initial API and implementation
- * Alexander Kerner - Generics
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.peak.detector.core;
 
 import org.eclipse.chemclipse.chromatogram.peak.detector.settings.IPeakDetectorSettings;
-import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public abstract class AbstractPeakDetector<P extends IPeak, C extends IChromatogram<P>, R> implements IPeakDetector<P, C, R> {
+public abstract class AbstractPeakDetector implements IPeakDetector {
 
 	@Override
-	public IProcessingInfo<R> validate(IChromatogramSelection<?, ?> chromatogramSelection, IPeakDetectorSettings peakDetectorSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<?> validate(IChromatogramSelection<?, ?> chromatogramSelection, IPeakDetectorSettings peakDetectorSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo<R> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
 		if(chromatogramSelection == null) {
 			processingInfo.addErrorMessage("Peak Detector", "The chromatogram selection must not be null.");
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/core/IPeakDetector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/core/IPeakDetector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 Lablicate GmbH.
+ * Copyright (c) 2014, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,18 +8,15 @@
  *
  * Contributors:
  * Dr. Philip Wenig - initial API and implementation
- * Alexander Kerner - Generics
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.peak.detector.core;
 
 import org.eclipse.chemclipse.chromatogram.peak.detector.settings.IPeakDetectorSettings;
-import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public interface IPeakDetector<P extends IPeak, C extends IChromatogram<P>, R> {
+public interface IPeakDetector {
 
-	IProcessingInfo<R> validate(IChromatogramSelection<?, ?> chromatogramSelection, IPeakDetectorSettings peakDetectorSettings, IProgressMonitor monitor);
+	IProcessingInfo<?> validate(IChromatogramSelection<?, ?> chromatogramSelection, IPeakDetectorSettings peakDetectorSettings, IProgressMonitor monitor);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector.supplier.firstderivative/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/supplier/firstderivative/core/PeakDetectorWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector.supplier.firstderivative/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/supplier/firstderivative/core/PeakDetectorWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -36,8 +36,6 @@ import org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderiv
 import org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.support.IFirstDerivativeDetectorSlope;
 import org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.support.IFirstDerivativeDetectorSlopes;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.exceptions.ChromatogramIsNullException;
 import org.eclipse.chemclipse.model.exceptions.PeakException;
@@ -67,19 +65,19 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.e4.core.services.translation.TranslationService;
 
-public class PeakDetectorWSD<P extends IPeak, C extends IChromatogram<P>, R> extends BasePeakDetector<P, C, R> implements IPeakDetectorWSD<P, C, R> {
+public class PeakDetectorWSD extends BasePeakDetector implements IPeakDetectorWSD {
 
 	private static final Logger logger = Logger.getLogger(PeakDetectorWSD.class);
 	//
 	private static final float NORMALIZATION_BASE = 100000.0f;
 
 	@Override
-	public IProcessingInfo<R> detect(IChromatogramSelectionWSD chromatogramSelection, IPeakDetectorSettingsWSD detectorSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<?> detect(IChromatogramSelectionWSD chromatogramSelection, IPeakDetectorSettingsWSD detectorSettings, IProgressMonitor monitor) {
 
 		/*
 		 * Check whether the chromatogram selection is null or not.
 		 */
-		IProcessingInfo<R> processingInfo = validate(chromatogramSelection, detectorSettings, monitor);
+		IProcessingInfo<?> processingInfo = validate(chromatogramSelection, detectorSettings, monitor);
 		if(!processingInfo.hasErrorMessages()) {
 			if(detectorSettings instanceof PeakDetectorSettingsWSD peakDetectorSettings) {
 				SubMonitor subMonitor = SubMonitor.convert(monitor, 100);
@@ -107,7 +105,7 @@ public class PeakDetectorWSD<P extends IPeak, C extends IChromatogram<P>, R> ext
 	}
 
 	@Override
-	public IProcessingInfo<R> detect(IChromatogramSelectionWSD chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<?> detect(IChromatogramSelectionWSD chromatogramSelection, IProgressMonitor monitor) {
 
 		PeakDetectorSettingsWSD peakDetectorSettings = PreferenceSupplier.getPeakDetectorSettingsWSD();
 		chromatogramSelection.getChromatogram().setDirty(true);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/core/AbstractPeakDetectorWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/core/AbstractPeakDetectorWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,8 +12,6 @@
 package org.eclipse.chemclipse.chromatogram.wsd.peak.detector.core;
 
 import org.eclipse.chemclipse.chromatogram.peak.detector.core.AbstractPeakDetector;
-import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IPeak;
 
-public abstract class AbstractPeakDetectorWSD<P extends IPeak, C extends IChromatogram<P>, R> extends AbstractPeakDetector<P, C, R> implements IPeakDetectorWSD<P, C, R> {
+public abstract class AbstractPeakDetectorWSD extends AbstractPeakDetector implements IPeakDetectorWSD {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/core/AbstractPeakDetectorWSDSignal.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/core/AbstractPeakDetectorWSDSignal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,23 +13,21 @@
 package org.eclipse.chemclipse.chromatogram.wsd.peak.detector.core;
 
 import org.eclipse.chemclipse.chromatogram.wsd.peak.detector.settings.IPeakDetectorSettingsWSD;
-import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.chemclipse.wsd.model.core.selection.IChromatogramSelectionWSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class AbstractPeakDetectorWSDSignal<P extends IPeak, C extends IChromatogram<P>, R> extends AbstractPeakDetectorWSD<P, C, R> {
+public class AbstractPeakDetectorWSDSignal extends AbstractPeakDetectorWSD {
 
 	@Override
-	public IProcessingInfo<R> detect(IChromatogramSelectionWSD chromatogramSelection, IPeakDetectorSettingsWSD peakDetectorSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<?> detect(IChromatogramSelectionWSD chromatogramSelection, IPeakDetectorSettingsWSD peakDetectorSettings, IProgressMonitor monitor) {
 
 		return new ProcessingInfo<>();
 	}
 
 	@Override
-	public IProcessingInfo<R> detect(IChromatogramSelectionWSD chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<?> detect(IChromatogramSelectionWSD chromatogramSelection, IProgressMonitor monitor) {
 
 		return new ProcessingInfo<>();
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/core/IPeakDetectorWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/core/IPeakDetectorWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,13 +15,11 @@ package org.eclipse.chemclipse.chromatogram.wsd.peak.detector.core;
 import org.eclipse.chemclipse.chromatogram.peak.detector.core.IPeakDetector;
 import org.eclipse.chemclipse.chromatogram.peak.detector.exceptions.ValueMustNotBeNullException;
 import org.eclipse.chemclipse.chromatogram.wsd.peak.detector.settings.IPeakDetectorSettingsWSD;
-import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.model.core.selection.IChromatogramSelectionWSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public interface IPeakDetectorWSD<P extends IPeak, C extends IChromatogram<P>, R> extends IPeakDetector<P, C, R> {
+public interface IPeakDetectorWSD extends IPeakDetector {
 
 	/**
 	 * All peak detector plugins must implement this class.
@@ -31,7 +29,7 @@ public interface IPeakDetectorWSD<P extends IPeak, C extends IChromatogram<P>, R
 	 * @param monitor
 	 * @throws ValueMustNotBeNullException
 	 */
-	IProcessingInfo<R> detect(IChromatogramSelectionWSD chromatogramSelection, IPeakDetectorSettingsWSD peakDetectorSettings, IProgressMonitor monitor);
+	IProcessingInfo<?> detect(IChromatogramSelectionWSD chromatogramSelection, IPeakDetectorSettingsWSD peakDetectorSettings, IProgressMonitor monitor);
 
 	/**
 	 * The same as the other method but without settings.
@@ -40,7 +38,7 @@ public interface IPeakDetectorWSD<P extends IPeak, C extends IChromatogram<P>, R
 	 * @param monitor
 	 * @throws ValueMustNotBeNullException
 	 */
-	default IProcessingInfo<R> detect(IChromatogramSelectionWSD chromatogramSelection, IProgressMonitor monitor) {
+	default IProcessingInfo<?> detect(IChromatogramSelectionWSD chromatogramSelection, IProgressMonitor monitor) {
 
 		return detect(chromatogramSelection, null, monitor);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/core/PeakDetectorWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/core/PeakDetectorWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -62,7 +62,7 @@ public class PeakDetectorWSD {
 	public static IProcessingInfo<?> detect(IChromatogramSelectionWSD chromatogramSelection, IPeakDetectorSettingsWSD peakDetectorSettings, String peakDetectorId, IProgressMonitor monitor) {
 
 		IProcessingInfo<?> processingInfo;
-		IPeakDetectorWSD<?, ?, ?> peakDetector = getPeakDetector(peakDetectorId);
+		IPeakDetectorWSD peakDetector = getPeakDetector(peakDetectorId);
 		if(peakDetector != null) {
 			processingInfo = peakDetector.detect(chromatogramSelection, peakDetectorSettings, monitor);
 		} else {
@@ -83,7 +83,7 @@ public class PeakDetectorWSD {
 	public static IProcessingInfo<?> detect(IChromatogramSelectionWSD chromatogramSelection, String peakDetectorId, IProgressMonitor monitor) {
 
 		IProcessingInfo<?> processingInfo;
-		IPeakDetectorWSD<?, ?, ?> peakDetector = getPeakDetector(peakDetectorId);
+		IPeakDetectorWSD peakDetector = getPeakDetector(peakDetectorId);
 		if(peakDetector != null) {
 			processingInfo = peakDetector.detect(chromatogramSelection, monitor);
 		} else {
@@ -123,14 +123,14 @@ public class PeakDetectorWSD {
 		return peakDetectorSupport;
 	}
 
-	private static IPeakDetectorWSD<?, ?, ?> getPeakDetector(final String peakDetectorId) {
+	private static IPeakDetectorWSD getPeakDetector(final String peakDetectorId) {
 
 		IConfigurationElement element;
 		element = getConfigurationElement(peakDetectorId);
-		IPeakDetectorWSD<?, ?, ?> instance = null;
+		IPeakDetectorWSD instance = null;
 		if(element != null) {
 			try {
-				instance = (IPeakDetectorWSD<?, ?, ?>)element.createExecutableExtension(PEAK_DETECTOR);
+				instance = (IPeakDetectorWSD)element.createExecutableExtension(PEAK_DETECTOR);
 			} catch(CoreException e) {
 				logger.warn(e);
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/impl/AlkanePatternDetectorCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/impl/AlkanePatternDetectorCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2024 Lablicate GmbH.
+ * Copyright (c) 2016, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,7 @@
  *
  * Contributors:
  * Philip Wenig - initial API and implementation
- * Alexander Kerner - Generics, Loggging
+ * Alexander Kerner - Loggging
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.impl;
 
@@ -16,6 +16,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.chemclipse.chromatogram.csd.peak.detector.core.IPeakDetectorCSD;
 import org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.firstderivative.core.PeakDetectorCSD;
 import org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.firstderivative.settings.PeakDetectorSettingsCSD;
 import org.eclipse.chemclipse.chromatogram.peak.detector.model.Threshold;
@@ -56,7 +57,7 @@ public class AlkanePatternDetectorCSD {
 				/*
 				 * Peak detector.
 				 */
-				PeakDetectorCSD<?, ?, ?> peakDetectorCSD = new PeakDetectorCSD<>();
+				IPeakDetectorCSD peakDetectorCSD = new PeakDetectorCSD();
 				PeakDetectorSettingsCSD peakDetectorSettings = new PeakDetectorSettingsCSD();
 				peakDetectorSettings.setThreshold(Threshold.LOW);
 				peakDetectorSettings.setDetectorType(DetectorType.BB);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/impl/AlkanePatternDetectorMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/impl/AlkanePatternDetectorMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2024 Lablicate GmbH.
+ * Copyright (c) 2016, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,7 @@
  *
  * Contributors:
  * Philip Wenig - initial API and implementation
- * Alexander Kerner - Generics, Logging
+ * Alexander Kerner - Logging
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.impl;
 
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.msd.identifier.settings.IPeakIdentifierSettingsMSD;
+import org.eclipse.chemclipse.chromatogram.msd.peak.detector.core.IPeakDetectorMSD;
 import org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.core.PeakDetectorMSD;
 import org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.settings.PeakDetectorSettingsMSD;
 import org.eclipse.chemclipse.chromatogram.peak.detector.model.Threshold;
@@ -66,7 +67,7 @@ public class AlkanePatternDetectorMSD {
 				 * Peak detector.
 				 */
 				chromatogramMSD.removeAllPeaks();
-				PeakDetectorMSD<?, ?, ?> peakDetectorMSD = new PeakDetectorMSD<>();
+				IPeakDetectorMSD peakDetectorMSD = new PeakDetectorMSD();
 				PeakDetectorSettingsMSD peakDetectorSettings = new PeakDetectorSettingsMSD();
 				peakDetectorSettings.setThreshold(Threshold.LOW);
 				peakDetectorSettings.setDetectorType(DetectorType.BB);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative/src/org/eclipse/chemclipse/chromatogram/xxd/peak/detector/supplier/firstderivative/core/BasePeakDetector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative/src/org/eclipse/chemclipse/chromatogram/xxd/peak/detector/supplier/firstderivative/core/BasePeakDetector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -28,7 +28,7 @@ import org.eclipse.chemclipse.numeric.miscellaneous.Evaluation;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
 
-public class BasePeakDetector<P extends IPeak, C extends IChromatogram<P>, R> extends AbstractPeakDetector<P, C, R> {
+public class BasePeakDetector extends AbstractPeakDetector {
 
 	protected static final float NORMALIZATION_BASE = 100000.0f;
 	protected static final int CONSECUTIVE_SCAN_STEPS = 3;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.thirdderivative/src/org/eclipse/chemclipse/chromatogram/xxd/peak/detector/supplier/thirdderivative/core/PeakDetector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.thirdderivative/src/org/eclipse/chemclipse/chromatogram/xxd/peak/detector/supplier/thirdderivative/core/PeakDetector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 Lablicate GmbH.
+ * Copyright (c) 2014, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -13,26 +13,24 @@ package org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.thirdderi
 
 import org.eclipse.chemclipse.chromatogram.msd.peak.detector.core.AbstractPeakDetectorMSD;
 import org.eclipse.chemclipse.chromatogram.msd.peak.detector.settings.IPeakDetectorSettingsMSD;
-import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class PeakDetector<P extends IPeak, C extends IChromatogram<P>, R> extends AbstractPeakDetectorMSD<P, C, R> {
+public class PeakDetector extends AbstractPeakDetectorMSD {
 
 	@Override
-	public IProcessingInfo<R> detect(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
+	public IProcessingInfo<?> detect(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
 
-		IProcessingInfo<R> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
 		return processingInfo;
 	}
 
 	@Override
-	public IProcessingInfo<R> detect(IChromatogramSelectionMSD chromatogramSelection, IPeakDetectorSettingsMSD peakDetectorSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<?> detect(IChromatogramSelectionMSD chromatogramSelection, IPeakDetectorSettingsMSD peakDetectorSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo<R> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
 		return processingInfo;
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/firstderivative/core/FirstDerivativePeakDetector_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/firstderivative/core/FirstDerivativePeakDetector_2_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -14,6 +14,7 @@ package org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderi
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import org.eclipse.chemclipse.chromatogram.msd.peak.detector.core.IPeakDetectorMSD;
 import org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.core.BasePeakDetector;
 import org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.support.IFirstDerivativeDetectorSlopes;
 
@@ -24,7 +25,7 @@ import org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderiv
 public class FirstDerivativePeakDetector_2_Test extends FirstDerivativeSlopesTestCase {
 
 	private IFirstDerivativeDetectorSlopes slopes;
-	private PeakDetectorMSD<?, ?, ?> firstDerivativePeakDetector;
+	private IPeakDetectorMSD firstDerivativePeakDetector;
 	private Class<?> firstDerivativePeakDetectorClass;
 	private Method method;
 
@@ -32,7 +33,7 @@ public class FirstDerivativePeakDetector_2_Test extends FirstDerivativeSlopesTes
 	protected void setUp() throws Exception {
 
 		super.setUp();
-		firstDerivativePeakDetector = new PeakDetectorMSD<>();
+		firstDerivativePeakDetector = new PeakDetectorMSD();
 		firstDerivativePeakDetectorClass = BasePeakDetector.class;
 		slopes = getFirstDerivativeSlopes();
 		slopes.calculateMovingAverage(5);

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/firstderivative/core/FirstDerivativePeakDetector_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/firstderivative/core/FirstDerivativePeakDetector_3_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -14,6 +14,7 @@ package org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderi
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import org.eclipse.chemclipse.chromatogram.msd.peak.detector.core.IPeakDetectorMSD;
 import org.eclipse.chemclipse.chromatogram.peak.detector.support.IRawPeak;
 import org.eclipse.chemclipse.chromatogram.peak.detector.support.RawPeak;
 import org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.core.BasePeakDetector;
@@ -26,7 +27,7 @@ import junit.framework.TestCase;
  */
 public class FirstDerivativePeakDetector_3_Test extends TestCase {
 
-	private PeakDetectorMSD<?, ?, ?> firstDerivativePeakDetector;
+	private IPeakDetectorMSD firstDerivativePeakDetector;
 	private Class<?> firstDerivativePeakDetectorClass;
 	private Method method;
 	private IRawPeak rawPeak;
@@ -35,7 +36,7 @@ public class FirstDerivativePeakDetector_3_Test extends TestCase {
 	protected void setUp() throws Exception {
 
 		super.setUp();
-		firstDerivativePeakDetector = new PeakDetectorMSD<>();
+		firstDerivativePeakDetector = new PeakDetectorMSD();
 		firstDerivativePeakDetectorClass = BasePeakDetector.class;
 	}
 


### PR DESCRIPTION
as it seems to be applied incorrectly here. `IProcessingInfo` has no result other than messages for this class, so there is no point in connecting it to the `PeakDetector` classes. It only leads to result types like `PeakDetectorCSD<?, ?, ?>` with three unbounded wildcards, which doesn't help with type safety in any way. I find it verbose and hard to read. The `BasePeakDetector` already solves the problem with inheritance and the CSD/MSD/WSD suffix with casting to the correct type/interface.