### PR TITLE
Don't mirror Nebula in ChemClipse update site

### DIFF
--- a/chemclipse/sites/chemclipse/category.xml
+++ b/chemclipse/sites/chemclipse/category.xml
@@ -16,4 +16,5 @@
    </category-def>
    <repository-reference location="https://download.eclipse.org/releases/2025-06/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/oomph/simrel-orbit/2023-06/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/nebula/updates/release/3.1.1/" enabled="true" />
 </site>


### PR DESCRIPTION
Same as https://github.com/eclipse-chemclipse/chemclipse/pull/2252. Decreases repository size → 39.1 MB.