### PR TITLE
Fix metadata fields when reading from .msp

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.FilenameUtils;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
@@ -86,11 +87,13 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 	@Override
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
-		List<String> massSpectraData = getMassSpectraData(file);
-
-		IMassSpectra massSpectra = extractMassSpectra(massSpectraData, monitor);
+		IMassSpectra massSpectra = new MassSpectra();
 		massSpectra.setConverterId(CONVERTER_ID);
 		massSpectra.setName(file.getName());
+
+		List<String> massSpectraData = getMassSpectraData(file);
+		extractMassSpectra(massSpectra, massSpectraData, monitor);
+
 		/*
 		 * Compound Information (*.CID)
 		 */
@@ -170,14 +173,14 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 	}
 
 	/**
-	 * Returns a mass spectra object or null, if something has gone wrong.
+	 * Adds parsed mass spectra to the massSpectra object.
 	 * 
+	 * @param massSpectra
 	 * @param massSpectraData
-	 * @return IMassSpectra
+	 * @param monitor
 	 */
-	private IMassSpectra extractMassSpectra(List<String> massSpectraData, IProgressMonitor monitor) {
+	private void extractMassSpectra(IMassSpectra massSpectra, List<String> massSpectraData, IProgressMonitor monitor) {
 
-		IMassSpectra massSpectra = new MassSpectra();
 		String referenceIdentifierMarker = org.eclipse.chemclipse.msd.converter.preferences.PreferenceSupplier.getReferenceIdentifierMarker();
 		String referenceIdentifierPrefix = org.eclipse.chemclipse.msd.converter.preferences.PreferenceSupplier.getReferenceIdentifierPrefix();
 
@@ -189,7 +192,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 			monitor.beginTask("Extract mass spectra", massSpectraData.size());
 			for(String massSpectrumData : massSpectraData) {
 				if(monitor.isCanceled()) {
-					return massSpectra;
+					return;
 				}
 				addMassSpectrum(massSpectra, massSpectrumData, referenceIdentifierMarker, referenceIdentifierPrefix);
 				monitor.worked(1);
@@ -210,7 +213,6 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 				}
 			}
 		}
-		return massSpectra;
 	}
 
 	/**
@@ -223,6 +225,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 
 		IVendorLibraryMassSpectrum massSpectrum = new VendorLibraryMassSpectrum();
 		ILibraryInformation libraryInformation = massSpectrum.getLibraryInformation();
+		libraryInformation.setDatabase(FilenameUtils.removeExtension(massSpectra.getName()));
 		/*
 		 * Extract name and reference identifier.
 		 * Additionally, add the reference identifier if it is stored as a pattern.
@@ -250,7 +253,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 		libraryInformation.setCasNumber(casNumber);
 
 		String database = extractContentAsString(massSpectrumData, databaseNamePattern, 3);
-		libraryInformation.setDatabase(database);
+		libraryInformation.setReferenceIdentifier(database);
 
 		String inchiKey = extractContentAsString(massSpectrumData, inchiKeyPattern, 2);
 		libraryInformation.setInChIKey(inchiKey);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader.java
@@ -62,6 +62,10 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 	private static final Pattern casNumberPattern = Pattern.compile("(CAS(NO|#)?:[ ]+)([0-9-]*)", Pattern.CASE_INSENSITIVE);
 	private static final Pattern databaseNamePattern = Pattern.compile("(DB(NO|#)?:)(.*)", Pattern.CASE_INSENSITIVE);
 	private static final Pattern referenceIdentifierPattern = Pattern.compile("(REFID:)(.*)", Pattern.CASE_INSENSITIVE);
+
+	private static final Pattern inchiKeyPattern = Pattern.compile("(InChIKey:)(.*)", Pattern.CASE_INSENSITIVE);
+	private static final Pattern inchiPattern = Pattern.compile("(InChI:)(.*)", Pattern.CASE_INSENSITIVE);
+
 	private static final Pattern smilesPattern = Pattern.compile("(SMILES:)(.*)", Pattern.CASE_INSENSITIVE);
 	private static final Pattern retentionTimePattern = Pattern.compile("(RT:)(.*)", Pattern.CASE_INSENSITIVE);
 	private static final Pattern relativeRetentionTimePattern = Pattern.compile("(RRT:)(.*)", Pattern.CASE_INSENSITIVE);
@@ -247,6 +251,13 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 
 		String database = extractContentAsString(massSpectrumData, databaseNamePattern, 3);
 		libraryInformation.setDatabase(database);
+
+		String inchiKey = extractContentAsString(massSpectrumData, inchiKeyPattern, 2);
+		libraryInformation.setInChIKey(inchiKey);
+
+		String inchi = extractContentAsString(massSpectrumData, inchiPattern, 2);
+		libraryInformation.setInChI(inchi);
+
 		String smiles = extractContentAsString(massSpectrumData, smilesPattern, 2);
 		libraryInformation.setSmiles(smiles);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader.java
@@ -76,14 +76,14 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 	private static final Pattern exactMassPattern = Pattern.compile("(ExactMass:)(.*)", Pattern.CASE_INSENSITIVE);
 	private static final Pattern ionModePattern = Pattern.compile("(Ion_mode:)(.*)", Pattern.CASE_INSENSITIVE);
 	private static final Pattern spectrumTypePattern = Pattern.compile("(Spectrum_type:)(.*)", Pattern.CASE_INSENSITIVE);
-	//
+
 	private static final String RETENTION_INDICES_DELIMITER = ", ";
 
 	@Override
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
 		List<String> massSpectraData = getMassSpectraData(file);
-		//
+
 		IMassSpectra massSpectra = extractMassSpectra(massSpectraData, monitor);
 		massSpectra.setConverterId(CONVERTER_ID);
 		massSpectra.setName(file.getName());
@@ -107,7 +107,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 				ConverterMOL.transfer(moleculeStructureMap, massSpectra);
 			}
 		}
-		//
+
 		return massSpectra;
 	}
 
@@ -120,7 +120,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 
 		Charset charset = PreferenceSupplier.getCharsetImportMSP();
 		List<String> massSpectraData = new ArrayList<>();
-		//
+
 		try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(new FileInputStream(file), charset))) {
 			StringBuilder builder = new StringBuilder();
 			String line;
@@ -132,7 +132,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 				 * StringBuilder. In all other cases append the found lines to the
 				 * StringBuilder.
 				 */
-				if(line.length() == 0) {
+				if(line.isEmpty()) {
 					addMassSpectrumData(builder, massSpectraData);
 					builder = new StringBuilder();
 				} else {
@@ -145,7 +145,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 			 */
 			addMassSpectrumData(builder, massSpectraData);
 		}
-		//
+
 		return massSpectraData;
 	}
 
@@ -176,7 +176,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 		IMassSpectra massSpectra = new MassSpectra();
 		String referenceIdentifierMarker = org.eclipse.chemclipse.msd.converter.preferences.PreferenceSupplier.getReferenceIdentifierMarker();
 		String referenceIdentifierPrefix = org.eclipse.chemclipse.msd.converter.preferences.PreferenceSupplier.getReferenceIdentifierPrefix();
-		//
+
 		if(massSpectraData.size() > 1) {
 			/*
 			 * Iterates through the saved mass spectrum text data and converts it to
@@ -227,23 +227,29 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 		extractNameAndReferenceIdentifier(massSpectrum, name, referenceIdentifierMarker, referenceIdentifierPrefix);
 		String referenceIdentifier = extractContentAsString(massSpectrumData, referenceIdentifierPattern, 2);
 		massSpectrum.getLibraryInformation().setReferenceIdentifier(referenceIdentifier);
-		//
+
 		String formula = extractContentAsString(massSpectrumData, formulaPattern, 2);
 		libraryInformation.setFormula(formula);
+
 		double molWeight = extractContentAsDouble(massSpectrumData, molweightPattern);
 		libraryInformation.setMolWeight(molWeight);
+
 		Set<String> synonyms = extractSynonyms(massSpectrumData, synonymPattern);
 		massSpectrum.getLibraryInformation().setSynonyms(synonyms);
+
 		String comments = extractContentAsString(massSpectrumData, commentsPattern, 2);
 		String comment = extractContentAsString(massSpectrumData, commentPattern, 2);
 		String commentData = comments + comment;
 		libraryInformation.setComments(commentData.trim());
+
 		String casNumber = extractContentAsString(massSpectrumData, casNumberPattern, 3);
 		libraryInformation.setCasNumber(casNumber);
+
 		String database = extractContentAsString(massSpectrumData, databaseNamePattern, 3);
 		libraryInformation.setDatabase(database);
 		String smiles = extractContentAsString(massSpectrumData, smilesPattern, 2);
 		libraryInformation.setSmiles(smiles);
+
 		int retentionTime = extractContentAsInt(massSpectrumData, retentionTimePattern, 2);
 		if(retentionTime == 0) {
 			retentionTime = extractContentAsInt(massSpectrumData, nameRetentionTimePattern, 2);
@@ -253,13 +259,13 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 		massSpectrum.setRelativeRetentionTime(relativeRetentionTime);
 		String retentionIndices = extractContentAsString(massSpectrumData, retentionIndexPattern, 2);
 		extractRetentionIndices(massSpectrum, retentionIndices, RETENTION_INDICES_DELIMITER);
-		//
+
 		String instrument = extractContentAsString(massSpectrumData, instrumentPattern, 2);
 		massSpectrum.putProperty(IRegularLibraryMassSpectrum.PROPERTY_INSTRUMENT_NAME, instrument);
-		//
+
 		String instrumentType = extractContentAsString(massSpectrumData, instrumentTypePattern, 2);
 		massSpectrum.putProperty(IRegularLibraryMassSpectrum.PROPERTY_INSTRUMENT_TYPE, instrumentType);
-		//
+
 		String ionMode = extractContentAsString(massSpectrumData, ionModePattern, 2);
 		if(ionMode.equals("POSITIVE")) {
 			massSpectrum.setPolarity(Polarity.POSITIVE);
@@ -275,10 +281,13 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 		}
 		String precursorType = extractContentAsString(massSpectrumData, precursorTypePattern, 2);
 		massSpectrum.putProperty(IRegularLibraryMassSpectrum.PROPERTY_PRECURSOR_TYPE, precursorType);
+
 		double precursorMZ = extractContentAsDouble(massSpectrumData, precursorMassPattern);
 		massSpectrum.setPrecursorIon(precursorMZ);
+
 		double exactMass = extractContentAsDouble(massSpectrumData, exactMassPattern);
 		massSpectrum.setNeutralMass(exactMass);
+
 		String collisionEnergy = extractContentAsString(massSpectrumData, collisionEnergyPattern, 2);
 		massSpectrum.putProperty(IRegularLibraryMassSpectrum.PROPERTY_COLLISION_ENERGY, collisionEnergy);
 		/*
@@ -309,7 +318,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 		if(data.matches()) {
 			ionData = data.group(5);
 		}
-		//
+
 		IIon amdisIon = null;
 		double ion;
 		float abundance;

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_3_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2024 Lablicate GmbH.
+ * Copyright (c) 2016, 2025 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -51,7 +51,7 @@ public class MSPImportConverter_3_ITest extends TestCase {
 		assertEquals(1, massSpectra.size());
 	}
 
-	public void test_2()  {
+	public void test_2() {
 
 		IScanMSD massSpectrum = massSpectra.getMassSpectrum(1);
 		ILibraryMassSpectrum libraryMassSpectrum = (ILibraryMassSpectrum)massSpectrum;
@@ -60,7 +60,8 @@ public class MSPImportConverter_3_ITest extends TestCase {
 		assertEquals(0.0f, massSpectrum.getRetentionIndex());
 		assertEquals("+EI Scan (rt: 10.818 min)", libraryMassSpectrum.getLibraryInformation().getName());
 		assertEquals("", libraryMassSpectrum.getLibraryInformation().getCasNumber());
-		assertEquals("365", libraryMassSpectrum.getLibraryInformation().getDatabase());
+		assertEquals("365", libraryMassSpectrum.getLibraryInformation().getReferenceIdentifier());
+		assertEquals("Lib3", libraryMassSpectrum.getLibraryInformation().getDatabase());
 		assertEquals(65, massSpectrum.getNumberOfIons());
 		assertEquals(0.80f, massSpectrum.getIon(50.0156d).getAbundance());
 		assertEquals(0.07f, massSpectrum.getIon(50.0785d).getAbundance());

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MassBankMS2ImportConverter_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MassBankMS2ImportConverter_ITest.java
@@ -68,6 +68,7 @@ public class MassBankMS2ImportConverter_ITest extends ImportConverterMspTestCase
 		assertEquals("VFMQMACUYWGDOJ-AWEZNQCLSA-N", libraryInformation.getInChIKey());
 		assertEquals("CC(=O)N[C@@H](CC1=CC=CC=C1)C2=CC(=CC(=O)O2)OC", libraryInformation.getSmiles());
 		assertEquals("N-[(1S)-1-(4-methoxy-6-oxopyran-2-yl)-2-phenylethyl]acetamide", libraryInformation.getSynonyms().iterator().next());
-		assertEquals("MSBNK-AAFC-AC000854", libraryInformation.getDatabase());
+		assertEquals("MSBNK-AAFC-AC000854", libraryInformation.getReferenceIdentifier());
+		assertEquals("MassBank", libraryInformation.getDatabase());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MassBankMS2ImportConverter_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MassBankMS2ImportConverter_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -13,10 +13,10 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msp;
 
 import java.io.File;
 
+import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.ImportConverterMspTestCase;
 import org.eclipse.chemclipse.msd.model.core.IRegularLibraryMassSpectrum;
-import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.junit.Test;
 
@@ -45,17 +45,29 @@ public class MassBankMS2ImportConverter_ITest extends ImportConverterMspTestCase
 	@Test
 	public void testMassSpectrum() {
 
-		IScanMSD massSpectrum = massSpectra.getMassSpectrum(1);
-		assertNotNull(massSpectrum);
-		if(massSpectrum instanceof IRegularLibraryMassSpectrum regularLibraryMassSpectrum) {
-			assertEquals((short)2, regularLibraryMassSpectrum.getMassSpectrometer());
-			assertEquals(288.1225d, regularLibraryMassSpectrum.getPrecursorIon());
-			assertEquals(287.11575d, regularLibraryMassSpectrum.getNeutralMass());
-			assertEquals("30(NCE)", regularLibraryMassSpectrum.getProperty(IRegularLibraryMassSpectrum.PROPERTY_COLLISION_ENERGY));
-			assertEquals(Polarity.POSITIVE, regularLibraryMassSpectrum.getPolarity());
-			assertEquals("[M+H]+", regularLibraryMassSpectrum.getProperty(IRegularLibraryMassSpectrum.PROPERTY_PRECURSOR_TYPE));
-			assertEquals("LC-ESI-ITFT", regularLibraryMassSpectrum.getProperty(IRegularLibraryMassSpectrum.PROPERTY_INSTRUMENT_TYPE));
-			assertEquals("Q-Exactive Orbitrap Thermo Scientific", regularLibraryMassSpectrum.getProperty(IRegularLibraryMassSpectrum.PROPERTY_INSTRUMENT_NAME));
-		}
+		IRegularLibraryMassSpectrum regularLibraryMassSpectrum = (IRegularLibraryMassSpectrum)massSpectra.getMassSpectrum(1);
+		assertNotNull(regularLibraryMassSpectrum);
+		assertEquals((short)2, regularLibraryMassSpectrum.getMassSpectrometer());
+		assertEquals(288.1225d, regularLibraryMassSpectrum.getPrecursorIon());
+		assertEquals(287.11575d, regularLibraryMassSpectrum.getNeutralMass());
+		assertEquals("30(NCE)", regularLibraryMassSpectrum.getProperty(IRegularLibraryMassSpectrum.PROPERTY_COLLISION_ENERGY));
+		assertEquals(Polarity.POSITIVE, regularLibraryMassSpectrum.getPolarity());
+		assertEquals("[M+H]+", regularLibraryMassSpectrum.getProperty(IRegularLibraryMassSpectrum.PROPERTY_PRECURSOR_TYPE));
+		assertEquals("LC-ESI-ITFT", regularLibraryMassSpectrum.getProperty(IRegularLibraryMassSpectrum.PROPERTY_INSTRUMENT_TYPE));
+		assertEquals("Q-Exactive Orbitrap Thermo Scientific", regularLibraryMassSpectrum.getProperty(IRegularLibraryMassSpectrum.PROPERTY_INSTRUMENT_NAME));
+	}
+
+	@Test
+	public void testLibraryInformation() {
+
+		IRegularLibraryMassSpectrum massSpectrum = (IRegularLibraryMassSpectrum)massSpectra.getMassSpectrum(1);
+		ILibraryInformation libraryInformation = massSpectrum.getLibraryInformation();
+		assertNotNull(libraryInformation);
+		assertEquals("Pyrophen", libraryInformation.getName());
+		assertEquals("InChI=1S/C16H17NO4/c1-11(18)17-14(8-12-6-4-3-5-7-12)15-9-13(20-2)10-16(19)21-15/h3-7,9-10,14H,8H2,1-2H3,(H,17,18)/t14-/m0/s1", libraryInformation.getInChI());
+		assertEquals("VFMQMACUYWGDOJ-AWEZNQCLSA-N", libraryInformation.getInChIKey());
+		assertEquals("CC(=O)N[C@@H](CC1=CC=CC=C1)C2=CC(=CC(=O)O2)OC", libraryInformation.getSmiles());
+		assertEquals("N-[(1S)-1-(4-methoxy-6-oxopyran-2-yl)-2-phenylethyl]acetamide", libraryInformation.getSynonyms().iterator().next());
+		assertEquals("MSBNK-AAFC-AC000854", libraryInformation.getDatabase());
 	}
 }


### PR DESCRIPTION
This adds support for @IUPAC-InChI metadata as seen in @massbank files. Also corrects a confusion of database reference identifier and database name.