### PR TITLE
Improve peak matching in Target Transfer

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/support/PeakSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/support/PeakSupport.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Philip Wenig - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.model.core.support;
+
+import java.util.List;
+
+import org.eclipse.chemclipse.model.core.IPeak;
+
+public class PeakSupport {
+
+	public static IPeak selectNearestPeak(List<? extends IPeak> peaks, IPeak peak) {
+
+		return selectNearestPeak(peaks, peak.getPeakModel().getRetentionTimeAtPeakMaximum());
+	}
+
+	public static IPeak selectNearestPeak(List<? extends IPeak> peaks, int retentionTime) {
+
+		IPeak nearestPeak = null;
+		for(IPeak peak : peaks) {
+			if(nearestPeak == null) {
+				nearestPeak = peak;
+			} else {
+				int deltaNearest = Math.abs(retentionTime - nearestPeak.getPeakModel().getRetentionTimeAtPeakMaximum());
+				int deltaCurrent = Math.abs(retentionTime - peak.getPeakModel().getRetentionTimeAtPeakMaximum());
+				if(deltaCurrent <= deltaNearest) {
+					nearestPeak = peak;
+				}
+			}
+		}
+		return nearestPeak;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/PeakSelectionHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/PeakSelectionHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 Lablicate GmbH.
+ * Copyright (c) 2018, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,6 +15,7 @@ import java.util.List;
 
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IPeak;
+import org.eclipse.chemclipse.model.core.support.PeakSupport;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.swt.ui.notifier.UpdateNotifierUI;
@@ -74,43 +75,26 @@ public class PeakSelectionHandler extends AbstractHandledEventProcessor implemen
 				/*
 				 * Fire an update.
 				 */
-				IPeak peak = selectNearestPeak(peaks, retentionTime);
+				IPeak peak = PeakSupport.selectNearestPeak(peaks, retentionTime);
 				if(peak != null) {
-					//
+
 					chromatogramSelection.setSelectedPeak(peak);
 					extendedChromatogramUI.updateSelectedPeak();
-					//
+
 					boolean moveRetentionTimeOnPeakSelection = preferenceStore.getBoolean(PreferenceSupplier.P_MOVE_RETENTION_TIME_ON_PEAK_SELECTION);
 					if(moveRetentionTimeOnPeakSelection) {
 						ChromatogramDataSupport.adjustChromatogramSelection(peak, chromatogramSelection);
 					}
-					//
+
 					extendedChromatogramUI.updateSelection();
-					//
+
 					UpdateNotifierUI.update(event.display, peak);
 					IIdentificationTarget identificationTarget = IIdentificationTarget.getIdentificationTarget(peak);
 					UpdateNotifierUI.update(event.display, identificationTarget);
-					//
+
 					showClickbindingHelp(baseChart, "Peak Selection", "Select nearest peak.");
 				}
 			}
 		}
-	}
-
-	private IPeak selectNearestPeak(List<IPeak> peaks, int retentionTime) {
-
-		IPeak nearestPeak = null;
-		for(IPeak peak : peaks) {
-			if(nearestPeak == null) {
-				nearestPeak = peak;
-			} else {
-				int deltaNearest = Math.abs(retentionTime - nearestPeak.getPeakModel().getRetentionTimeAtPeakMaximum());
-				int deltaCurrent = Math.abs(retentionTime - peak.getPeakModel().getRetentionTimeAtPeakMaximum());
-				if(deltaCurrent <= deltaNearest) {
-					nearestPeak = peak;
-				}
-			}
-		}
-		return nearestPeak;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/chromatogram/TargetTransferFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/chromatogram/TargetTransferFilter.java
@@ -29,6 +29,7 @@ import org.eclipse.chemclipse.model.implementation.IdentificationTarget;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.model.supplier.IChromatogramSelectionProcessSupplier;
 import org.eclipse.chemclipse.model.support.LimitSupport;
+import org.eclipse.chemclipse.model.targets.TargetSupport;
 import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.core.ICategories;
 import org.eclipse.chemclipse.processing.supplier.AbstractProcessSupplier;
@@ -73,7 +74,6 @@ public class TargetTransferFilter implements IProcessTypeSupplier {
 			int stopRetentionTime = chromatogramSelection.getStopRetentionTime();
 			float limitMatchFactor = processSettings.getLimitMatchFactor();
 			float matchFactor = processSettings.getMatchQuality();
-			boolean useBestTargetOnly = processSettings.isUseBestTargetOnly();
 			//
 			List<? extends IPeak> peaks = chromatogram.getPeaks(startRetentionTime, stopRetentionTime);
 			List<IChromatogram<?>> referenceChromatograms = chromatogram.getReferencedChromatograms();
@@ -87,11 +87,8 @@ public class TargetTransferFilter implements IProcessTypeSupplier {
 							 * Transfer Targets
 							 */
 							List<IIdentificationTarget> identificationTargets = new ArrayList<>(peak.getTargets());
-							if(useBestTargetOnly) {
-								Collections.sort(identificationTargets, (t1, t2) -> Float.compare(t2.getComparisonResult().getMatchFactor(), t1.getComparisonResult().getMatchFactor()));
-								IIdentificationTarget identificationTarget = identificationTargets.get(0);
-								identificationTargets.clear();
-								identificationTargets.add(identificationTarget);
+							if(processSettings.isUseBestTargetOnly()) {
+								peak.getTargets().add(TargetSupport.getBestIdentificationTarget(peak));
 							}
 							/*
 							 * Reference Peaks

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/chromatogram/TargetTransferFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/chromatogram/TargetTransferFilter.java
@@ -107,6 +107,7 @@ public class TargetTransferFilter implements IProcessTypeSupplier {
 			float matchFactor = processSettings.getMatchQuality();
 			IComparisonResult comparisonResult = matchFactor > 0 ? new ComparisonResult(matchFactor) : identificationTarget.getComparisonResult();
 			IdentificationTarget newIdentificationTarget = new IdentificationTarget(identificationTarget.getLibraryInformation(), comparisonResult, NAME);
+			newIdentificationTarget.setVerified(identificationTarget.isVerified());
 			peak.getTargets().add(newIdentificationTarget);
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/chromatogram/settings/TargetTransferFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/chromatogram/settings/TargetTransferFilterSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -27,10 +27,10 @@ public class TargetTransferFilterSettings {
 	@JsonProperty(value = "Transfer Best Target Only", defaultValue = "false")
 	@JsonPropertyDescription(value = "If this value is true, only the best target will be transfered.")
 	private boolean useBestTargetOnly = false;
-	@JsonProperty(value = "Match Quality", defaultValue = "80.0")
-	@JsonPropertyDescription(value = "The match quality is set as the Match Factor.")
+	@JsonProperty(value = "Match Quality", defaultValue = "")
+	@JsonPropertyDescription(value = "Overrides the match quality.")
 	@FloatSettingsProperty(minValue = PreferenceSupplier.MIN_FACTOR, maxValue = PreferenceSupplier.MAX_FACTOR)
-	private float matchQuality = 80.0f;
+	private float matchQuality = 0f;
 
 	public float getLimitMatchFactor() {
 


### PR DESCRIPTION
This reduces some edge cases while transferring peaks. Instead of choosing the first retention time overlap, I choose the nearest peak within retention overlap to improve targeting. To avoid mislabelling, I also copy the original match factor to get the target sorting right. You can still override the match factor with a fixed value. Also fixes the manual verification tick not being transferred, which also broke the peak labelling. While not perfect, this gives much better results when transferring deconvoluted MS peaks onto a FID with first derivative (CB) peak detection.