### PR TITLE
Fix key bindings for processor commands

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -610,6 +610,9 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 
 		Command command = commandService.getCommand(supplier.getId());
 		Category category = commandService.getCategory(supplier.getCategory());
+		if(!category.isDefined()) {
+			category.define(supplier.getCategory(), "");
+		}
 		command.define(supplier.getName(), supplier.getDescription(), category);
 		command.setHandler(new DynamicHandler(cachedEntry, chromatogramChartControl.get()));
 		addMainMenu(supplier, command);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -199,6 +199,8 @@ import org.eclipse.swtchart.extensions.menu.ResetChartHandler;
 import org.eclipse.swtchart.extensions.model.ICustomSeries;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
+import org.eclipse.ui.internal.keys.model.KeyController;
+import org.eclipse.ui.keys.IBindingService;
 
 public class ExtendedChromatogramUI extends Composite implements IToolbarConfig, IExtendedPartUI {
 
@@ -604,6 +606,7 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 			IChartMenuEntry cachedEntry = new ProcessorSupplierMenuEntry<>(supplier, processTypeSupport, this::executeSupplier);
 			addCommand(supplier, cachedEntry);
 		}
+		restoreKeyBindingsFromSettings();
 	}
 
 	private void addCommand(IProcessSupplier<?> supplier, IChartMenuEntry cachedEntry) {
@@ -616,6 +619,15 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 		command.define(supplier.getName(), supplier.getDescription(), category);
 		command.setHandler(new DynamicHandler(cachedEntry, chromatogramChartControl.get()));
 		addMainMenu(supplier, command);
+	}
+
+	@SuppressWarnings("restriction")
+	private void restoreKeyBindingsFromSettings() {
+
+		IBindingService bindingService = PlatformUI.getWorkbench().getService(IBindingService.class);
+		KeyController keyController = new KeyController();
+		keyController.init(PlatformUI.getWorkbench());
+		keyController.saveBindings(bindingService);
 	}
 
 	private void addMainMenu(IProcessSupplier<?> supplier, Command command) {


### PR DESCRIPTION
Go to `Window` → `Preferences` then `General` → `Keys`.
* The ChemClipse commands now have a category set.
* When you add a binding, close the editor or restart the application, the key binding is no longer forgotten.