### PR TITLE
Silence warnings in the build

### DIFF
--- a/chemclipse/pom.xml
+++ b/chemclipse/pom.xml
@@ -273,6 +273,11 @@
 					<artifactId>eclipse-macsigner-plugin</artifactId>
 					<version>${cbi-version}</version>
 				</plugin>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>build-helper-maven-plugin</artifactId>
+					<version>3.6.0</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
Maven 3.x suggests that every plugin has version set explicitly. Maven 4 planned to elevate this to error.
This removes multiple instances of:
```
[WARNING] Some problems were encountered while building the effective
model for org.eclipse.chemclipse:org.eclipse.chemclipse.converter:eclipse-plugin:0.9.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for
org.codehaus.mojo:build-helper-maven-plugin is missing.

```