### PR TITLE
Drop Apache Jena dependency

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/META-INF/MANIFEST.MF
@@ -11,19 +11,10 @@ Bundle-Activator: org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.Activa
 Bundle-Vendor: ChemClipse
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.support;bundle-version="0.9.0",
- wrapped.org.apache.jena.jena-base;bundle-version="3.16.0",
- wrapped.org.apache.jena.jena-core;bundle-version="3.16.0",
- wrapped.org.apache.jena.jena-iri;bundle-version="3.16.0",
- wrapped.org.apache.jena.jena-arq;bundle-version="3.16.0",
- wrapped.org.apache.jena.jena-shaded-guava;bundle-version="3.16.0",
- org.apache.commons.lang3;bundle-version="3.12.0",
- org.apache.thrift;bundle-version="0.12.0",
- org.apache.commons.commons-compress;bundle-version="1.22.0",
- slf4j.api;bundle-version="2.0.16",
  org.eclipse.chemclipse.logging;bundle-version="0.9.0",
  org.eclipse.chemclipse.model;bundle-version="0.9.0",
  org.eclipse.chemclipse.chromatogram.xxd.identifier;bundle-version="0.9.0",
- org.apache.httpcomponents.httpclient;bundle-version="4.5.14",
- org.apache.httpcomponents.httpcore;bundle-version="4.4.16"
+ com.fasterxml.jackson.core.jackson-databind;bundle-version="2.19.0",
+ com.fasterxml.jackson.core.jackson-core;bundle-version="2.19.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/Activator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/Activator.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.identifier.supplier.wikidata;
 
-import org.apache.jena.query.ARQ;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
@@ -33,7 +32,6 @@ public class Activator implements BundleActivator {
 	public void start(BundleContext bundleContext) throws Exception {
 
 		Activator.context = bundleContext;
-		ARQ.init();
 	}
 
 	/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/query/QueryEntity.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/query/QueryEntity.java
@@ -30,30 +30,32 @@ public class QueryEntity {
 
 	public static String fromCAS(String cas) {
 
-		String select = Wikidata.PROP + Wikidata.STATEMENT + Wikidata.WIKIBASE + Wikidata.BIGDATA + Wikidata.WDT + //
-				"SELECT DISTINCT ?item WHERE {\n" //
-				+ "  SERVICE wikibase:label { bd:serviceParam wikibase:language \"en\". }\n" //
-				+ "  {\n" //
-				+ "    SELECT DISTINCT ?item WHERE {\n" //
-				+ "      ?item p:P231 ?cas.\n" //
-				+ "      ?cas (ps:P231) \"" + cas + "\".\n" //
-				+ "    }\n" //
-				+ "  }\n" //
-				+ "}"; //
+		String select = Wikidata.PROP + Wikidata.STATEMENT + Wikidata.WIKIBASE + Wikidata.BIGDATA + Wikidata.WDT + """
+				SELECT DISTINCT ?item WHERE {
+				  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+				  {
+				    SELECT DISTINCT ?item WHERE {
+				      ?item p:P231 ?cas.
+				      ?cas (ps:P231) "%s".
+				    }
+				  }
+				}
+				""".formatted(cas);
 		return query(select);
 	}
 
 	// TODO: case insensitive query that is not super slow
 	public static String fromName(String name) {
 
-		String select = Wikidata.PROP + Wikidata.BIGDATA + Wikidata.SCHEMA + Wikidata.WIKIBASE + Wikidata.WD + Wikidata.WDT + //
-				"SELECT distinct ?item WHERE { \n" + //
-				"  ?item ?label \"" + name.toLowerCase() + "\"@en . \n" + //
-				"  ?item wdt:P31 wd:Q113145171 . \n" + //
-				"  ?article schema:about ?item . \n" + //
-				"  ?article schema:inLanguage \"en\" . \n" + //
-				"  SERVICE wikibase:label { bd:serviceParam wikibase:language \"en\". }\n" + //
-				"}";
+		String select = Wikidata.PROP + Wikidata.BIGDATA + Wikidata.SCHEMA + Wikidata.WIKIBASE + Wikidata.WD + Wikidata.WDT + """
+				SELECT distinct ?item WHERE {
+				  ?item ?label "%s"@en .
+				  ?item wdt:P31 wd:Q113145171 .
+				  ?article schema:about ?item .
+				  ?article schema:inLanguage "en" .
+				  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+				}
+				""".formatted(name.toLowerCase());
 		return query(select);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/query/QueryEntity.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/query/QueryEntity.java
@@ -12,15 +12,21 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.query;
 
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QueryFactory;
-import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.ResultSet;
-import org.apache.jena.rdf.model.RDFNode;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.eclipse.chemclipse.logging.core.Logger;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class QueryEntity {
+
+	private static final Logger logger = Logger.getLogger(QueryEntity.class);
 
 	public static String fromCAS(String cas) {
 
@@ -53,15 +59,30 @@ public class QueryEntity {
 
 	private static String query(String queryString) {
 
-		Query query = QueryFactory.create(queryString);
-		try (QueryExecution qexec = QueryExecutionFactory.sparqlService(Wikidata.ENDPOINT, query)) {
-			ResultSet results = qexec.execSelect();
-			while(results.hasNext()) {
-				QuerySolution solution = results.next();
-				RDFNode entity = solution.get("item");
-				return entity.toString();
+		String url;
+		try {
+			url = Wikidata.ENDPOINT + "?query=" + java.net.URLEncoder.encode(queryString, "UTF-8");
+			HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url)).header("Accept", "application/json").build();
+			HttpClient client = HttpClient.newHttpClient();
+			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+			ObjectMapper mapper = new ObjectMapper();
+			JsonNode root = mapper.readTree(response.body());
+			JsonNode bindings = root.path("results").path("bindings");
+			for(JsonNode binding : bindings) {
+				JsonNode picNode = binding.path("item").path("value");
+				if(!picNode.isMissingNode()) {
+					return picNode.asText();
+				}
 			}
+		} catch(UnsupportedEncodingException e) {
+			logger.error(e);
+		} catch(IOException e) {
+			logger.error(e);
+		} catch(InterruptedException e) {
+			logger.error(e);
 		}
+
 		return null;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/query/QueryStructuralFormula.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/query/QueryStructuralFormula.java
@@ -28,74 +28,79 @@ public class QueryStructuralFormula {
 
 	private static final Logger logger = Logger.getLogger(QueryStructuralFormula.class);
 
+	private QueryStructuralFormula() {
+
+	}
+
 	public static String fromName(String name) {
 
-		String select = Wikidata.PROP + Wikidata.RDFS + Wikidata.SKOS + Wikidata.WIKIBASE + Wikidata.BIGDATA + Wikidata.WDT + //
-				"SELECT ?item ?itemLabel ?pic\n" + //
-				"WHERE {\n" + //
-				"  {\n" + //
-				"    ?item rdfs:label \"" + name + "\"@en.\n" + //
-				"  }\n" + //
-				"  UNION\n" + //
-				"  {\n" + //
-				"    ?item skos:altLabel \"" + name + "\"@en.\n" + //
-				"  }\n" + //
-				"  ?item wdt:P117 ?pic\n" + //
-				"  SERVICE wikibase:label { bd:serviceParam wikibase:language \"en\". }\n" + //
-				"}";
+		String select = Wikidata.PROP + Wikidata.RDFS + Wikidata.SKOS + Wikidata.WIKIBASE + Wikidata.BIGDATA + Wikidata.WDT + """
+				SELECT ?item ?itemLabel ?pic
+				WHERE {
+				  {
+				    ?item rdfs:label "%s"@en.
+				  }
+				  UNION
+				  {
+				    ?item skos:altLabel "%s"@en.
+				  }
+				  ?item wdt:P117 ?pic
+				  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+				}
+				""".formatted(name, name);
 		return query(select);
 	}
 
 	public static String fromCAS(String cas) {
 
-		String select = Wikidata.PROP + Wikidata.STATEMENT + Wikidata.WIKIBASE + Wikidata.BIGDATA + Wikidata.WDT + //
-				"SELECT ?item ?itemLabel ?pic WHERE {\n" + //
-				"  ?item p:P231 ?_cas.\n" + //
-				"  ?_cas (ps:P231) \"" + cas + "\".\n" + //
-				"  ?item wdt:P117 ?pic\n" + //
-				"  SERVICE wikibase:label { bd:serviceParam wikibase:language \"[AUTO_LANGUAGE],en\" }\n" //
-				+ "}";
+		String select = Wikidata.PROP + Wikidata.STATEMENT + Wikidata.WIKIBASE + Wikidata.BIGDATA + Wikidata.WDT + """
+				SELECT ?item ?itemLabel ?pic WHERE {
+				  ?item p:P231 ?_cas.
+				  ?_cas (ps:P231) "%s".
+				  ?item wdt:P117 ?pic
+				  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
+				}
+				""".formatted(cas);
 		return query(select);
 	}
 
 	public static String fromSMILES(String smiles) {
 
-		String select = Wikidata.PROP + Wikidata.STATEMENT + Wikidata.WIKIBASE + Wikidata.BIGDATA + Wikidata.WDT + //
-				"SELECT ?item ?itemLabel ?pic WHERE {\n" + //
-				"  ?item p:P233 ?_smiles.\n" + //
-				"  ?_smiles (ps:P233) \"" + smiles + "\".\n" + //
-				"  ?item wdt:P117 ?pic\n" + //
-				"  SERVICE wikibase:label { bd:serviceParam wikibase:language \"[AUTO_LANGUAGE],en\" }\n" //
-				+ "}";
+		String select = Wikidata.PROP + Wikidata.STATEMENT + Wikidata.WIKIBASE + Wikidata.BIGDATA + Wikidata.WDT + """
+				SELECT ?item ?itemLabel ?pic WHERE {
+				  ?item p:P233 ?_smiles.
+				  ?_smiles (ps:P233) "%s".
+				  ?item wdt:P117 ?pic
+				  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
+				}
+				""".formatted(smiles);
 		return query(select);
 	}
 
 	public static String fromInChI(String inchi) {
 
-		String select = Wikidata.PROP + Wikidata.STATEMENT + Wikidata.WIKIBASE + Wikidata.BIGDATA + Wikidata.WDT + //
-				"SELECT ?item ?itemLabel ?pic WHERE {\n" + //
-				"  ?item p:P234 ?_inchi.\n" + //
-				"  ?_inchi (ps:P234) \"" + inchi + "\".\n" + //
-				"  ?item wdt:P117 ?pic\n" + //
-				"  SERVICE wikibase:label { bd:serviceParam wikibase:language \"[AUTO_LANGUAGE],en\" }\n" //
-				+ "}";
+		String select = Wikidata.PROP + Wikidata.STATEMENT + Wikidata.WIKIBASE + Wikidata.BIGDATA + Wikidata.WDT + """
+				SELECT ?item ?itemLabel ?pic WHERE {
+				  ?item p:P234 ?_inchi.
+				  ?_inchi (ps:P234) "%s".
+				  ?item wdt:P117 ?pic
+				  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
+				}
+				""".formatted(inchi);
 		return query(select);
 	}
 
 	public static String fromInChIKey(String inchiKey) {
 
-		String select = Wikidata.PROP + Wikidata.STATEMENT + Wikidata.WIKIBASE + Wikidata.BIGDATA + Wikidata.WDT + //
-				"SELECT ?item ?itemLabel ?pic WHERE {\n" + //
-				"  ?item p:P235 ?_inchiKey.\n" + //
-				"  ?_inchiKey (ps:P235) \"" + inchiKey + "\".\n" + //
-				"  ?item wdt:P117 ?pic\n" + //
-				"  SERVICE wikibase:label { bd:serviceParam wikibase:language \"[AUTO_LANGUAGE],en\" }\n" //
-				+ "}";
+		String select = Wikidata.PROP + Wikidata.STATEMENT + Wikidata.WIKIBASE + Wikidata.BIGDATA + Wikidata.WDT + """
+				SELECT ?item ?itemLabel ?pic WHERE {
+				  ?item p:P235 ?_inchiKey.
+				  ?_inchiKey (ps:P235) "%s".
+				  ?item wdt:P117 ?pic
+				  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
+				}
+				""".formatted(inchiKey);
 		return query(select);
-	}
-
-	private QueryStructuralFormula() {
-
 	}
 
 	private static String query(String queryString) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/query/QueryStructuralFormula.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/query/QueryStructuralFormula.java
@@ -12,15 +12,21 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.query;
 
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QueryFactory;
-import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.ResultSet;
-import org.apache.jena.rdf.model.RDFNode;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.eclipse.chemclipse.logging.core.Logger;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class QueryStructuralFormula {
+
+	private static final Logger logger = Logger.getLogger(QueryStructuralFormula.class);
 
 	public static String fromName(String name) {
 
@@ -94,14 +100,27 @@ public class QueryStructuralFormula {
 
 	private static String query(String queryString) {
 
-		Query query = QueryFactory.create(queryString);
-		try (QueryExecution qexec = QueryExecutionFactory.sparqlService(Wikidata.ENDPOINT, query)) {
-			ResultSet results = qexec.execSelect();
-			while(results.hasNext()) {
-				QuerySolution solution = results.next();
-				RDFNode pic = solution.get("pic");
-				return pic.toString();
+		try {
+			String url = Wikidata.ENDPOINT + "?query=" + java.net.URLEncoder.encode(queryString, "UTF-8");
+			HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url)).header("Accept", "application/json").build();
+			HttpClient client = HttpClient.newHttpClient();
+			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+			ObjectMapper mapper = new ObjectMapper();
+			JsonNode root = mapper.readTree(response.body());
+			JsonNode bindings = root.path("results").path("bindings");
+			for(JsonNode binding : bindings) {
+				JsonNode picNode = binding.path("pic").path("value");
+				if(!picNode.isMissingNode()) {
+					return picNode.asText();
+				}
 			}
+		} catch(UnsupportedEncodingException e) {
+			logger.error(e);
+		} catch(IOException e) {
+			logger.error(e);
+		} catch(InterruptedException e) {
+			logger.error(e);
 		}
 		return null;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/query/Wikidata.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/src/org/eclipse/chemclipse/xxd/identifier/supplier/wikidata/query/Wikidata.java
@@ -15,7 +15,7 @@ package org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.query;
 public class Wikidata {
 
 	public static final String ENDPOINT = "https://query.wikidata.org/sparql";
-	//
+
 	public static final String PROP = "PREFIX p: <http://www.wikidata.org/prop/>\n";
 	public static final String STATEMENT = "PREFIX ps: <http://www.wikidata.org/prop/statement/>\n";
 	public static final String WIKIBASE = "PREFIX wikibase: <http://wikiba.se/ontology#>\n";

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -127,49 +127,5 @@
 			</dependency>
 		</dependencies>
 	</location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="org.apache.jena" missingManifest="generate" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>org.apache.jena</groupId>
-				<artifactId>jena-arq</artifactId>
-				<version>3.16.0</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.jena</groupId>
-				<artifactId>jena-base</artifactId>
-				<version>3.16.0</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.jena</groupId>
-				<artifactId>jena-core</artifactId>
-				<version>3.16.0</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.jena</groupId>
-				<artifactId>jena-iri</artifactId>
-				<version>3.16.0</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.jena</groupId>
-				<artifactId>jena-shaded-guava</artifactId>
-				<version>3.16.0</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
-	</location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>org.apache.thrift</groupId>
-				<artifactId>libthrift</artifactId>
-				<version>0.12.0</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
-	</location>
 </locations>
 </target>


### PR DESCRIPTION
I overengineered https://github.com/eclipse-chemclipse/chemclipse/pull/1286 and https://github.com/eclipse-chemclipse/chemclipse/pull/1435 as in the SPARQL queries only run server side and the exchange is via a simple JSON API that can be parsed with libraries that already  exist in the platform. This drops technical dept and outdated libraries.