### PR TITLE
Move peak integrated area to abstract chromatogram

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/AbstractChromatogramCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/AbstractChromatogramCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2024 Lablicate GmbH.
+ * Copyright (c) 2012, 2025 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -66,16 +66,6 @@ public abstract class AbstractChromatogramCSD extends AbstractChromatogram<IChro
 		if(chromatogramSelection instanceof ChromatogramSelectionCSD chromatogramSelectionCSD) {
 			chromatogramSelectionCSD.update(true);
 		}
-	}
-
-	@Override
-	public double getPeakIntegratedArea() {
-
-		double integratedArea = 0.0d;
-		for(IChromatogramPeakCSD peak : getPeaks()) {
-			integratedArea += peak.getIntegratedArea();
-		}
-		return integratedArea;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractChromatogram.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractChromatogram.java
@@ -768,6 +768,16 @@ public abstract class AbstractChromatogram<T extends IPeak> extends AbstractMeas
 	}
 
 	@Override
+	public double getPeakIntegratedArea() {
+
+		double integratedArea = 0.0d;
+		for(IPeak peak : getPeaks()) {
+			integratedArea += peak.getIntegratedArea();
+		}
+		return integratedArea;
+	}
+
+	@Override
 	public double getChromatogramIntegratedArea() {
 
 		return getIntegratedArea(chromatogramIntegrationEntries);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogramMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogramMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -250,16 +250,6 @@ public abstract class AbstractChromatogramMSD extends AbstractChromatogram<IChro
 			}
 		}
 		return highestIon;
-	}
-
-	@Override
-	public double getPeakIntegratedArea() {
-
-		double integratedArea = 0.0d;
-		for(IChromatogramPeakMSD peak : getPeaks()) {
-			integratedArea += peak.getIntegratedArea();
-		}
-		return integratedArea;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/core/AbstractChromatogramVSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/core/AbstractChromatogramVSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 Lablicate GmbH.
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -23,16 +23,6 @@ public abstract class AbstractChromatogramVSD extends AbstractChromatogram<IChro
 	public void updateNoiseFactor() {
 
 		// TODO - Noise Calculation
-	}
-
-	@Override
-	public double getPeakIntegratedArea() {
-
-		double integratedArea = 0.0d;
-		for(IChromatogramPeakVSD peak : getPeaks()) {
-			integratedArea += peak.getIntegratedArea();
-		}
-		return integratedArea;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/AbstractChromatogramWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/AbstractChromatogramWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2024 Lablicate GmbH.
+ * Copyright (c) 2013, 2025 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -87,16 +87,6 @@ public abstract class AbstractChromatogramWSD extends AbstractChromatogram<IChro
 		if(chromatogramSelection instanceof ChromatogramSelectionWSD chromatogramSelectionWSD) {
 			chromatogramSelectionWSD.update(true);
 		}
-	}
-
-	@Override
-	public double getPeakIntegratedArea() {
-
-		double integratedArea = 0.0d;
-		for(IChromatogramPeakWSD peak : getPeaks()) {
-			integratedArea += peak.getIntegratedArea();
-		}
-		return integratedArea;
 	}
 
 	@Override


### PR DESCRIPTION
because it is defined at generic peak level:

https://github.com/eclipse-chemclipse/chemclipse/blob/4a47e143fe0be2504a38512bcfc60e06d63467f4/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IPeak.java#L139

so there is no need to duplicate.