### PR TITLE
Sync tycho-build with main tycho version

### DIFF
--- a/chemclipse/.mvn/extensions.xml
+++ b/chemclipse/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>2.7.0</version>
+    <version>4.0.11</version>
   </extension>
 </extensions>

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.test/build.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.test/build.properties
@@ -2,4 +2,4 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .
-tycho.pomless.testbundle=false
+pom.model.packaging=eclipse-plugin


### PR DESCRIPTION
Should reduce warnings/errors printed on build start like:
```
[WARNING] The POM for org.apache.commons:commons-lang3:jar:3.10 is
invalid, transitive dependencies (if any) will not be available: 1
problem was encountered while building the effective model for
org.apache.commons:commons-lang3:3.10
[FATAL] Non-parseable POM
/home/jenkins/agent/workspace/chemclipse_develop/.mvn/org/apache/commons/commons-parent/50/commons-parent-50.pom:
UTF-8 BOM plus xml decl of ISO-8859-1 is incompatible (position:
START_DOCUMENT seen <?xml version="1.0" encoding="ISO-8859-1"... @1:42)
@ /home/jenkins/agent/workspace/chemclipse_develop/.mvn/org/apache/commons/commons-parent/50/commons-parent-50.pom,
line 1, column 42
```

Reference to the old tycho brings old plexus-util as transitive dependency and it ends up with problem https://github.com/codehaus-plexus/plexus-utils/commit/bb346ad63efc6f0cbfd5b1f1736df677bad276cf .