### PR TITLE
Do not override tycho director plugin build phase binding 

### DIFF
--- a/chemclipse/pom.xml
+++ b/chemclipse/pom.xml
@@ -206,22 +206,6 @@
 					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>tycho-p2-director-plugin</artifactId>
 					<version>${tycho.version}</version>
-					<executions>
-						<execution>
-							<id>materialize-products</id>
-							<goals>
-								<goal>materialize-products</goal>
-							</goals>
-							<phase>install</phase>
-						</execution>
-						<execution>
-							<id>archive-products</id>
-							<goals>
-								<goal>archive-products</goal>
-							</goals>
-							<phase>install</phase>
-						</execution>
-					</executions>
 					<configuration>
 						<formats>
 							<linux>tar.gz</linux>


### PR DESCRIPTION
Allows to generate products locally without polluting ~/.m2.