### PR TITLE
Remove dependencies from features

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.assets.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.assets.feature/feature.xml
@@ -27,8 +27,4 @@
          id="org.eclipse.chemclipse.assets.ui"
          version="0.0.0"/>
 
-   <plugin
-         id="jakarta.inject.jakarta.inject-api"
-         version="0.0.0"/>
-
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.feature/feature.xml
@@ -3,8 +3,7 @@
       id="org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.feature"
       label="Peakidentification Process"
       version="0.9.0.qualifier"
-      provider-name="ChemClipse"
-      plugin="org.eclipse.chemclipse.feature.branding"
+      provider-name="ChemClipse" plugin="org.eclipse.chemclipse.feature.branding"
       license-feature="org.eclipse.license"
       license-feature-version="2.0.2.qualifier">
 
@@ -22,10 +21,16 @@
 
    <plugin
          id="org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification"
-         version="0.0.0"/>
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
    <plugin
          id="org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.ui"
-         version="0.0.0"/>
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.feature/feature.xml
@@ -20,20 +20,8 @@
       %license
    </license>
 
-   <includes
-         id="org.eclipse.chemclipse.xml.feature"
-         version="0.0.0"/>
-
    <plugin
          id="org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn"
-         version="0.0.0"/>
-
-   <plugin
-         id="jakarta.annotation-api"
-         version="0.0.0"/>
-
-   <plugin
-         id="jakarta.xml.bind-api"
          version="0.0.0"/>
 
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.feature/feature.xml
@@ -52,8 +52,4 @@
          id="org.eclipse.chemclipse.chromatogram.wsd.peak.detector.supplier.firstderivative.ui"
          version="0.0.0"/>
 
-   <plugin
-         id="org.apache.commons.lang3"
-         version="0.0.0"/>
-
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.excel.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.excel.feature/feature.xml
@@ -3,8 +3,7 @@
       id="org.eclipse.chemclipse.msd.converter.supplier.excel.feature"
       label="Excel Converter"
       version="0.9.0.qualifier"
-      provider-name="ChemClipse"
-      plugin="org.eclipse.chemclipse.feature.branding"
+      provider-name="ChemClipse" plugin="org.eclipse.chemclipse.feature.branding"
       license-feature="org.eclipse.license"
       license-feature-version="2.0.2.qualifier">
 
@@ -22,26 +21,16 @@
 
    <plugin
          id="org.eclipse.chemclipse.msd.converter.supplier.excel"
-         version="0.0.0"/>
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
    <plugin
          id="org.eclipse.chemclipse.msd.converter.supplier.excel.ui"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.poi"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.poi.ooxml"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.poi.ooxml.schemas"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.commons.commons-collections4"
-         version="0.0.0"/>
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzdata.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzdata.feature/feature.xml
@@ -24,10 +24,6 @@
       <discovery label="mzData" url="https://www.psidev.info/mass-spectrometry-workgroup#mzdata"/>
    </url>
 
-   <includes
-         id="org.eclipse.chemclipse.xml.feature"
-         version="0.0.0"/>
-
    <plugin
          id="org.eclipse.chemclipse.msd.converter.supplier.mzdata"
          version="0.0.0"/>

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzxml.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzxml.feature/feature.xml
@@ -20,10 +20,6 @@
       %license
    </license>
 
-   <includes
-         id="org.eclipse.chemclipse.xml.feature"
-         version="0.0.0"/>
-
    <plugin
          id="org.eclipse.chemclipse.msd.converter.supplier.mzxml"
          version="0.0.0"/>

--- a/chemclipse/features/org.eclipse.chemclipse.nmr.converter.supplier.nmrml.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.nmr.converter.supplier.nmrml.feature/feature.xml
@@ -22,10 +22,6 @@
       <discovery label="nmrML.org" url="https://www.nmrml.org/"/>
    </url>
 
-   <includes
-         id="org.eclipse.chemclipse.xml.feature"
-         version="0.0.0"/>
-
    <plugin
          id="org.eclipse.chemclipse.nmr.converter.supplier.nmrml"
          version="0.0.0"/>

--- a/chemclipse/features/org.eclipse.chemclipse.pcr.converter.supplier.rdml.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.pcr.converter.supplier.rdml.feature/feature.xml
@@ -24,10 +24,6 @@
       <discovery label="RDML" url="http://rdml.org/"/>
    </url>
 
-   <includes
-         id="org.eclipse.chemclipse.xml.feature"
-         version="0.0.0"/>
-
    <plugin
          id="org.eclipse.chemclipse.pcr.converter.supplier.rdml"
          version="0.0.0"/>

--- a/chemclipse/features/org.eclipse.chemclipse.pcr.report.supplier.tabular.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.pcr.report.supplier.tabular.feature/feature.xml
@@ -43,12 +43,4 @@
          id="org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui"
          version="0.0.0"/>
 
-   <plugin
-         id="org.apache.commons.commons-collections4"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.commons.csv"
-         version="0.0.0"/>
-
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.base.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.base.feature/feature.xml
@@ -380,20 +380,4 @@
          id="org.eclipse.chemclipse.ux.extension.pcr.ui"
          version="0.0.0"/>
 
-   <plugin
-         id="org.apache.commons.commons-io"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.nebula.widgets.richtext"
-         version="0.0.0"/>
-
-   <plugin
-         id="com.google.guava"
-         version="0.0.0"/>
-
-   <plugin
-         id="com.google.guava.failureaccess"
-         version="0.0.0"/>
-
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.compilation.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.compilation.core.feature/feature.xml
@@ -324,8 +324,4 @@
          id="org.eclipse.chemclipse.nmr.converter.supplier.nmrml.feature"
          version="0.0.0"/>
 
-   <plugin
-         id="org.eclipse.ui.ide"
-         version="0.0.0"/>
-
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
@@ -173,6 +173,18 @@
          version="0.0.0"/>
 
    <plugin
+         id="org.eclipse.e4.ui.css.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.e4.ui.css.swt"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.e4.ui.css.swt.theme"
+         version="0.0.0"/>
+
+   <plugin
          id="org.eclipse.e4.ui.di"
          version="0.0.0"/>
 
@@ -342,6 +354,10 @@
 
    <plugin
          id="org.eclipse.help"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.help.base"
          version="0.0.0"/>
 
    <plugin
@@ -544,30 +560,10 @@
          id="org.eclipse.ui.intro.quicklinks"
          version="0.0.0"/>
 
-   <plugin
-         id="org.apache.xmlgraphics"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.commons.math3"
-         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.jdt.core.compiler.batch"
          version="0.0.0"/>
-
-   <plugin
-         id="com.sun.jna"
-         version="0.0.0"/>
-
-   <plugin
-         id="com.sun.jna.platform"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.felix.scr"
-         version="0.0.0"/>
-
    <plugin
          id="org.eclipse.ui.monitoring"
          version="0.0.0"/>
@@ -577,33 +573,8 @@
          version="0.0.0"/>
 
    <plugin
-         id="ch.qos.logback.classic"
-         version="0.0.0"/>
-
-   <plugin
-         id="ch.qos.logback.core"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.ui.themes"
          version="0.0.0"/>
-
-   <plugin
-         id="org.apache.commons.commons-codec"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.tukaani.xz"
-         version="0.0.0"/>
-
-   <plugin
-         id="com.github.weisj.jsvg"
-         version="0.0.0"/>
-
-   <plugin
-         id="slf4j.api"
-         version="0.0.0"/>
-
    <plugin
          id="org.eclipse.ltk.core.refactoring"
          version="0.0.0"/>
@@ -627,89 +598,4 @@
    <plugin
          id="org.eclipse.search.core"
          version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.http.service.api"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.http.whiteboard"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.jetty.servlet-api"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.lucene.analysis-common"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.lucene.analysis-smartcn"
-         version="0.0.0"/>
-
-   <plugin
-         id="bcpg"
-         version="0.0.0"/>
-
-   <plugin
-         id="bcprov"
-         version="0.0.0"/>
-         
-   <plugin
-         id="bcutil"
-         version="0.0.0"/>
-
-   <plugin
-         id="com.sun.el.javax.el"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.mortbay.jasper.apache-jsp"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.mortbay.jasper.apache-el"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.jetty.ee8.security"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.jetty.ee8.server"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.jetty.ee8.servlet"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.jetty.session"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.coordinator"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.orbit.xml-apis-ext"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.batik.css"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.batik.constants"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.batik.i18n"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.batik.util"
-         version="0.0.0"/>
-
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.test.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.test.feature/feature.xml
@@ -2,11 +2,8 @@
 <feature
       id="org.eclipse.chemclipse.rcp.app.test.feature"
       label="RCP Test App Feature"
-      version="0.9.0.qualifier"
-      provider-name="ChemClipse"
-      plugin="org.eclipse.chemclipse.feature.branding"
-      license-feature="org.eclipse.license"
-      license-feature-version="2.0.2.qualifier">
+      version="0.9.0.qualifier" provider-name="ChemClipse" plugin="org.eclipse.chemclipse.feature.branding"
+      license-feature="org.eclipse.license" license-feature-version="2.0.2.qualifier">
 
    <description url="http://www.chemclipse.net">
       Helper functions for unit and integration tests.
@@ -22,14 +19,9 @@
 
    <plugin
          id="org.eclipse.chemclipse.rcp.app.test"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.junit"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.hamcrest"
-         version="0.0.0"/>
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.connector.supplier.microsoft.office.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.connector.supplier.microsoft.office.feature/feature.xml
@@ -24,8 +24,4 @@
          id="org.eclipse.chemclipse.rcp.connector.supplier.microsoft.office.ui"
          version="0.0.0"/>
 
-   <plugin
-         id="org.apache.commons.commons-collections4"
-         version="0.0.0"/>
-
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.cml.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.cml.feature/feature.xml
@@ -24,10 +24,6 @@
       <discovery label="Chemical Markup Language" url="https://xml-cml.org"/>
    </url>
 
-   <includes
-         id="org.eclipse.chemclipse.xml.feature"
-         version="0.0.0"/>
-
    <plugin
          id="org.eclipse.chemclipse.xxd.converter.supplier.cml"
          version="0.0.0"/>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.feature/feature.xml
@@ -24,8 +24,4 @@
          id="org.eclipse.chemclipse.xxd.converter.supplier.jcampdx"
          version="0.0.0"/>
 
-   <plugin
-         id="jakarta.activation-api"
-         version="0.0.0"/>
-
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.mzml.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.mzml.feature/feature.xml
@@ -24,10 +24,6 @@
       <discovery label="mzML" url="https://www.psidev.info/mzML"/>
    </url>
 
-   <includes
-         id="org.eclipse.chemclipse.xml.feature"
-         version="0.0.0"/>
-
    <plugin
          id="org.eclipse.chemclipse.msd.converter.supplier.mzml"
          version="0.0.0"/>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.feature/feature.xml
@@ -22,50 +22,16 @@
 
    <plugin
          id="org.eclipse.chemclipse.xxd.identifier.supplier.wikidata"
-         version="0.0.0"/>
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
    <plugin
          id="org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.ui"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.commons.commons-compress"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.httpcomponents.httpclient"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.httpcomponents.httpcore"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.thrift"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.slf4j.api"
-         version="0.0.0"/>
-
-   <plugin
-         id="wrapped.org.apache.jena.jena-arq"
-         version="0.0.0"/>
-
-   <plugin
-         id="wrapped.org.apache.jena.jena-base"
-         version="0.0.0"/>
-
-   <plugin
-         id="wrapped.org.apache.jena.jena-core"
-         version="0.0.0"/>
-
-   <plugin
-         id="wrapped.org.apache.jena.jena-iri"
-         version="0.0.0"/>
-
-   <plugin
-         id="wrapped.org.apache.jena.jena-shaded-guava"
-         version="0.0.0"/>
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
 </feature>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.process.supplier.pca.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.process.supplier.pca.feature/feature.xml
@@ -22,34 +22,51 @@
 
    <plugin
          id="org.eclipse.chemclipse.xxd.process.supplier.pca"
-         version="0.0.0"/>
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
    <plugin
          id="org.eclipse.chemclipse.xxd.process.supplier.pca.ui"
-         version="0.0.0"/>
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
    <plugin
          id="wrapped.org.ejml.ejml-core"
-         version="0.0.0"/>
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
    <plugin
          id="wrapped.org.ejml.ejml-ddense"
-         version="0.0.0"/>
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
    <plugin
          id="wrapped.org.ejml.ejml-experimental"
-         version="0.0.0"/>
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
    <plugin
          id="wrapped.org.ejml.ejml-fdense"
-         version="0.0.0"/>
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
    <plugin
          id="wrapped.org.ejml.ejml-simple"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.commons.commons-collections4"
-         version="0.0.0"/>
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
 </feature>


### PR DESCRIPTION
This is not required anymore since https://github.com/eclipse-chemclipse/chemclipse/pull/2260 and bad practice https://github.com/eclipse-simrel/.github/blob/main/wiki/SimRel/Simultaneous_Release_Requirements.md#do-not-include-non-project-content-in-features

Partially reverts:
* https://github.com/eclipse-chemclipse/chemclipse/pull/2255/
* https://github.com/eclipse-chemclipse/chemclipse/pull/2259