### PR TITLE
Fix jenkins warning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,6 @@
 pipeline {
 	agent {
-		kubernetes {
-			label 'ubuntu-latest'
-		}
+		label 'ubuntu-latest'
 	}
 	triggers {
 		githubPush()


### PR DESCRIPTION
The following warning "[WARNING] label option is deprecated. To use a static pod template, use the 'inheritFrom' option." is due to the fact that a custom image is defined (via the kubernetes section). As nothing is changed for the image it's better to use it directly.