### PR TITLE
Remove generics from PeakIdentifier

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/impl/PeakIdentifierRemoveUnidentified.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/impl/PeakIdentifierRemoveUnidentified.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,16 +20,17 @@ import org.eclipse.chemclipse.chromatogram.csd.identifier.settings.IPeakIdentifi
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramPeakCSD;
 import org.eclipse.chemclipse.csd.model.core.IPeakCSD;
+import org.eclipse.chemclipse.model.identifier.IPeakIdentificationResults;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class PeakIdentifierRemoveUnidentified<T> extends AbstractPeakIdentifierCSD<T> {
+public class PeakIdentifierRemoveUnidentified extends AbstractPeakIdentifierCSD {
 
 	@Override
-	public IProcessingInfo<T> identify(List<? extends IPeakCSD> peaks, IPeakIdentifierSettingsCSD peakIdentifierSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IPeakIdentificationResults> identify(List<? extends IPeakCSD> peaks, IPeakIdentifierSettingsCSD peakIdentifierSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo<T> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<IPeakIdentificationResults> processingInfo = new ProcessingInfo<>();
 		/*
 		 * Remove all unidentified peaks.
 		 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/peak/AbstractPeakIdentifierCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/peak/AbstractPeakIdentifierCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -20,7 +20,7 @@ import org.eclipse.chemclipse.csd.model.core.IPeakCSD;
 import org.eclipse.chemclipse.model.exceptions.ValueMustNotBeNullException;
 import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
-public abstract class AbstractPeakIdentifierCSD<T> implements IPeakIdentifierCSD<T> {
+public abstract class AbstractPeakIdentifierCSD implements IPeakIdentifierCSD {
 
 	private List<LiteratureReference> literatureReferences = new ArrayList<>();
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/peak/IPeakIdentifierCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/peak/IPeakIdentifierCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -16,11 +16,12 @@ import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.csd.identifier.settings.IPeakIdentifierSettingsCSD;
 import org.eclipse.chemclipse.csd.model.core.IPeakCSD;
+import org.eclipse.chemclipse.model.identifier.IPeakIdentificationResults;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.support.literature.LiteratureReference;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public interface IPeakIdentifierCSD<T> {
+public interface IPeakIdentifierCSD {
 
 	/**
 	 * Identifies a list of peaks.
@@ -30,7 +31,7 @@ public interface IPeakIdentifierCSD<T> {
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	IProcessingInfo<T> identify(List<? extends IPeakCSD> peaks, IPeakIdentifierSettingsCSD peakIdentifierSettings, IProgressMonitor monitor);
+	IProcessingInfo<IPeakIdentificationResults> identify(List<? extends IPeakCSD> peaks, IPeakIdentifierSettingsCSD peakIdentifierSettings, IProgressMonitor monitor);
 
 	List<LiteratureReference> getLiteratureReferences();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/peak/PeakIdentifierCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/peak/PeakIdentifierCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -24,7 +24,7 @@ import org.eclipse.chemclipse.csd.model.core.IPeakCSD;
 import org.eclipse.chemclipse.csd.model.core.selection.IChromatogramSelectionCSD;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.exceptions.NoIdentifierAvailableException;
-import org.eclipse.chemclipse.model.identifier.IIdentificationResults;
+import org.eclipse.chemclipse.model.identifier.IPeakIdentificationResults;
 import org.eclipse.chemclipse.model.identifier.core.Identifier;
 import org.eclipse.chemclipse.processing.core.ICategories;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -85,15 +85,14 @@ public class PeakIdentifierCSD {
 	 * Returns a {@link IPeakIdentifierCSD} instance given by the identifierId or
 	 * null, if none is available.
 	 */
-	@SuppressWarnings("unchecked")
-	private static <T> IPeakIdentifierCSD<T> getPeakIdentifier(final String identifierId) {
+	private static IPeakIdentifierCSD getPeakIdentifier(final String identifierId) {
 
 		IConfigurationElement element;
 		element = getConfigurationElement(identifierId);
-		IPeakIdentifierCSD<T> instance = null;
+		IPeakIdentifierCSD instance = null;
 		if(element != null) {
 			try {
-				instance = (IPeakIdentifierCSD<T>)element.createExecutableExtension(Identifier.IDENTIFIER);
+				instance = (IPeakIdentifierCSD)element.createExecutableExtension(Identifier.IDENTIFIER);
 			} catch(CoreException e) {
 				logger.error(e);
 			}
@@ -147,7 +146,7 @@ public class PeakIdentifierCSD {
 	 * @return {@link IProcessingInfo}
 	 * @throws NoIdentifierAvailableException
 	 */
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(IChromatogramPeakCSD peak, IPeakIdentifierSettingsCSD identifierSettings, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(IChromatogramPeakCSD peak, IPeakIdentifierSettingsCSD identifierSettings, String identifierId, IProgressMonitor monitor) {
 
 		List<IChromatogramPeakCSD> peaks = new ArrayList<>();
 		peaks.add(peak);
@@ -163,7 +162,7 @@ public class PeakIdentifierCSD {
 	 * @return {@link IProcessingInfo}
 	 * @throws NoIdentifierAvailableException
 	 */
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(IPeakCSD peak, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(IPeakCSD peak, String identifierId, IProgressMonitor monitor) {
 
 		return identify(Collections.singletonList(peak), identifierId, monitor);
 	}
@@ -178,9 +177,9 @@ public class PeakIdentifierCSD {
 	 * @return {@link IProcessingInfo}
 	 * @throws NoIdentifierAvailableException
 	 */
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(List<? extends IPeakCSD> peaks, IPeakIdentifierSettingsCSD identifierSettings, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(List<? extends IPeakCSD> peaks, IPeakIdentifierSettingsCSD identifierSettings, String identifierId, IProgressMonitor monitor) {
 
-		IPeakIdentifierCSD<T> peakIdentifier = getPeakIdentifier(identifierId);
+		IPeakIdentifierCSD peakIdentifier = getPeakIdentifier(identifierId);
 		if(peakIdentifier != null) {
 			return peakIdentifier.identify(peaks, identifierSettings, monitor);
 		} else {
@@ -197,17 +196,17 @@ public class PeakIdentifierCSD {
 	 * @return {@link IProcessingInfo}
 	 * @throws NoIdentifierAvailableException
 	 */
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(List<? extends IPeakCSD> peaks, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(List<? extends IPeakCSD> peaks, String identifierId, IProgressMonitor monitor) {
 
 		return identify(peaks, null, identifierId, monitor);
 	}
 
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(IChromatogramSelectionCSD chromatogramSelectionCSD, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(IChromatogramSelectionCSD chromatogramSelectionCSD, String identifierId, IProgressMonitor monitor) {
 
 		return identify(chromatogramSelectionCSD, null, identifierId, monitor);
 	}
 
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(IChromatogramSelectionCSD chromatogramSelectionCSD, IPeakIdentifierSettingsCSD peakIdentifierSettingsCSD, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(IChromatogramSelectionCSD chromatogramSelectionCSD, IPeakIdentifierSettingsCSD peakIdentifierSettingsCSD, String identifierId, IProgressMonitor monitor) {
 
 		return identify(chromatogramSelectionCSD.getChromatogram().getPeaks(chromatogramSelectionCSD), peakIdentifierSettingsCSD, identifierId, monitor);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/peak/AbstractPeakIdentifierMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/peak/AbstractPeakIdentifierMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -13,11 +13,10 @@
 package org.eclipse.chemclipse.chromatogram.msd.identifier.peak;
 
 import org.eclipse.chemclipse.model.exceptions.ValueMustNotBeNullException;
-import org.eclipse.chemclipse.model.identifier.IIdentificationResults;
 import org.eclipse.chemclipse.model.identifier.IIdentifierSettings;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 
-public abstract class AbstractPeakIdentifierMSD<T extends IIdentificationResults> implements IPeakIdentifierMSD<T> {
+public abstract class AbstractPeakIdentifierMSD implements IPeakIdentifierMSD {
 
 	/**
 	 * Validates that the peak is not null.<br/>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/peak/IPeakIdentifierMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/peak/IPeakIdentifierMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -16,12 +16,12 @@ package org.eclipse.chemclipse.chromatogram.msd.identifier.peak;
 import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.msd.identifier.settings.IPeakIdentifierSettingsMSD;
-import org.eclipse.chemclipse.model.identifier.IIdentificationResults;
+import org.eclipse.chemclipse.model.identifier.IPeakIdentificationResults;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public interface IPeakIdentifierMSD<T extends IIdentificationResults> {
+public interface IPeakIdentifierMSD {
 
 	/**
 	 * Identifies a list of peaks.
@@ -31,5 +31,5 @@ public interface IPeakIdentifierMSD<T extends IIdentificationResults> {
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	IProcessingInfo<T> identify(List<? extends IPeakMSD> peaks, IPeakIdentifierSettingsMSD peakIdentifierSettings, IProgressMonitor monitor);
+	IProcessingInfo<IPeakIdentificationResults> identify(List<? extends IPeakMSD> peaks, IPeakIdentifierSettingsMSD peakIdentifierSettings, IProgressMonitor monitor);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/peak/PeakIdentifierMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/peak/PeakIdentifierMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -21,7 +21,7 @@ import java.util.List;
 import org.eclipse.chemclipse.chromatogram.msd.identifier.settings.IPeakIdentifierSettingsMSD;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.exceptions.NoIdentifierAvailableException;
-import org.eclipse.chemclipse.model.identifier.IIdentificationResults;
+import org.eclipse.chemclipse.model.identifier.IPeakIdentificationResults;
 import org.eclipse.chemclipse.model.identifier.core.Identifier;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
@@ -88,15 +88,14 @@ public class PeakIdentifierMSD {
 	 * Returns a {@link IPeakIdentifierMSD} instance given by the identifierId or
 	 * null, if none is available.
 	 */
-	@SuppressWarnings("unchecked")
-	private static <T extends IIdentificationResults> IPeakIdentifierMSD<T> getPeakIdentifier(final String identifierId) {
+	private static IPeakIdentifierMSD getPeakIdentifier(final String identifierId) {
 
 		IConfigurationElement element;
 		element = getConfigurationElement(identifierId);
-		IPeakIdentifierMSD<T> instance = null;
+		IPeakIdentifierMSD instance = null;
 		if(element != null) {
 			try {
-				instance = (IPeakIdentifierMSD<T>)element.createExecutableExtension(Identifier.IDENTIFIER);
+				instance = (IPeakIdentifierMSD)element.createExecutableExtension(Identifier.IDENTIFIER);
 			} catch(CoreException e) {
 				logger.warn(e);
 			}
@@ -153,7 +152,7 @@ public class PeakIdentifierMSD {
 	 * @return {@link IProcessingInfo}
 	 * @throws NoIdentifierAvailableException
 	 */
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(IChromatogramPeakMSD peak, IPeakIdentifierSettingsMSD identifierSettings, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(IChromatogramPeakMSD peak, IPeakIdentifierSettingsMSD identifierSettings, String identifierId, IProgressMonitor monitor) {
 
 		List<IChromatogramPeakMSD> peaks = new ArrayList<>();
 		peaks.add(peak);
@@ -169,7 +168,7 @@ public class PeakIdentifierMSD {
 	 * @return {@link IProcessingInfo}
 	 * @throws NoIdentifierAvailableException
 	 */
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(IPeakMSD peak, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(IPeakMSD peak, String identifierId, IProgressMonitor monitor) {
 
 		return identify(Collections.singletonList(peak), identifierId, monitor);
 	}
@@ -184,9 +183,9 @@ public class PeakIdentifierMSD {
 	 * @return {@link IProcessingInfo}
 	 * @throws NoIdentifierAvailableException
 	 */
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(List<? extends IPeakMSD> peaks, IPeakIdentifierSettingsMSD identifierSettings, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(List<? extends IPeakMSD> peaks, IPeakIdentifierSettingsMSD identifierSettings, String identifierId, IProgressMonitor monitor) {
 
-		IPeakIdentifierMSD<T> peakIdentifier = getPeakIdentifier(identifierId);
+		IPeakIdentifierMSD peakIdentifier = getPeakIdentifier(identifierId);
 		if(peakIdentifier != null) {
 			return peakIdentifier.identify(peaks, identifierSettings, monitor);
 		} else {
@@ -203,18 +202,18 @@ public class PeakIdentifierMSD {
 	 * @return {@link IProcessingInfo}
 	 * @throws NoIdentifierAvailableException
 	 */
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(List<? extends IPeakMSD> peaks, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(List<? extends IPeakMSD> peaks, String identifierId, IProgressMonitor monitor) {
 
 		return identify(peaks, null, identifierId, monitor);
 	}
 
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(IChromatogramSelectionMSD chromatogramSelectionMSD, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(IChromatogramSelectionMSD chromatogramSelectionMSD, String identifierId, IProgressMonitor monitor) {
 
 		chromatogramSelectionMSD.getChromatogram().setDirty(true);
 		return identify(chromatogramSelectionMSD, null, identifierId, monitor);
 	}
 
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(IChromatogramSelectionMSD chromatogramSelectionMSD, IPeakIdentifierSettingsMSD peakIdentifierSettingsMSD, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(IChromatogramSelectionMSD chromatogramSelectionMSD, IPeakIdentifierSettingsMSD peakIdentifierSettingsMSD, String identifierId, IProgressMonitor monitor) {
 
 		chromatogramSelectionMSD.getChromatogram().setDirty(true);
 		return identify(chromatogramSelectionMSD.getChromatogram().getPeaks(chromatogramSelectionMSD), peakIdentifierSettingsMSD, identifierId, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/impl/PeakIdentifierRemoveUnidentified.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/impl/PeakIdentifierRemoveUnidentified.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.peak.AbstractPeakIdentifierWSD;
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.settings.IPeakIdentifierSettingsWSD;
+import org.eclipse.chemclipse.model.identifier.IPeakIdentificationResults;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramPeakWSD;
@@ -23,12 +24,12 @@ import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
 import org.eclipse.chemclipse.wsd.model.core.IPeakWSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class PeakIdentifierRemoveUnidentified<T> extends AbstractPeakIdentifierWSD<T> {
+public class PeakIdentifierRemoveUnidentified extends AbstractPeakIdentifierWSD {
 
 	@Override
-	public IProcessingInfo<T> identify(List<? extends IPeakWSD> peaks, IPeakIdentifierSettingsWSD peakIdentifierSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IPeakIdentificationResults> identify(List<? extends IPeakWSD> peaks, IPeakIdentifierSettingsWSD peakIdentifierSettings, IProgressMonitor monitor) {
 
-		IProcessingInfo<T> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<IPeakIdentificationResults> processingInfo = new ProcessingInfo<>();
 		/*
 		 * Remove all unidentified peaks.
 		 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/peak/AbstractPeakIdentifierWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/peak/AbstractPeakIdentifierWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -20,7 +20,7 @@ import org.eclipse.chemclipse.model.exceptions.ValueMustNotBeNullException;
 import org.eclipse.chemclipse.support.literature.LiteratureReference;
 import org.eclipse.chemclipse.wsd.model.core.IPeakWSD;
 
-public abstract class AbstractPeakIdentifierWSD<T> implements IPeakIdentifierWSD<T> {
+public abstract class AbstractPeakIdentifierWSD implements IPeakIdentifierWSD {
 
 	private List<LiteratureReference> literatureReferences = new ArrayList<>();
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/peak/IPeakIdentifierWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/peak/IPeakIdentifierWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -15,12 +15,13 @@ package org.eclipse.chemclipse.chromatogram.wsd.identifier.peak;
 import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.settings.IPeakIdentifierSettingsWSD;
+import org.eclipse.chemclipse.model.identifier.IPeakIdentificationResults;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.support.literature.LiteratureReference;
 import org.eclipse.chemclipse.wsd.model.core.IPeakWSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public interface IPeakIdentifierWSD<T> {
+public interface IPeakIdentifierWSD {
 
 	/**
 	 * Identifies a list of peaks.
@@ -30,7 +31,7 @@ public interface IPeakIdentifierWSD<T> {
 	 * @param monitor
 	 * @return {@link IProcessingInfo}
 	 */
-	IProcessingInfo<T> identify(List<? extends IPeakWSD> peaks, IPeakIdentifierSettingsWSD peakIdentifierSettings, IProgressMonitor monitor);
+	IProcessingInfo<IPeakIdentificationResults> identify(List<? extends IPeakWSD> peaks, IPeakIdentifierSettingsWSD peakIdentifierSettings, IProgressMonitor monitor);
 
 	List<LiteratureReference> getLiteratureReferences();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/peak/PeakIdentifierWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/peak/PeakIdentifierWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -20,7 +20,7 @@ import java.util.List;
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.settings.IPeakIdentifierSettingsWSD;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.exceptions.NoIdentifierAvailableException;
-import org.eclipse.chemclipse.model.identifier.IIdentificationResults;
+import org.eclipse.chemclipse.model.identifier.IPeakIdentificationResults;
 import org.eclipse.chemclipse.model.identifier.core.Identifier;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.IProcessingMessage;
@@ -84,15 +84,14 @@ public class PeakIdentifierWSD {
 	 * Returns a {@link IPeakIdentifierWSD} instance given by the identifierId or
 	 * null, if none is available.
 	 */
-	@SuppressWarnings("unchecked")
-	private static <T> IPeakIdentifierWSD<T> getPeakIdentifier(final String identifierId) {
+	private static IPeakIdentifierWSD getPeakIdentifier(final String identifierId) {
 
 		IConfigurationElement element;
 		element = getConfigurationElement(identifierId);
-		IPeakIdentifierWSD<T> instance = null;
+		IPeakIdentifierWSD instance = null;
 		if(element != null) {
 			try {
-				instance = (IPeakIdentifierWSD<T>)element.createExecutableExtension(Identifier.IDENTIFIER);
+				instance = (IPeakIdentifierWSD)element.createExecutableExtension(Identifier.IDENTIFIER);
 			} catch(CoreException e) {
 				logger.error(e);
 			}
@@ -146,7 +145,7 @@ public class PeakIdentifierWSD {
 	 * @return {@link IProcessingInfo}
 	 * @throws NoIdentifierAvailableException
 	 */
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(IChromatogramPeakWSD peak, IPeakIdentifierSettingsWSD identifierSettings, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(IChromatogramPeakWSD peak, IPeakIdentifierSettingsWSD identifierSettings, String identifierId, IProgressMonitor monitor) {
 
 		List<IChromatogramPeakWSD> peaks = new ArrayList<>();
 		peaks.add(peak);
@@ -162,7 +161,7 @@ public class PeakIdentifierWSD {
 	 * @return {@link IProcessingInfo}
 	 * @throws NoIdentifierAvailableException
 	 */
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(IPeakWSD peak, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(IPeakWSD peak, String identifierId, IProgressMonitor monitor) {
 
 		return identify(Collections.singletonList(peak), identifierId, monitor);
 	}
@@ -177,9 +176,9 @@ public class PeakIdentifierWSD {
 	 * @return {@link IProcessingInfo}
 	 * @throws NoIdentifierAvailableException
 	 */
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(List<? extends IPeakWSD> peaks, IPeakIdentifierSettingsWSD identifierSettings, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(List<? extends IPeakWSD> peaks, IPeakIdentifierSettingsWSD identifierSettings, String identifierId, IProgressMonitor monitor) {
 
-		IPeakIdentifierWSD<T> peakIdentifier = getPeakIdentifier(identifierId);
+		IPeakIdentifierWSD peakIdentifier = getPeakIdentifier(identifierId);
 		if(peakIdentifier != null) {
 			return peakIdentifier.identify(peaks, identifierSettings, monitor);
 		} else {
@@ -196,18 +195,18 @@ public class PeakIdentifierWSD {
 	 * @return {@link IProcessingInfo}
 	 * @throws NoIdentifierAvailableException
 	 */
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(List<? extends IPeakWSD> peaks, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(List<? extends IPeakWSD> peaks, String identifierId, IProgressMonitor monitor) {
 
 		return identify(peaks, null, identifierId, monitor);
 	}
 
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(IChromatogramSelectionWSD chromatogramSelectionWSD, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(IChromatogramSelectionWSD chromatogramSelectionWSD, String identifierId, IProgressMonitor monitor) {
 
 		chromatogramSelectionWSD.getChromatogram().setDirty(true);
 		return identify(chromatogramSelectionWSD, null, identifierId, monitor);
 	}
 
-	public static <T extends IIdentificationResults> IProcessingInfo<T> identify(IChromatogramSelectionWSD chromatogramSelectionWSD, IPeakIdentifierSettingsWSD peakIdentifierSettingsWSD, String identifierId, IProgressMonitor monitor) {
+	public static IProcessingInfo<IPeakIdentificationResults> identify(IChromatogramSelectionWSD chromatogramSelectionWSD, IPeakIdentifierSettingsWSD peakIdentifierSettingsWSD, String identifierId, IProgressMonitor monitor) {
 
 		chromatogramSelectionWSD.getChromatogram().setDirty(true);
 		return identify(chromatogramSelectionWSD.getChromatogram().getPeaks(chromatogramSelectionWSD), peakIdentifierSettingsWSD, identifierId, monitor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/core/PeakIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/core/PeakIdentifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Lablicate GmbH.
+ * Copyright (c) 2016, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,18 +21,18 @@ import org.eclipse.chemclipse.chromatogram.msd.identifier.settings.IPeakIdentifi
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.impl.AlkaneIdentifier;
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.settings.PeakIdentifierAlkaneSettings;
-import org.eclipse.chemclipse.model.identifier.IIdentificationResults;
+import org.eclipse.chemclipse.model.identifier.IPeakIdentificationResults;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class PeakIdentifier extends AbstractPeakIdentifierMSD<IIdentificationResults> {
+public class PeakIdentifier extends AbstractPeakIdentifierMSD {
 
 	@Override
-	public IProcessingInfo<IIdentificationResults> identify(List<? extends IPeakMSD> peaks, IPeakIdentifierSettingsMSD peakIdentifierSettings, IProgressMonitor monitor) {
+	public IProcessingInfo<IPeakIdentificationResults> identify(List<? extends IPeakMSD> peaks, IPeakIdentifierSettingsMSD peakIdentifierSettings, IProgressMonitor monitor) {
 
-		ProcessingInfo<IIdentificationResults> processingInfo = new ProcessingInfo<>();
+		ProcessingInfo<IPeakIdentificationResults> processingInfo = new ProcessingInfo<>();
 		try {
 			AlkaneIdentifier alkaneIdentifier = new AlkaneIdentifier();
 			PeakIdentifierAlkaneSettings alkaneSettings;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/core/PeakIdentifierFile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/core/PeakIdentifierFile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 Lablicate GmbH.
+ * Copyright (c) 2015, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -27,7 +27,7 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class PeakIdentifierFile implements IPeakIdentifierMSD<IPeakIdentificationResults> {
+public class PeakIdentifierFile implements IPeakIdentifierMSD {
 
 	@Override
 	public IProcessingInfo<IPeakIdentificationResults> identify(List<? extends IPeakMSD> peaks, IPeakIdentifierSettingsMSD identifierSettings, IProgressMonitor monitor) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/core/PeakIdentifierUnknown.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/core/PeakIdentifierUnknown.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 Lablicate GmbH.
+ * Copyright (c) 2019, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -36,7 +36,7 @@ import org.eclipse.chemclipse.support.literature.LiteratureReference;
 import org.eclipse.chemclipse.wsd.model.core.IPeakWSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class PeakIdentifierUnknown implements IPeakIdentifierMSD<IPeakIdentificationResults>, IPeakIdentifierCSD<IPeakIdentificationResults>, IPeakIdentifierWSD<IPeakIdentificationResults> {
+public class PeakIdentifierUnknown implements IPeakIdentifierMSD, IPeakIdentifierCSD, IPeakIdentifierWSD {
 
 	@Override
 	public IProcessingInfo<IPeakIdentificationResults> identify(List<? extends IPeakMSD> peaks, IPeakIdentifierSettingsMSD identifierSettings, IProgressMonitor monitor) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak/src/org/eclipse/chemclipse/msd/classifier/supplier/molpeak/core/PeakIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak/src/org/eclipse/chemclipse/msd/classifier/supplier/molpeak/core/PeakIdentifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Lablicate GmbH.
+ * Copyright (c) 2016, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -28,7 +28,7 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class PeakIdentifier extends AbstractPeakIdentifierMSD<IPeakIdentificationResults> {
+public class PeakIdentifier extends AbstractPeakIdentifierMSD {
 
 	@Override
 	public IProcessingInfo<IPeakIdentificationResults> identify(List<? extends IPeakMSD> peaks, IPeakIdentifierSettingsMSD identifierSettings, IProgressMonitor monitor) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/core/PeakIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/core/PeakIdentifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -32,7 +32,7 @@ import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingMessage;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class PeakIdentifier extends AbstractPeakIdentifierMSD<IPeakIdentificationResults> {
+public class PeakIdentifier extends AbstractPeakIdentifierMSD {
 
 	@Override
 	public IProcessingInfo<IPeakIdentificationResults> identify(List<? extends IPeakMSD> peaks, IPeakIdentifierSettingsMSD identifierSettings, IProgressMonitor monitor) {


### PR DESCRIPTION
My point is that the return type is always the same so there is no real need for generics. Removing them again makes the API clearer and avoids suppressed warnings.