### PR TITLE
Downgrade Apache Jena to version 2

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/META-INF/MANIFEST.MF
@@ -11,19 +11,13 @@ Bundle-Activator: org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.Activa
 Bundle-Vendor: ChemClipse
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.support;bundle-version="0.9.0",
- wrapped.org.apache.jena.jena-base;bundle-version="3.16.0",
- wrapped.org.apache.jena.jena-core;bundle-version="3.16.0",
- wrapped.org.apache.jena.jena-iri;bundle-version="3.16.0",
- wrapped.org.apache.jena.jena-arq;bundle-version="3.16.0",
- wrapped.org.apache.jena.jena-shaded-guava;bundle-version="3.16.0",
- org.apache.commons.lang3;bundle-version="3.12.0",
- org.apache.thrift;bundle-version="0.12.0",
- org.apache.commons.commons-compress;bundle-version="1.22.0",
  org.slf4j.api;bundle-version="1.7.30",
  org.eclipse.chemclipse.logging;bundle-version="0.9.0",
  org.eclipse.chemclipse.model;bundle-version="0.9.0",
  org.eclipse.chemclipse.chromatogram.xxd.identifier;bundle-version="0.9.0",
- org.apache.httpcomponents.httpclient;bundle-version="4.5.14",
- org.apache.httpcomponents.httpcore;bundle-version="4.4.16"
+ wrapped.org.apache.jena.jena-arq;bundle-version="2.13.0",
+ wrapped.org.apache.jena.jena-core;bundle-version="2.13.0",
+ wrapped.org.apache.jena.jena-iri;bundle-version="1.1.2",
+ org.apache.xerces;bundle-version="2.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/Activator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/Activator.java
@@ -12,9 +12,10 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.identifier.supplier.wikidata;
 
-import org.apache.jena.query.ARQ;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
+
+import com.hp.hpl.jena.query.ARQ;
 
 public class Activator implements BundleActivator {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/query/QueryEntity.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/query/QueryEntity.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.query;
 
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QueryFactory;
-import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.ResultSet;
-import org.apache.jena.rdf.model.RDFNode;
+import com.hp.hpl.jena.query.Query;
+import com.hp.hpl.jena.query.QueryExecution;
+import com.hp.hpl.jena.query.QueryExecutionFactory;
+import com.hp.hpl.jena.query.QueryFactory;
+import com.hp.hpl.jena.query.QuerySolution;
+import com.hp.hpl.jena.query.ResultSet;
+import com.hp.hpl.jena.rdf.model.RDFNode;
 
 public class QueryEntity {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/query/QueryStructuralFormula.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/query/QueryStructuralFormula.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.query;
 
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QueryFactory;
-import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.ResultSet;
-import org.apache.jena.rdf.model.RDFNode;
+import com.hp.hpl.jena.query.Query;
+import com.hp.hpl.jena.query.QueryExecution;
+import com.hp.hpl.jena.query.QueryExecutionFactory;
+import com.hp.hpl.jena.query.QueryFactory;
+import com.hp.hpl.jena.query.QuerySolution;
+import com.hp.hpl.jena.query.ResultSet;
+import com.hp.hpl.jena.rdf.model.RDFNode;
 
 public class QueryStructuralFormula {
 

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -25,7 +25,8 @@
 	<unit id="org.apache.commons.lang3"/>
 	<unit id="org.apache.httpcomponents.httpclient"/>
 	<unit id="org.apache.httpcomponents.httpcore"/>
-	<repository location="https://download.eclipse.org/releases/2025-06/"/>
+	<unit id="org.apache.xerces"/>
+	<repository location="https://download.eclipse.org/releases/2025-03/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.slf4j.api"/>
@@ -140,41 +141,19 @@
 			<dependency>
 				<groupId>org.apache.jena</groupId>
 				<artifactId>jena-arq</artifactId>
-				<version>3.16.0</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.jena</groupId>
-				<artifactId>jena-base</artifactId>
-				<version>3.16.0</version>
+				<version>2.13.0</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.jena</groupId>
 				<artifactId>jena-core</artifactId>
-				<version>3.16.0</version>
+				<version>2.13.0</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.jena</groupId>
 				<artifactId>jena-iri</artifactId>
-				<version>3.16.0</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.jena</groupId>
-				<artifactId>jena-shaded-guava</artifactId>
-				<version>3.16.0</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
-	</location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>org.apache.thrift</groupId>
-				<artifactId>libthrift</artifactId>
-				<version>0.12.0</version>
+				<version>1.1.2</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
Use the old original namespace for compatibility reasons.