### PR TITLE
Simplify Status creation

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/preferences/PreferenceSupplier.java
@@ -146,7 +146,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 
 	private static final IStatus error(String message) {
 
-		return new Status(IStatus.ERROR, Activator.getContext().getBundle().getSymbolicName(), message);
+		return Status.error(message);
 	}
 
 	public static PeakIdentifierSettings getPeakIdentifierSettings() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/dialogs/PerspectiveChooserDialog.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/dialogs/PerspectiveChooserDialog.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 
 import org.eclipse.chemclipse.rcp.app.ui.Activator;
 import org.eclipse.chemclipse.rcp.app.ui.preferences.PreferenceSupplier;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
@@ -91,7 +90,7 @@ public class PerspectiveChooserDialog extends Dialog {
 					try {
 						store.save();
 					} catch(IOException e) {
-						Activator.getDefault().getLog().log(new Status(IStatus.ERROR, getClass().getName(), "Saving preferences failed", e));
+						Activator.getDefault().getLog().log(Status.error("Saving preferences failed", e));
 					}
 				}
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.connector.supplier.microsoft.office.ui/src/org/eclipse/chemclipse/rcp/connector/supplier/microsoft/office/ui/wizards/OfficeFileWizard.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.connector.supplier.microsoft.office.ui/src/org/eclipse/chemclipse/rcp/connector/supplier/microsoft/office/ui/wizards/OfficeFileWizard.java
@@ -20,7 +20,6 @@ import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.rcp.connector.supplier.microsoft.office.ui.Activator;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
@@ -28,7 +27,6 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -178,7 +176,6 @@ public abstract class OfficeFileWizard extends Wizard implements INewWizard {
 
 	private void throwCoreException(String message) throws CoreException {
 
-		IStatus status = new Status(IStatus.ERROR, Activator.getDefault().getBundle().getSymbolicName(), IStatus.OK, message, null);
-		throw new CoreException(status);
+		throw new CoreException(Status.error(message));
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/DataExplorerTreeUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/DataExplorerTreeUI.java
@@ -27,7 +27,6 @@ import org.eclipse.chemclipse.ux.extension.ui.l10n.ExtensionMessages;
 import org.eclipse.chemclipse.ux.extension.ui.listener.DataExplorerDragListener;
 import org.eclipse.chemclipse.ux.extension.ui.provider.DataExplorerContentProvider;
 import org.eclipse.chemclipse.ux.extension.ui.provider.DataExplorerLabelProvider;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.preference.IPersistentPreferenceStore;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -147,7 +146,7 @@ public class DataExplorerTreeUI {
 				try {
 					persistentPreferenceStore.save();
 				} catch(IOException e) {
-					Activator.getDefault().getLog().log(new Status(IStatus.ERROR, Activator.getDefault().getBundle().getSymbolicName(), ExtensionMessages.storingPreferencesFailed, e));
+					Activator.getDefault().getLog().log(Status.error(ExtensionMessages.storingPreferencesFailed, e));
 				}
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/TaskTile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/TaskTile.java
@@ -20,7 +20,6 @@ import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.swt.ui.support.Fonts;
 import org.eclipse.chemclipse.ux.extension.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.ui.definitions.TileDefinition;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyAdapter;
@@ -229,7 +228,7 @@ public class TaskTile extends Composite {
 			try {
 				definitionConsumer.accept(definition);
 			} catch(RuntimeException e) {
-				Activator.getDefault().getLog().log(new Status(IStatus.ERROR, "TaskTile", "invoke of consumer failed", e)); //$NON-NLS-1$ //$NON-NLS-2$
+				Activator.getDefault().getLog().log(Status.error("Invoke of consumer failed", e)); //$NON-NLS-1$
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/runnables/LibraryServiceRunnable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/runnables/LibraryServiceRunnable.java
@@ -29,7 +29,6 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.jface.operation.IRunnableWithProgress;
@@ -90,7 +89,7 @@ public class LibraryServiceRunnable implements IRunnableWithProgress {
 					return;
 				}
 			} catch(Exception e) {
-				Activator.getDefault().getLog().log(new Status(IStatus.ERROR, getClass().getName(), "Fetching mass spectrum failed!", e));
+				Activator.getDefault().getLog().log(Status.error("Fetching mass spectrum failed!", e));
 			}
 		}
 		libraryMassSpectrumConsumer.accept(null);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedComparisonScanUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedComparisonScanUI.java
@@ -43,7 +43,6 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageScans;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.runnables.LibraryServiceRunnable;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.ScanDataSupport;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.e4.ui.di.Focus;
@@ -249,7 +248,7 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 		} catch(InterruptedException e) {
 			Thread.currentThread().interrupt();
 		} catch(ExecutionException e) {
-			Activator.getDefault().getLog().log(new Status(IStatus.ERROR, getClass().getName(), "Update scan failed.", e));
+			Activator.getDefault().getLog().log(Status.error("Update scan failed.", e));
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSubtractScanUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSubtractScanUI.java
@@ -41,7 +41,6 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.preferences.Preferenc
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageScans;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageSubtract;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.runnables.LibraryServiceRunnable;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.e4.ui.di.Focus;
@@ -291,7 +290,7 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 					} catch(InterruptedException ex) {
 						Thread.currentThread().interrupt();
 					} catch(ExecutionException ex) {
-						Activator.getDefault().getLog().log(new Status(IStatus.ERROR, getClass().getName(), "Fetch comparison scan failed.", ex));
+						Activator.getDefault().getLog().log(Status.error("Fetch comparison scan failed.", ex));
 					}
 				}
 			}


### PR DESCRIPTION
Use the static helpers that dynamically figure bundleId. This even fixes a case where wrong bundleId has been passed.