### PR TITLE
Fix MALDI-TOF MS identification not executing

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/META-INF/MANIFEST.MF
@@ -28,5 +28,5 @@ Bundle-Vendor: ChemClipse
 Import-Package: org.osgi.service.component.annotations;version="1.2.0"
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.identifier.chromatogram.ChromatogramIdentifierProcessTypeSupplier.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.MassSpectrumIdentifierProcessTypeSupplier.xml,
- OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.ScanMassSpectrumIdentifierProcessTypeSupplier.xml,
+ OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.StandaloneMassSpectrumIdentifierProcessTypeSupplier.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.identifier.peak.PeakIdentifierMSDProcessTypeSupplier.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.ScanMassSpectrumIdentifierProcessTypeSupplier.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.ScanMassSpectrumIdentifierProcessTypeSupplier.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.ScanMassSpectrumIdentifierProcessTypeSupplier">
-   <service>
-      <provide interface="org.eclipse.chemclipse.processing.supplier.IProcessTypeSupplier"/>
-   </service>
-   <implementation class="org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.ScanMassSpectrumIdentifierProcessTypeSupplier"/>
-</scr:component>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.StandaloneMassSpectrumIdentifierProcessTypeSupplier.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.StandaloneMassSpectrumIdentifierProcessTypeSupplier.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.StandaloneMassSpectrumIdentifierProcessTypeSupplier">
+   <service>
+      <provide interface="org.eclipse.chemclipse.processing.supplier.IProcessTypeSupplier"/>
+   </service>
+   <implementation class="org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.StandaloneMassSpectrumIdentifierProcessTypeSupplier"/>
+</scr:component>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/massspectrum/StandaloneMassSpectrumIdentifierProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/massspectrum/StandaloneMassSpectrumIdentifierProcessTypeSupplier.java
@@ -30,12 +30,12 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.osgi.service.component.annotations.Component;
 
 @Component(service = IProcessTypeSupplier.class)
-public class ScanMassSpectrumIdentifierProcessTypeSupplier implements IProcessTypeSupplier {
+public class StandaloneMassSpectrumIdentifierProcessTypeSupplier implements IProcessTypeSupplier {
 
 	@Override
 	public String getCategory() {
 
-		return ICategories.SCAN_IDENTIFIER;
+		return ICategories.MASS_SPECTRUM_IDENTIFIER;
 	}
 
 	@Override
@@ -46,7 +46,7 @@ public class ScanMassSpectrumIdentifierProcessTypeSupplier implements IProcessTy
 			List<IProcessSupplier<?>> list = new ArrayList<>();
 			for(String processorId : support.getAvailableIdentifierIds()) {
 				IMassSpectrumIdentifierSupplier supplier = support.getIdentifierSupplier(processorId);
-				list.add(new MassSpectrumIdentifierProcessorSupplier(supplier, this));
+				list.add(new StandaloneMassSpectrumIdentifierProcessorSupplier(supplier, this));
 			}
 			return list;
 		} catch(NoIdentifierAvailableException e) {
@@ -54,12 +54,12 @@ public class ScanMassSpectrumIdentifierProcessTypeSupplier implements IProcessTy
 		}
 	}
 
-	private static final class MassSpectrumIdentifierProcessorSupplier extends ScanProcessSupplier<IMassSpectrumIdentifierSettings> {
+	private static final class StandaloneMassSpectrumIdentifierProcessorSupplier extends ScanProcessSupplier<IMassSpectrumIdentifierSettings> {
 
 		private IMassSpectrumIdentifierSupplier supplier;
 
 		@SuppressWarnings("unchecked")
-		public MassSpectrumIdentifierProcessorSupplier(IMassSpectrumIdentifierSupplier supplier, IProcessTypeSupplier parent) {
+		public StandaloneMassSpectrumIdentifierProcessorSupplier(IMassSpectrumIdentifierSupplier supplier, IProcessTypeSupplier parent) {
 
 			super("ScanMassSpectrumIdentifier." + supplier.getId(), supplier.getIdentifierName(), supplier.getDescription(), (Class<IMassSpectrumIdentifierSettings>)supplier.getSettingsClass(), parent, DataType.MSD);
 			this.supplier = supplier;
@@ -74,10 +74,8 @@ public class ScanMassSpectrumIdentifierProcessTypeSupplier implements IProcessTy
 				} else {
 					messageConsumer.addMessages(MassSpectrumIdentifier.identify(scanMSD, supplier.getId(), monitor));
 				}
-			} else {
-				messageConsumer.addWarnMessage(getName(), "Only standalone mass spectra (e.g. MALDI-TOF) are supported. Skip processing");
+				scan.setDirty(true);
 			}
-			scan.setDirty(true);
 			return scan;
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/core/ICategories.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/core/ICategories.java
@@ -41,6 +41,7 @@ public interface ICategories {
 	String FILTER = Messages.filter;
 	String MASS_SPECTRUM = Messages.massSpectrum;
 	String MASS_SPECTRUM_FILTER = Messages.massSpectrumFilter;
+	String MASS_SPECTRUM_IDENTIFIER = Messages.massSpectrumIdentifier;
 	String PROCEDURES = Messages.procedures;
 	String IDENTIFIER = Messages.identifier;
 	String EXPORT = Messages.export;

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/l10n/Messages.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/l10n/Messages.java
@@ -17,7 +17,7 @@ import org.eclipse.osgi.util.NLS;
 public class Messages extends NLS {
 
 	private static final String BUNDLE_NAME = "org.eclipse.chemclipse.processing.l10n.messages"; //$NON-NLS-1$
-	//
+
 	public static String baselineDetector;
 	public static String chromatogramCalculator;
 	public static String chromatogramClassifier;
@@ -39,6 +39,7 @@ public class Messages extends NLS {
 	public static String peakMassSpectrumFilter;
 	public static String scanMassSpectrumFilter;
 	public static String massSpectrumFilter;
+	public static String massSpectrumIdentifier;
 	public static String system;
 	public static String userMethods;
 	public static String userInterface;
@@ -47,7 +48,7 @@ public class Messages extends NLS {
 	public static String procedures;
 	public static String identifier;
 	public static String export;
-	//
+
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/l10n/messages.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/l10n/messages.properties
@@ -24,6 +24,7 @@ userInterface=User Interface
 filter=Filter
 massSpectrum=Mass Spectrum
 massSpectrumFilter=Mass Spectrum Filter
+massSpectrumIdentifier=Mass Spectrum Identifier
 procedures=Procedures
 identifier=Identifier
 export=Export

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
@@ -192,7 +192,7 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 			return false;
 		}
 
-		return supplier.getCategory() == ICategories.SCAN_IDENTIFIER;
+		return supplier.getCategory() == ICategories.MASS_SPECTRUM_IDENTIFIER;
 	}
 
 	private void addCommand(IProcessSupplier<?> supplier, IChartMenuEntry cachedEntry) {


### PR DESCRIPTION
This was regressed during https://github.com/eclipse-chemclipse/chemclipse/commit/e6d92a9abb16e4601300e29fbcce992a2b7c913b where they both got assigned the same category string.