### PR TITLE
Reduce excessive logging

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/support/DataUpdateSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/support/DataUpdateSupport.java
@@ -177,8 +177,6 @@ public class DataUpdateSupport {
 			 */
 			eventBroker.subscribe(topic, eventHandler);
 			handlerMap.put(topic, eventHandler);
-			//
-			logger.info("Subscription added on topic '" + topic + "' and properties '" + Arrays.asList(properties) + "'.");
 		}
 	}
 
@@ -229,7 +227,6 @@ public class DataUpdateSupport {
 		 */
 		String topic = event.getTopic();
 		if(topic.matches(IChemClipseEvents.EDITOR_CLOSE_REGEX)) {
-			logger.info("Handle editor close event: " + topic);
 			/*
 			 * Clear the given topics.
 			 */
@@ -238,7 +235,6 @@ public class DataUpdateSupport {
 				if(object instanceof List<?> elements) {
 					for(Object element : elements) {
 						if(element instanceof String topicToBeCleared) {
-							logger.info("Clear mapped objects of topic: " + topicToBeCleared);
 							objectMap.remove(topicToBeCleared);
 						}
 					}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/support/PartSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/support/PartSupport.java
@@ -19,7 +19,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.descriptor.basic.MPartDescriptor;
 import org.eclipse.e4.ui.model.application.ui.MUIElement;
@@ -38,8 +37,6 @@ import org.eclipse.swt.widgets.Control;
 
 public class PartSupport {
 
-	private static final Logger logger = Logger.getLogger(PartSupport.class);
-	//
 	public static final String PERSPECTIVE_DATA_ANALYSIS = "org.eclipse.chemclipse.ux.extension.xxd.ui.perspective.main";
 	public static final String AREA = "org.eclipse.chemclipse.rcp.app.ui.editor";
 	/*
@@ -389,8 +386,6 @@ public class PartSupport {
 			} else {
 				hidePart(part, partService);
 			}
-			//
-			logger.info("Visibility changed to '" + visible + "' for the part id: " + part.getElementId());
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/addons/PerspectiveSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/addons/PerspectiveSupport.java
@@ -77,8 +77,6 @@ public class PerspectiveSupport {
 					GroupHandler.updateGroupHandlerMenu();
 				}
 			} else if(topic.equals(IChemClipseEvents.TOPIC_PART_CLOSED)) {
-				Object object = objects.get(0);
-				logger.info("Part has been closed: " + object);
 				GroupHandler.updateGroupHandlerMenu();
 			}
 		});

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanTableUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanTableUI.java
@@ -17,7 +17,6 @@ import java.util.EnumMap;
 import java.util.List;
 
 import org.eclipse.chemclipse.csd.model.core.IScanCSD;
-import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.types.DataType;
 import org.eclipse.chemclipse.msd.model.core.IIon;
@@ -46,8 +45,6 @@ import org.eclipse.swt.widgets.Composite;
 
 public class ScanTableUI extends ExtendedTableViewer {
 
-	private static final Logger logger = Logger.getLogger(ScanTableUI.class);
-	//
 	private EnumMap<DataType, ITableLabelProvider> labelProviderMap;
 	private EnumMap<DataType, ViewerComparator> viewerComparatorMap;
 	private EnumMap<DataType, IContentProvider> contentProviderMap;
@@ -190,7 +187,6 @@ public class ScanTableUI extends ExtendedTableViewer {
 			/*
 			 * Lazy (Virtual)
 			 */
-			logger.info("Lazy (Virtual) Modus");
 			setContentProvider(contentProvider);
 			setUseHashlookup(true);
 			setComparator(null);
@@ -198,7 +194,6 @@ public class ScanTableUI extends ExtendedTableViewer {
 			/*
 			 * Normal
 			 */
-			logger.info("Normal Modus");
 			setContentProvider(contentProvider);
 			setUseHashlookup(false);
 			ViewerComparator viewerComparator = getViewerComparator(dataType);


### PR DESCRIPTION
Polluting Eclipse log for every part/editor close/visibility event makes it pretty easy to miss important information in the logs.