### PR TITLE
Add back XML runtime requirements

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzdata.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzdata.feature/feature.xml
@@ -3,7 +3,8 @@
       id="org.eclipse.chemclipse.msd.converter.supplier.mzdata.feature"
       label="MSD mzData"
       version="0.9.0.qualifier"
-      provider-name="ChemClipse" plugin="org.eclipse.chemclipse.feature.branding"
+      provider-name="ChemClipse"
+      plugin="org.eclipse.chemclipse.feature.branding"
       license-feature="org.eclipse.license"
       license-feature-version="2.0.2.qualifier">
 
@@ -23,18 +24,16 @@
       <discovery label="mzData" url="https://www.psidev.info/mass-spectrometry-workgroup#mzdata"/>
    </url>
 
+   <includes
+         id="org.eclipse.chemclipse.xml.feature"
+         version="0.0.0"/>
+
    <plugin
          id="org.eclipse.chemclipse.msd.converter.supplier.mzdata"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.chemclipse.msd.converter.supplier.mzdata.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzxml.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzxml.feature/feature.xml
@@ -20,18 +20,16 @@
       %license
    </license>
 
+   <includes
+         id="org.eclipse.chemclipse.xml.feature"
+         version="0.0.0"/>
+
    <plugin
          id="org.eclipse.chemclipse.msd.converter.supplier.mzxml"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.chemclipse.msd.converter.supplier.mzxml.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.nmr.converter.supplier.nmrml.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.nmr.converter.supplier.nmrml.feature/feature.xml
@@ -22,11 +22,12 @@
       <discovery label="nmrML.org" url="https://www.nmrml.org/"/>
    </url>
 
+   <includes
+         id="org.eclipse.chemclipse.xml.feature"
+         version="0.0.0"/>
+
    <plugin
          id="org.eclipse.chemclipse.nmr.converter.supplier.nmrml"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.pcr.converter.supplier.rdml.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.pcr.converter.supplier.rdml.feature/feature.xml
@@ -24,6 +24,10 @@
       <discovery label="RDML" url="http://rdml.org/"/>
    </url>
 
+   <includes
+         id="org.eclipse.chemclipse.xml.feature"
+         version="0.0.0"/>
+
    <plugin
          id="org.eclipse.chemclipse.pcr.converter.supplier.rdml"
          version="0.0.0"/>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.base.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.base.feature/feature.xml
@@ -24,6 +24,10 @@
          id="org.eclipse.chemclipse.assets.feature"
          version="0.0.0"/>
 
+   <includes
+         id="org.eclipse.chemclipse.xml.feature"
+         version="0.0.0"/>
+
    <plugin
          id="org.eclipse.chemclipse.keystore"
          version="0.0.0"/>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/feature.xml
@@ -24,11 +24,6 @@
          id="org.eclipse.chemclipse.rcp.app.compilation.core.feature"
          version="0.0.0"/>
 
-   <requires>
-      <import plugin="org.glassfish.hk2.osgi-resource-locator"/>
-      <import plugin="com.sun.xml.bind.jaxb-osgi"/>
-   </requires>
-
    <plugin
          id="org.eclipse.chemclipse.rcp.compilation.community.ui"
          version="0.0.0"/>

--- a/chemclipse/features/org.eclipse.chemclipse.xml.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.xml.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.chemclipse.xml.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.xml.feature/.settings/org.eclipse.core.resources.prefs
+++ b/chemclipse/features/org.eclipse.chemclipse.xml.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=utf8

--- a/chemclipse/features/org.eclipse.chemclipse.xml.feature/build.properties
+++ b/chemclipse/features/org.eclipse.chemclipse.xml.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/chemclipse/features/org.eclipse.chemclipse.xml.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.xml.feature/feature.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
-      id="org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.feature"
-      label="Nucleotide BLAST"
+      id="org.eclipse.chemclipse.xml.feature"
+      label="ChemClipse"
       version="0.9.0.qualifier"
       provider-name="ChemClipse"
       plugin="org.eclipse.chemclipse.feature.branding"
@@ -9,7 +9,7 @@
       license-feature-version="2.0.2.qualifier">
 
    <description url="https://www.chemclipse.net">
-      This plugin uses NCBI BLAST+ to identify based on DNA sequences.
+      Essential packages for XML.
    </description>
 
    <copyright url="https://www.chemclipse.net">
@@ -20,16 +20,12 @@
       %license
    </license>
 
-   <includes
-         id="org.eclipse.chemclipse.xml.feature"
+   <plugin
+         id="com.sun.xml.bind.jaxb-osgi"
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn"
-         version="0.0.0"/>
-
-   <plugin
-         id="jakarta.annotation-api"
+         id="org.glassfish.hk2.osgi-resource-locator"
          version="0.0.0"/>
 
    <plugin

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.cml.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.cml.feature/feature.xml
@@ -24,6 +24,10 @@
       <discovery label="Chemical Markup Language" url="https://xml-cml.org"/>
    </url>
 
+   <includes
+         id="org.eclipse.chemclipse.xml.feature"
+         version="0.0.0"/>
+
    <plugin
          id="org.eclipse.chemclipse.xxd.converter.supplier.cml"
          version="0.0.0"/>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.mzml.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.mzml.feature/feature.xml
@@ -24,6 +24,10 @@
       <discovery label="mzML" url="https://www.psidev.info/mzML"/>
    </url>
 
+   <includes
+         id="org.eclipse.chemclipse.xml.feature"
+         version="0.0.0"/>
+
    <plugin
          id="org.eclipse.chemclipse.msd.converter.supplier.mzml"
          version="0.0.0"/>


### PR DESCRIPTION
This reverts https://github.com/eclipse-chemclipse/chemclipse/pull/2254 as they were not found at runtime but also re-arranges them in their own bundle for re-use at XML based feature level and so we don't forget. Closes https://github.com/eclipse-chemclipse/chemclipse/issues/2258.