### PR TITLE
Downgrade to Eclipse 2025-03

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/META-INF/MANIFEST.MF
@@ -42,7 +42,7 @@ Require-Bundle: org.eclipse.core.runtime,
  com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.9.2",
  org.eclipse.core.commands;bundle-version="3.9.100",
  org.eclipse.chemclipse.rcp.app;bundle-version="0.9.0",
- com.google.guava;bundle-version="33.4.8"
+ com.google.guava;bundle-version="33.4.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.xxd.filter.peaks,

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -25,7 +25,7 @@
 	<unit id="org.apache.commons.lang3"/>
 	<unit id="org.apache.httpcomponents.httpclient"/>
 	<unit id="org.apache.httpcomponents.httpcore"/>
-	<repository location="https://download.eclipse.org/releases/2025-06/"/>
+	<repository location="https://download.eclipse.org/releases/2025-03/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.slf4j.api"/>

--- a/chemclipse/sites/chemclipse/category.xml
+++ b/chemclipse/sites/chemclipse/category.xml
@@ -14,6 +14,6 @@
          Update site for derivative products.
       </description>
    </category-def>
-   <repository-reference location="https://download.eclipse.org/releases/2025-06/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/releases/2025-03/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/oomph/simrel-orbit/2023-06/" enabled="true" />
 </site>


### PR DESCRIPTION
We do see resolver issues that cause performance problems. Wikidata test case takes 2 min. with 2025-06 and 2 seconds with 2025-03.