### PR TITLE
Add back bundles not included via osgi metadata

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
@@ -24,6 +24,11 @@
          id="org.eclipse.chemclipse.rcp.app.compilation.core.feature"
          version="0.0.0"/>
 
+   <requires>
+      <import plugin="org.glassfish.hk2.osgi-resource-locator"/>
+      <import plugin="com.sun.xml.bind.jaxb-osgi"/>
+   </requires>
+
    <plugin
          id="org.eclipse.chemclipse.rcp.compilation.community.ui"
          version="0.0.0"/>
@@ -48,5 +53,4 @@
          id="org.eclipse.chemclipse.swt.win32"
          version="0.0.0"/>
 
-   
 </feature>


### PR DESCRIPTION
These bundles are not included via regular OSGi metadata for some reason thus has to be explicitly required.