### PR TITLE
Show detailed feedback about UV/Vis, *IR and Raman converter errors

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.ui/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.chemclipse.vsd.model;bundle-version="0.9.0",
  org.eclipse.chemclipse.processing;bundle-version="0.9.0",
  org.apache.commons.commons-io;bundle-version="2.14.0",
- org.eclipse.chemclipse.converter.ui;bundle-version="0.9.0"
+ org.eclipse.chemclipse.converter.ui;bundle-version="0.9.0",
+ org.eclipse.chemclipse.processing.ui;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.chemclipse.vsd.converter.ui.Activator

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.ui/src/org/eclipse/chemclipse/vsd/converter/ui/swt/VibrationalSpectroscopyFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.ui/src/org/eclipse/chemclipse/vsd/converter/ui/swt/VibrationalSpectroscopyFileSupport.java
@@ -23,6 +23,7 @@ import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.processing.converter.ISupplier;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.exceptions.TypeCastException;
+import org.eclipse.chemclipse.processing.ui.support.ProcessingInfoPartSupport;
 import org.eclipse.chemclipse.vsd.converter.core.ScanConverterVSD;
 import org.eclipse.chemclipse.vsd.converter.ui.l10n.VibrationalSpectroscopyMessages;
 import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
@@ -151,6 +152,7 @@ public class VibrationalSpectroscopyFileSupport {
 						monitor.beginTask(VibrationalSpectroscopyMessages.saveRaman, IProgressMonitor.UNKNOWN);
 					}
 					IProcessingInfo<File> processingInfo = ScanConverterVSD.convert(file, spectrum, supplier.getId(), monitor);
+					ProcessingInfoPartSupport.getInstance().update(processingInfo);
 					processingInfo.getProcessingResult();
 				} catch(TypeCastException e) {
 					logger.warn(e);

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter/src/org/eclipse/chemclipse/vsd/converter/core/ScanConverterVSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter/src/org/eclipse/chemclipse/vsd/converter/core/ScanConverterVSD.java
@@ -49,7 +49,8 @@ public class ScanConverterVSD {
 
 	public static IProcessingInfo<ISpectrumVSD> convert(final File file, final String converterId, final IProgressMonitor monitor) {
 
-		IProcessingInfo<ISpectrumVSD> processingInfo;
+		IProcessingInfo<ISpectrumVSD> processingInfo = new ProcessingInfo<>();
+		;
 		/*
 		 * Do not use a safe runnable here, because an object must
 		 * be returned or null.
@@ -57,8 +58,6 @@ public class ScanConverterVSD {
 		IScanImportConverter importConverter = getScanImportConverter(converterId);
 		if(importConverter != null) {
 			processingInfo = importConverter.convert(file, monitor);
-		} else {
-			processingInfo = getImportProcessingError(file);
 		}
 		return processingInfo;
 	}
@@ -78,7 +77,7 @@ public class ScanConverterVSD {
 	 */
 	private static IProcessingInfo<ISpectrumVSD> getScan(final File file, IProgressMonitor monitor) {
 
-		IProcessingInfo<ISpectrumVSD> processingInfo;
+		IProcessingInfo<ISpectrumVSD> processingInfo = new ProcessingInfo<>();
 		IScanConverterSupport converterSupport = getScanConverterSupport();
 		try {
 			List<String> availableConverterIds = converterSupport.getAvailableConverterIds(file);
@@ -98,12 +97,12 @@ public class ScanConverterVSD {
 		} catch(NoConverterAvailableException e) {
 			logger.info(e);
 		}
-		return getImportProcessingError(file);
+		return processingInfo;
 	}
 
 	public static IProcessingInfo<File> convert(final File file, final ISpectrumVSD scan, final String converterId, final IProgressMonitor monitor) {
 
-		IProcessingInfo<File> processingInfo;
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		/*
 		 * Do not use a safe runnable here, because an object must
 		 * be returned or null.
@@ -111,8 +110,6 @@ public class ScanConverterVSD {
 		IScanExportConverter exportConverter = getScanExportConverter(converterId);
 		if(exportConverter != null) {
 			processingInfo = exportConverter.convert(file, scan, monitor);
-		} else {
-			processingInfo = getExportProcessingError(file);
 		}
 		return processingInfo;
 	}
@@ -218,19 +215,5 @@ public class ScanConverterVSD {
 			fileContentMatcher = new NoFileContentMatcher();
 		}
 		return fileContentMatcher;
-	}
-
-	private static IProcessingInfo<File> getExportProcessingError(File file) {
-
-		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
-		processingInfo.addErrorMessage("Scan Converter", "No suitable export converter was found for: " + file);
-		return processingInfo;
-	}
-
-	private static IProcessingInfo<ISpectrumVSD> getImportProcessingError(File file) {
-
-		IProcessingInfo<ISpectrumVSD> processingInfo = new ProcessingInfo<>();
-		processingInfo.addErrorMessage("Scan Converter", "No suitable import converter was found for: " + file);
-		return processingInfo;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.ui/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.chemclipse.wsd.converter,
  org.eclipse.chemclipse.logging,
  org.eclipse.chemclipse.support.ui,
- org.eclipse.chemclipse.converter.ui
+ org.eclipse.chemclipse.converter.ui,
+ org.eclipse.chemclipse.processing.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.wsd.converter.ui.swt

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.ui/src/org/eclipse/chemclipse/wsd/converter/ui/swt/UVVisSpectrumFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.ui/src/org/eclipse/chemclipse/wsd/converter/ui/swt/UVVisSpectrumFileSupport.java
@@ -23,6 +23,7 @@ import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.processing.converter.ISupplier;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.exceptions.TypeCastException;
+import org.eclipse.chemclipse.processing.ui.support.ProcessingInfoPartSupport;
 import org.eclipse.chemclipse.wsd.converter.core.ScanConverterWSD;
 import org.eclipse.chemclipse.wsd.converter.ui.l10n.UltravioletVisibleSpectroscopy;
 import org.eclipse.chemclipse.wsd.model.core.ISpectrumWSD;
@@ -146,6 +147,7 @@ public class UVVisSpectrumFileSupport {
 				try {
 					monitor.beginTask(UltravioletVisibleSpectroscopy.saveUVVis, IProgressMonitor.UNKNOWN);
 					IProcessingInfo<File> processingInfo = ScanConverterWSD.convert(file, spectrum, supplier.getId(), monitor);
+					ProcessingInfoPartSupport.getInstance().update(processingInfo);
 					processingInfo.getProcessingResult();
 				} catch(TypeCastException e) {
 					logger.warn(e);

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/src/org/eclipse/chemclipse/wsd/converter/core/ScanConverterWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/src/org/eclipse/chemclipse/wsd/converter/core/ScanConverterWSD.java
@@ -48,7 +48,7 @@ public class ScanConverterWSD {
 
 	public static IProcessingInfo<ISpectrumWSD> convert(final File file, final String converterId, final IProgressMonitor monitor) {
 
-		IProcessingInfo<ISpectrumWSD> processingInfo;
+		IProcessingInfo<ISpectrumWSD> processingInfo = new ProcessingInfo<>();
 		/*
 		 * Do not use a safe runnable here, because an object must
 		 * be returned or null.
@@ -56,8 +56,6 @@ public class ScanConverterWSD {
 		IScanImportConverter importConverter = getScanImportConverter(converterId);
 		if(importConverter != null) {
 			processingInfo = importConverter.convert(file, monitor);
-		} else {
-			processingInfo = getImportProcessingError(file);
 		}
 		return processingInfo;
 	}
@@ -77,7 +75,7 @@ public class ScanConverterWSD {
 	 */
 	private static IProcessingInfo<ISpectrumWSD> getScan(final File file, IProgressMonitor monitor) {
 
-		IProcessingInfo<ISpectrumWSD> processingInfo;
+		IProcessingInfo<ISpectrumWSD> processingInfo = new ProcessingInfo<>();
 		IScanConverterSupport converterSupport = getScanConverterSupport();
 		try {
 			List<String> availableConverterIds = converterSupport.getAvailableConverterIds(file);
@@ -97,12 +95,12 @@ public class ScanConverterWSD {
 		} catch(NoConverterAvailableException e) {
 			logger.info(e);
 		}
-		return getImportProcessingError(file);
+		return processingInfo;
 	}
 
 	public static IProcessingInfo<File> convert(final File file, final ISpectrumWSD scan, final String converterId, final IProgressMonitor monitor) {
 
-		IProcessingInfo<File> processingInfo;
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		/*
 		 * Do not use a safe runnable here, because an object must
 		 * be returned or null.
@@ -110,8 +108,6 @@ public class ScanConverterWSD {
 		IScanExportConverter exportConverter = getScanExportConverter(converterId);
 		if(exportConverter != null) {
 			processingInfo = exportConverter.convert(file, scan, monitor);
-		} else {
-			processingInfo = getExportProcessingError(file);
 		}
 		return processingInfo;
 	}
@@ -217,19 +213,5 @@ public class ScanConverterWSD {
 			fileContentMatcher = new NoFileContentMatcher();
 		}
 		return fileContentMatcher;
-	}
-
-	private static IProcessingInfo<File> getExportProcessingError(File file) {
-
-		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
-		processingInfo.addErrorMessage("Scan Converter", "No suitable export converter was found for: " + file);
-		return processingInfo;
-	}
-
-	private static IProcessingInfo<ISpectrumWSD> getImportProcessingError(File file) {
-
-		IProcessingInfo<ISpectrumWSD> processingInfo = new ProcessingInfo<>();
-		processingInfo.addErrorMessage("Scan Converter", "No suitable import converter was found for: " + file);
-		return processingInfo;
 	}
 }


### PR DESCRIPTION
I forgot about it at https://github.com/eclipse-chemclipse/chemclipse/pull/1866. Every error from the converter got overridden with a generic `no suitable import converter was found` message, which is not helpful.