### PR TITLE
Remove generics and suffix filter names for chromatogram filters

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/plugin.xml
@@ -5,7 +5,7 @@
          point="org.eclipse.chemclipse.chromatogram.msd.filter.chromatogramFilterSupplier">
       <ChromatogramFilterSupplier
             description="This filter applies the backfolding algorithm."
-            filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.core.ChromatogramFilter"
+            filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.core.ChromatogramFilterMSD"
             filterName="Backfolding"
             filterSettings="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.settings.ChromatogramFilterSettings"
             id="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding">

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/ChromatogramFilterMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/ChromatogramFilterMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Lablicate GmbH.
+ * Copyright (c) 2011, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -30,7 +30,7 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class ChromatogramFilter extends AbstractChromatogramFilterMSD {
+public class ChromatogramFilterMSD extends AbstractChromatogramFilterMSD {
 
 	@Override
 	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/plugin.xml
@@ -5,7 +5,7 @@
          point="org.eclipse.chemclipse.chromatogram.msd.filter.chromatogramFilterSupplier">
       <ChromatogramFilterSupplier
             description="This filter applies the CODA background remover algorithm."
-            filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.core.ChromatogramFilter"
+            filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.core.ChromatogramFilterMSD"
             filterName="CODA"
             filterSettings="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.settings.FilterSettings"
             id="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda">

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/core/ChromatogramFilterMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/core/ChromatogramFilterMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Lablicate GmbH.
+ * Copyright (c) 2011, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -30,7 +30,7 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class ChromatogramFilter extends AbstractChromatogramFilterMSD {
+public class ChromatogramFilterMSD extends AbstractChromatogramFilterMSD {
 
 	private static final int MOVING_AVERAGE_WINDOW = 5;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/AbstractChromatogramFilterMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/AbstractChromatogramFilterMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -17,7 +17,7 @@ import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 
-public abstract class AbstractChromatogramFilterMSD implements IChromatogramFilterMSD<IChromatogramFilterResult> {
+public abstract class AbstractChromatogramFilterMSD implements IChromatogramFilterMSD {
 
 	private static final String DESCRIPTION = "Chromatogram Filter";
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/ChromatogramFilterMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/ChromatogramFilterMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -62,7 +62,7 @@ public class ChromatogramFilterMSD {
 	public static IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, String filterId, IProgressMonitor monitor) {
 
 		IProcessingInfo<IChromatogramFilterResult> processingInfo;
-		IChromatogramFilterMSD<IChromatogramFilterResult> chromatogramFilter = getChromatogramFilter(filterId);
+		IChromatogramFilterMSD chromatogramFilter = getChromatogramFilter(filterId);
 		if(chromatogramFilter != null) {
 			processingInfo = chromatogramFilter.applyFilter(chromatogramSelection, chromatogramFilterSettings, monitor);
 			chromatogramSelection.getChromatogram().setDirty(true);
@@ -86,7 +86,7 @@ public class ChromatogramFilterMSD {
 	public static IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, String filterId, IProgressMonitor monitor) {
 
 		IProcessingInfo<IChromatogramFilterResult> processingInfo;
-		IChromatogramFilterMSD<IChromatogramFilterResult> chromatogramFilter = getChromatogramFilter(filterId);
+		IChromatogramFilterMSD chromatogramFilter = getChromatogramFilter(filterId);
 		if(chromatogramFilter != null) {
 			processingInfo = chromatogramFilter.applyFilter(chromatogramSelection, monitor);
 		} else {
@@ -131,12 +131,11 @@ public class ChromatogramFilterMSD {
 	 * Returns a {@link IChromatogramFilterMSD} instance given by the filterId or
 	 * null, if none is available.
 	 */
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	private static IChromatogramFilterMSD<IChromatogramFilterResult> getChromatogramFilter(final String filterId) {
+	private static IChromatogramFilterMSD getChromatogramFilter(final String filterId) {
 
 		IConfigurationElement element;
 		element = getConfigurationElement(filterId);
-		IChromatogramFilterMSD<IChromatogramFilterResult> instance = null;
+		IChromatogramFilterMSD instance = null;
 		if(element != null) {
 			try {
 				instance = (IChromatogramFilterMSD)element.createExecutableExtension(FILTER);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/IChromatogramFilterMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/IChromatogramFilterMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,13 +12,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.core.chromatogram;
 
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 
-public interface IChromatogramFilterMSD<R> {
+public interface IChromatogramFilterMSD {
 
 	/**
 	 * Apply the filter in the given chromatogram selection and take care of the
@@ -31,7 +32,7 @@ public interface IChromatogramFilterMSD<R> {
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	IProcessingInfo<R> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor);
+	IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor);
 
 	/**
 	 * Apply the filter in the given chromatogram selection.
@@ -42,7 +43,7 @@ public interface IChromatogramFilterMSD<R> {
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	IProcessingInfo<R> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor);
+	IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor);
 
 	/**
 	 * Validates the selection and settings and returns a process info instance.
@@ -51,5 +52,5 @@ public interface IChromatogramFilterMSD<R> {
 	 * @param chromatogramFilterSettings
 	 * @return {@link IProcessingInfo}
 	 */
-	IProcessingInfo<R> validate(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings);
+	IProcessingInfo<IChromatogramFilterResult> validate(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings);
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/AbstractChromatogramFilter_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/chromatogram/AbstractChromatogramFilter_1_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.core.chromatogram;
 
-import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.model.exceptions.ChromatogramIsNullException;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -27,7 +26,7 @@ import junit.framework.TestCase;
  */
 public class AbstractChromatogramFilter_1_Test extends TestCase {
 
-	private IChromatogramFilterMSD<IChromatogramFilterResult> filter;
+	private IChromatogramFilterMSD filter;
 	private IChromatogramSelectionMSD chromatogramSelection;
 	private IChromatogramMSD chromatogram;
 	private IChromatogramFilterSettings chromatogramFilterSettings;

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/BackfoldingFilter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/BackfoldingFilter_1_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Lablicate GmbH.
+ * Copyright (c) 2011, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -17,14 +17,14 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 
 public class BackfoldingFilter_1_ITest extends ChromatogramImporterTestCase {
 
-	private IChromatogramFilterMSD<?> chromatogramFilter;
+	private IChromatogramFilterMSD chromatogramFilter;
 	private ChromatogramFilterSettings chromatogramFilterSettings;
 
 	@Override
 	protected void setUp() throws Exception {
 
 		super.setUp();
-		chromatogramFilter = new ChromatogramFilter();
+		chromatogramFilter = new ChromatogramFilterMSD();
 		chromatogramFilterSettings = new ChromatogramFilterSettings();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/core/CodaFilter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/core/CodaFilter_1_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Lablicate GmbH.
+ * Copyright (c) 2011, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -17,14 +17,14 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 
 public class CodaFilter_1_ITest extends ChromatogramImporterTestCase {
 
-	private IChromatogramFilterMSD<?> chromatogramFilter;
+	private IChromatogramFilterMSD chromatogramFilter;
 	private FilterSettings chromatogramFilterSettings;
 
 	@Override
 	protected void setUp() throws Exception {
 
 		super.setUp();
-		chromatogramFilter = new ChromatogramFilter();
+		chromatogramFilter = new ChromatogramFilterMSD();
 		chromatogramFilterSettings = new FilterSettings();
 	}
 


### PR DESCRIPTION
I am not sure if generics were implemented at the right place because `IChromatogramFilterResult` is always the result no matter the detector type.