### PR TITLE
Allow subtraction of library spectra

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/ComparisonScanChartPart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/ComparisonScanChartPart.java
@@ -65,7 +65,7 @@ public class ComparisonScanChartPart extends AbstractPart<ExtendedComparisonScan
 					} else if(object instanceof IPeakMSD peakMSD) {
 						identificationTarget = IIdentificationTarget.getIdentificationTarget(peakMSD);
 					}
-					//
+
 					if(identificationTarget != null) {
 						getControl().update(scan, identificationTarget);
 						return true;
@@ -77,7 +77,7 @@ public class ComparisonScanChartPart extends AbstractPart<ExtendedComparisonScan
 					if(object instanceof Object[] values) {
 						Object object1 = values[0];
 						Object object2 = values[1];
-						//
+
 						if(object1 instanceof IScanMSD unknownMassSpectrum && object2 instanceof IIdentificationTarget identificationTarget) {
 							getControl().update(unknownMassSpectrum, identificationTarget);
 						}
@@ -86,7 +86,7 @@ public class ComparisonScanChartPart extends AbstractPart<ExtendedComparisonScan
 					if(object instanceof Object[] values) {
 						Object object1 = values[0];
 						Object object2 = values[1];
-						//
+
 						if(object1 instanceof IScanMSD unknownMassSpectrum && object2 instanceof IScanMSD referenceMassSpectrum) {
 							getControl().update(unknownMassSpectrum, referenceMassSpectrum);
 						}
@@ -94,7 +94,7 @@ public class ComparisonScanChartPart extends AbstractPart<ExtendedComparisonScan
 				}
 			}
 		}
-		//
+
 		return false;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/SubtractScanPart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/SubtractScanPart.java
@@ -65,7 +65,6 @@ public class SubtractScanPart extends AbstractPart<ExtendedSubtractScanUI> {
 							getControl().update(objectSelection);
 						}
 					}
-					//
 					return true;
 				} else if(IChemClipseEvents.TOPIC_CHROMATOGRAM_XXD_UPDATE_SELECTION.equals(topic)) {
 					if(object instanceof IChromatogramSelectionMSD) {
@@ -80,7 +79,7 @@ public class SubtractScanPart extends AbstractPart<ExtendedSubtractScanUI> {
 				}
 			}
 		}
-		//
+
 		return false;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/SubtractScanPart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/SubtractScanPart.java
@@ -13,6 +13,7 @@ package org.eclipse.chemclipse.ux.extension.xxd.ui.parts;
 
 import java.util.List;
 
+import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.support.events.IChemClipseEvents;
@@ -71,6 +72,11 @@ public class SubtractScanPart extends AbstractPart<ExtendedSubtractScanUI> {
 						getControl().update(object);
 						return true;
 					}
+				} else if(IChemClipseEvents.TOPIC_PEAK_XXD_UPDATE_SELECTION.equals(topic)) {
+					if(object instanceof IPeakMSD) {
+						getControl().update(object);
+						return true;
+					}
 				}
 			}
 		}
@@ -81,7 +87,7 @@ public class SubtractScanPart extends AbstractPart<ExtendedSubtractScanUI> {
 	@Override
 	protected boolean isUpdateTopic(String topic) {
 
-		return isSessionSubtractTopic(topic) || isChromatogramTopic(topic) || isCloseEvent(topic);
+		return isSessionSubtractTopic(topic) || isChromatogramTopic(topic) || isPeakTopic(topic) || isCloseEvent(topic);
 	}
 
 	private boolean isSessionSubtractTopic(String topic) {
@@ -92,6 +98,11 @@ public class SubtractScanPart extends AbstractPart<ExtendedSubtractScanUI> {
 	private boolean isChromatogramTopic(String topic) {
 
 		return IChemClipseEvents.TOPIC_CHROMATOGRAM_XXD_UPDATE_SELECTION.equals(topic);
+	}
+
+	private boolean isPeakTopic(String topic) {
+
+		return IChemClipseEvents.TOPIC_PEAK_XXD_UPDATE_SELECTION.equals(topic);
 	}
 
 	private boolean isCloseEvent(String topic) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedComparisonScanUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedComparisonScanUI.java
@@ -63,13 +63,13 @@ import jakarta.inject.Inject;
 public class ExtendedComparisonScanUI extends Composite implements IExtendedPartUI {
 
 	private static final Logger logger = Logger.getLogger(ExtendedComparisonScanUI.class);
-	//
+
 	private static final float NORMALIZATION_FACTOR = 1000.0f;
-	//
+
 	private static final String OPTION_UPDATE_SCAN_1 = "UPDATE_SCAN_1";
 	private static final String OPTION_UPDATE_SCAN_2 = "UPDATE_SCAN_2";
 	private static final String OPTION_LIBRARY_SEARCH = "LIBRARY_SEARCH";
-	//
+
 	private static final String PREFIX_U = "[U]";
 	private static final String PREFIX_R = "[R]";
 	private static final String PREFIX_UR = "[U-R]";
@@ -79,7 +79,7 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 	private static final String TITLE_REFERENCE = "REFERENCE MS";
 	private static final String POSTFIX_NONE = "";
 	private static final String POSTFIX_SHIFTED = " SHIFTED (+1)";
-	//
+
 	private AtomicReference<Button> buttonOptimizedScan = new AtomicReference<>();
 	private AtomicReference<Button> buttonToolbarInfo = new AtomicReference<>();
 	private AtomicReference<InformationUI> toolbarInfoTop = new AtomicReference<>();
@@ -87,17 +87,17 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 	private AtomicReference<ScanChartUI> scanChartControl = new AtomicReference<>();
 	private AtomicReference<Button> buttonToolbarEdit = new AtomicReference<>();
 	private AtomicReference<Composite> toolbarEdit = new AtomicReference<>();
-	//
+
 	private IScanMSD scan1 = null;
 	private IScanMSD scan2 = null;
 	private IScanMSD scan1Optimized = null;
 	private IScanMSD scan2Optimized = null;
-	//
+
 	private String displayOption = OPTION_LIBRARY_SEARCH;
 	private boolean displayDifference = false;
 	private boolean displayMirrored = true;
 	private boolean displayShifted = false;
-	//
+
 	private final ScanDataSupport scanDataSupport = new ScanDataSupport();
 
 	@Inject
@@ -281,10 +281,10 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 
 		IScanMSD firstScan = (scan1Optimized != null) ? scan1Optimized : scan1;
 		IScanMSD secondScan = (scan2Optimized != null) ? scan2Optimized : scan2;
-		//
+
 		toolbarInfoTop.get().setText(scanDataSupport.getMassSpectrumLabel(firstScan, PREFIX_U, TITLE_UNKNOWN, POSTFIX_NONE));
 		toolbarInfoBottom.get().setText(scanDataSupport.getMassSpectrumLabel(secondScan, PREFIX_R, TITLE_REFERENCE, shifted ? POSTFIX_SHIFTED : POSTFIX_NONE));
-		//
+
 		if(shifted) {
 			IScanMSD scan2Shifted = new ScanMSD();
 			IExtractedIonSignal extractedIonSignalScan2 = secondScan.getExtractedIonSignal();
@@ -306,18 +306,18 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 
 		IScanMSD firstScan = (scan1Optimized != null) ? scan1Optimized : scan1;
 		IScanMSD secondScan = (scan2Optimized != null) ? scan2Optimized : scan2;
-		//
+
 		toolbarInfoTop.get().setText(scanDataSupport.getMassSpectrumLabel(firstScan, PREFIX_UR, TITLE_UNKNOWN, POSTFIX_NONE));
 		toolbarInfoBottom.get().setText(scanDataSupport.getMassSpectrumLabel(secondScan, PREFIX_UR, TITLE_REFERENCE, shifted ? POSTFIX_SHIFTED : POSTFIX_NONE));
-		//
+
 		IExtractedIonSignal extractedIonSignalReference = firstScan.getExtractedIonSignal();
 		IExtractedIonSignal extractedIonSignalComparison = secondScan.getExtractedIonSignal();
 		int startIon = (extractedIonSignalReference.getStartIon() < extractedIonSignalComparison.getStartIon()) ? extractedIonSignalReference.getStartIon() : extractedIonSignalComparison.getStartIon();
 		int stopIon = (extractedIonSignalReference.getStopIon() > extractedIonSignalComparison.getStopIon()) ? extractedIonSignalReference.getStopIon() : extractedIonSignalComparison.getStopIon();
-		//
+
 		IScanMSD scanDifference1 = new ScanMSD();
 		IScanMSD scanDifference2 = new ScanMSD();
-		//
+
 		for(int ion = startIon; ion <= stopIon; ion++) {
 			float abundance = extractedIonSignalReference.getAbundance(ion) - extractedIonSignalComparison.getAbundance(ion);
 			if(abundance > 0) {
@@ -331,7 +331,7 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 				}
 			}
 		}
-		//
+
 		scanChartControl.get().setInput(scanDifference1, scanDifference2, mirrored);
 	}
 
@@ -339,7 +339,7 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 
 		toolbarInfoTop.get().setText("");
 		toolbarInfoBottom.get().setText("");
-		//
+
 		if(scan1 != null) {
 			IScanMSD firstScan = (scan1Optimized != null) ? scan1Optimized : scan1;
 			toolbarInfoTop.get().setText(scanDataSupport.getMassSpectrumLabel(firstScan, PREFIX_U, TITLE_UNKNOWN, POSTFIX_NONE));
@@ -363,13 +363,13 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 	private void createControl() {
 
 		setLayout(new GridLayout(1, true));
-		//
+
 		createToolbarMain(this);
 		createToolbarInfoTop(this);
 		createToolbarOptions(this);
 		createScanChart(this);
 		createToolbarInfoBottom(this);
-		//
+
 		initialize();
 	}
 
@@ -387,7 +387,7 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 		gridData.horizontalAlignment = SWT.END;
 		composite.setLayoutData(gridData);
 		composite.setLayout(new GridLayout(6, false));
-		//
+
 		createButtonToggleInfo(composite);
 		createButtonToggleEdit(composite);
 		createResetButton(composite);
@@ -412,11 +412,11 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 		GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
 		composite.setLayoutData(gridData);
 		composite.setLayout(new GridLayout(3, false));
-		//
+
 		createUpdateGroup(composite);
 		createDisplayGroup(composite);
 		createMirrorOptionSection(composite);
-		//
+
 		toolbarEdit.set(composite);
 	}
 
@@ -428,7 +428,7 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 		group.setToolTipText("Select the display option.");
 		group.setLayout(new RowLayout(SWT.HORIZONTAL));
 		group.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		//
+
 		Button updateScan1 = new Button(group, SWT.RADIO);
 		updateScan1.setText("Scan 1");
 		updateScan1.setSelection(displayOption.equals(OPTION_UPDATE_SCAN_1));
@@ -441,7 +441,7 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 				updateChart();
 			}
 		});
-		//
+
 		Button updateScan2 = new Button(group, SWT.RADIO);
 		updateScan2.setText("Scan 2");
 		updateScan2.setSelection(displayOption.equals(OPTION_UPDATE_SCAN_2));
@@ -454,7 +454,7 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 				updateChart();
 			}
 		});
-		//
+
 		Button updateLibraryScan = new Button(group, SWT.RADIO);
 		updateLibraryScan.setText("Library Search");
 		updateLibraryScan.setSelection(displayOption.equals(OPTION_LIBRARY_SEARCH));
@@ -478,7 +478,7 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 		group.setText("");
 		group.setLayout(new RowLayout(SWT.HORIZONTAL));
 		group.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		//
+
 		Button buttonNormalModus = new Button(group, SWT.RADIO);
 		buttonNormalModus.setText(LABEL_UR_NORMAL);
 		buttonNormalModus.setToolTipText("Use the normal modus.");
@@ -492,7 +492,7 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 				updateChart();
 			}
 		});
-		//
+
 		Button buttonDifferenceModus = new Button(group, SWT.RADIO);
 		buttonDifferenceModus.setText(LABEL_UR_DIFFERENCE);
 		buttonDifferenceModus.setToolTipText("Use the difference modus.");
@@ -515,7 +515,7 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 		gridData.horizontalAlignment = SWT.END;
 		composite.setLayoutData(gridData);
 		composite.setLayout(new GridLayout(2, false));
-		//
+
 		Button buttonMirrored = new Button(composite, SWT.PUSH);
 		buttonMirrored.setText("");
 		buttonMirrored.setToolTipText("Set whether the data shall be displayed normal or mirrored.");
@@ -530,7 +530,7 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 				updateChart();
 			}
 		});
-		//
+
 		Button buttonShifted = new Button(composite, SWT.PUSH);
 		buttonShifted.setText("");
 		buttonShifted.setToolTipText("Set whether the data shall be shifted or not.");
@@ -551,7 +551,7 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 
 		ScanChartUI scanChartUI = new ScanChartUI(parent, SWT.BORDER);
 		scanChartUI.setLayoutData(new GridData(GridData.FILL_BOTH));
-		//
+
 		scanChartControl.set(scanChartUI);
 	}
 
@@ -569,7 +569,7 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 
 		InformationUI informationUI = new InformationUI(parent, SWT.NONE);
 		informationUI.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		//
+
 		return informationUI;
 	}
 
@@ -637,7 +637,7 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 					if(scan2 != null && scan2.getOptimizedMassSpectrum() != null) {
 						scan2Optimized = scan2.getOptimizedMassSpectrum().makeDeepCopy().normalize(NORMALIZATION_FACTOR);
 					}
-					//
+
 					button.setEnabled(false);
 					updateChart();
 				} catch(CloneNotSupportedException e) {
@@ -645,7 +645,7 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 				}
 			}
 		});
-		//
+
 		buttonOptimizedScan.set(button);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSubtractScanUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSubtractScanUI.java
@@ -66,14 +66,13 @@ import jakarta.inject.Inject;
 public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI {
 
 	private static final Logger logger = Logger.getLogger(ExtendedSubtractScanUI.class);
-	//
+
 	private TabFolder tabFolder;
 	private ScanChartUI scanChartUI;
 	private ExtendedScanTableUI extendedScanTableUI;
-	//
+
 	private AtomicReference<Button> buttonSelectedScanControl = new AtomicReference<>();
 	private AtomicReference<Button> buttonCombinedScanControl = new AtomicReference<>();
-	//
 	private AtomicReference<Button> buttonComparisonScanControl = new AtomicReference<>();
 
 	private IScanMSD scanMSD = null;
@@ -107,21 +106,21 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 		} else if(object == null) {
 			chromatogramSelectionMSD = null;
 		}
-		//
+
 		updateScanData(scanMSD);
 	}
 
 	private void createControl() {
 
 		setLayout(new FillLayout());
-		//
+
 		Composite composite = new Composite(this, SWT.NONE);
 		GridLayout layout = new GridLayout(1, true);
 		composite.setLayout(layout);
-		//
+
 		createToolbarMain(composite);
 		createScanTabFolderSection(composite);
-		//
+
 		loadSessionMassSpectrum(composite.getDisplay());
 		updateWidgets();
 	}
@@ -132,7 +131,6 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 		GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
 		gridData.horizontalAlignment = SWT.END;
 		composite.setLayoutData(gridData);
-		//
 		composite.setLayout(new GridLayout(7, false));
 
 		createAddSelectedScanButton(composite);
@@ -149,7 +147,7 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 		Composite composite = new Composite(parent, SWT.NONE);
 		composite.setLayoutData(new GridData(GridData.FILL_BOTH));
 		composite.setLayout(new GridLayout(1, true));
-		//
+
 		tabFolder = new TabFolder(composite, SWT.BOTTOM);
 		tabFolder.setBackground(getDisplay().getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
 		tabFolder.setLayoutData(new GridData(GridData.FILL_BOTH));
@@ -161,7 +159,7 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 				updateScanData(scanMSD);
 			}
 		});
-		//
+
 		createScanChart(tabFolder);
 		createScanTable(tabFolder);
 	}
@@ -173,7 +171,7 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 		Composite composite = new Composite(tabFolder, SWT.NONE);
 		composite.setLayout(new GridLayout(1, true));
 		tabItem.setControl(composite);
-		//
+
 		scanChartUI = new ScanChartUI(composite, SWT.BORDER);
 		scanChartUI.setLayoutData(new GridData(GridData.FILL_BOTH));
 	}
@@ -186,12 +184,12 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 		composite.setBackground(getDisplay().getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
 		composite.setLayout(new GridLayout(1, true));
 		tabItem.setControl(composite);
-		//
+
 		extendedScanTableUI = new ExtendedScanTableUI(composite, SWT.NONE);
 		extendedScanTableUI.setLayoutData(new GridData(GridData.FILL_BOTH));
 		extendedScanTableUI.forceEnableEditModus(true);
 		extendedScanTableUI.setFireUpdate(false);
-		//
+
 		extendedScanTableUI.addEditListener(new EditListener() {
 
 			@Override
@@ -225,7 +223,7 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 				}
 			}
 		});
-		//
+
 		buttonSelectedScanControl.set(button);
 	}
 
@@ -250,7 +248,7 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 				}
 			}
 		});
-		//
+
 		buttonCombinedScanControl.set(button);
 	}
 
@@ -315,7 +313,6 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 				messageBox.setText("Clear Session");
 				messageBox.setMessage("Would you like to clear the session subtract scan?");
 				if(messageBox.open() == SWT.YES) {
-					//
 					scanMSD = null;
 					updateScanData(scanMSD);
 					saveSessionMassSpectrum(e.display, null);
@@ -345,7 +342,7 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 				clipboard.dispose();
 			}
 		});
-		//
+
 		return button;
 	}
 
@@ -407,7 +404,7 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 				extendedScanTableUI.setInput(scanMSD);
 			}
 		}
-		//
+
 		updateWidgets();
 	}
 
@@ -427,7 +424,7 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 
 		PreferenceSupplierModelMSD.setSessionSubtractMassSpectrum(scanMSD);
 		PreferenceSupplierModelMSD.storeSessionSubtractMassSpectrum();
-		//
+
 		if(display != null) {
 			fireUpdateEvent(display);
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSubtractScanUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSubtractScanUI.java
@@ -12,11 +12,16 @@
 package org.eclipse.chemclipse.ux.extension.xxd.ui.swt;
 
 import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import org.eclipse.chemclipse.converter.exceptions.NoConverterAvailableException;
 import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.support.CalculationType;
+import org.eclipse.chemclipse.model.targets.TargetSupport;
+import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
@@ -26,13 +31,20 @@ import org.eclipse.chemclipse.msd.swt.ui.support.DatabaseFileSupport;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
 import org.eclipse.chemclipse.support.events.IChemClipseEvents;
+import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
 import org.eclipse.chemclipse.swt.ui.notifier.UpdateNotifierUI;
 import org.eclipse.chemclipse.ux.extension.ui.swt.IExtendedPartUI;
 import org.eclipse.chemclipse.ux.extension.ui.swt.ISettingsHandler;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.preferences.PreferenceSupplierModelMSD;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageScans;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageSubtract;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.runnables.LibraryServiceRunnable;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.e4.ui.di.Focus;
+import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.Clipboard;
 import org.eclipse.swt.dnd.TextTransfer;
@@ -62,7 +74,10 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 	private AtomicReference<Button> buttonSelectedScanControl = new AtomicReference<>();
 	private AtomicReference<Button> buttonCombinedScanControl = new AtomicReference<>();
 	//
+	private AtomicReference<Button> buttonComparisonScanControl = new AtomicReference<>();
+
 	private IScanMSD scanMSD = null;
+	private IPeakMSD peakMSD = null;
 	private IChromatogramSelectionMSD chromatogramSelectionMSD = null;
 
 	@Inject
@@ -87,6 +102,8 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 			this.chromatogramSelectionMSD = chromatogramSelectionMSD;
 		} else if(object instanceof IScanMSD scanMSD) {
 			this.scanMSD = scanMSD;
+		} else if(object instanceof IPeakMSD peakMSD) {
+			this.peakMSD = peakMSD;
 		} else if(object == null) {
 			chromatogramSelectionMSD = null;
 		}
@@ -115,10 +132,12 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 		GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
 		gridData.horizontalAlignment = SWT.END;
 		composite.setLayoutData(gridData);
-		composite.setLayout(new GridLayout(6, false));
 		//
+		composite.setLayout(new GridLayout(7, false));
+
 		createAddSelectedScanButton(composite);
 		createAddCombinedScanButton(composite);
+		createAddComparisonScanButton(composite);
 		createClearSessionButton(composite);
 		createButtonCopyTracesClipboard(composite);
 		createSaveButton(composite);
@@ -233,6 +252,53 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 		});
 		//
 		buttonCombinedScanControl.set(button);
+	}
+
+	private void createAddComparisonScanButton(Composite parent) {
+
+		Button button = new Button(parent, SWT.PUSH);
+		button.setToolTipText("Add comparison scan to subtract spectrum.");
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_COMPARISON_SCAN, IApplicationImage.SIZE_16x16));
+		button.addSelectionListener(new SelectionAdapter() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+
+				if(peakMSD != null && !peakMSD.getTargets().isEmpty()) {
+
+					IIdentificationTarget identificationTarget = TargetSupport.getBestIdentificationTarget(peakMSD);
+					LibraryServiceRunnable runnable = new LibraryServiceRunnable(identificationTarget, new Consumer<IScanMSD>() {
+
+						@Override
+						public void accept(IScanMSD referenceMassSpectrum) {
+
+							saveSessionMassSpectrum(e.display, referenceMassSpectrum);
+						}
+					});
+
+					try {
+						if(runnable.requireProgressMonitor()) {
+							DisplayUtils.executeInUserInterfaceThread(() -> {
+								ProgressMonitorDialog monitor = new ProgressMonitorDialog(getShell());
+								monitor.run(true, true, runnable);
+								return null;
+							});
+						} else {
+							DisplayUtils.executeBusy(() -> {
+								runnable.run(new NullProgressMonitor());
+								return null;
+							});
+						}
+					} catch(InterruptedException ex) {
+						Thread.currentThread().interrupt();
+					} catch(ExecutionException ex) {
+						Activator.getDefault().getLog().log(new Status(IStatus.ERROR, getClass().getName(), "Fetch comparison scan failed.", ex));
+					}
+				}
+			}
+		});
+
+		buttonComparisonScanControl.set(button);
 	}
 
 	private void createClearSessionButton(Composite parent) {


### PR DESCRIPTION
This is a step towards deconvoluting peaks by removing m/z of known targets to see what's left.