### PR TITLE
Use the GitHub web hook

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
 		}
 	}
 	triggers {
-		pollSCM('H/5 * * * *')
+		githubPush()
 	}
 	parameters {
 		booleanParam(name: 'CODESIGN', defaultValue: false, description: 'Sign the artifacts.')


### PR DESCRIPTION
https://plugins.jenkins.io/github/#plugin-content-github-hook-trigger-for-gitscm-polling is now possible thanks to https://github.com/eclipse-chemclipse/.eclipsefdn/commit/d2331d075be41c0b85eacda972276a7fdd28d55e which is more efficient than continous polling.