### PR TITLE
Add missing default processor icons

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/processors/ProcessorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/processors/ProcessorSupport.java
@@ -166,6 +166,8 @@ public class ProcessorSupport {
 			imageFileName = IApplicationImage.IMAGE_SAVE;
 			if(processSupplier.getName().contains("*.CAL")) {
 				imageFileName = IApplicationImage.IMAGE_SAMPLE_CALIBRATION;
+			} else if(processSupplier.getName().contains("CSV")) {
+				imageFileName = IApplicationImage.IMAGE_CSV;
 			} else if(processSupplier.getName().contains("Excel")) {
 				imageFileName = IApplicationImage.IMAGE_EXCEL_DOCUMENT;
 			} else if(processSupplier.getName().contains("ZIP")) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/processors/ProcessorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/processors/ProcessorSupport.java
@@ -27,7 +27,7 @@ import org.eclipse.chemclipse.support.util.ValueParserSupport;
 public class ProcessorSupport {
 
 	private static final Logger logger = Logger.getLogger(ProcessorSupport.class);
-	//
+
 	public static final String PROCESSOR_IMAGE_DEFAULT = IApplicationImage.IMAGE_EXECUTE_EXTENSION;
 	/*
 	 * The processors must not contain the following persistence delimiters.
@@ -36,7 +36,7 @@ public class ProcessorSupport {
 	 */
 	private static final String VALUE_DELIMITER = "§";
 	private static final String PROCESSOR_DELIMITER = "%";
-	//
+
 	private static ValueParserSupport valueParseSupport = new ValueParserSupport();
 
 	public static List<Processor> getActiveProcessors(Set<IProcessSupplier<?>> processSuppliers, String settings) {
@@ -82,7 +82,7 @@ public class ProcessorSupport {
 	public static String getActiveProcessors(List<Processor> processors) {
 
 		StringBuilder builder = new StringBuilder();
-		//
+
 		if(processors != null) {
 			List<Processor> activeProcessors = processors.stream().filter(Processor::isActive).toList();
 			Iterator<Processor> iterator = activeProcessors.iterator();
@@ -90,7 +90,7 @@ public class ProcessorSupport {
 				Processor processor = iterator.next();
 				if(isValid(processor)) {
 					IProcessSupplier<?> processSupplier = processor.getProcessSupplier();
-					//
+
 					builder.append(processSupplier.getId());
 					builder.append(VALUE_DELIMITER);
 					builder.append(processor.getImageFileName());
@@ -98,7 +98,7 @@ public class ProcessorSupport {
 					builder.append(processor.isActive());
 					builder.append(VALUE_DELIMITER);
 					builder.append(processor.getIndex());
-					//
+
 					if(iterator.hasNext()) {
 						builder.append(PROCESSOR_DELIMITER);
 					}
@@ -107,7 +107,7 @@ public class ProcessorSupport {
 				}
 			}
 		}
-		//
+
 		return builder.toString();
 	}
 
@@ -126,7 +126,7 @@ public class ProcessorSupport {
 			}
 			Collections.sort(processors, (p1, p2) -> Integer.compare(p1.getIndex(), p2.getIndex()));
 		}
-		//
+
 		return processorsFiltered;
 	}
 
@@ -254,7 +254,7 @@ public class ProcessorSupport {
 			if(processSupplier.getName().contains("Add Peaks to DB")) {
 				imageFileName = IApplicationImage.IMAGE_ADD_PEAKS_TO_QUANTITATION_TABLE;
 			}
-		} else if(processSupplier.getCategory().equals("Peak Massspectrum Filter") || processSupplier.getCategory().equals("Scan Massspectrum Filter")) {
+		} else if(processSupplier.getCategory().equals("Peak Mass Spectrum Filter") || processSupplier.getCategory().equals("Scan Mass Spectrum Filter")) {
 			imageFileName = IApplicationImage.IMAGE_MASS_SPECTRUM;
 			if(processSupplier.getName().contains("Savitzky-Golay")) {
 				imageFileName = IApplicationImage.IMAGE_FILTER_SAVITZKY_GOLAY;
@@ -275,7 +275,7 @@ public class ProcessorSupport {
 		} else if(processSupplier.getCategory().equals("System")) {
 			imageFileName = IApplicationImage.IMAGE_PREFERENCES;
 		}
-		//
+
 		return imageFileName;
 	}
 
@@ -287,7 +287,7 @@ public class ProcessorSupport {
 			 */
 			TreeMap<Integer, Processor> processorMap = new TreeMap<>();
 			int indexActive = -1;
-			//
+
 			for(int i = 0; i < processors.size(); i++) {
 				Processor processor = processors.get(i);
 				if(processor.isActive()) {
@@ -297,7 +297,7 @@ public class ProcessorSupport {
 					}
 				}
 			}
-			//
+
 			if(indexActive >= 0) {
 				Integer indexSwitch = moveUp ? processorMap.lowerKey(indexActive) : processorMap.higherKey(indexActive);
 				if(indexSwitch != null) {
@@ -321,7 +321,7 @@ public class ProcessorSupport {
 				return processor;
 			}
 		}
-		//
+
 		return null;
 	}
 
@@ -341,18 +341,18 @@ public class ProcessorSupport {
 		if(processor == null) {
 			return false;
 		}
-		//
+
 		IProcessSupplier<?> processSupplier = processor.getProcessSupplier();
 		String id = processSupplier.getId();
 		if(id.contains(VALUE_DELIMITER) || id.contains(PROCESSOR_DELIMITER)) {
 			return false;
 		}
-		//
+
 		String imageFileName = processor.getImageFileName();
 		if(imageFileName.contains(VALUE_DELIMITER) || imageFileName.contains(PROCESSOR_DELIMITER)) {
 			return false;
 		}
-		//
+
 		return true;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/charts/ChartPCR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/charts/ChartPCR.java
@@ -53,7 +53,6 @@ import org.eclipse.swtchart.extensions.menu.IChartMenuEntry;
 
 public class ChartPCR extends LineChart {
 
-	private static final String MENU_ICON = "org.eclipse.chemclipse.xxd.process.ui.menu.icon"; //$NON-NLS-1$
 	private static final Logger logger = Logger.getLogger(ChartPCR.class);
 	//
 	private IPlate plate;
@@ -145,7 +144,7 @@ public class ChartPCR extends LineChart {
 				public Image getIcon() {
 
 					IExtensionRegistry registry = Platform.getExtensionRegistry();
-					IConfigurationElement[] config = registry.getConfigurationElementsFor(MENU_ICON);
+					IConfigurationElement[] config = registry.getConfigurationElementsFor(IMenuIcon.EXTENSION_POINT_ID);
 					try {
 						for(IConfigurationElement element : config) {
 							final String id = element.getAttribute("id"); //$NON-NLS-1$

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ProcessorSupplierMenuEntry.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ProcessorSupplierMenuEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 Lablicate GmbH.
+ * Copyright (c) 2019, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -35,7 +35,6 @@ public class ProcessorSupplierMenuEntry<T> extends AbstractChartMenuEntry implem
 	private final BiConsumer<IProcessSupplier<T>, IProcessSupplierContext> executionConsumer;
 	private final IProcessSupplierContext context;
 	//
-	private static final String MENU_ICON = "org.eclipse.chemclipse.xxd.process.ui.menu.icon";
 	private static final Logger logger = Logger.getLogger(ProcessorSupplierMenuEntry.class);
 
 	public ProcessorSupplierMenuEntry(IProcessSupplier<T> processorSupplier, IProcessSupplierContext context, BiConsumer<IProcessSupplier<T>, IProcessSupplierContext> executionConsumer) {
@@ -65,7 +64,7 @@ public class ProcessorSupplierMenuEntry<T> extends AbstractChartMenuEntry implem
 	public Image getIcon() {
 
 		IExtensionRegistry registry = Platform.getExtensionRegistry();
-		IConfigurationElement[] config = registry.getConfigurationElementsFor(MENU_ICON);
+		IConfigurationElement[] config = registry.getConfigurationElementsFor(IMenuIcon.EXTENSION_POINT_ID);
 		try {
 			for(IConfigurationElement element : config) {
 				// NOTE: some process type suppliers add hard-coded prefixes

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.ui/src/org/eclipse/chemclipse/xxd/process/ui/menu/IMenuIcon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.ui/src/org/eclipse/chemclipse/xxd/process/ui/menu/IMenuIcon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2025 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -14,6 +14,8 @@ package org.eclipse.chemclipse.xxd.process.ui.menu;
 import org.eclipse.swt.graphics.Image;
 
 public interface IMenuIcon {
+
+	public static final String EXTENSION_POINT_ID = "org.eclipse.chemclipse.xxd.process.ui.menu.icon";
 
 	Image getImage();
 }


### PR DESCRIPTION
I regressed this during https://github.com/eclipse-chemclipse/chemclipse/pull/1636.