### PR TITLE
Fix GitHub Actions tool installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       id: maven
       with:
         candidate: maven
+        version: 3.9.10
 
     - name: Build with Maven
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,11 @@ jobs:
     - name: Checkout ChemClipse
       uses: actions/checkout@v4
 
-    - uses: sdkman/sdkman-action@main
-      name: Setup Temurin
-      id: temurin
+    - uses: actions/setup-java@v4
+      name: Setup Java
       with:
-        candidate: java
-        version: 21.0.7-tem
+        distribution: 'temurin'
+        java-version: '21'
 
     - uses: sdkman/sdkman-action@main
       name: Setup Maven


### PR DESCRIPTION
@SDKMan tried to install itself twice and failed the second time. It also failed at installing what it thinks is the latest Maven: 3.9.9 while 3.9.10 is released.