### PR TITLE
Add detection for legacy peak filter IDs in process methods

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/filter/IPeakFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/filter/IPeakFilter.java
@@ -14,6 +14,7 @@
 package org.eclipse.chemclipse.model.filter;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
@@ -62,4 +63,6 @@ public interface IPeakFilter<ConfigType> extends Filter<ConfigType> {
 
 		return new DataCategory[]{DataCategory.CSD, DataCategory.MSD, DataCategory.WSD, DataCategory.VSD};
 	}
+
+	List<String> getLegacyIDs();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/supplier/PeakFilterProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/supplier/PeakFilterProcessTypeSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -81,6 +81,12 @@ public class PeakFilterProcessTypeSupplier implements IProcessTypeSupplier {
 		private void doFilter(IChromatogramSelection chromatogramSelection, ConfigType processSettings, ProcessExecutionContext context) {
 
 			filter.filterPeaks(chromatogramSelection, processSettings, context);
+		}
+
+		@Override
+		public boolean matchesId(String id) {
+
+			return super.matchesId(id) || filter.getLegacyIDs().contains(id);
 		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/settings/serialization/JSONSerialization.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/settings/serialization/JSONSerialization.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/AbstractPeakFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/AbstractPeakFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.filter.peaks;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -54,5 +55,11 @@ public abstract class AbstractPeakFilter<ConfigType> implements IPeakFilter<Conf
 
 		chromatogramSelection.setSelectedPeak(null);
 		chromatogramSelection.getChromatogram().setDirty(true);
+	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		return new ArrayList<>();
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/AreaFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/AreaFilter.java
@@ -143,4 +143,12 @@ public class AreaFilter extends AbstractPeakFilter<AreaFilterSettings> {
 				throw new IllegalArgumentException("Unsupported Peak Filter Treatment Option!");
 		}
 	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.AreaFilter");
+		return legacyIDs;
+	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/AreaPercentFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/AreaPercentFilter.java
@@ -163,4 +163,12 @@ public class AreaPercentFilter extends AbstractPeakFilter<AreaPercentFilterSetti
 				throw new IllegalArgumentException("Unsupported Peak Filter Treatment Option!");
 		}
 	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.AreaPercentFilter");
+		return legacyIDs;
+	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/AsymmetryFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/AsymmetryFilter.java
@@ -139,4 +139,12 @@ public class AsymmetryFilter extends AbstractPeakFilter<AsymmetryFilterSettings>
 				throw new IllegalArgumentException("Unsupported Peak Filter Treatment Option!");
 		}
 	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.AsymmetryFilter");
+		return legacyIDs;
+	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/ClassifiedPeaksFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/ClassifiedPeaksFilter.java
@@ -13,7 +13,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.filter.peaks;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 import org.eclipse.chemclipse.model.core.IPeak;
@@ -70,5 +72,13 @@ public class ClassifiedPeaksFilter extends AbstractPeakFilter<ClassifiedPeaksFil
 			subMonitor.worked(1);
 		}
 		subMonitor.done();
+	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.ClassifiedPeaksFilter");
+		return legacyIDs;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeleteIntegrationsFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeleteIntegrationsFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.filter.peaks;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.filter.IPeakFilter;
@@ -59,5 +61,13 @@ public class DeleteIntegrationsFilter extends AbstractPeakFilter<DeleteIntegrati
 				subMonitor.worked(1);
 			}
 		}
+	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.DeleteIntegrationsFilter");
+		return legacyIDs;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeletePeaksByModelFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeletePeaksByModelFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Lablicate GmbH.
+ * Copyright (c) 2024, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -81,5 +81,13 @@ public class DeletePeaksByModelFilter extends AbstractPeakFilter<DeletePeaksByMo
 			deletePeaks(peaksToDelete, chromatogramSelection);
 			resetPeakSelection(chromatogramSelection);
 		}
+	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.DeletePeaksByModelFilter");
+		return legacyIDs;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeletePeaksByQuantitationFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeletePeaksByQuantitationFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -114,5 +114,13 @@ public class DeletePeaksByQuantitationFilter extends AbstractPeakFilter<DeletePe
 		}
 
 		return false;
+	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.DeletePeaksByQuantitationFilter");
+		return legacyIDs;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeletePeaksByTargetFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeletePeaksByTargetFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -146,5 +146,13 @@ public class DeletePeaksByTargetFilter extends AbstractPeakFilter<DeletePeaksByT
 		}
 
 		return false;
+	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.DeletePeaksByTargetFilter");
+		return legacyIDs;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeletePeaksByTraceFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeletePeaksByTraceFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -113,5 +113,13 @@ public class DeletePeaksByTraceFilter extends AbstractPeakFilter<DeletePeaksByTr
 		}
 
 		return false;
+	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.DeletePeaksByTraceFilter");
+		return legacyIDs;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeletePeaksFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeletePeaksFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -105,5 +105,13 @@ public class DeletePeaksFilter extends AbstractPeakFilter<DeletePeaksFilterSetti
 			deletePeaks(peaksToDelete, chromatogramSelection);
 			resetPeakSelection(chromatogramSelection);
 		}
+	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.DeletePeaksFilter");
+		return legacyIDs;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeleteQuantitationReferencesFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeleteQuantitationReferencesFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 Lablicate GmbH.
+ * Copyright (c) 2022, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.filter.peaks;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.filter.IPeakFilter;
@@ -60,5 +62,13 @@ public class DeleteQuantitationReferencesFilter extends AbstractPeakFilter<Delet
 			}
 			subMonitor.worked(1);
 		}
+	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.DeleteQuantitationReferencesFilter");
+		return legacyIDs;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeleteQuantitationsFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeleteQuantitationsFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.filter.peaks;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.filter.IPeakFilter;
@@ -55,5 +57,13 @@ public class DeleteQuantitationsFilter extends AbstractPeakFilter<DeleteQuantita
 				subMonitor.worked(1);
 			}
 		}
+	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.DeleteQuantitationsFilter");
+		return legacyIDs;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeleteStandardsFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeleteStandardsFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.filter.peaks;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.filter.IPeakFilter;
@@ -61,5 +63,13 @@ public class DeleteStandardsFilter extends AbstractPeakFilter<DeleteStandardsFil
 				subMonitor.worked(1);
 			}
 		}
+	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.DeleteStandardsFilter");
+		return legacyIDs;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeleteTargetsFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeleteTargetsFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.filter.peaks;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.filter.IPeakFilter;
@@ -59,5 +61,13 @@ public class DeleteTargetsFilter extends AbstractPeakFilter<DeleteTargetsFilterS
 			TargetsFilter.filter(peak, configuration);
 			subMonitor.worked(1);
 		}
+	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.DeleteTargetsFilter");
+		return legacyIDs;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/HighPassPeaksFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/HighPassPeaksFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.filter.peaks;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -61,5 +62,13 @@ public class HighPassPeaksFilter extends AbstractPeakFilter<HighPassPeaksFilterS
 
 		deletePeaks(peaksToDelete, chromatogramSelection);
 		resetPeakSelection(chromatogramSelection);
+	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.HighPassPeaksFilter");
+		return legacyIDs;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/LowPassPeaksFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/LowPassPeaksFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.filter.peaks;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -61,5 +62,13 @@ public class LowPassPeaksFilter extends AbstractPeakFilter<LowPassPeaksFilterSet
 
 		deletePeaks(peaksToDelete, chromatogramSelection);
 		resetPeakSelection(chromatogramSelection);
+	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.LowPassPeaksFilter");
+		return legacyIDs;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/MinimumTracesFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/MinimumTracesFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -83,5 +83,13 @@ public class MinimumTracesFilter extends AbstractPeakFilter<MinimumTracesFilterS
 	public DataCategory[] getDataCategories() {
 
 		return new DataCategory[]{DataCategory.MSD};
+	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.MinimumTracesFilter");
+		return legacyIDs;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/PeakActiveForAnalysisFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/PeakActiveForAnalysisFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 Lablicate GmbH.
+ * Copyright (c) 2022, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.filter.peaks;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.filter.IPeakFilter;
@@ -59,5 +61,13 @@ public class PeakActiveForAnalysisFilter extends AbstractPeakFilter<PeakActiveFo
 			subMonitor.worked(1);
 		}
 		subMonitor.done();
+	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.PeakActiveForAnalysisFilter");
+		return legacyIDs;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/ShapeFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/ShapeFilter.java
@@ -159,4 +159,12 @@ public class ShapeFilter extends AbstractPeakFilter<ShapeFilterSettings> {
 				throw new IllegalArgumentException("Unsupported Peak Filter Treatment Option!");
 		}
 	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.ShapeFilter");
+		return legacyIDs;
+	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/SignalToNoisePeakFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/SignalToNoisePeakFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -74,5 +74,13 @@ public class SignalToNoisePeakFilter extends AbstractPeakFilter<SignalToNoisePea
 
 		deletePeaks(peaksToDelete, chromatogramSelection);
 		resetPeakSelection(chromatogramSelection);
+	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.SignalToNoisePeakFilter");
+		return legacyIDs;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/WidthFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/WidthFilter.java
@@ -139,4 +139,12 @@ public class WidthFilter extends AbstractPeakFilter<WidthFilterSettings> {
 				throw new IllegalArgumentException("Unsupported Peak Filter Treatment Option!");
 		}
 	}
+
+	@Override
+	public List<String> getLegacyIDs() {
+
+		List<String> legacyIDs = new ArrayList<>();
+		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.WidthFilter");
+		return legacyIDs;
+	}
 }


### PR DESCRIPTION
The IDs for process methods use a hardcoded ID based on class name with inconsistent prefixes/suffixes to avoid collisions, which seems like a bad idea in the first place. In https://github.com/eclipse-chemclipse/chemclipse/pull/1093/ I accidentally changed the IDs of most peak filters with a simple namespace change. This adds a method to auto-detect and migrate those previous IDs, in the same vein as https://github.com/eclipse-chemclipse/chemclipse/issues/1891 did for the settings content. It also allows us to clean them up with less volatile IDs in the future.