### PR TITLE
Remove generics from selected peaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 bin/
 target/
 workspace/
-# files generated (temporary) by the tycho maven builds
+
+# Tycho
 .polyglot.*
-.META-INF_MANIFEST.MF
-feature.xml.takari_issue_192
+*.tycho
+.tycho-consumer-pom.xml
+
+# Tests
+/chemclipse/tests/org.eclipse.chemclipse.rcp.app.fragment.test/*.pdf

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/selection/AbstractChromatogramSelection.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/selection/AbstractChromatogramSelection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2023 Lablicate GmbH.
+ * Copyright (c) 2012, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,7 @@ import java.util.List;
 
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IChromatogramPeak;
+import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.exceptions.ChromatogramIsNullException;
 import org.eclipse.chemclipse.numeric.core.Point;
@@ -30,7 +31,7 @@ public abstract class AbstractChromatogramSelection<T extends IChromatogramPeak,
 	private float startAbundance;
 	private float stopAbundance;
 	//
-	private List<T> selectedPeaks = new ArrayList<>();
+	private List<IPeak> selectedPeaks = new ArrayList<>();
 	private List<IScan> selectedIdentifiedScans = new ArrayList<>();
 	/*
 	 * UI fields
@@ -39,7 +40,7 @@ public abstract class AbstractChromatogramSelection<T extends IChromatogramPeak,
 	private boolean lockOffset;
 	private Point offset;
 
-	public AbstractChromatogramSelection(C chromatogram) throws ChromatogramIsNullException {
+	protected AbstractChromatogramSelection(C chromatogram) throws ChromatogramIsNullException {
 
 		/*
 		 * Check
@@ -240,7 +241,7 @@ public abstract class AbstractChromatogramSelection<T extends IChromatogramPeak,
 	}
 
 	@Override
-	public T getSelectedPeak() {
+	public IPeak getSelectedPeak() {
 
 		if(!selectedPeaks.isEmpty()) {
 			return validatePeak(selectedPeaks.get(0));
@@ -250,7 +251,7 @@ public abstract class AbstractChromatogramSelection<T extends IChromatogramPeak,
 	}
 
 	@Override
-	public List<T> getSelectedPeaks() {
+	public List<IPeak> getSelectedPeaks() {
 
 		if(chromatogram.getNumberOfPeaks() == 0) {
 			selectedPeaks.clear();
@@ -260,7 +261,7 @@ public abstract class AbstractChromatogramSelection<T extends IChromatogramPeak,
 	}
 
 	@Override
-	public void setSelectedPeak(T selectedPeak) {
+	public void setSelectedPeak(IPeak selectedPeak) {
 
 		selectedPeaks.clear();
 		if(selectedPeak != null) {
@@ -269,7 +270,7 @@ public abstract class AbstractChromatogramSelection<T extends IChromatogramPeak,
 	}
 
 	@Override
-	public void setSelectedPeaks(List<T> selectedPeaks) {
+	public void setSelectedPeaks(List<IPeak> selectedPeaks) {
 
 		this.selectedPeaks.clear();
 		this.selectedPeaks.addAll(selectedPeaks);

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/selection/ChromatogramSelection.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/selection/ChromatogramSelection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 Lablicate GmbH.
+ * Copyright (c) 2013, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,6 +15,7 @@ package org.eclipse.chemclipse.model.selection;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IChromatogramPeak;
+import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.exceptions.ChromatogramIsNullException;
 
@@ -85,7 +86,7 @@ public class ChromatogramSelection<T extends IChromatogramPeak, C extends IChrom
 	}
 
 	@Override
-	public void setSelectedPeak(T selectedPeak) {
+	public void setSelectedPeak(IPeak selectedPeak) {
 
 		logger.warn("Bad boy - setSelectedPeak(IPeak selectedPeak): don't use the ChromatogramSelection implementation");
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/selection/IChromatogramSelection.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/selection/IChromatogramSelection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 Lablicate GmbH.
+ * Copyright (c) 2012, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -167,13 +167,13 @@ public interface IChromatogramSelection<P extends IPeak, C extends IChromatogram
 	 *
 	 * @return IPeak
 	 */
-	P getSelectedPeak();
+	IPeak getSelectedPeak();
 
-	List<P> getSelectedPeaks();
+	List<IPeak> getSelectedPeaks();
 
-	void setSelectedPeak(P selectedPeak);
+	void setSelectedPeak(IPeak selectedPeak);
 
-	void setSelectedPeaks(List<P> selectedPeaks);
+	void setSelectedPeaks(List<IPeak> selectedPeaks);
 
 	IScan getSelectedIdentifiedScan();
 
@@ -234,7 +234,7 @@ public interface IChromatogramSelection<P extends IPeak, C extends IChromatogram
 	 * @param peak
 	 * @return P
 	 */
-	default P validatePeak(P peak) {
+	default IPeak validatePeak(IPeak peak) {
 
 		if(peak != null) {
 			if(peak.isMarkedAsDeleted()) {
@@ -243,7 +243,7 @@ public interface IChromatogramSelection<P extends IPeak, C extends IChromatogram
 				return null;
 			}
 		}
-		//
+
 		return peak;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakQuantitationListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakQuantitationListUI.java
@@ -100,7 +100,7 @@ public class ExtendedPeakQuantitationListUI extends Composite implements IExtend
 		//
 		peakQuantitationListUI.getTable().addSelectionListener(new SelectionAdapter() {
 
-			@SuppressWarnings({"rawtypes", "unchecked"})
+			@SuppressWarnings({"rawtypes"})
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelection_10_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelection_10_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -42,7 +42,7 @@ public class ChromatogramSelection_10_Test extends TestCase {
 		peak = EasyMock.createNiceMock(IChromatogramPeakMSD.class);
 		EasyMock.expect(peak.getIntegratedArea()).andStubReturn(893002.3d);
 		EasyMock.replay(peak);
-		List<IChromatogramPeakMSD> peaks = new ArrayList<IChromatogramPeakMSD>();
+		List<IChromatogramPeakMSD> peaks = new ArrayList<>();
 		peaks.add(peak);
 		/*
 		 * When the chromatogram selection will initialized, the first peak will
@@ -67,7 +67,7 @@ public class ChromatogramSelection_10_Test extends TestCase {
 
 	public void testGetSelectedPeak_1() {
 
-		IChromatogramPeakMSD selectedPeak = selection.getSelectedPeak();
+		IChromatogramPeakMSD selectedPeak = (IChromatogramPeakMSD)selection.getSelectedPeak();
 		assertNotNull(selectedPeak);
 		assertEquals("IntegratedArea", 893002.3d, selectedPeak.getIntegratedArea());
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelection_8_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelection_8_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -86,7 +86,7 @@ public class ChromatogramSelection_8_Test extends TestCase {
 	public void testSetSelectedPeak_2() {
 
 		selection.setSelectedPeak(peak);
-		peak = selection.getSelectedPeak();
+		peak = (IChromatogramPeakMSD)selection.getSelectedPeak();
 		assertNotNull(peak);
 		assertEquals("IntegratedArea", 893002.3d, peak.getIntegratedArea());
 	}


### PR DESCRIPTION
We can live without generics here. Aligns the interface with selected scans. Split from https://github.com/eclipse-chemclipse/chemclipse/pull/2068