### PR TITLE
Remove generics from scan converter VSD

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.supplier.cml/src/org/eclipse/chemclipse/vsd/converter/supplier/cml/converter/ScanImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.supplier.cml/src/org/eclipse/chemclipse/vsd/converter/supplier/cml/converter/ScanImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,15 +20,15 @@ import org.eclipse.chemclipse.vsd.converter.core.AbstractScanImportConverter;
 import org.eclipse.chemclipse.vsd.converter.core.IScanImportConverter;
 import org.eclipse.chemclipse.vsd.converter.supplier.cml.io.ScanReader;
 import org.eclipse.chemclipse.vsd.converter.supplier.cml.model.IVendorSpectrumVSD;
+import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ScanImportConverter extends AbstractScanImportConverter implements IScanImportConverter {
 
 	@Override
-	public IProcessingInfo<IVendorSpectrumVSD> convert(File file, IProgressMonitor monitor) {
+	public IProcessingInfo<ISpectrumVSD> convert(File file, IProgressMonitor monitor) {
 
-		IProcessingInfo<IVendorSpectrumVSD> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<ISpectrumVSD> processingInfo = new ProcessingInfo<>();
 		IVendorSpectrumVSD vendorScan = null;
 		ScanReader scanReader = new ScanReader();
 		vendorScan = scanReader.read(file, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.supplier.csv/src/org/eclipse/chemclipse/vsd/converter/supplier/csv/core/ScanImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.supplier.csv/src/org/eclipse/chemclipse/vsd/converter/supplier/csv/core/ScanImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,17 +21,17 @@ import org.eclipse.chemclipse.vsd.converter.core.AbstractScanImportConverter;
 import org.eclipse.chemclipse.vsd.converter.core.IScanImportConverter;
 import org.eclipse.chemclipse.vsd.converter.supplier.csv.io.ScanReader;
 import org.eclipse.chemclipse.vsd.converter.supplier.csv.model.IVendorSpectrumVSD;
+import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ScanImportConverter extends AbstractScanImportConverter implements IScanImportConverter {
 
 	private static final Logger logger = Logger.getLogger(ScanImportConverter.class);
 
 	@Override
-	public IProcessingInfo<?> convert(File file, IProgressMonitor monitor) {
+	public IProcessingInfo<ISpectrumVSD> convert(File file, IProgressMonitor monitor) {
 
-		IProcessingInfo<IVendorSpectrumVSD> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<ISpectrumVSD> processingInfo = new ProcessingInfo<>();
 		try {
 			ScanReader scanReader = new ScanReader();
 			IVendorSpectrumVSD vendorScan = scanReader.read(file, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter/src/org/eclipse/chemclipse/vsd/converter/core/AbstractScanImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter/src/org/eclipse/chemclipse/vsd/converter/core/AbstractScanImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -13,6 +13,5 @@ package org.eclipse.chemclipse.vsd.converter.core;
 
 import org.eclipse.chemclipse.converter.core.AbstractImportConverter;
 
-@SuppressWarnings("rawtypes")
 public abstract class AbstractScanImportConverter extends AbstractImportConverter implements IScanImportConverter {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter/src/org/eclipse/chemclipse/vsd/converter/core/IScanImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter/src/org/eclipse/chemclipse/vsd/converter/core/IScanImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -16,9 +16,10 @@ import java.io.File;
 
 import org.eclipse.chemclipse.converter.core.IImportConverter;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public interface IScanImportConverter<T> extends IImportConverter {
+public interface IScanImportConverter extends IImportConverter {
 
-	IProcessingInfo<T> convert(File file, IProgressMonitor monitor);
+	IProcessingInfo<ISpectrumVSD> convert(File file, IProgressMonitor monitor);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter/src/org/eclipse/chemclipse/vsd/converter/core/ScanConverterVSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter/src/org/eclipse/chemclipse/vsd/converter/core/ScanConverterVSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -54,7 +54,7 @@ public class ScanConverterVSD {
 		 * Do not use a safe runnable here, because an object must
 		 * be returned or null.
 		 */
-		IScanImportConverter<ISpectrumVSD> importConverter = getScanImportConverter(converterId);
+		IScanImportConverter importConverter = getScanImportConverter(converterId);
 		if(importConverter != null) {
 			processingInfo = importConverter.convert(file, monitor);
 		} else {
@@ -87,7 +87,7 @@ public class ScanConverterVSD {
 				 * Do not use a safe runnable here, because an object must
 				 * be returned or null.
 				 */
-				IScanImportConverter<ISpectrumVSD> importConverter = getScanImportConverter(converterId);
+				IScanImportConverter importConverter = getScanImportConverter(converterId);
 				if(importConverter != null) {
 					processingInfo = importConverter.convert(file, monitor);
 					if(!processingInfo.hasErrorMessages()) {
@@ -117,15 +117,14 @@ public class ScanConverterVSD {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("unchecked")
-	private static IScanImportConverter<ISpectrumVSD> getScanImportConverter(final String converterId) {
+	private static IScanImportConverter getScanImportConverter(final String converterId) {
 
 		IConfigurationElement element;
 		element = getConfigurationElement(converterId);
-		IScanImportConverter<ISpectrumVSD> instance = null;
+		IScanImportConverter instance = null;
 		if(element != null) {
 			try {
-				instance = (IScanImportConverter<ISpectrumVSD>)element.createExecutableExtension(Converter.IMPORT_CONVERTER);
+				instance = (IScanImportConverter)element.createExecutableExtension(Converter.IMPORT_CONVERTER);
 			} catch(CoreException e) {
 				logger.error(e);
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/vsd/converter/supplier/jcampdx/converter/ScanImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/vsd/converter/supplier/jcampdx/converter/ScanImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 Lablicate GmbH.
+ * Copyright (c) 2021, 2025 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,17 +21,17 @@ import org.eclipse.chemclipse.vsd.converter.core.AbstractScanImportConverter;
 import org.eclipse.chemclipse.vsd.converter.core.IScanImportConverter;
 import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.io.ScanReader;
 import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.model.IVendorSpectrumVSD;
+import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ScanImportConverter extends AbstractScanImportConverter implements IScanImportConverter {
 
 	private static final Logger logger = Logger.getLogger(ScanImportConverter.class);
 
 	@Override
-	public IProcessingInfo<IVendorSpectrumVSD> convert(File file, IProgressMonitor monitor) {
+	public IProcessingInfo<ISpectrumVSD> convert(File file, IProgressMonitor monitor) {
 
-		IProcessingInfo<IVendorSpectrumVSD> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<ISpectrumVSD> processingInfo = new ProcessingInfo<>();
 		try {
 			ScanReader scanReader = new ScanReader();
 			IVendorSpectrumVSD vendorScan = scanReader.read(file, monitor);

--- a/chemclipse/tests/org.eclipse.chemclipse.vsd.converter.supplier.cml.test/src/org/eclipse/chemclipse/vsd/converter/supplier/cml/test/But2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.vsd.converter.supplier.cml.test/src/org/eclipse/chemclipse/vsd/converter/supplier/cml/test/But2_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,6 +17,7 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.cml.PathResolver;
 import org.eclipse.chemclipse.vsd.converter.supplier.cml.converter.ScanImportConverter;
 import org.eclipse.chemclipse.vsd.converter.supplier.cml.model.IVendorSpectrumVSD;
+import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Test;
 
@@ -24,7 +25,7 @@ import junit.framework.TestCase;
 
 public class But2_ITest extends TestCase {
 
-	private IVendorSpectrumVSD vendorSpectrum;
+	private ISpectrumVSD spectrumVSD;
 
 	@Override
 	protected void setUp() throws Exception {
@@ -32,30 +33,32 @@ public class But2_ITest extends TestCase {
 		super.setUp();
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.BUT2));
 		ScanImportConverter importConverter = new ScanImportConverter();
-		IProcessingInfo<IVendorSpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
-		vendorSpectrum = processingInfo.getProcessingResult();
+		IProcessingInfo<ISpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
+		spectrumVSD = processingInfo.getProcessingResult();
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
 
-		vendorSpectrum = null;
+		spectrumVSD = null;
 		super.tearDown();
 	}
 
 	@Test
 	public void testLoading() {
 
-		assertNotNull(vendorSpectrum);
-		assertEquals("2-Butanol", vendorSpectrum.getSampleName());
-		assertEquals("but2", vendorSpectrum.getDataName());
-		assertEquals("C 4 H 10 O 1", vendorSpectrum.getFormula());
-		assertEquals("78-92-2", vendorSpectrum.getCasNumber());
+		assertNotNull(spectrumVSD);
+		assertEquals("2-Butanol", spectrumVSD.getSampleName());
+		assertEquals("but2", spectrumVSD.getDataName());
+		if(spectrumVSD instanceof IVendorSpectrumVSD vendorSpectrumVSD) {
+			assertEquals("C 4 H 10 O 1", vendorSpectrumVSD.getFormula());
+			assertEquals("78-92-2", vendorSpectrumVSD.getCasNumber());
+		}
 	}
 
 	@Test
 	public void testSignals() {
 
-		assertEquals(224, vendorSpectrum.getScanVSD().getProcessedSignals().size());
+		assertEquals(224, spectrumVSD.getScanVSD().getProcessedSignals().size());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.vsd.converter.supplier.cml.test/src/org/eclipse/chemclipse/vsd/converter/supplier/cml/test/PCLANIL_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.vsd.converter.supplier.cml.test/src/org/eclipse/chemclipse/vsd/converter/supplier/cml/test/PCLANIL_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,7 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.cml.PathResolver;
 import org.eclipse.chemclipse.vsd.converter.supplier.cml.converter.ScanImportConverter;
 import org.eclipse.chemclipse.vsd.converter.supplier.cml.model.IVendorSpectrumVSD;
+import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Test;
 
@@ -25,7 +26,7 @@ import junit.framework.TestCase;
 
 public class PCLANIL_ITest extends TestCase {
 
-	private IVendorSpectrumVSD vendorSpectrum;
+	private ISpectrumVSD spectrumVSD;
 
 	@Override
 	protected void setUp() throws Exception {
@@ -33,31 +34,33 @@ public class PCLANIL_ITest extends TestCase {
 		super.setUp();
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.PCLANIL));
 		ScanImportConverter importConverter = new ScanImportConverter();
-		IProcessingInfo<IVendorSpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
-		vendorSpectrum = processingInfo.getProcessingResult();
+		IProcessingInfo<ISpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
+		spectrumVSD = processingInfo.getProcessingResult();
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
 
-		vendorSpectrum = null;
+		spectrumVSD = null;
 		super.tearDown();
 	}
 
 	@Test
 	public void testLoading() {
 
-		assertNotNull(vendorSpectrum);
-		assertEquals("para-chloroaniline", vendorSpectrum.getSampleName());
-		assertEquals("IR_para-chlor", vendorSpectrum.getDataName());
-		assertEquals("C6H6ClN", vendorSpectrum.getFormula());
-		assertEquals("106-47-8", vendorSpectrum.getCasNumber());
-		assertEquals("PERKIN-ELMER 1000 FT-IR", vendorSpectrum.getInstrument());
+		assertNotNull(spectrumVSD);
+		assertEquals("para-chloroaniline", spectrumVSD.getSampleName());
+		assertEquals("IR_para-chlor", spectrumVSD.getDataName());
+		assertEquals("PERKIN-ELMER 1000 FT-IR", spectrumVSD.getInstrument());
+		if(spectrumVSD instanceof IVendorSpectrumVSD vendorSpectrumVSD) {
+			assertEquals("C6H6ClN", vendorSpectrumVSD.getFormula());
+			assertEquals("106-47-8", vendorSpectrumVSD.getCasNumber());
+		}
 	}
 
 	@Test
 	public void testSignals() {
 
-		assertEquals(1801, vendorSpectrum.getScanVSD().getProcessedSignals().size());
+		assertEquals(1801, spectrumVSD.getScanVSD().getProcessedSignals().size());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedDecrease1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedDecrease1_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,7 +15,7 @@ import java.io.File;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.converter.ScanImportConverter;
-import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.model.IVendorSpectrumVSD;
+import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Test;
 
@@ -23,7 +23,7 @@ import junit.framework.TestCase;
 
 public class FixedDecrease1_ITest extends TestCase {
 
-	private IVendorSpectrumVSD vendorSpectrum;
+	private ISpectrumVSD spectrumVSD;
 
 	@Override
 	protected void setUp() throws Exception {
@@ -31,26 +31,26 @@ public class FixedDecrease1_ITest extends TestCase {
 		super.setUp();
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.FIXDEC1));
 		ScanImportConverter importConverter = new ScanImportConverter();
-		IProcessingInfo<IVendorSpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
-		vendorSpectrum = processingInfo.getProcessingResult();
+		IProcessingInfo<ISpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
+		spectrumVSD = processingInfo.getProcessingResult();
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
 
-		vendorSpectrum = null;
+		spectrumVSD = null;
 		super.tearDown();
 	}
 
 	@Test
 	public void testLoading() {
 
-		assertNotNull(vendorSpectrum);
+		assertNotNull(spectrumVSD);
 	}
 
 	@Test
 	public void testSignals() {
 
-		assertEquals(3951, vendorSpectrum.getScanVSD().getProcessedSignals().size());
+		assertEquals(3951, spectrumVSD.getScanVSD().getProcessedSignals().size());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedIncrease1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedIncrease1_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,7 +15,7 @@ import java.io.File;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.converter.ScanImportConverter;
-import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.model.IVendorSpectrumVSD;
+import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Test;
 
@@ -23,7 +23,7 @@ import junit.framework.TestCase;
 
 public class FixedIncrease1_ITest extends TestCase {
 
-	private IVendorSpectrumVSD vendorSpectrum;
+	private ISpectrumVSD spectrumVSD;
 
 	@Override
 	protected void setUp() throws Exception {
@@ -31,26 +31,26 @@ public class FixedIncrease1_ITest extends TestCase {
 		super.setUp();
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.FIXINC1));
 		ScanImportConverter importConverter = new ScanImportConverter();
-		IProcessingInfo<IVendorSpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
-		vendorSpectrum = processingInfo.getProcessingResult();
+		IProcessingInfo<ISpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
+		spectrumVSD = processingInfo.getProcessingResult();
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
 
-		vendorSpectrum = null;
+		spectrumVSD = null;
 		super.tearDown();
 	}
 
 	@Test
 	public void testLoading() {
 
-		assertNotNull(vendorSpectrum);
+		assertNotNull(spectrumVSD);
 	}
 
 	@Test
 	public void testSignals() {
 
-		assertEquals(3736, vendorSpectrum.getScanVSD().getProcessedSignals().size());
+		assertEquals(3736, spectrumVSD.getScanVSD().getProcessedSignals().size());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedIncrease2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedIncrease2_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,7 +15,7 @@ import java.io.File;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.converter.ScanImportConverter;
-import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.model.IVendorSpectrumVSD;
+import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Test;
 
@@ -23,7 +23,7 @@ import junit.framework.TestCase;
 
 public class FixedIncrease2_ITest extends TestCase {
 
-	private IVendorSpectrumVSD vendorSpectrum;
+	private ISpectrumVSD spectrumVSD;
 
 	@Override
 	protected void setUp() throws Exception {
@@ -31,26 +31,26 @@ public class FixedIncrease2_ITest extends TestCase {
 		super.setUp();
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.FIXINC2));
 		ScanImportConverter importConverter = new ScanImportConverter();
-		IProcessingInfo<IVendorSpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
-		vendorSpectrum = processingInfo.getProcessingResult();
+		IProcessingInfo<ISpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
+		spectrumVSD = processingInfo.getProcessingResult();
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
 
-		vendorSpectrum = null;
+		spectrumVSD = null;
 		super.tearDown();
 	}
 
 	@Test
 	public void testLoading() {
 
-		assertNotNull(vendorSpectrum);
+		assertNotNull(spectrumVSD);
 	}
 
 	@Test
 	public void testSignals() {
 
-		assertEquals(3601, vendorSpectrum.getScanVSD().getProcessedSignals().size());
+		assertEquals(3601, spectrumVSD.getScanVSD().getProcessedSignals().size());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/JCAMPTestPolys_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/JCAMPTestPolys_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,7 +15,7 @@ import java.io.File;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.converter.ScanImportConverter;
-import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.model.IVendorSpectrumVSD;
+import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Test;
 
@@ -23,7 +23,7 @@ import junit.framework.TestCase;
 
 public class JCAMPTestPolys_ITest extends TestCase {
 
-	private IVendorSpectrumVSD vendorSpectrum;
+	private ISpectrumVSD spectrumVSD;
 
 	@Override
 	protected void setUp() throws Exception {
@@ -31,26 +31,26 @@ public class JCAMPTestPolys_ITest extends TestCase {
 		super.setUp();
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.JTPOLYS));
 		ScanImportConverter importConverter = new ScanImportConverter();
-		IProcessingInfo<IVendorSpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
-		vendorSpectrum = processingInfo.getProcessingResult();
+		IProcessingInfo<ISpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
+		spectrumVSD = processingInfo.getProcessingResult();
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
 
-		vendorSpectrum = null;
+		spectrumVSD = null;
 		super.tearDown();
 	}
 
 	@Test
 	public void testLoading() {
 
-		assertNotNull(vendorSpectrum);
+		assertNotNull(spectrumVSD);
 	}
 
 	@Test
 	public void testSignals() {
 
-		assertEquals(1844, vendorSpectrum.getScanVSD().getProcessedSignals().size());
+		assertEquals(1844, spectrumVSD.getScanVSD().getProcessedSignals().size());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/PacDecreasing_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/PacDecreasing_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,7 +15,7 @@ import java.io.File;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.converter.ScanImportConverter;
-import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.model.IVendorSpectrumVSD;
+import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Test;
 
@@ -23,7 +23,7 @@ import junit.framework.TestCase;
 
 public class PacDecreasing_ITest extends TestCase {
 
-	private IVendorSpectrumVSD vendorSpectrum;
+	private ISpectrumVSD spectrumVSD;
 
 	@Override
 	protected void setUp() throws Exception {
@@ -31,26 +31,26 @@ public class PacDecreasing_ITest extends TestCase {
 		super.setUp();
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.PACDEC1));
 		ScanImportConverter importConverter = new ScanImportConverter();
-		IProcessingInfo<IVendorSpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
-		vendorSpectrum = processingInfo.getProcessingResult();
+		IProcessingInfo<ISpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
+		spectrumVSD = processingInfo.getProcessingResult();
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
 
-		vendorSpectrum = null;
+		spectrumVSD = null;
 		super.tearDown();
 	}
 
 	@Test
 	public void testLoading() {
 
-		assertNotNull(vendorSpectrum);
+		assertNotNull(spectrumVSD);
 	}
 
 	@Test
 	public void testSignals() {
 
-		assertEquals(3301, vendorSpectrum.getScanVSD().getProcessedSignals().size());
+		assertEquals(3301, spectrumVSD.getScanVSD().getProcessedSignals().size());
 	}
 }


### PR DESCRIPTION
as seems needless as there is only one return type that makes sense, so by removing it we gain more type safety in the `IProcessingInfo` return type and resolve some warnings that also indicate that generics were used in a wrong way.