### PR TITLE
Make the control always print itself

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/handlers/CreateSnapshotHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/handlers/CreateSnapshotHandler.java
@@ -86,6 +86,7 @@ public class CreateSnapshotHandler {
 			try {
 				gc = new GC(compositeParent);
 				image = new Image(DisplayUtils.getDisplay(), compositeParent.getBounds());
+				compositeParent.print(gc);
 				gc.copyArea(image, 0, 0);
 			} finally {
 				gc.dispose();


### PR DESCRIPTION
Fixes https://github.com/eclipse-chemclipse/chemclipse/issues/1994 . It's best to be explicit what needs to be done.