### PR TITLE
Fail on compile warning

### DIFF
--- a/chemclipse/pom.xml
+++ b/chemclipse/pom.xml
@@ -31,6 +31,8 @@
 		<buildTimestamp>${maven.build.timestamp}</buildTimestamp>
 		<buildId>${buildTimestamp}</buildId>
 		<releaseName>0.9.0</releaseName>
+		<maven.compiler.showWarnings>true</maven.compiler.showWarnings>
+		<maven.compiler.failOnWarning>true</maven.compiler.failOnWarning>
 	</properties>
 	<build>
 		<!-- PLUGINS -->


### PR DESCRIPTION
Enabled unconditionally so builds fail even locally when there is a warning.