### PR TITLE
Fix processes always marking chromatograms as dirty

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -769,7 +769,6 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 							DefaultProcessingResult<Object> processingInfo = new DefaultProcessingResult<>();
 							IProcessSupplier.applyProcessor(settings, IChromatogramSelectionProcessSupplier.createConsumer(chromatogramSelection), new ProcessExecutionContext(monitor, processingInfo, processSupplierContext));
 							IChromatogram chromatogram = chromatogramSelection.getChromatogram();
-							chromatogram.setDirty(true);
 							updateResult(processingInfo);
 							AuditTrailSupport.updateAuditTrail(chromatogram, processingInfo, processSupplier);
 							NoiseFactorSupport.updateNoiseFactor(chromatogram, processSupplier);
@@ -1248,7 +1247,6 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 						IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
 						ProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, processingInfo, processTypeSupport), IChromatogramSelectionProcessSupplier.createConsumer(chromatogramSelection));
 						IChromatogram chromatogram = chromatogramSelection.getChromatogram();
-						chromatogram.setDirty(true);
 						updateResult(processingInfo);
 						AuditTrailSupport.updateAuditTrail(chromatogram, processingInfo, processMethod, processTypeSupport);
 						NoiseFactorSupport.updateNoiseFactor(chromatogram, processMethod, processTypeSupport);


### PR DESCRIPTION
This regressed in https://github.com/eclipse-chemclipse/chemclipse/commit/9ba73fbff40c227f6eb3803a703f4d14d38548ea. The process entries already set the chromatogram dirty and not all of them do change the data.