### PR TITLE
Remove the CI profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,4 @@ jobs:
         MAVEN_ARGS: "--batch-mode --no-transfer-progress -Dstyle.color=always"
       run: |
         source $HOME/.sdkman/bin/sdkman-init.sh
-        mvn -f chemclipse/releng/org.eclipse.chemclipse.aggregator/pom.xml -T 1C verify -Pci
+        mvn -f chemclipse/releng/org.eclipse.chemclipse.aggregator/pom.xml -T 1C verify

--- a/chemclipse/pom.xml
+++ b/chemclipse/pom.xml
@@ -284,30 +284,6 @@
 
 	<profiles>
 		<profile>
-			<id>ci</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.eclipse.tycho</groupId>
-						<artifactId>tycho-p2-director-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>materialize-products</id>
-								<goals>
-									<goal>materialize-products</goal>
-								</goals>
-								<phase>none</phase>
-							</execution>
-							<execution>
-								<id>archive-products</id>
-								<phase>none</phase>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-		<profile>
 			<id>eclipse-sign</id>
 			<activation>
 				<activeByDefault>false</activeByDefault>


### PR DESCRIPTION
The workaround seems to be no longer required as `verify` already does not materialize products.