### PR TITLE
Remove ejml-experimental from target platform

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.xxd.process.supplier.pca.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.process.supplier.pca.feature/feature.xml
@@ -49,13 +49,6 @@
          unpack="false"/>
 
    <plugin
-         id="wrapped.org.ejml.ejml-experimental"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="wrapped.org.ejml.ejml-fdense"
          download-size="0"
          install-size="0"

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -108,12 +108,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.ejml</groupId>
-				<artifactId>ejml-experimental</artifactId>
-				<version>0.43</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.ejml</groupId>
 				<artifactId>ejml-fdense</artifactId>
 				<version>0.43</version>
 				<type>jar</type>


### PR DESCRIPTION
It contains and exports(tries to override them?) same packages as other ejml bundles and this causes exponential growth of uses clauses calculations.
This is the reason for slow down when using 2025-06.