### PR TITLE
Add support for MegaBLAST

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/LocalNucleotideBLAST.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/LocalNucleotideBLAST.java
@@ -76,6 +76,8 @@ public class LocalNucleotideBLAST {
 		processBuilder.command().add(settings.getDatabase());
 		processBuilder.command().add("-query");
 		processBuilder.command().add(fasta.getAbsolutePath());
+		processBuilder.command().add("-task");
+		processBuilder.command().add(settings.getTask().value());
 		processBuilder.command().add("-outfmt");
 		processBuilder.command().add("5");
 		processBuilder.command().add("-out");

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/LocalNucleotideBLAST.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/LocalNucleotideBLAST.java
@@ -115,7 +115,7 @@ public class LocalNucleotideBLAST {
 				libraryInformation.setMiscellaneous(hit.getId());
 				libraryInformation.setComments(hit.getAccession());
 				for(Hsp hsp : hit.getHsps().getHsp()) {
-					ComparisonResult comparisionResult = new ComparisonResult((float)hsp.getBitScore(), (float)hsp.getScore(), (float)hsp.getEvalue(), 0f); // TODO: wrong model
+					ComparisonResult comparisionResult = new ComparisonResult((float)hsp.getBitScore(), (float)hsp.getScore(), (float)hsp.getEvalue(), hsp.getIdentity().floatValue()); // TODO: wrong model
 					IdentificationTarget identificationTarget = new IdentificationTarget(libraryInformation, comparisionResult);
 					identificationTarget.setIdentifier(blastOutput.getVersion());
 					chromatogram.getTargets().add(identificationTarget);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/IdentifierSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/IdentifierSettings.java
@@ -38,6 +38,9 @@ public class IdentifierSettings extends AbstractIdentifierSettingsWSD implements
 	@JsonPropertyDescription(value = "Select the database to query against.")
 	private String database = "16S_ribosomal_RNA";
 
+	@JsonProperty(value = "Task", defaultValue = "blastn")
+	private Task task = Task.BLASTN;
+
 	public File getDatabaseFolder() {
 
 		return databaseFolder;
@@ -56,6 +59,16 @@ public class IdentifierSettings extends AbstractIdentifierSettingsWSD implements
 	public void setDatabase(String database) {
 
 		this.database = database;
+	}
+
+	public Task getTask() {
+
+		return task;
+	}
+
+	public void setTask(Task task) {
+
+		this.task = task;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/Task.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/Task.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings;
+
+import org.eclipse.chemclipse.support.text.ILabel;
+
+public enum Task implements ILabel {
+
+	BLASTN("blastn", "BLASTN"), //
+	BLASTN_SHORT("blastn-short", "short sequence BLASTN"), //
+	MEGABLAST("megablast", "MegaBLAST"), //
+	DC_MEGABLAST("dc-megablast", "discontiguous MegaBLAST"); //
+
+	private String label = "";
+	private String value = "";
+
+	private Task(String value, String label) {
+
+		this.value = value;
+		this.label = label;
+	}
+
+	@Override
+	public String label() {
+
+		return label;
+	}
+
+	public String value() {
+
+		return value;
+	}
+
+	public static String[][] getOptions() {
+
+		return ILabel.getOptions(values());
+	}
+}


### PR DESCRIPTION
and other BLASTN variants which are included in the NCBI Toolkit distribution. MegaBLAST is faster and intended for comparing closely related sequences. Discontiguous MegaBLAST allows mismatches and is intended for cross-species comparisons. Also display the identity % value. Follow-up to https://github.com/eclipse-chemclipse/chemclipse/pull/2081.