### PR TITLE
Fix peaks not getting sorted by retention time when creating an RI calibration file

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/PagePeakAssignment.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/PagePeakAssignment.java
@@ -65,7 +65,7 @@ import org.eclipse.swt.widgets.Text;
 public class PagePeakAssignment extends AbstractExtendedWizardPage {
 
 	private static final Logger logger = Logger.getLogger(PagePeakAssignment.class);
-	//
+
 	private RetentionIndexWizardElements wizardElements;
 	private PeakTableRetentionIndexViewerUI peakTableViewerUI;
 	private PeakTargetsViewerUI targetsViewerUI;
@@ -75,9 +75,9 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 	private Button buttonNext;
 	private String[] availableStandards;
 	private int indexSelectedStandard;
-	//
+
 	private String databaseName;
-	//
+
 	private static final int ACTION_INCREASE_INDEX = 1;
 	private static final int ACTION_DECREASE_INDEX = 2;
 
@@ -88,7 +88,7 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 		setDescription("Please assign the alkanes.");
 		this.wizardElements = wizardElements;
 		availableStandards = wizardElements.getAvailableStandards();
-		//
+
 		File file = new File(AlkaneIdentifier.getDatabase());
 		databaseName = file.getName();
 	}
@@ -132,7 +132,7 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 				peaks.sort(new PeakRetentionTimeComparator());
 				peakTableViewerUI.setInput(peaks);
 				peakTableViewerUI.getTable().setSelection(0);
-				//
+
 				if(!peaks.isEmpty()) {
 					IPeak peak = peaks.get(0);
 					Set<IIdentificationTarget> targets = peak.getTargets();
@@ -143,7 +143,7 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 				peakTableViewerUI.setInput(null);
 				textCurrentIndexName.setText("");
 			}
-			//
+
 			updateLabel();
 			validateSelection();
 		}
@@ -154,14 +154,14 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 
 		Composite composite = new Composite(parent, SWT.NONE);
 		composite.setLayout(new GridLayout(3, false));
-		//
+
 		createRetentionIndexField(composite);
 		createAutoAssignField(composite);
 		createPeakTableField(composite);
 		createTargetSpinnerField(composite);
 		createAssignIndexField(composite);
 		createPeakTargetsField(composite);
-		//
+
 		validateSelection();
 		setControl(composite);
 	}
@@ -174,10 +174,10 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 		gridDataComposite.horizontalSpan = 3;
 		composite.setLayoutData(gridDataComposite);
 		composite.setLayout(new GridLayout(2, true));
-		//
+
 		Combo comboStartIndex = createComboStartIndex(composite);
 		Combo comboStopIndex = createComboStopIndex(composite);
-		//
+
 		labelIndexRange = createLabelIndexRange(composite);
 		/*
 		 * Auto-Complete
@@ -192,7 +192,7 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 		combo.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		combo.setItems(availableStandards);
 		combo.setToolTipText("Start Index");
-		//
+
 		combo.addModifyListener(new ModifyListener() {
 
 			@Override
@@ -201,7 +201,7 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 				setStartIndexName(combo);
 			}
 		});
-		//
+
 		return combo;
 	}
 
@@ -217,7 +217,7 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 		combo.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		combo.setItems(availableStandards);
 		combo.setToolTipText("Stop Index");
-		//
+
 		combo.addModifyListener(new ModifyListener() {
 
 			@Override
@@ -226,7 +226,7 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 				setStopIndexName(combo);
 			}
 		});
-		//
+
 		return combo;
 	}
 
@@ -244,7 +244,7 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 		gridDataLabel.grabExcessHorizontalSpace = true;
 		gridDataLabel.horizontalSpan = 2;
 		label.setLayoutData(gridDataLabel);
-		//
+
 		return label;
 	}
 
@@ -254,7 +254,7 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 		button.setText("Auto Assign Standards");
 		button.setToolTipText("Automatically assign the selected index range.");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EXECUTE, IApplicationImageProvider.SIZE_16x16));
-		//
+
 		GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
 		gridData.horizontalSpan = 3;
 		button.setLayoutData(gridData);
@@ -272,7 +272,7 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 						IChromatogram chromatogram = chromatogramSelection.getChromatogram();
 						List<? extends IPeak> chromatogramPeaks = chromatogram.getPeaks();
 						List<String> selectedIndices = wizardElements.getSelectedIndices();
-						//
+
 						if(chromatogramPeaks.size() == selectedIndices.size()) {
 							for(int i = 0; i < chromatogramPeaks.size(); i++) {
 								IPeak chromatogramPeak = chromatogramPeaks.get(i);
@@ -332,13 +332,13 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 				setCurrentIndexName(ACTION_DECREASE_INDEX);
 			}
 		});
-		//
+
 		textCurrentIndexName = new Text(parent, SWT.BORDER);
 		textCurrentIndexName.setText("");
 		GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
 		gridData.grabExcessHorizontalSpace = true;
 		textCurrentIndexName.setLayoutData(gridData);
-		//
+
 		buttonNext = new Button(parent, SWT.PUSH);
 		buttonNext.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_NEXT, IApplicationImageProvider.SIZE_16x16));
 		buttonNext.addSelectionListener(new SelectionAdapter() {
@@ -381,7 +381,7 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 		if(deleteOtherTargets) {
 			peak.getTargets().clear();
 		}
-		//
+
 		try {
 			float factor = 100.0f;
 			IPeakLibraryInformation libraryInformation = new PeakLibraryInformation();
@@ -488,7 +488,7 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 				}
 				break;
 		}
-		//
+
 		textCurrentIndexName.setText(availableStandards[indexSelectedStandard]);
 	}
 
@@ -592,7 +592,7 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 				return list.toArray(new IContentProposal[0]);
 			}
 		};
-		//
+
 		autoComplete(combo, proposalProvider);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/PagePeakAssignment.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/PagePeakAssignment.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.impl.AlkaneIdentifier;
 import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.model.comparator.PeakRetentionTimeComparator;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.exceptions.ReferenceMustNotBeNullException;
@@ -128,6 +129,7 @@ public class PagePeakAssignment extends AbstractExtendedWizardPage {
 				 */
 				IChromatogram chromatogram = chromatogramSelection.getChromatogram();
 				List<? extends IPeak> peaks = chromatogram.getPeaks();
+				peaks.sort(new PeakRetentionTimeComparator());
 				peakTableViewerUI.setInput(peaks);
 				peakTableViewerUI.getTable().setSelection(0);
 				//

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/comparator/PeakRetentionTimeComparator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/comparator/PeakRetentionTimeComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 Lablicate GmbH.
+ * Copyright (c) 2013, 2025 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,10 +21,12 @@ public class PeakRetentionTimeComparator implements Comparator<IPeak> {
 	private SortOrder sortOrder;
 
 	public PeakRetentionTimeComparator() {
+
 		sortOrder = SortOrder.ASC;
 	}
 
 	public PeakRetentionTimeComparator(SortOrder sortOrder) {
+
 		this.sortOrder = sortOrder;
 	}
 
@@ -33,7 +35,7 @@ public class PeakRetentionTimeComparator implements Comparator<IPeak> {
 
 		int retentionTime1 = peak1.getPeakModel().getRetentionTimeAtPeakMaximum();
 		int retentionTime2 = peak2.getPeakModel().getRetentionTimeAtPeakMaximum();
-		//
+
 		int returnValue;
 		switch(sortOrder) {
 			case ASC:


### PR DESCRIPTION
It uses the order in which the peaks were detected, which might differ if some were added/removed manually in the editor. I think this problem was introduced in https://github.com/eclipse-chemclipse/chemclipse/pull/2068 as `PeakRTMap` (now `PeakRetentionTimeMap`) is longer used for storage in all cases.