### PR TITLE
Fetch Apache POI from Eclipse Orbit

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
@@ -213,18 +213,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="wrapped.org.apache.poi.ooxml-schemas"
-         version="0.0.0"/>
-
-   <plugin
-         id="wrapped.org.apache.poi.poi"
-         version="0.0.0"/>
-
-   <plugin
-         id="wrapped.org.apache.poi.poi-ooxml"
-         version="0.0.0"/>
-
-   <plugin
          id="org.apache.commons.commons-codec"
          version="0.0.0"/>
 
@@ -286,18 +274,6 @@
 
    <plugin
          id="org.eclipse.search.core"
-         version="0.0.0"/>
-
-   <plugin
-         id="bcpg"
-         version="0.0.0"/>
-
-   <plugin
-         id="bcprov"
-         version="0.0.0"/>
-
-   <plugin
-         id="bcutil"
          version="0.0.0"/>
 
    <plugin
@@ -374,6 +350,26 @@
 
    <plugin
          id="org.apache.httpcomponents.httpcore"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.poi"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.poi.ooxml"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.poi.ooxml.schemas"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.bouncycastle.bcpg"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.bouncycastle.bcprov"
          version="0.0.0"/>
 
 </feature>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.excel/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.excel/META-INF/MANIFEST.MF
@@ -15,9 +15,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.processing;bundle-version="0.8.0",
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
- wrapped.org.apache.poi.ooxml-schemas;bundle-version="1.4.0",
- wrapped.org.apache.poi.poi;bundle-version="4.1.1",
- wrapped.org.apache.poi.poi-ooxml;bundle-version="4.1.1"
+ org.apache.poi;bundle-version="4.1.1",
+ org.apache.poi.ooxml;bundle-version="4.1.1",
+ org.apache.poi.ooxml.schemas;bundle-version="4.1.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.msd.converter.supplier.excel.converter,

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/META-INF/MANIFEST.MF
@@ -16,8 +16,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
  org.eclipse.chemclipse.numeric;bundle-version="0.8.0",
  org.eclipse.chemclipse.pcr.report.supplier.tabular,
- wrapped.org.apache.poi.poi;bundle-version="4.1.1",
- wrapped.org.apache.poi.poi-ooxml;bundle-version="4.1.1"
+ org.apache.poi;bundle-version="4.1.1",
+ org.apache.poi.ooxml;bundle-version="4.1.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.chemclipse.pcr.report.supplier.tabular

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.connector.supplier.microsoft.office.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.connector.supplier.microsoft.office.ui/META-INF/MANIFEST.MF
@@ -18,9 +18,9 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.ide;bundle-version="3.10.2",
  org.eclipse.core.resources;bundle-version="3.9.1",
  org.eclipse.chemclipse.swt.win32;bundle-version="0.9.0",
- wrapped.org.apache.poi.ooxml-schemas;bundle-version="1.4.0",
- wrapped.org.apache.poi.poi;bundle-version="4.1.1",
- wrapped.org.apache.poi.poi-ooxml;bundle-version="4.1.1",
- org.eclipse.chemclipse.support.ui;bundle-version="0.9.0"
+ org.eclipse.chemclipse.support.ui;bundle-version="0.9.0",
+ org.apache.poi;bundle-version="4.1.1",
+ org.apache.poi.ooxml;bundle-version="4.1.1",
+ org.apache.poi.ooxml.schemas;bundle-version="4.1.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/META-INF/MANIFEST.MF
@@ -20,10 +20,10 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.csd.model;bundle-version="0.9.0",
  wrapped.org.ejml.ejml-core;bundle-version="0.43.0",
  wrapped.org.ejml.ejml-ddense;bundle-version="0.43.0",
- wrapped.org.apache.poi.ooxml-schemas;bundle-version="1.4.0",
- wrapped.org.apache.poi.poi;bundle-version="4.1.1",
- wrapped.org.apache.poi.poi-ooxml;bundle-version="4.1.1",
- org.apache.commons.commons-csv;bundle-version="1.8.0"
+ org.apache.commons.commons-csv;bundle-version="1.8.0",
+ org.apache.poi;bundle-version="4.1.1",
+ org.apache.poi.ooxml;bundle-version="4.1.1",
+ org.apache.poi.ooxml.schemas;bundle-version="4.1.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.xxd.process.supplier.pca.core,

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -18,6 +18,7 @@
 	<unit id="org.apache.commons.codec"/>
 	<unit id="org.apache.commons.commons-collections4"/>
 	<unit id="org.apache.commons.commons-compress"/>
+	<unit id="org.apache.commons.io"/>
 	<unit id="org.apache.commons.lang3"/>
 	<unit id="org.apache.httpcomponents.httpclient"/>
 	<unit id="org.apache.httpcomponents.httpcore"/>
@@ -43,6 +44,12 @@
 		<repository location="https://download.eclipse.org/nebula/updates/release/3.1.1/"/>
 		<unit id="org.eclipse.nebula.feature.feature.group"/>
 		<unit id="org.eclipse.nebula.widgets.richtext.feature.feature.group"/>
+	</location>
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<repository location="https://download.eclipse.org/oomph/simrel-orbit/2023-06"/>
+		<unit id="org.apache.poi" />
+		<unit id="org.apache.poi.ooxml" />
+		<unit id="org.apache.poi.ooxml.schemas" />
 	</location>
 	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="org.apache.commons" missingManifest="generate" type="Maven">
 		<dependencies>
@@ -178,28 +185,6 @@
 				<groupId>org.apache.thrift</groupId>
 				<artifactId>libthrift</artifactId>
 				<version>0.12.0</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
-	</location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" label="org.apache.poi" missingManifest="generate" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>org.apache.poi</groupId>
-				<artifactId>ooxml-schemas</artifactId>
-				<version>1.4</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.poi</groupId>
-				<artifactId>poi-ooxml</artifactId>
-				<version>4.1.1</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.poi</groupId>
-				<artifactId>poi</artifactId>
-				<version>4.1.1</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -18,7 +18,7 @@
 	<unit id="org.apache.commons.codec"/>
 	<unit id="org.apache.commons.commons-collections4"/>
 	<unit id="org.apache.commons.commons-compress"/>
-	<unit id="org.apache.commons.io"/>
+	<unit id="org.apache.commons.commons-io"/>
 	<unit id="org.apache.commons.lang3"/>
 	<unit id="org.apache.httpcomponents.httpclient"/>
 	<unit id="org.apache.httpcomponents.httpcore"/>

--- a/chemclipse/sites/chemclipse/category.xml
+++ b/chemclipse/sites/chemclipse/category.xml
@@ -15,4 +15,5 @@
       </description>
    </category-def>
    <repository-reference location="https://download.eclipse.org/releases/2025-06/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/oomph/simrel-orbit/2023-06/" enabled="true" />
 </site>


### PR DESCRIPTION
https://download.eclipse.org/oomph/simrel-orbit/2023-06/ ships the same version we do. This is an attempt to shrink the ChemClipse update site size.