### PR TITLE
Resolve the dependencies at per feature level

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.assets.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.assets.feature/feature.xml
@@ -27,4 +27,8 @@
          id="org.eclipse.chemclipse.assets.ui"
          version="0.0.0"/>
 
+   <plugin
+         id="jakarta.inject.jakarta.inject-api"
+         version="0.0.0"/>
+
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.feature/feature.xml
@@ -3,7 +3,8 @@
       id="org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.feature"
       label="Peakidentification Process"
       version="0.9.0.qualifier"
-      provider-name="ChemClipse" plugin="org.eclipse.chemclipse.feature.branding"
+      provider-name="ChemClipse"
+      plugin="org.eclipse.chemclipse.feature.branding"
       license-feature="org.eclipse.license"
       license-feature-version="2.0.2.qualifier">
 
@@ -21,16 +22,10 @@
 
    <plugin
          id="org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.feature/feature.xml
@@ -24,4 +24,12 @@
          id="org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn"
          version="0.0.0"/>
 
+   <plugin
+         id="jakarta.annotation-api"
+         version="0.0.0"/>
+
+   <plugin
+         id="jakarta.xml.bind-api"
+         version="0.0.0"/>
+
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.feature/feature.xml
@@ -52,4 +52,8 @@
          id="org.eclipse.chemclipse.chromatogram.wsd.peak.detector.supplier.firstderivative.ui"
          version="0.0.0"/>
 
+   <plugin
+         id="org.apache.commons.lang3"
+         version="0.0.0"/>
+
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.excel.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.excel.feature/feature.xml
@@ -3,7 +3,8 @@
       id="org.eclipse.chemclipse.msd.converter.supplier.excel.feature"
       label="Excel Converter"
       version="0.9.0.qualifier"
-      provider-name="ChemClipse" plugin="org.eclipse.chemclipse.feature.branding"
+      provider-name="ChemClipse"
+      plugin="org.eclipse.chemclipse.feature.branding"
       license-feature="org.eclipse.license"
       license-feature-version="2.0.2.qualifier">
 
@@ -21,16 +22,26 @@
 
    <plugin
          id="org.eclipse.chemclipse.msd.converter.supplier.excel"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.chemclipse.msd.converter.supplier.excel.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.poi"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.poi.ooxml"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.poi.ooxml.schemas"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.commons.commons-collections4"
+         version="0.0.0"/>
 
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.pcr.report.supplier.tabular.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.pcr.report.supplier.tabular.feature/feature.xml
@@ -21,44 +21,34 @@
 
    <plugin
          id="org.eclipse.chemclipse.pcr.report.supplier.tabular.csv"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.chemclipse.pcr.report.supplier.tabular.excel"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.chemclipse.pcr.report.supplier.tabular.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.chemclipse.pcr.report.supplier.tabular"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.commons.commons-csv"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.commons.commons-collections4"
+         version="0.0.0"/>
 
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.base.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.base.feature/feature.xml
@@ -376,4 +376,20 @@
          id="org.eclipse.chemclipse.ux.extension.pcr.ui"
          version="0.0.0"/>
 
+   <plugin
+         id="org.apache.commons.commons-io"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.nebula.widgets.richtext"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.google.guava"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.google.guava.failureaccess"
+         version="0.0.0"/>
+
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.compilation.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.compilation.core.feature/feature.xml
@@ -324,4 +324,8 @@
          id="org.eclipse.chemclipse.nmr.converter.supplier.nmrml.feature"
          version="0.0.0"/>
 
+   <plugin
+         id="org.eclipse.ui.ide"
+         version="0.0.0"/>
+
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
@@ -173,18 +173,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.e4.ui.css.core"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.e4.ui.css.swt"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.e4.ui.css.swt.theme"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.e4.ui.di"
          version="0.0.0"/>
 
@@ -357,10 +345,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.help.base"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.help.ui"
          version="0.0.0"/>
 
@@ -469,10 +453,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.junit"
-         version="0.0.0"/>
-
-   <plugin
          id="org.sat4j.core"
          version="0.0.0"/>
 
@@ -573,10 +553,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.cm"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.jdt.core.compiler.batch"
          version="0.0.0"/>
 
@@ -613,10 +589,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.e4.ui.css.swt.theme"
-         version="0.0.0"/>
-
-   <plugin
          id="org.apache.commons.commons-codec"
          version="0.0.0"/>
 
@@ -626,6 +598,114 @@
 
    <plugin
          id="com.github.weisj.jsvg"
+         version="0.0.0"/>
+
+   <plugin
+         id="slf4j.api"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.ltk.core.refactoring"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.ltk.ui.refactoring"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.ui.intro"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.e4.ui.ide"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.debug.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.search.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.equinox.http.service.api"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.http.whiteboard"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.jetty.servlet-api"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.lucene.analysis-common"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.lucene.analysis-smartcn"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.bouncycastle.bcpg"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.bouncycastle.bcprov"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.sun.el.javax.el"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.mortbay.jasper.apache-jsp"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.mortbay.jasper.apache-el"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.jetty.ee8.security"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.jetty.ee8.server"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.jetty.ee8.servlet"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.jetty.session"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.osgi.service.coordinator"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.orbit.xml-apis-ext"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.batik.css"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.batik.constants"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.batik.i18n"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.batik.util"
          version="0.0.0"/>
 
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.test.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.test.feature/feature.xml
@@ -2,8 +2,11 @@
 <feature
       id="org.eclipse.chemclipse.rcp.app.test.feature"
       label="RCP Test App Feature"
-      version="0.9.0.qualifier" provider-name="ChemClipse" plugin="org.eclipse.chemclipse.feature.branding"
-      license-feature="org.eclipse.license" license-feature-version="2.0.2.qualifier">
+      version="0.9.0.qualifier"
+      provider-name="ChemClipse"
+      plugin="org.eclipse.chemclipse.feature.branding"
+      license-feature="org.eclipse.license"
+      license-feature-version="2.0.2.qualifier">
 
    <description url="http://www.chemclipse.net">
       Helper functions for unit and integration tests.
@@ -19,9 +22,14 @@
 
    <plugin
          id="org.eclipse.chemclipse.rcp.app.test"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
+
+   <plugin
+         id="org.junit"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.hamcrest"
+         version="0.0.0"/>
 
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.connector.supplier.microsoft.office.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.connector.supplier.microsoft.office.feature/feature.xml
@@ -24,4 +24,8 @@
          id="org.eclipse.chemclipse.rcp.connector.supplier.microsoft.office.ui"
          version="0.0.0"/>
 
+   <plugin
+         id="org.apache.commons.commons-collections4"
+         version="0.0.0"/>
+
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.feature/feature.xml
@@ -24,4 +24,8 @@
          id="org.eclipse.chemclipse.xxd.converter.supplier.jcampdx"
          version="0.0.0"/>
 
+   <plugin
+         id="jakarta.activation-api"
+         version="0.0.0"/>
+
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.feature/feature.xml
@@ -22,16 +22,50 @@
 
    <plugin
          id="org.eclipse.chemclipse.xxd.identifier.supplier.wikidata"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.commons.commons-compress"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.httpcomponents.httpclient"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.httpcomponents.httpcore"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.thrift"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.slf4j.api"
+         version="0.0.0"/>
+
+   <plugin
+         id="wrapped.org.apache.jena.jena-arq"
+         version="0.0.0"/>
+
+   <plugin
+         id="wrapped.org.apache.jena.jena-base"
+         version="0.0.0"/>
+
+   <plugin
+         id="wrapped.org.apache.jena.jena-core"
+         version="0.0.0"/>
+
+   <plugin
+         id="wrapped.org.apache.jena.jena-iri"
+         version="0.0.0"/>
+
+   <plugin
+         id="wrapped.org.apache.jena.jena-shaded-guava"
+         version="0.0.0"/>
 
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.process.supplier.pca.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.process.supplier.pca.feature/feature.xml
@@ -22,51 +22,34 @@
 
    <plugin
          id="org.eclipse.chemclipse.xxd.process.supplier.pca"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.chemclipse.xxd.process.supplier.pca.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="wrapped.org.ejml.ejml-core"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="wrapped.org.ejml.ejml-ddense"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="wrapped.org.ejml.ejml-experimental"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="wrapped.org.ejml.ejml-fdense"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="wrapped.org.ejml.ejml-simple"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.commons.commons-collections4"
+         version="0.0.0"/>
 
 </feature>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative/META-INF/MANIFEST.MF
@@ -18,7 +18,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.chromatogram.xxd.calculator;bundle-version="0.8.0",
  org.eclipse.chemclipse.chromatogram.xxd.classifier;bundle-version="0.8.0",
  org.eclipse.e4.core.services;bundle-version="2.3.400",
- org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative
+ org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative,
+ org.apache.commons.lang3;bundle-version="3.17.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.core,
@@ -26,5 +27,4 @@ Export-Package: org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.f
  org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.settings
 Bundle-Vendor: ChemClipse
 Import-Package: com.fasterxml.jackson.databind.annotation;version="2.9.93",
- org.apache.commons.lang3;version="3.1.0",
  org.osgi.service.component.annotations;version="1.2.0"

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/META-INF/MANIFEST.MF
@@ -41,7 +41,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.pcr.converter;bundle-version="0.8.0",
  com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.9.2",
  org.eclipse.core.commands;bundle-version="3.9.100",
- org.eclipse.chemclipse.rcp.app;bundle-version="0.9.0"
+ org.eclipse.chemclipse.rcp.app;bundle-version="0.9.0",
+ com.google.guava;bundle-version="33.4.8"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.xxd.filter.peaks,
@@ -49,8 +50,7 @@ Export-Package: org.eclipse.chemclipse.xxd.filter.peaks,
  org.eclipse.chemclipse.xxd.filter.peaks.settings,
  org.eclipse.chemclipse.xxd.filter.preferences,
  org.eclipse.chemclipse.xxd.filter.support
-Import-Package: com.google.common.collect,
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: org.osgi.service.component.annotations;version="1.2.0"
 Service-Component: OSGI-INF/org.eclipse.chemclipse.xxd.filter.chromatogram.IntensityCutOffFilter.xml,
  OSGI-INF/org.eclipse.chemclipse.xxd.filter.chromatogram.MeasurementResultsFilter.xml,
  OSGI-INF/org.eclipse.chemclipse.xxd.filter.chromatogram.ShiftIntensityFilter.xml,


### PR DESCRIPTION
This includes a partial revert of https://github.com/eclipse-chemclipse/chemclipse/pull/2253/ but I tried to put the dependencies near the plug-ins that require it now.