### PR TITLE
Replace getChromatogramXXD with typed getChromatogram

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/selection/ChromatogramSelectionCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/selection/ChromatogramSelectionCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 Lablicate GmbH.
+ * Copyright (c) 2013, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -50,9 +50,9 @@ public class ChromatogramSelectionCSD extends AbstractChromatogramSelection<IChr
 	}
 
 	@Override
-	public IChromatogramCSD getChromatogramCSD() {
+	public IChromatogramCSD getChromatogram() {
 
-		IChromatogram<?> chromatogram = getChromatogram();
+		IChromatogram<?> chromatogram = super.getChromatogram();
 		if(chromatogram instanceof IChromatogramCSD chromatogramCSD) {
 			return chromatogramCSD;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/selection/IChromatogramSelectionCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/selection/IChromatogramSelectionCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2019 Lablicate GmbH.
+ * Copyright (c) 2013, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -23,14 +23,10 @@ public interface IChromatogramSelectionCSD extends IChromatogramSelection<IChrom
 	 * Returns the stored chromatogram.
 	 * May return null.
 	 *
-	 * @deprecated use {@link #getChromatogram()} instead
 	 * @return {@link IChromatogramCSD}
 	 */
-	@Deprecated
-	default IChromatogramCSD getChromatogramCSD() {
-
-		return getChromatogram();
-	}
+	@Override
+	IChromatogramCSD getChromatogram();
 
 	/**
 	 * Returns the selected scan of the current chromatogram or null, if none is

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelectionMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelectionMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -88,10 +88,9 @@ public class ChromatogramSelectionMSD extends AbstractChromatogramSelection<IChr
 	}
 
 	@Override
-	@Deprecated
-	public IChromatogramMSD getChromatogramMSD() {
+	public IChromatogramMSD getChromatogram() {
 
-		IChromatogram<?> chromatogram = getChromatogram();
+		IChromatogram<?> chromatogram = super.getChromatogram();
 		if(chromatogram instanceof IChromatogramMSD chromatogramMSD) {
 			return chromatogramMSD;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/selection/IChromatogramSelectionMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/selection/IChromatogramSelectionMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -33,14 +33,10 @@ public interface IChromatogramSelectionMSD extends IChromatogramSelection<IChrom
 	 * Returns the stored chromatogram.
 	 * May return null.
 	 *
-	 * @deprecated use {@link #getChromatogram()} instead
 	 * @return {@link IChromatogramMSD}
 	 */
-	@Deprecated
-	default IChromatogramMSD getChromatogramMSD() {
-
-		return getChromatogram();
-	}
+	@Override
+	IChromatogramMSD getChromatogram();
 
 	/**
 	 * Returns the selected scan of the current chromatogram or null, if none is

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/core/selection/IChromatogramSelectionVSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/core/selection/IChromatogramSelectionVSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,5 +18,9 @@ import org.eclipse.chemclipse.vsd.model.core.IScanVSD;
 
 public interface IChromatogramSelectionVSD extends IChromatogramSelection<IChromatogramPeakVSD, IChromatogramVSD> {
 
+	@Override
+	IChromatogramVSD getChromatogram();
+
+	@Override
 	IScanVSD getSelectedScan();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/selection/ChromatogramSelectionWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/selection/ChromatogramSelectionWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 Lablicate GmbH.
+ * Copyright (c) 2013, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -69,10 +69,9 @@ public class ChromatogramSelectionWSD extends AbstractChromatogramSelection<IChr
 	}
 
 	@Override
-	@Deprecated
-	public IChromatogramWSD getChromatogramWSD() {
+	public IChromatogramWSD getChromatogram() {
 
-		IChromatogram<?> chromatogram = getChromatogram();
+		IChromatogram<?> chromatogram = super.getChromatogram();
 		if(chromatogram instanceof IChromatogramWSD chromatogramWSD) {
 			return chromatogramWSD;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/selection/IChromatogramSelectionWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/selection/IChromatogramSelectionWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 Lablicate GmbH.
+ * Copyright (c) 2013, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -25,14 +25,10 @@ public interface IChromatogramSelectionWSD extends IChromatogramSelection<IChrom
 	 * Returns the stored chromatogram.
 	 * May return null.
 	 *
-	 * @deprecated use {@link #getChromatogram()} instead
 	 * @return {@link IChromatogramWSD}
 	 */
-	@Deprecated
-	default IChromatogramWSD getChromatogramWSD() {
-
-		return getChromatogram();
-	}
+	@Override
+	IChromatogramWSD getChromatogram();
 
 	/**
 	 * Returns the selected scan of the current chromatogram or null, if none is


### PR DESCRIPTION
It is possible to override types of method signatures so we can make the API always return the correct type.