### PR TITLE
Do not downgrade bouncycastle version

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
@@ -649,11 +649,15 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.bouncycastle.bcpg"
+         id="bcpg"
          version="0.0.0"/>
 
    <plugin
-         id="org.bouncycastle.bcprov"
+         id="bcprov"
+         version="0.0.0"/>
+         
+   <plugin
+         id="bcutil"
          version="0.0.0"/>
 
    <plugin

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -15,6 +15,9 @@
 	<unit id="org.glassfish.hk2.osgi-resource-locator"/>
 	<unit id="com.sun.xml.bind.jaxb-osgi"/>
 	<unit id="jakarta.xml.bind-api"/>
+	<unit id="bcprov"/>
+	<unit id="bcpg"/>
+	<unit id="bcutil"/>
 	<unit id="org.apache.commons.codec"/>
 	<unit id="org.apache.commons.commons-collections4"/>
 	<unit id="org.apache.commons.commons-compress"/>


### PR DESCRIPTION
org.bouncycastle are the old symbolic name the new ones from upstream are just bcprov/bcutil/bcpg.