### PR TITLE
Fix NLS missing message: settings

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/l10n/messages.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/l10n/messages.properties
@@ -19,6 +19,7 @@ resetSettingsForAllProcessors=Would you like to reset the settings for all proce
 expandAllProcessorItems=Expand all processor items.
 collapseAllProcessorItems=Collapse all processor items.
 displaySettings=Display Settings
+settings=Settings
 yes=yes
 no=no
 options=Options

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/l10n/messages_de.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/l10n/messages_de.properties
@@ -19,6 +19,7 @@ resetSettingsForAllProcessors=Sollen die Einstellungen für alle Prozessoren zurü
 expandAllProcessorItems=Erweitert alle Prozessorelemente.
 collapseAllProcessorItems=Blenden Sie alle Prozessorelemente aus.
 displaySettings=Anzeigeeinstellungen
+settings=Einstellungen
 yes=ja
 no=nein
 options=Optionen


### PR DESCRIPTION
Regression introduced in https://github.com/eclipse-chemclipse/chemclipse/pull/2111 which is visible when the processor has literature references.