### PR TITLE
Fetch Apache Commons CSV/Math3/XMLBeans from Orbit

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.pcr.report.supplier.tabular.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.pcr.report.supplier.tabular.feature/feature.xml
@@ -44,11 +44,11 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.apache.commons.commons-csv"
+         id="org.apache.commons.commons-collections4"
          version="0.0.0"/>
 
    <plugin
-         id="org.apache.commons.commons-collections4"
+         id="org.apache.commons.csv"
          version="0.0.0"/>
 
 </feature>

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/META-INF/MANIFEST.MF
@@ -17,8 +17,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.numeric;bundle-version="0.8.0",
  org.eclipse.chemclipse.pcr.report.supplier.tabular;bundle-version="0.9.0",
  org.apache.commons.lang3;bundle-version="3.12.0",
- org.apache.commons.commons-csv;bundle-version="1.8.0",
- org.apache.commons.commons-io;bundle-version="2.11.0"
+ org.apache.commons.commons-io;bundle-version="2.11.0",
+ org.apache.commons.csv;bundle-version="1.8.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.preferences

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/csv/core/PCRExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/csv/core/PCRExportConverter.java
@@ -68,8 +68,7 @@ public class PCRExportConverter extends AbstractPlateExportConverter implements 
 	public IProcessingInfo<File> convert(File file, IPlate plate, IProgressMonitor monitor) {
 
 		decimalFormat.applyPattern("#,##0.00");
-		CSVFormat csvFormat = CSVFormat.RFC4180.builder() //
-				.setDelimiter(PreferenceSupplier.getDelimiter().getCharacter()).build();
+		CSVFormat csvFormat = CSVFormat.RFC4180.withDelimiter(PreferenceSupplier.getDelimiter().getCharacter());
 		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		if(plate != null) {
 			try (CSVPrinter csvPrinter = new CSVPrinter(new FileWriter(file, false), csvFormat)) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/META-INF/MANIFEST.MF
@@ -20,8 +20,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.csd.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.csd.converter;bundle-version="0.8.0",
  com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.9.9",
- org.apache.commons.commons-csv;bundle-version="1.8.0",
- org.eclipse.chemclipse.vsd.model;bundle-version="0.9.0"
+ org.eclipse.chemclipse.vsd.model;bundle-version="0.9.0",
+ org.apache.commons.csv;bundle-version="1.8.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Import-Package: org.osgi.service.component.annotations;version="1.2.0"

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/core/FileContentMatcherPeak.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/core/FileContentMatcherPeak.java
@@ -30,8 +30,7 @@ public class FileContentMatcherPeak extends AbstractFileContentMatcher implement
 	public boolean checkFileFormat(File file) {
 
 		try {
-			CSVFormat csvFormat = CSVFormat.EXCEL.builder().setHeader().build();
-			try (CSVParser parser = new CSVParser(new FileReader(file), csvFormat)) {
+			try (CSVParser parser = new CSVParser(new FileReader(file), CSVFormat.EXCEL.withHeader())) {
 				String[] array = parser.getHeaderMap().keySet().toArray(new String[0]);
 				return Arrays.equals(array, CSVPeakConverter.HEADERS);
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/core/CSVPeakConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/core/CSVPeakConverter.java
@@ -165,8 +165,7 @@ public class CSVPeakConverter implements IPeakExportConverter, IPeakImportConver
 
 	public static void writePeaks(IPeaksMSD peaks, Writer writer, boolean writeHeader) throws IOException {
 
-		CSVFormat csvFormat = CSVFormat.EXCEL.builder().setNullString("").setQuoteMode(QuoteMode.ALL).build();
-		try (CSVPrinter csv = new CSVPrinter(writer, csvFormat)) {
+		try (CSVPrinter csv = new CSVPrinter(writer, CSVFormat.EXCEL.withNullString("").withQuoteMode(QuoteMode.ALL))) {
 			if(writeHeader) {
 				csv.printRecord(Arrays.asList(HEADERS));
 			}
@@ -212,8 +211,7 @@ public class CSVPeakConverter implements IPeakExportConverter, IPeakImportConver
 	public static IPeaksMSD readPeaks(Reader reader) throws IOException, ParseException {
 
 		PeaksMSD result = new PeaksMSD();
-		CSVFormat csvFormat = CSVFormat.EXCEL.builder().setHeader(HEADERS).setSkipHeaderRecord(true).build();
-		try (CSVParser parser = new CSVParser(reader, csvFormat)) {
+		try (CSVParser parser = new CSVParser(reader, CSVFormat.EXCEL.withHeader(HEADERS).withSkipHeaderRecord())) {
 			NumberFormat nf;
 			synchronized(NUMBER_FORMAT) {
 				nf = (NumberFormat)NUMBER_FORMAT.clone();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/core/ChromatogramReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/core/ChromatogramReader.java
@@ -83,7 +83,7 @@ public class ChromatogramReader extends AbstractChromatogramMSDReader implements
 			String zeroMarker = PreferenceSupplier.getImportZeroMarker();
 			zeroMarker = zeroMarker.startsWith(ZERO_VALUE) ? zeroMarker : ZERO_VALUE;
 			char delimiter = PreferenceSupplier.getImportDelimiter().getCharacter();
-			CSVParser csvParser = new CSVParser(fileReader, CSVFormat.newFormat(delimiter).builder().setHeader().build());
+			CSVParser csvParser = new CSVParser(fileReader, CSVFormat.newFormat(delimiter).withHeader());
 			chromatogram = new VendorChromatogram();
 			if(!overview) {
 				/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/META-INF/MANIFEST.MF
@@ -20,10 +20,10 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.csd.model;bundle-version="0.9.0",
  wrapped.org.ejml.ejml-core;bundle-version="0.43.0",
  wrapped.org.ejml.ejml-ddense;bundle-version="0.43.0",
- org.apache.commons.commons-csv;bundle-version="1.8.0",
  org.apache.poi;bundle-version="4.1.1",
  org.apache.poi.ooxml;bundle-version="4.1.1",
- org.apache.poi.ooxml.schemas;bundle-version="4.1.1"
+ org.apache.poi.ooxml.schemas;bundle-version="4.1.1",
+ org.apache.commons.csv;bundle-version="1.8.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.xxd.process.supplier.pca.core,

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/PcaExtractionFileLongText.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/PcaExtractionFileLongText.java
@@ -141,8 +141,7 @@ public class PcaExtractionFileLongText implements IExtractionData {
 					/*
 					 * Data
 					 */
-					CSVFormat csvFormat = CSVFormat.TDF.builder().setHeader().build();
-					CSVParser parser = new CSVParser(reader, csvFormat);
+					CSVParser parser = new CSVParser(reader, CSVFormat.TDF.withHeader());
 					for(CSVRecord record : parser.getRecords()) {
 						int size = record.size();
 						if(size == 7) {
@@ -184,8 +183,7 @@ public class PcaExtractionFileLongText implements IExtractionData {
 					/*
 					 * Data
 					 */
-					CSVFormat csvFormat = CSVFormat.TDF.builder().setHeader().build();
-					CSVParser parser = new CSVParser(reader, csvFormat);
+					CSVParser parser = new CSVParser(reader, CSVFormat.TDF.withHeader());
 					for(CSVRecord record : parser.getRecords()) {
 						int size = record.size();
 						if(size == 7) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/PcaExtractionFileText.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/PcaExtractionFileText.java
@@ -119,8 +119,7 @@ public class PcaExtractionFileText implements IExtractionData {
 					/*
 					 * Data
 					 */
-					CSVFormat csvFormat = CSVFormat.TDF.builder().setHeader().build();
-					CSVParser parser = new CSVParser(reader, csvFormat);
+					CSVParser parser = new CSVParser(reader, CSVFormat.TDF.withHeader());
 					Map<Integer, String> indexMap = extractIndexMap(parser);
 					for(CSVRecord record : parser.getRecords()) {
 						/*

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -50,25 +50,12 @@
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<repository location="https://download.eclipse.org/oomph/simrel-orbit/2023-06"/>
-		<unit id="org.apache.poi" />
-		<unit id="org.apache.poi.ooxml" />
-		<unit id="org.apache.poi.ooxml.schemas" />
-	</location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="org.apache.commons" missingManifest="generate" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-csv</artifactId>
-				<version>1.10.0</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-math3</artifactId>
-				<version>3.6.1</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
+		<unit id="org.apache.poi"/>
+		<unit id="org.apache.poi.ooxml"/>
+		<unit id="org.apache.poi.ooxml.schemas"/>
+		<unit id="org.apache.commons.csv"/>
+		<unit id="org.apache.commons.math3"/>
+		<unit id="org.apache.xmlbeans"/>
 	</location>
 	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
 		<dependencies>
@@ -188,16 +175,6 @@
 				<groupId>org.apache.thrift</groupId>
 				<artifactId>libthrift</artifactId>
 				<version>0.12.0</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
-	</location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>org.apache.xmlbeans</groupId>
-				<artifactId>xmlbeans</artifactId>
-				<version>3.1.0</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/META-INF/MANIFEST.MF
@@ -10,5 +10,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.junit;bundle-version="4.8.1",
  org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0",
  org.apache.commons.commons-collections4;bundle-version="4.4.0",
- wrapped.org.apache.xmlbeans.xmlbeans;bundle-version="3.1.0",
- org.apache.commons.commons-compress;bundle-version="1.22.0"
+ org.apache.commons.commons-compress;bundle-version="1.22.0",
+ org.apache.xmlbeans;bundle-version="3.1.0"


### PR DESCRIPTION
as we already have the repository added in https://github.com/eclipse-chemclipse/chemclipse/pull/2250. This partly reverts https://github.com/eclipse-chemclipse/chemclipse/pull/1538 as the Apache Commons CSV is a downgrade. The other versions are identical.