### PR TITLE
Resolve unchecked casting in ChromatogramCalculator

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.peak.resolution/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/peak/resolution/core/ChromatogramCalculator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.peak.resolution/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/peak/resolution/core/ChromatogramCalculator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -47,12 +47,11 @@ public class ChromatogramCalculator extends AbstractChromatogramCalculator {
 		return applyCalculator(chromatogramSelection);
 	}
 
-	@SuppressWarnings("unchecked")
 	IProcessingInfo<IPeakResolutionResult> applyCalculator(IChromatogramSelection<?, ?> chromatogramSelection) {
 
 		IProcessingInfo<IPeakResolutionResult> processingInfo = new ProcessingInfo<>();
 		PeakResolutionResult peakResolutionResult = new PeakResolutionResult(ResultStatus.OK, Messages.peakResolutionCalculated);
-		applyCalculator((List<IPeak>)chromatogramSelection.getChromatogram().getPeaks(), peakResolutionResult);
+		applyCalculator(chromatogramSelection.getChromatogram().getPeaks(), peakResolutionResult);
 		IMeasurementResult<?> measurementResult = new MeasurementResult(Messages.peakResolution, //
 				"org.eclipse.chemclipse.chromatogram.xxd.calculator.peak.resolution", // //$NON-NLS-1$
 				Messages.peakResolutionDescription, peakResolutionResult);
@@ -61,9 +60,9 @@ public class ChromatogramCalculator extends AbstractChromatogramCalculator {
 		return processingInfo;
 	}
 
-	void applyCalculator(List<IPeak> peaks, PeakResolutionResult peakResolutionResult) {
+	void applyCalculator(List<? extends IPeak> peaks, PeakResolutionResult peakResolutionResult) {
 
-		Iterator<IPeak> iterator = peaks.iterator();
+		Iterator<? extends IPeak> iterator = peaks.iterator();
 		IPeak current = iterator.next();
 		while(iterator.hasNext()) {
 			IPeak next = iterator.next();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v32/model/Separation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v32/model/Separation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 Lablicate GmbH.
+ * Copyright (c) 2015, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -14,6 +14,7 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v32.model;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
@@ -30,7 +31,7 @@ public class Separation implements Serializable {
 	public List<SeparationTechnique> getSeparationTechnique() {
 
 		if(separationTechnique == null) {
-			separationTechnique = new ArrayList<SeparationTechnique>();
+			separationTechnique = new ArrayList<>();
 		}
 		return this.separationTechnique;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlReader10.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlReader10.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 Lablicate GmbH.
+ * Copyright (c) 2021, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -52,20 +52,14 @@ public class XmlReader10 {
 	public static int getTimeMultiplicator(CVParamType cvParam) {
 
 		int multiplicator = 1;
-		if(cvParam.getUnitAccession().equals("UO:0000028")) {
-			if(cvParam.getUnitName().equals("millisecond")) {
-				multiplicator = 1;
-			}
+		if(cvParam.getUnitAccession().equals("UO:0000028") && cvParam.getUnitName().equals("millisecond")) {
+			multiplicator = 1;
 		}
-		if(cvParam.getUnitAccession().equals("UO:0000010")) {
-			if(cvParam.getUnitName().equals("second")) {
-				multiplicator = 1000;
-			}
+		if(cvParam.getUnitAccession().equals("UO:0000010") && cvParam.getUnitName().equals("second")) {
+			multiplicator = 1000;
 		}
-		if(cvParam.getUnitAccession().equals("UO:0000031")) {
-			if(cvParam.getUnitName().equals("minute")) {
-				multiplicator = 60 * 1000;
-			}
+		if(cvParam.getUnitAccession().equals("UO:0000031") && cvParam.getUnitName().equals("minute")) {
+			multiplicator = 60 * 1000;
 		}
 		return multiplicator;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlReader110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlReader110.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 Lablicate GmbH.
+ * Copyright (c) 2021, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -54,20 +54,14 @@ public class XmlReader110 {
 	public static float getTimeMultiplicator(CVParamType cvParam) {
 
 		float multiplicator = 1f;
-		if(cvParam.getUnitAccession().equals("UO:0000028")) {
-			if(cvParam.getUnitName().equals("millisecond")) {
-				multiplicator = 1f;
-			}
+		if(cvParam.getUnitAccession().equals("UO:0000028") && cvParam.getUnitName().equals("millisecond")) {
+			multiplicator = 1f;
 		}
-		if(cvParam.getUnitAccession().equals("UO:0000010")) {
-			if(cvParam.getUnitName().equals("second")) {
-				multiplicator = (float)IChromatogramOverview.SECOND_CORRELATION_FACTOR;
-			}
+		if(cvParam.getUnitAccession().equals("UO:0000010") && cvParam.getUnitName().equals("second")) {
+			multiplicator = (float)IChromatogramOverview.SECOND_CORRELATION_FACTOR;
 		}
-		if(cvParam.getUnitAccession().equals("UO:0000031")) {
-			if(cvParam.getUnitName().equals("minute")) {
-				multiplicator = (float)IChromatogramOverview.MINUTE_CORRELATION_FACTOR;
-			}
+		if(cvParam.getUnitAccession().equals("UO:0000031") && cvParam.getUnitName().equals("minute")) {
+			multiplicator = (float)IChromatogramOverview.MINUTE_CORRELATION_FACTOR;
 		}
 		return multiplicator;
 	}


### PR DESCRIPTION
We can cast to a type without generic wild cards later on.