### PR TITLE
Add a simple model for spot location and MALDI target ID

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/MassSpectrumReaderVersion105.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/MassSpectrumReaderVersion105.java
@@ -48,24 +48,24 @@ import jakarta.xml.bind.Unmarshaller;
 public class MassSpectrumReaderVersion105 extends AbstractMassSpectraReader implements IMassSpectraReader {
 
 	public static final String VERSION = "1.05";
-	//
+
 	private static final Logger logger = Logger.getLogger(MassSpectrumReaderVersion105.class);
 
 	@Override
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
 		IStandaloneMassSpectrum massSpectrum = null;
-		//
+
 		try {
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);
 			NodeList nodeList = document.getElementsByTagName(ReaderVersion105.NODE_MZ_DATA);
-			//
+
 			JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
 			Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
 			MzData mzData = (MzData)unmarshaller.unmarshal(nodeList.item(0));
-			//
+
 			massSpectrum = new StandaloneMassSpectrum();
 			massSpectrum.setFile(file);
 			massSpectrum.setIdentifier(file.getName());
@@ -79,7 +79,7 @@ public class MassSpectrumReaderVersion105 extends AbstractMassSpectraReader impl
 		} catch(ParserConfigurationException e) {
 			logger.warn(e);
 		}
-		//
+
 		IVendorMassSpectra massSpectra = new VendorMassSpectra();
 		massSpectra.setName(file.getName());
 		massSpectra.addMassSpectrum(massSpectrum);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/MassSpectrumReaderVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/MassSpectrumReaderVersion110.java
@@ -49,15 +49,15 @@ public class MassSpectrumReaderVersion110 extends AbstractMassSpectraReader impl
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
 		IStandaloneMassSpectrum massSpectrum = null;
-		//
+
 		try {
-			//
+
 			massSpectrum = new VendorMassSpectrum();
 			massSpectrum.setFile(file);
 			massSpectrum.setIdentifier(file.getName());
-			//
+
 			MzMLType mzML = XmlReader110.getMzML(file);
-			//
+
 			FileDescriptionType fileDescription = mzML.getFileDescription();
 			if(fileDescription != null) {
 				ParamGroupType fileContent = fileDescription.getFileContent();
@@ -69,12 +69,15 @@ public class MassSpectrumReaderVersion110 extends AbstractMassSpectraReader impl
 					}
 				}
 			}
-			//
+
 			double[] mzs = null;
 			double[] intensities = null;
-			//
+
 			RunType run = mzML.getRun();
 			for(SpectrumType spectrum : run.getSpectrumList().getSpectrum()) {
+
+				massSpectrum.setPosition(spectrum.getSpotID());
+
 				for(CVParamType cvParam : spectrum.getCvParam()) {
 					if(cvParam.getAccession().equals("MS:1000127") && cvParam.getName().equals("centroid spectrum")) {
 						massSpectrum.setMassSpectrumType(MassSpectrumType.CENTROID);
@@ -101,7 +104,7 @@ public class MassSpectrumReaderVersion110 extends AbstractMassSpectraReader impl
 		} catch(DataFormatException e) {
 			logger.warn(e);
 		}
-		//
+
 		IVendorMassSpectra massSpectra = new VendorMassSpectra();
 		massSpectra.setName(file.getName());
 		massSpectra.addMassSpectrum(massSpectrum);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/MassSpectrumWriterVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/MassSpectrumWriterVersion110.java
@@ -111,7 +111,7 @@ public class MassSpectrumWriterVersion110 implements IMassSpectraWriter {
 		for(IScanMSD massSpectrum : massSpectra.getList()) {
 			if(massSpectrum instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
 				SourceFileType sourceFile = XmlWriter110.createSourceFile(standaloneMassSpectrum.getFile());
-				//
+
 				if(massSpectra.getConverterId().equals("org.eclipse.chemclipse.msd.converter.supplier.mzdata.ms")) {
 					CVParamType cvParamFileFormat = new CVParamType();
 					cvParamFileFormat.setCvRef(XmlWriter110.MS);
@@ -242,6 +242,9 @@ public class MassSpectrumWriterVersion110 implements IMassSpectraWriter {
 				spectrum.getCvParam().add(XmlWriter110.createSpectrumDimension(massSpectrum));
 				spectrum.getCvParam().add(XmlWriter110.createSpectrumLevel(massSpectrum));
 				spectrum.getCvParam().add(XmlWriter110.createSpectrumType(massSpectrum));
+			}
+			if(scanMSD instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
+				spectrum.setSpotID(standaloneMassSpectrum.getPosition());
 			}
 			spectrum.setDefaultArrayLength(scanMSD.getNumberOfIons());
 			spectrumList.getSpectrum().add(spectrum);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion20.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion20.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 Lablicate GmbH.
+ * Copyright (c) 2015, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -30,6 +30,7 @@ import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v20.model.DataProcessing;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v20.model.Maldi;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v20.model.MsRun;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v20.model.ObjectFactory;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v20.model.Peaks;
@@ -54,24 +55,24 @@ import jakarta.xml.bind.Unmarshaller;
 public class MassSpectrumReaderVersion20 extends AbstractMassSpectraReader implements IMassSpectraReader {
 
 	public static final String VERSION = "mzXML_2.0";
-	//
+
 	private static final Logger logger = Logger.getLogger(MassSpectrumReaderVersion20.class);
 
 	@Override
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
 		IStandaloneMassSpectrum massSpectrum = null;
-		//
+
 		try {
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);
 			NodeList nodeList = document.getElementsByTagName(AbstractChromatogramReaderVersion.NODE_MS_RUN);
-			//
+
 			JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
 			Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
 			MsRun msrun = (MsRun)unmarshaller.unmarshal(nodeList.item(0));
-			//
+
 			massSpectrum = new VendorMassSpectrum();
 			massSpectrum.setFile(file);
 			massSpectrum.setIdentifier(file.getName());
@@ -95,6 +96,14 @@ public class MassSpectrumReaderVersion20 extends AbstractMassSpectraReader imple
 					} else if(polarity.equals("-")) {
 						massSpectrum.setPolarity(Polarity.NEGATIVE);
 					}
+				}
+				/*
+				 * Plate
+				 */
+				Maldi maldi = scan.getMaldi();
+				if(maldi != null) {
+					massSpectrum.setPlate(maldi.getPlateID());
+					massSpectrum.setPosition(maldi.getSpotID());
 				}
 				/*
 				 * Get the ions.

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion21.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion21.java
@@ -30,6 +30,7 @@ import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.DataProcessing;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.Maldi;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.MsRun;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.ObjectFactory;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.Peaks;
@@ -61,17 +62,17 @@ public class MassSpectrumReaderVersion21 extends AbstractMassSpectraReader imple
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
 		IStandaloneMassSpectrum massSpectrum = null;
-		//
+
 		try {
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);
 			NodeList nodeList = document.getElementsByTagName(AbstractChromatogramReaderVersion.NODE_MS_RUN);
-			//
+
 			JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
 			Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
 			MsRun msrun = (MsRun)unmarshaller.unmarshal(nodeList.item(0));
-			//
+
 			massSpectrum = new VendorMassSpectrum();
 			massSpectrum.setFile(file);
 			massSpectrum.setIdentifier(file.getName());
@@ -95,6 +96,14 @@ public class MassSpectrumReaderVersion21 extends AbstractMassSpectraReader imple
 					} else if(polarity.equals("-")) {
 						massSpectrum.setPolarity(Polarity.NEGATIVE);
 					}
+				}
+				/*
+				 * Plate
+				 */
+				Maldi maldi = scan.getMaldi();
+				if(maldi != null) {
+					massSpectrum.setPlate(maldi.getPlateID());
+					massSpectrum.setPosition(maldi.getSpotID());
 				}
 				/*
 				 * Get the ions.

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion22.java
@@ -30,6 +30,7 @@ import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.DataProcessing;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.Maldi;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.MsRun;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.MzXML;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.ObjectFactory;
@@ -55,25 +56,25 @@ import jakarta.xml.bind.Unmarshaller;
 public class MassSpectrumReaderVersion22 extends AbstractMassSpectraReader implements IMassSpectraReader {
 
 	public static final String VERSION = "mzXML_2.2";
-	//
+
 	private static final Logger logger = Logger.getLogger(MassSpectrumReaderVersion22.class);
 
 	@Override
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
 		IStandaloneMassSpectrum massSpectrum = null;
-		//
+
 		try {
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
 			documentBuilderFactory.setNamespaceAware(true);
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);
 			NodeList nodeList = document.getElementsByTagName(AbstractChromatogramReaderVersion.NODE_MZXML);
-			//
+
 			JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
 			Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
 			MzXML mzXML = (MzXML)unmarshaller.unmarshal(nodeList.item(0));
-			//
+
 			massSpectrum = new VendorMassSpectrum();
 			massSpectrum.setFile(file);
 			massSpectrum.setIdentifier(file.getName());
@@ -97,6 +98,14 @@ public class MassSpectrumReaderVersion22 extends AbstractMassSpectraReader imple
 					} else if(scan.getPolarity().equals("-")) {
 						massSpectrum.setPolarity(Polarity.NEGATIVE);
 					}
+				}
+				/*
+				 * Plate
+				 */
+				Maldi maldi = scan.getMaldi();
+				if(maldi != null) {
+					massSpectrum.setPlate(maldi.getPlateID());
+					massSpectrum.setPosition(maldi.getSpotID());
 				}
 				/*
 				 * Get the ions.

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumWriterVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumWriterVersion22.java
@@ -27,6 +27,7 @@ import org.eclipse.chemclipse.msd.converter.io.IMassSpectraWriter;
 import org.eclipse.chemclipse.msd.converter.massspectrum.MassSpectrumConverter;
 import org.eclipse.chemclipse.msd.converter.massspectrum.MassSpectrumConverterSupport;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.DataProcessing;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.Maldi;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.MsRun;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.MzXML;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.ObjectFactory;
@@ -39,6 +40,7 @@ import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.core.runtime.IProduct;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -157,9 +159,22 @@ public class MassSpectrumWriterVersion22 implements IMassSpectraWriter {
 			scan.setMsLevel(BigInteger.valueOf(regularMassSpectrum.getMassSpectrometer()));
 			scan.setCentroided(regularMassSpectrum.getMassSpectrumType() == MassSpectrumType.CENTROID);
 		}
+		if(scanMSD instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
+			scan.setMaldi(createMaldi(standaloneMassSpectrum));
+		}
 		scan.setPeaksCount(BigInteger.valueOf(scanMSD.getNumberOfIons()));
 		scan.setPeaks(createPeaks(scanMSD));
 		return scan;
+	}
+
+	private Maldi createMaldi(IStandaloneMassSpectrum standaloneMassSpectrum) {
+
+		Maldi maldi = new Maldi();
+		if(maldi != null) {
+			maldi.setPlateID(standaloneMassSpectrum.getPlate());
+			maldi.setSpotID(standaloneMassSpectrum.getPosition());
+		}
+		return null;
 	}
 
 	private Peaks createPeaks(IScanMSD scanMSD) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractStandaloneMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractStandaloneMassSpectrum.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 Lablicate GmbH.
+ * Copyright (c) 2022, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -24,9 +24,11 @@ public abstract class AbstractStandaloneMassSpectrum extends AbstractRegularMass
 	 * Renew the serialVersionUID any time you have changed some fields or
 	 * methods.
 	 */
-	private static final long serialVersionUID = 7180911179209208598L;
-	//
+	private static final long serialVersionUID = 7180911179209208599L;
+
 	private File file;
+	private String plate;
+	private String position;
 	private String sample;
 	private String description;
 	private String operator;
@@ -44,6 +46,30 @@ public abstract class AbstractStandaloneMassSpectrum extends AbstractRegularMass
 	public void setFile(File file) {
 
 		this.file = file;
+	}
+
+	@Override
+	public String getPlate() {
+
+		return plate;
+	}
+
+	@Override
+	public void setPlate(String plate) {
+
+		this.plate = plate;
+	}
+
+	@Override
+	public String getPosition() {
+
+		return position;
+	}
+
+	@Override
+	public void setPosition(String position) {
+
+		this.position = position;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IStandaloneMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IStandaloneMassSpectrum.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 Lablicate GmbH.
+ * Copyright (c) 2022, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -50,6 +50,20 @@ public interface IStandaloneMassSpectrum extends IRegularMassSpectrum {
 	String getSampleName();
 
 	void setSampleName(String name);
+
+	/**
+	 * @return ID of the MALDI target
+	 */
+	String getPlate();
+
+	void setPlate(String plate);
+
+	/**
+	 * @return location (coordinate) on the plate
+	 */
+	String getPosition();
+
+	void setPosition(String plateLocation);
 
 	String getDescription();
 


### PR DESCRIPTION
There is more to model here as depicted in https://github.com/eclipse-chemclipse/chemclipse/blob/5fb21c5aaa91e38f6006c2bd08fa9d402b5fa2b6/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v32/model/Plate.java#L30-L45

but spot/plate as text seems to be the common denominator between all the MALDI formats.

There is also overlap between microplates, which could be addressed in the future.