### PR TITLE
Added a MALDI editor export menu

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.cml/src/org/eclipse/chemclipse/msd/converter/supplier/cml/converter/MassSpectrumExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.cml/src/org/eclipse/chemclipse/msd/converter/supplier/cml/converter/MassSpectrumExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,27 +12,64 @@
 package org.eclipse.chemclipse.msd.converter.supplier.cml.converter;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 
+import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
+import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.msd.converter.io.IMassSpectraWriter;
 import org.eclipse.chemclipse.msd.converter.massspectrum.AbstractMassSpectrumExportConverter;
+import org.eclipse.chemclipse.msd.converter.supplier.cml.converter.io.MassSpectraWriter;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.msd.model.implementation.MassSpectra;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.osgi.util.NLS;
 
 public class MassSpectrumExportConverter extends AbstractMassSpectrumExportConverter {
+
+	private static final Logger logger = Logger.getLogger(MassSpectrumExportConverter.class);
+	private static final String DESCRIPTION = "CML Mass Spectra Export Converter";
 
 	@Override
 	public IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
 
-		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
-		return processingInfo;
+		IMassSpectra massSpectra = new MassSpectra();
+		massSpectra.addMassSpectrum(massSpectrum);
+		return convert(file, massSpectra, append, monitor);
 	}
 
 	@Override
 	public IProcessingInfo<File> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
 
+		IProcessingInfo<File> processingInfo = validate(file, massSpectra);
+		if(!processingInfo.hasErrorMessages()) {
+			try {
+				IMassSpectraWriter massSpectraWriter = new MassSpectraWriter();
+				massSpectraWriter.write(file, massSpectra, append, monitor);
+				processingInfo.setProcessingResult(file);
+			} catch(FileNotFoundException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.fileNotFound, file.getAbsolutePath()));
+			} catch(FileIsNotWriteableException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.fileNotWritable, file.getAbsolutePath()));
+			} catch(IOException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.failedToWriteFile, file.getAbsolutePath()));
+			}
+		}
+		return processingInfo;
+	}
+
+	private IProcessingInfo<File> validate(File file, IMassSpectra massSpectra) {
+
 		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
+		processingInfo.addMessages(super.validate(file));
+		processingInfo.addMessages(super.validate(massSpectra));
 		return processingInfo;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/plugin.xml
@@ -27,7 +27,7 @@
             importContentMatcher="org.eclipse.chemclipse.msd.converter.supplier.mzdata.converter.MassSpectrumFileContentMatcher"
             importConverter="org.eclipse.chemclipse.msd.converter.supplier.mzdata.converter.MassSpectrumImportConverter"
             importMagicNumberMatcher="org.eclipse.chemclipse.msd.converter.supplier.mzdata.converter.MagicNumberMatcher"
-            isExportable="false"
+            isExportable="true"
             isImportable="true">
       </MassSpectrumSupplier>
    </extension>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/MassSpectrumExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/MassSpectrumExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -13,31 +13,64 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mzdata.converter;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 
+import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
+import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.msd.converter.io.IMassSpectraWriter;
 import org.eclipse.chemclipse.msd.converter.massspectrum.AbstractMassSpectrumExportConverter;
+import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.io.MassSpectrumWriterVersion105;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.msd.model.implementation.MassSpectra;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.osgi.util.NLS;
 
 public class MassSpectrumExportConverter extends AbstractMassSpectrumExportConverter {
 
+	private static final Logger logger = Logger.getLogger(MassSpectrumExportConverter.class);
 	private static final String DESCRIPTION = "mzXML Mass Spectra Export Converter";
 
 	@Override
 	public IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
 
-		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
-		processingInfo.addErrorMessage(DESCRIPTION, "It's not possible to export mass spectrum data as mzXML yet.");
-		return processingInfo;
+		IMassSpectra massSpectra = new MassSpectra();
+		massSpectra.addMassSpectrum(massSpectrum);
+		return convert(file, massSpectra, append, monitor);
 	}
 
 	@Override
 	public IProcessingInfo<File> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
 
+		IProcessingInfo<File> processingInfo = validate(file, massSpectra);
+		if(!processingInfo.hasErrorMessages()) {
+			try {
+				IMassSpectraWriter massSpectraWriter = new MassSpectrumWriterVersion105();
+				massSpectraWriter.write(file, massSpectra, append, monitor);
+				processingInfo.setProcessingResult(file);
+			} catch(FileNotFoundException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.fileNotFound, file.getAbsolutePath()));
+			} catch(FileIsNotWriteableException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.fileNotWritable, file.getAbsolutePath()));
+			} catch(IOException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.failedToWriteFile, file.getAbsolutePath()));
+			}
+		}
+		return processingInfo;
+	}
+
+	private IProcessingInfo<File> validate(File file, IMassSpectra massSpectra) {
+
 		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
-		processingInfo.addErrorMessage(DESCRIPTION, "It's not possible to export mass spectrum data as mzXML yet.");
+		processingInfo.addMessages(super.validate(file));
+		processingInfo.addMessages(super.validate(massSpectra));
 		return processingInfo;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/plugin.xml
@@ -27,7 +27,7 @@
             importContentMatcher="org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.MassSpectrumFileContentMatcher"
             importConverter="org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.MassSpectrumImportConverter"
             importMagicNumberMatcher="org.eclipse.chemclipse.xxd.converter.supplier.mzml.converter.MagicNumberMatcher"
-            isExportable="false"
+            isExportable="true"
             isImportable="true">
       </MassSpectrumSupplier>
    </extension>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Lablicate GmbH.
+ * Copyright (c) 2021, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,31 +12,64 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 
+import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
+import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.msd.converter.io.IMassSpectraWriter;
 import org.eclipse.chemclipse.msd.converter.massspectrum.AbstractMassSpectrumExportConverter;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.io.MassSpectrumWriterVersion110;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.msd.model.implementation.MassSpectra;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.osgi.util.NLS;
 
 public class MassSpectrumExportConverter extends AbstractMassSpectrumExportConverter {
 
+	private static final Logger logger = Logger.getLogger(MassSpectrumExportConverter.class);
 	private static final String DESCRIPTION = "mzML Mass Spectra Export Converter";
 
 	@Override
 	public IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
 
-		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
-		processingInfo.addErrorMessage(DESCRIPTION, "It's not possible to export mass spectrum data as mzML yet.");
-		return processingInfo;
+		IMassSpectra massSpectra = new MassSpectra();
+		massSpectra.addMassSpectrum(massSpectrum);
+		return convert(file, massSpectra, append, monitor);
 	}
 
 	@Override
 	public IProcessingInfo<File> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
 
+		IProcessingInfo<File> processingInfo = validate(file, massSpectra);
+		if(!processingInfo.hasErrorMessages()) {
+			try {
+				IMassSpectraWriter massSpectraWriter = new MassSpectrumWriterVersion110();
+				massSpectraWriter.write(file, massSpectra, append, monitor);
+				processingInfo.setProcessingResult(file);
+			} catch(FileNotFoundException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.fileNotFound, file.getAbsolutePath()));
+			} catch(FileIsNotWriteableException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.fileNotWritable, file.getAbsolutePath()));
+			} catch(IOException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.failedToWriteFile, file.getAbsolutePath()));
+			}
+		}
+		return processingInfo;
+	}
+
+	private IProcessingInfo<File> validate(File file, IMassSpectra massSpectra) {
+
 		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
-		processingInfo.addErrorMessage(DESCRIPTION, "It's not possible to export mass spectrum data as mzML yet.");
+		processingInfo.addMessages(super.validate(file));
+		processingInfo.addMessages(super.validate(massSpectra));
 		return processingInfo;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/plugin.xml
@@ -27,7 +27,7 @@
             importContentMatcher="org.eclipse.chemclipse.msd.converter.supplier.mzxml.converter.MassSpectrumFileContentMatcher"
             importConverter="org.eclipse.chemclipse.msd.converter.supplier.mzxml.converter.MassSpectrumImportConverter"
             importMagicNumberMatcher="org.eclipse.chemclipse.msd.converter.supplier.mzxml.converter.MagicNumberMatcher"
-            isExportable="false"
+            isExportable="true"
             isImportable="true">
       </MassSpectrumSupplier>
    </extension>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,17 +20,27 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.IMassSpectrumIdentifierSupplier;
+import org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.IMassSpectrumIdentifierSupport;
+import org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.MassSpectrumIdentifier;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.processing.core.ICategories;
+import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
+import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
+import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
 import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
 import org.eclipse.chemclipse.ux.extension.msd.ui.internal.provider.BarSeriesIon;
 import org.eclipse.chemclipse.ux.extension.msd.ui.internal.provider.BarSeriesIonComparator;
 import org.eclipse.chemclipse.ux.extension.msd.ui.internal.provider.UpdateMenuEntry;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.PaintEvent;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtchart.IAxis.Position;
 import org.eclipse.swtchart.ICustomPaintListener;
 import org.eclipse.swtchart.IPlotArea;
@@ -46,8 +56,10 @@ import org.eclipse.swtchart.extensions.core.IPrimaryAxisSettings;
 import org.eclipse.swtchart.extensions.core.ISecondaryAxisSettings;
 import org.eclipse.swtchart.extensions.core.ISeriesData;
 import org.eclipse.swtchart.extensions.core.RangeRestriction;
+import org.eclipse.swtchart.extensions.core.ScrollableChart;
 import org.eclipse.swtchart.extensions.core.SecondaryAxisSettings;
 import org.eclipse.swtchart.extensions.core.SeriesData;
+import org.eclipse.swtchart.extensions.menu.IChartMenuEntry;
 
 public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrumChart {
 
@@ -112,6 +124,7 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 		chartSettings.setCreateMenu(true);
 		//
 		chartSettings.addMenuEntry(new UpdateMenuEntry());
+		addMassSpectrumIdentifier(chartSettings);
 		//
 		RangeRestriction rangeRestriction = chartSettings.getRangeRestriction();
 		rangeRestriction.setZeroX(false);
@@ -295,5 +308,41 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 		}
 		//
 		return new SeriesData(xSeries, ySeries, "Mass Spectrum");
+	}
+
+	private void addMassSpectrumIdentifier(IChartSettings chartSettings) {
+
+		IMassSpectrumIdentifierSupport massSpectrumIdentifierSupport = MassSpectrumIdentifier.getMassSpectrumIdentifierSupport();
+		for(IMassSpectrumIdentifierSupplier supplier : massSpectrumIdentifierSupport.getSuppliers()) {
+			chartSettings.addMenuEntry(new IChartMenuEntry() {
+
+				@Override
+				public String getName() {
+
+					return supplier.getIdentifierName();
+				}
+
+				@Override
+				public String getCategory() {
+
+					return ICategories.IDENTIFIER;
+				}
+
+				@Override
+				public Image getIcon() {
+
+					return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_IDENTIFY_MASS_SPECTRUM, IApplicationImageProvider.SIZE_16x16);
+				}
+
+				@Override
+				public void execute(Shell shell, ScrollableChart scrollableChart) {
+
+					if(massSpectrum != null) {
+						MassSpectrumIdentifier.identify(massSpectrum, supplier.getId(), new NullProgressMonitor());
+						update();
+					}
+				}
+			});
+		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,9 +20,6 @@ import java.util.Locale;
 import org.eclipse.chemclipse.chromatogram.msd.filter.core.massspectrum.IMassSpectrumFilterSupplier;
 import org.eclipse.chemclipse.chromatogram.msd.filter.core.massspectrum.IMassSpectrumFilterSupport;
 import org.eclipse.chemclipse.chromatogram.msd.filter.core.massspectrum.MassSpectrumFilter;
-import org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.IMassSpectrumIdentifierSupplier;
-import org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.IMassSpectrumIdentifierSupport;
-import org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.MassSpectrumIdentifier;
 import org.eclipse.chemclipse.model.core.IMassSpectrumPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
@@ -31,15 +28,11 @@ import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.processing.core.ICategories;
-import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
-import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
-import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
 import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
 import org.eclipse.chemclipse.ux.extension.msd.ui.internal.provider.UpdateMenuEntry;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
@@ -120,7 +113,6 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 		//
 		chartSettings.addMenuEntry(new UpdateMenuEntry());
 		addMassSpectrumFilter(chartSettings);
-		addMassSpectrumIdentifier(chartSettings);
 		//
 		RangeRestriction rangeRestriction = chartSettings.getRangeRestriction();
 		rangeRestriction.setZeroX(false);
@@ -161,42 +153,6 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 					if(massSpectrum != null) {
 						MassSpectrumFilter.applyFilter(massSpectrum, supplier.getId(), new NullProgressMonitor());
 						massSpectrum.setDirty(true);
-						update();
-					}
-				}
-			});
-		}
-	}
-
-	private void addMassSpectrumIdentifier(IChartSettings chartSettings) {
-
-		IMassSpectrumIdentifierSupport massSpectrumIdentifierSupport = MassSpectrumIdentifier.getMassSpectrumIdentifierSupport();
-		for(IMassSpectrumIdentifierSupplier supplier : massSpectrumIdentifierSupport.getSuppliers()) {
-			chartSettings.addMenuEntry(new IChartMenuEntry() {
-
-				@Override
-				public String getName() {
-
-					return supplier.getIdentifierName();
-				}
-
-				@Override
-				public String getCategory() {
-
-					return ICategories.IDENTIFIER;
-				}
-
-				@Override
-				public Image getIcon() {
-
-					return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_IDENTIFY_MASS_SPECTRUM, IApplicationImageProvider.SIZE_16x16);
-				}
-
-				@Override
-				public void execute(Shell shell, ScrollableChart scrollableChart) {
-
-					if(massSpectrum != null) {
-						MassSpectrumIdentifier.identify(massSpectrum, supplier.getId(), new NullProgressMonitor());
 						update();
 					}
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.msd.ui.swt;
 
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
@@ -24,17 +26,27 @@ import org.eclipse.chemclipse.model.core.IMassSpectrumPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.model.notifier.UpdateNotifier;
+import org.eclipse.chemclipse.msd.converter.massspectrum.MassSpectrumConverter;
+import org.eclipse.chemclipse.msd.converter.massspectrum.MassSpectrumConverterSupport;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.processing.converter.ISupplier;
 import org.eclipse.chemclipse.processing.core.ICategories;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.processing.core.ProcessingInfo;
+import org.eclipse.chemclipse.processing.ui.support.ProcessingInfoPartSupport;
 import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
 import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
 import org.eclipse.chemclipse.ux.extension.msd.ui.internal.provider.UpdateMenuEntry;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jface.dialogs.ProgressMonitorDialog;
+import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtchart.IAxis.Position;
 import org.eclipse.swtchart.ILineSeries.PlotSymbolType;
@@ -113,6 +125,7 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 		//
 		chartSettings.addMenuEntry(new UpdateMenuEntry());
 		addMassSpectrumFilter(chartSettings);
+		addMassSpectrumExport(chartSettings);
 		//
 		RangeRestriction rangeRestriction = chartSettings.getRangeRestriction();
 		rangeRestriction.setZeroX(false);
@@ -263,5 +276,72 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 		}
 		labelMarker.setLabels(labels, 1, SWT.VERTICAL);
 		plotarea.addCustomPaintListener(labelMarker);
+	}
+
+	private void addMassSpectrumExport(IChartSettings chartSettings) {
+
+		MassSpectrumConverterSupport converterSupport = MassSpectrumConverter.getMassSpectrumConverterSupport();
+		List<ISupplier> exportSupplier = converterSupport.getExportSupplier();
+		for(ISupplier supplier : exportSupplier) {
+			chartSettings.addMenuEntry(new IChartMenuEntry() {
+
+				@Override
+				public String getName() {
+
+					return supplier.getFilterName();
+				}
+
+				@Override
+				public String getToolTipText() {
+
+					return supplier.getDescription();
+				}
+
+				@Override
+				public String getCategory() {
+
+					return "Export";
+				}
+
+				@Override
+				public void execute(Shell shell, ScrollableChart scrollableChart) {
+
+					if(massSpectrum == null) {
+						return;
+					}
+					FileDialog fileDialog = new FileDialog(shell, SWT.SAVE);
+					fileDialog.setText("Mass Spectrum Export");
+					String fileName = "Mass Spectrum";
+					if(massSpectrum instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
+						fileName = standaloneMassSpectrum.getName();
+					}
+					fileDialog.setFileName(fileName + "." + supplier.getFileExtension());
+					fileDialog.setFilterExtensions(new String[]{"*" + supplier.getFileExtension()});
+					fileDialog.setFilterNames(new String[]{supplier.getFilterName()});
+					String pathname = fileDialog.open();
+					if(pathname != null) {
+						File file = new File(pathname);
+						ProgressMonitorDialog dialog = new ProgressMonitorDialog(shell);
+						try {
+							dialog.run(true, true, new IRunnableWithProgress() {
+
+								@Override
+								public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
+
+									IProcessingInfo<File> convert = MassSpectrumConverter.convert(file, massSpectrum, false, supplier.getId(), monitor);
+									ProcessingInfoPartSupport.getInstance().update(convert);
+								}
+							});
+						} catch(InvocationTargetException e) {
+							IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
+							processingInfo.addErrorMessage("MS Export", "Export failed", e.getCause());
+							ProcessingInfoPartSupport.getInstance().update(processingInfo);
+						} catch(InterruptedException e) {
+							Thread.currentThread().interrupt();
+						}
+					}
+				}
+			});
+		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/plugin.xml
@@ -28,7 +28,21 @@
             isExportable="false"
             isImportable="true">
       </DatabaseSupplier>
-   </extension>    
+   </extension>
+   <extension
+         point="org.eclipse.chemclipse.msd.converter.massSpectrumSupplier">
+      <MassSpectrumSupplier
+            description="Reads and writes JCAMP-DX Mass Spectra"
+            exportConverter="org.eclipse.chemclipse.msd.converter.supplier.jcampdx.converter.MassSpectrumExportConverter"
+            fileExtension=".jdx"
+            filterName="JCAMP-DX Mass Spectra (*.jdx)"
+            id="org.eclipse.chemclipse.msd.converter.supplier.jcampdx.jdx"
+            importConverter="org.eclipse.chemclipse.msd.converter.supplier.jcampdx.converter.MassSpectrumImportConverter"
+            importMagicNumberMatcher="org.eclipse.chemclipse.msd.converter.supplier.jcampdx.io.MagicNumberMatcherMassSpectrum"
+            isExportable="false"
+            isImportable="false">
+      </MassSpectrumSupplier>
+   </extension>
    <extension
          point="org.eclipse.chemclipse.msd.converter.databaseSupplier">
       <DatabaseSupplier

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/converter/MassSpectrumExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/converter/MassSpectrumExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -7,10 +7,9 @@
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  * 
  * Contributors:
- * Dr. Philip Wenig - initial API and implementation
- * Matthias Mailänder - adapted for MALDI
+ * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
-package org.eclipse.chemclipse.msd.converter.supplier.mzxml.converter;
+package org.eclipse.chemclipse.msd.converter.supplier.jcampdx.converter;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -21,7 +20,7 @@ import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.msd.converter.io.IMassSpectraWriter;
 import org.eclipse.chemclipse.msd.converter.massspectrum.AbstractMassSpectrumExportConverter;
-import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.MassSpectrumWriterVersion22;
+import org.eclipse.chemclipse.msd.converter.supplier.jcampdx.io.MassSpectraWriter;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.implementation.MassSpectra;
@@ -33,7 +32,7 @@ import org.eclipse.osgi.util.NLS;
 public class MassSpectrumExportConverter extends AbstractMassSpectrumExportConverter {
 
 	private static final Logger logger = Logger.getLogger(MassSpectrumExportConverter.class);
-	private static final String DESCRIPTION = "mzML Mass Spectra Export Converter";
+	private static final String DESCRIPTION = "JCAMP-DX Mass Spectra Export Converter";
 
 	@Override
 	public IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
@@ -49,7 +48,7 @@ public class MassSpectrumExportConverter extends AbstractMassSpectrumExportConve
 		IProcessingInfo<File> processingInfo = validate(file, massSpectra);
 		if(!processingInfo.hasErrorMessages()) {
 			try {
-				IMassSpectraWriter massSpectraWriter = new MassSpectrumWriterVersion22();
+				IMassSpectraWriter massSpectraWriter = new MassSpectraWriter();
 				massSpectraWriter.write(file, massSpectra, append, monitor);
 				processingInfo.setProcessingResult(file);
 			} catch(FileNotFoundException e) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/converter/MassSpectrumImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/converter/MassSpectrumImportConverter.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ * 
+ * All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.jcampdx.converter;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
+import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
+import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
+import org.eclipse.chemclipse.msd.converter.massspectrum.AbstractMassSpectrumImportConverter;
+import org.eclipse.chemclipse.msd.converter.supplier.jcampdx.io.MassSpectraReader;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.osgi.util.NLS;
+
+public class MassSpectrumImportConverter extends AbstractMassSpectrumImportConverter {
+
+	private static final Logger logger = Logger.getLogger(MassSpectrumImportConverter.class);
+	private static final String DESCRIPTION = "JCAMP-DX Mass Spectrum Import";
+
+	@Override
+	public IProcessingInfo<IMassSpectra> convert(File file, IProgressMonitor monitor) {
+
+		IProcessingInfo<IMassSpectra> processingInfo = super.validate(file);
+		if(!processingInfo.hasErrorMessages()) {
+			try {
+				IMassSpectraReader massSpectraReader = new MassSpectraReader();
+				IMassSpectra massSpectra = massSpectraReader.read(file, monitor);
+				if(massSpectra != null && !massSpectra.isEmpty()) {
+					processingInfo.setProcessingResult(massSpectra);
+				} else {
+					processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.noMassSpectraStored, file.getAbsolutePath()));
+				}
+			} catch(FileNotFoundException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.fileNotFound, file.getAbsolutePath()));
+			} catch(FileIsNotReadableException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.fileNotReadable, file.getAbsolutePath()));
+			} catch(FileIsEmptyException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.emptyFile, file.getAbsolutePath()));
+			} catch(IOException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, NLS.bind(ConverterMessages.failedToReadFile, file.getAbsolutePath()));
+			}
+		}
+		return processingInfo;
+	}
+}


### PR DESCRIPTION
This glues the mz* file formats from 
* https://github.com/eclipse-chemclipse/chemclipse/pull/2009
* https://github.com/eclipse-chemclipse/chemclipse/pull/2005
* https://github.com/eclipse-chemclipse/chemclipse/pull/2006

to the editor via right-click: `Export`.

I also moved the identification right-click menu to centroided spectra because all of our algorithms require pre-processed ones.

There is some redundancy/inconsistency between the MS and the database MS suppliers, which I am not sure how to address yet.