### PR TITLE
Remove unused adapter interface from chromatogram and ion

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractChromatogram.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractChromatogram.java
@@ -44,7 +44,6 @@ import org.eclipse.chemclipse.support.history.EditHistory;
 import org.eclipse.chemclipse.support.history.IEditHistory;
 import org.eclipse.chemclipse.support.model.SeparationColumnType;
 import org.eclipse.core.runtime.ISafeRunnable;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.SafeRunner;
 
 public abstract class AbstractChromatogram extends AbstractMeasurementTarget implements IChromatogram {
@@ -528,13 +527,6 @@ public abstract class AbstractChromatogram extends AbstractMeasurementTarget imp
 		}
 		//
 		list.addAll(scans);
-	}
-
-	@Override
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	public Object getAdapter(Class adapter) {
-
-		return Platform.getAdapterManager().getAdapter(this, adapter);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IChromatogram.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IChromatogram.java
@@ -25,9 +25,8 @@ import org.eclipse.chemclipse.model.support.IScanRange;
 import org.eclipse.chemclipse.model.targets.ITargetDisplaySettings;
 import org.eclipse.chemclipse.model.updates.IUpdater;
 import org.eclipse.chemclipse.support.history.ISupplierEditHistory;
-import org.eclipse.core.runtime.IAdaptable;
 
-public interface IChromatogram extends SegmentedMeasurement, IMeasurement, IChromatogramOverview, IAdaptable, IChromatogramPeaks, ISupplierEditHistory, IChromatogramBaseline, IUpdater, IChromatogramIntegrationSupport, IChromatogramProcessorSupport, ITargetSupplier, ITargetDisplaySettings {
+public interface IChromatogram extends SegmentedMeasurement, IMeasurement, IChromatogramOverview, IChromatogramPeaks, ISupplierEditHistory, IChromatogramBaseline, IUpdater, IChromatogramIntegrationSupport, IChromatogramProcessorSupport, ITargetSupplier, ITargetDisplaySettings {
 
 	String DEFAULT_CHROMATOGRAM_NAME = "Chromatogram";
 	int MIN_SCANDELAY = 0;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -12,7 +12,6 @@
 package org.eclipse.chemclipse.msd.model.core;
 
 import org.eclipse.chemclipse.model.math.IonRoundMethod;
-import org.eclipse.core.runtime.Platform;
 
 /**
  * All ions implement the interface Serializable to enable an
@@ -212,13 +211,6 @@ public abstract class AbstractIon implements IIon {
 	public int compareTo(IIon other) {
 
 		return (int)(this.ion - other.getIon());
-	}
-
-	@Override
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	public Object getAdapter(Class adapter) {
-
-		return Platform.getAdapterManager().getAdapter(this, adapter);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IIon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -10,8 +10,6 @@
  * Dr. Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.core;
-
-import org.eclipse.core.runtime.IAdaptable;
 
 /**
  * This Interface declares a simple ion.<br/>
@@ -37,7 +35,7 @@ import org.eclipse.core.runtime.IAdaptable;
  * @author Philip Wenig
  * @author Alexander Kerner
  */
-public interface IIon extends IIonSerializable, IAdaptable, Comparable<IIon> {
+public interface IIon extends IIonSerializable, Comparable<IIon> {
 
 	String TIC_DESCRIPTION = "TIC";
 	double TIC_ION = 0.0d;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IStandaloneMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IStandaloneMassSpectrum.java
@@ -34,7 +34,6 @@ public interface IStandaloneMassSpectrum extends IRegularMassSpectrum {
 
 	/**
 	 * Set the file of the mass spectrum, e.g. if it is a MALDI-MS record.
-	 * If it's a GC/MS run, file is not needed cause the chromatogram holds the scans.
 	 * 
 	 * @param file
 	 */


### PR DESCRIPTION
Careful putting too much stuff onto ion as it is a very frequently occurring object. 