### PR TITLE
Optimize virtual machine arguments

### DIFF
--- a/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
+++ b/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
@@ -23,6 +23,7 @@
 -Dosgi.instance.area=@user.home/ChemClipse/0.8.x
 -Dosgi.user.area=@user.home/.chemclipse/0.8.x
 -XX:+UseG1GC
+-XX:+UseStringDeduplication
 --add-modules=ALL-SYSTEM
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread

--- a/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
+++ b/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
@@ -22,6 +22,7 @@
 -Dapplication.version=0.8.x
 -Dosgi.instance.area=@user.home/ChemClipse/0.8.x
 -Dosgi.user.area=@user.home/.chemclipse/0.8.x
+-XX:+UseG1GC
 --add-modules=ALL-SYSTEM
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread

--- a/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
+++ b/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
@@ -22,7 +22,6 @@
 -Dapplication.version=0.8.x
 -Dosgi.instance.area=@user.home/ChemClipse/0.8.x
 -Dosgi.user.area=@user.home/.chemclipse/0.8.x
--XX:-UseGCOverheadLimit
 --add-modules=ALL-SYSTEM
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread

--- a/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
+++ b/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
@@ -18,9 +18,7 @@
       </programArgs>
       <programArgsLin>--launcher.GTK_version 3
       </programArgsLin>
-      <vmArgs>-Xms512M
--Xmx2G
--Dapplication.name=ChemClipse
+      <vmArgs>-Dapplication.name=ChemClipse
 -Dapplication.version=0.8.x
 -Dosgi.instance.area=@user.home/ChemClipse/0.8.x
 -Dosgi.user.area=@user.home/.chemclipse/0.8.x

--- a/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
+++ b/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
@@ -28,6 +28,8 @@
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread
       </vmArgsMac>
+      <vmArgsWin>-Djavax.net.ssl.trustStoreType=Windows-ROOT -Djavax.net.ssl.trustStore=NONE
+      </vmArgsWin>
    </launcherArgs>
 
    <windowImages i16="/org.eclipse.chemclipse.rcp.compilation.community.ui/icons/logo_16x16.png" i32="/org.eclipse.chemclipse.rcp.compilation.community.ui/icons/logo_32x32.png" i48="/org.eclipse.chemclipse.rcp.compilation.community.ui/icons/logo_48x48.png" i64="/org.eclipse.chemclipse.rcp.compilation.community.ui/icons/logo_64x64.png" i128="/org.eclipse.chemclipse.rcp.compilation.community.ui/icons/logo_128x128.png"/>


### PR DESCRIPTION
This aligns it with https://github.com/eclipse-packaging/packages/issues/37 as the current JVM is pretty good at automatically managing its RAM requirements so it requires less user actions. We can also drop the overhead limit because ideally the user should not see it anymore only when you exceed physical limits, and then you definitely should see an error because you are overdoing it.

Another thing is string deduplication https://github.com/eclipse-packaging/packages/commit/f8e5b7db6b900634e7c00dd3b4700e5f2a0dcaed which is said to be helpful for large XML files used internally by Eclipse for the extension registry.

For the online functionality (PubChem/Wikidata) to work on Windows with SSL inspection enabled in the company firewall, default to the Windows certificate store. https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/929