### PR TITLE
Remove generics from scan converter WSD

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.cml/src/org/eclipse/chemclipse/wsd/converter/supplier/cml/converter/ScanImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.cml/src/org/eclipse/chemclipse/wsd/converter/supplier/cml/converter/ScanImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,17 +19,16 @@ import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.core.AbstractScanImportConverter;
 import org.eclipse.chemclipse.wsd.converter.core.IScanImportConverter;
 import org.eclipse.chemclipse.wsd.converter.supplier.cml.io.ScanReader;
-import org.eclipse.chemclipse.wsd.converter.supplier.cml.model.IVendorSpectrumWSD;
+import org.eclipse.chemclipse.wsd.model.core.ISpectrumWSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ScanImportConverter extends AbstractScanImportConverter implements IScanImportConverter {
 
 	@Override
-	public IProcessingInfo<IVendorSpectrumWSD> convert(File file, IProgressMonitor monitor) {
+	public IProcessingInfo<ISpectrumWSD> convert(File file, IProgressMonitor monitor) {
 
-		IProcessingInfo<IVendorSpectrumWSD> processingInfo = new ProcessingInfo<>();
-		IVendorSpectrumWSD vendorScan = null;
+		IProcessingInfo<ISpectrumWSD> processingInfo = new ProcessingInfo<>();
+		ISpectrumWSD vendorScan = null;
 		ScanReader scanReader = new ScanReader();
 		vendorScan = scanReader.read(file, monitor);
 		processingInfo.setProcessingResult(vendorScan);

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.spectroml/src/org/eclipse/chemclipse/wsd/converter/supplier/spectroml/converter/ScanImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.spectroml/src/org/eclipse/chemclipse/wsd/converter/supplier/spectroml/converter/ScanImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,15 +20,15 @@ import org.eclipse.chemclipse.wsd.converter.core.AbstractScanImportConverter;
 import org.eclipse.chemclipse.wsd.converter.core.IScanImportConverter;
 import org.eclipse.chemclipse.wsd.converter.supplier.spectroml.io.ScanReader;
 import org.eclipse.chemclipse.wsd.converter.supplier.spectroml.model.IVendorSpectrumWSD;
+import org.eclipse.chemclipse.wsd.model.core.ISpectrumWSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ScanImportConverter extends AbstractScanImportConverter implements IScanImportConverter {
 
 	@Override
-	public IProcessingInfo<IVendorSpectrumWSD> convert(File file, IProgressMonitor monitor) {
+	public IProcessingInfo<ISpectrumWSD> convert(File file, IProgressMonitor monitor) {
 
-		IProcessingInfo<IVendorSpectrumWSD> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<ISpectrumWSD> processingInfo = new ProcessingInfo<>();
 		IVendorSpectrumWSD vendorScan = null;
 		ScanReader scanReader = new ScanReader();
 		vendorScan = scanReader.read(file, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/src/org/eclipse/chemclipse/wsd/converter/core/AbstractScanImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/src/org/eclipse/chemclipse/wsd/converter/core/AbstractScanImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -13,6 +13,5 @@ package org.eclipse.chemclipse.wsd.converter.core;
 
 import org.eclipse.chemclipse.converter.core.AbstractImportConverter;
 
-@SuppressWarnings("rawtypes")
 public abstract class AbstractScanImportConverter extends AbstractImportConverter implements IScanImportConverter {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/src/org/eclipse/chemclipse/wsd/converter/core/IScanImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/src/org/eclipse/chemclipse/wsd/converter/core/IScanImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,9 +15,10 @@ import java.io.File;
 
 import org.eclipse.chemclipse.converter.core.IImportConverter;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.wsd.model.core.ISpectrumWSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public interface IScanImportConverter<T> extends IImportConverter {
+public interface IScanImportConverter extends IImportConverter {
 
-	IProcessingInfo<T> convert(File file, IProgressMonitor monitor);
+	IProcessingInfo<ISpectrumWSD> convert(File file, IProgressMonitor monitor);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/src/org/eclipse/chemclipse/wsd/converter/core/ScanConverterWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/src/org/eclipse/chemclipse/wsd/converter/core/ScanConverterWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -53,7 +53,7 @@ public class ScanConverterWSD {
 		 * Do not use a safe runnable here, because an object must
 		 * be returned or null.
 		 */
-		IScanImportConverter<ISpectrumWSD> importConverter = getScanImportConverter(converterId);
+		IScanImportConverter importConverter = getScanImportConverter(converterId);
 		if(importConverter != null) {
 			processingInfo = importConverter.convert(file, monitor);
 		} else {
@@ -86,7 +86,7 @@ public class ScanConverterWSD {
 				 * Do not use a safe runnable here, because an object must
 				 * be returned or null.
 				 */
-				IScanImportConverter<ISpectrumWSD> importConverter = getScanImportConverter(converterId);
+				IScanImportConverter importConverter = getScanImportConverter(converterId);
 				if(importConverter != null) {
 					processingInfo = importConverter.convert(file, monitor);
 					if(!processingInfo.hasErrorMessages()) {
@@ -116,15 +116,14 @@ public class ScanConverterWSD {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("unchecked")
-	private static IScanImportConverter<ISpectrumWSD> getScanImportConverter(final String converterId) {
+	private static IScanImportConverter getScanImportConverter(final String converterId) {
 
 		IConfigurationElement element;
 		element = getConfigurationElement(converterId);
-		IScanImportConverter<ISpectrumWSD> instance = null;
+		IScanImportConverter instance = null;
 		if(element != null) {
 			try {
-				instance = (IScanImportConverter<ISpectrumWSD>)element.createExecutableExtension(Converter.IMPORT_CONVERTER);
+				instance = (IScanImportConverter)element.createExecutableExtension(Converter.IMPORT_CONVERTER);
 			} catch(CoreException e) {
 				logger.error(e);
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/wsd/converter/supplier/jcampdx/converter/ScanImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/wsd/converter/supplier/jcampdx/converter/ScanImportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,17 +21,17 @@ import org.eclipse.chemclipse.wsd.converter.core.AbstractScanImportConverter;
 import org.eclipse.chemclipse.wsd.converter.core.IScanImportConverter;
 import org.eclipse.chemclipse.wsd.converter.supplier.jcampdx.io.ScanReader;
 import org.eclipse.chemclipse.wsd.converter.supplier.jcampdx.model.IVendorSpectrumWSD;
+import org.eclipse.chemclipse.wsd.model.core.ISpectrumWSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-@SuppressWarnings("rawtypes")
 public class ScanImportConverter extends AbstractScanImportConverter implements IScanImportConverter {
 
 	private static final Logger logger = Logger.getLogger(ScanImportConverter.class);
 
 	@Override
-	public IProcessingInfo<IVendorSpectrumWSD> convert(File file, IProgressMonitor monitor) {
+	public IProcessingInfo<ISpectrumWSD> convert(File file, IProgressMonitor monitor) {
 
-		IProcessingInfo<IVendorSpectrumWSD> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<ISpectrumWSD> processingInfo = new ProcessingInfo<>();
 		try {
 			ScanReader scanReader = new ScanReader();
 			IVendorSpectrumWSD vendorScan = scanReader.read(file, monitor);

--- a/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.cml.test/src/org/eclipse/chemclipse/wsd/converter/supplier/cml/test/Spectrum4_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.cml.test/src/org/eclipse/chemclipse/wsd/converter/supplier/cml/test/Spectrum4_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,6 +17,7 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.supplier.cml.PathResolver;
 import org.eclipse.chemclipse.wsd.converter.supplier.cml.converter.ScanImportConverter;
 import org.eclipse.chemclipse.wsd.converter.supplier.cml.model.IVendorSpectrumWSD;
+import org.eclipse.chemclipse.wsd.model.core.ISpectrumWSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Test;
 
@@ -24,7 +25,7 @@ import junit.framework.TestCase;
 
 public class Spectrum4_ITest extends TestCase {
 
-	private IVendorSpectrumWSD vendorSpectrum;
+	private ISpectrumWSD spectrumWSD;
 
 	@Override
 	protected void setUp() throws Exception {
@@ -32,28 +33,30 @@ public class Spectrum4_ITest extends TestCase {
 		super.setUp();
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.SPECTRUM4));
 		ScanImportConverter importConverter = new ScanImportConverter();
-		IProcessingInfo<IVendorSpectrumWSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
-		vendorSpectrum = processingInfo.getProcessingResult();
+		IProcessingInfo<ISpectrumWSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
+		spectrumWSD = processingInfo.getProcessingResult();
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
 
-		vendorSpectrum = null;
+		spectrumWSD = null;
 		super.tearDown();
 	}
 
 	@Test
 	public void testLoading() {
 
-		assertNotNull(vendorSpectrum);
-		assertEquals("sp04", vendorSpectrum.getDataName());
-		assertEquals("109-99-9", vendorSpectrum.getCasNumber());
+		assertNotNull(spectrumWSD);
+		assertEquals("sp04", spectrumWSD.getDataName());
+		if(spectrumWSD instanceof IVendorSpectrumWSD vendorSpectrumWSD) {
+			assertEquals("109-99-9", vendorSpectrumWSD.getCasNumber());
+		}
 	}
 
 	@Test
 	public void testSignals() {
 
-		assertEquals(1001, vendorSpectrum.getSignals().size());
+		assertEquals(1001, spectrumWSD.getSignals().size());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.spectroml.test/src/org/eclipse/chemclipse/wsd/converter/supplier/cml/test/SpectroML_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.spectroml.test/src/org/eclipse/chemclipse/wsd/converter/supplier/cml/test/SpectroML_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,7 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.supplier.spectroml.PathResolver;
 import org.eclipse.chemclipse.wsd.converter.supplier.spectroml.converter.ScanImportConverter;
 import org.eclipse.chemclipse.wsd.converter.supplier.spectroml.model.IVendorSpectrumWSD;
+import org.eclipse.chemclipse.wsd.model.core.ISpectrumWSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Test;
 
@@ -25,7 +26,7 @@ import junit.framework.TestCase;
 
 public class SpectroML_ITest extends TestCase {
 
-	private IVendorSpectrumWSD vendorSpectrum;
+	private ISpectrumWSD spectrumWSD;
 
 	@Override
 	protected void setUp() throws Exception {
@@ -33,40 +34,42 @@ public class SpectroML_ITest extends TestCase {
 		super.setUp();
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.SAMPLE));
 		ScanImportConverter importConverter = new ScanImportConverter();
-		IProcessingInfo<IVendorSpectrumWSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
-		vendorSpectrum = processingInfo.getProcessingResult();
+		IProcessingInfo<ISpectrumWSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
+		spectrumWSD = processingInfo.getProcessingResult();
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
 
-		vendorSpectrum = null;
+		spectrumWSD = null;
 		super.tearDown();
 	}
 
 	@Test
 	public void testLoading() {
 
-		assertNotNull(vendorSpectrum);
+		assertNotNull(spectrumWSD);
 	}
 
 	@Test
 	public void testMetadata() {
 
-		assertEquals("sample experiment", vendorSpectrum.getDataName());
-		assertEquals("simple measurement of drinking water", vendorSpectrum.getDetailedInfo());
-		assertEquals("HP 8453", vendorSpectrum.getInstrument());
-		assertEquals(2000, vendorSpectrum.getDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime().getYear());
-		assertEquals("Paul DeRose", vendorSpectrum.getOperator());
-		assertEquals("1063546374", vendorSpectrum.getBarcode());
-		assertEquals("water", vendorSpectrum.getSampleName());
-		assertEquals("7732-18-5", vendorSpectrum.getCasNumber());
-		assertEquals("H2O", vendorSpectrum.getFormula());
+		assertEquals("sample experiment", spectrumWSD.getDataName());
+		assertEquals("simple measurement of drinking water", spectrumWSD.getDetailedInfo());
+		assertEquals("HP 8453", spectrumWSD.getInstrument());
+		assertEquals(2000, spectrumWSD.getDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime().getYear());
+		assertEquals("Paul DeRose", spectrumWSD.getOperator());
+		assertEquals("1063546374", spectrumWSD.getBarcode());
+		assertEquals("water", spectrumWSD.getSampleName());
+		if(spectrumWSD instanceof IVendorSpectrumWSD vendorSpectrumWSD) {
+			assertEquals("7732-18-5", vendorSpectrumWSD.getCasNumber());
+			assertEquals("H2O", vendorSpectrumWSD.getFormula());
+		}
 	}
 
 	@Test
 	public void testSignals() {
 
-		assertEquals(3, vendorSpectrum.getSignals().size());
+		assertEquals(3, spectrumWSD.getSignals().size());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Grape_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Grape_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,7 +15,7 @@ import java.io.File;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.supplier.jcampdx.converter.ScanImportConverter;
-import org.eclipse.chemclipse.wsd.converter.supplier.jcampdx.model.IVendorSpectrumWSD;
+import org.eclipse.chemclipse.wsd.model.core.ISpectrumWSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Test;
 
@@ -23,7 +23,7 @@ import junit.framework.TestCase;
 
 public class Grape_ITest extends TestCase {
 
-	private IVendorSpectrumWSD vendorSpectrum;
+	private ISpectrumWSD spectrumWSD;
 
 	@Override
 	protected void setUp() throws Exception {
@@ -31,28 +31,28 @@ public class Grape_ITest extends TestCase {
 		super.setUp();
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.GRAPE));
 		ScanImportConverter importConverter = new ScanImportConverter();
-		IProcessingInfo<IVendorSpectrumWSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
-		vendorSpectrum = processingInfo.getProcessingResult();
+		IProcessingInfo<ISpectrumWSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
+		spectrumWSD = processingInfo.getProcessingResult();
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
 
-		vendorSpectrum = null;
+		spectrumWSD = null;
 		super.tearDown();
 	}
 
 	@Test
 	public void testLoading() {
 
-		assertNotNull(vendorSpectrum);
-		assertEquals("D&G Grape (SofDrink)", vendorSpectrum.getDataName());
-		assertEquals("PERKIN-ELMER LAMBDA 19 UV/VIS/NIR UV", vendorSpectrum.getInstrument());
+		assertNotNull(spectrumWSD);
+		assertEquals("D&G Grape (SofDrink)", spectrumWSD.getDataName());
+		assertEquals("PERKIN-ELMER LAMBDA 19 UV/VIS/NIR UV", spectrumWSD.getInstrument());
 	}
 
 	@Test
 	public void testSignals() {
 
-		assertEquals(451, vendorSpectrum.getSignals().size());
+		assertEquals(451, spectrumWSD.getSignals().size());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Pepsi_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Pepsi_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,7 +15,7 @@ import java.io.File;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.supplier.jcampdx.converter.ScanImportConverter;
-import org.eclipse.chemclipse.wsd.converter.supplier.jcampdx.model.IVendorSpectrumWSD;
+import org.eclipse.chemclipse.wsd.model.core.ISpectrumWSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Test;
 
@@ -23,7 +23,7 @@ import junit.framework.TestCase;
 
 public class Pepsi_ITest extends TestCase {
 
-	private IVendorSpectrumWSD vendorSpectrum;
+	private ISpectrumWSD spectrumWSD;
 
 	@Override
 	protected void setUp() throws Exception {
@@ -31,28 +31,28 @@ public class Pepsi_ITest extends TestCase {
 		super.setUp();
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.PEPSI));
 		ScanImportConverter importConverter = new ScanImportConverter();
-		IProcessingInfo<IVendorSpectrumWSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
-		vendorSpectrum = processingInfo.getProcessingResult();
+		IProcessingInfo<ISpectrumWSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
+		spectrumWSD = processingInfo.getProcessingResult();
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
 
-		vendorSpectrum = null;
+		spectrumWSD = null;
 		super.tearDown();
 	}
 
 	@Test
 	public void testLoading() {
 
-		assertNotNull(vendorSpectrum);
-		assertEquals("pepsi-cola (diluted)", vendorSpectrum.getDataName());
-		assertEquals("PERKIN-ELMER LAMBDA 19 UV/VIS/NIR UV", vendorSpectrum.getInstrument());
+		assertNotNull(spectrumWSD);
+		assertEquals("pepsi-cola (diluted)", spectrumWSD.getDataName());
+		assertEquals("PERKIN-ELMER LAMBDA 19 UV/VIS/NIR UV", spectrumWSD.getInstrument());
 	}
 
 	@Test
 	public void testSignals() {
 
-		assertEquals(101, vendorSpectrum.getSignals().size());
+		assertEquals(101, spectrumWSD.getSignals().size());
 	}
 }


### PR DESCRIPTION
Same idea as https://github.com/eclipse-chemclipse/chemclipse/pull/2024 as the API is pretty much mirrored.