### PR TITLE
Fix Peak/Scan list not updating after RI embedded transfer

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/core/ChromatogramRetentionIndexer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/core/ChromatogramRetentionIndexer.java
@@ -72,8 +72,9 @@ public class ChromatogramRetentionIndexer implements IProcessTypeSupplier {
 			if(processSettings.isStoreInChromatogram()) {
 				ISeparationColumnIndices separationColumnIndices = chromatogram.getSeparationColumnIndices();
 				RetentionIndexSupport.transferRetentionIndexMarker(retentionIndexMarker, separationColumnIndices);
+				chromatogramSelection.getChromatogram().setDirty(true);
 			}
-			//
+
 			return chromatogramSelection;
 		}
 	}


### PR DESCRIPTION
Makes it consistent with RI transfer (Scans and Peaks) which always updates.