### PR TITLE
Update to latest commons-csv from latest orbit

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/META-INF/MANIFEST.MF
@@ -18,7 +18,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.pcr.report.supplier.tabular;bundle-version="0.9.0",
  org.apache.commons.lang3;bundle-version="3.12.0",
  org.apache.commons.commons-io;bundle-version="2.11.0",
- org.apache.commons.csv;bundle-version="1.8.0"
+ org.apache.commons.commons-csv;bundle-version="1.8.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.preferences

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/csv/core/PCRExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/csv/core/PCRExportConverter.java
@@ -68,7 +68,7 @@ public class PCRExportConverter extends AbstractPlateExportConverter implements 
 	public IProcessingInfo<File> convert(File file, IPlate plate, IProgressMonitor monitor) {
 
 		decimalFormat.applyPattern("#,##0.00");
-		CSVFormat csvFormat = CSVFormat.RFC4180.withDelimiter(PreferenceSupplier.getDelimiter().getCharacter());
+		CSVFormat csvFormat = CSVFormat.RFC4180.builder().setDelimiter(PreferenceSupplier.getDelimiter().getCharacter()).get();
 		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
 		if(plate != null) {
 			try (CSVPrinter csvPrinter = new CSVPrinter(new FileWriter(file, false), csvFormat)) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.csd.converter;bundle-version="0.8.0",
  com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.9.9",
  org.eclipse.chemclipse.vsd.model;bundle-version="0.9.0",
- org.apache.commons.csv;bundle-version="1.8.0"
+ org.apache.commons.commons-csv;bundle-version="1.8.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Import-Package: org.osgi.service.component.annotations;version="1.2.0"

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/core/FileContentMatcherPeak.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/core/FileContentMatcherPeak.java
@@ -30,7 +30,7 @@ public class FileContentMatcherPeak extends AbstractFileContentMatcher implement
 	public boolean checkFileFormat(File file) {
 
 		try {
-			try (CSVParser parser = new CSVParser(new FileReader(file), CSVFormat.EXCEL.withHeader())) {
+			try (CSVParser parser = CSVParser.parse(new FileReader(file), CSVFormat.EXCEL.builder().setHeader().get())) {
 				String[] array = parser.getHeaderMap().keySet().toArray(new String[0]);
 				return Arrays.equals(array, CSVPeakConverter.HEADERS);
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/core/CSVPeakConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/core/CSVPeakConverter.java
@@ -165,7 +165,7 @@ public class CSVPeakConverter implements IPeakExportConverter, IPeakImportConver
 
 	public static void writePeaks(IPeaksMSD peaks, Writer writer, boolean writeHeader) throws IOException {
 
-		try (CSVPrinter csv = new CSVPrinter(writer, CSVFormat.EXCEL.withNullString("").withQuoteMode(QuoteMode.ALL))) {
+		try (CSVPrinter csv = new CSVPrinter(writer, CSVFormat.EXCEL.builder().setNullString("").setQuoteMode(QuoteMode.ALL).get())) {
 			if(writeHeader) {
 				csv.printRecord(Arrays.asList(HEADERS));
 			}
@@ -211,7 +211,7 @@ public class CSVPeakConverter implements IPeakExportConverter, IPeakImportConver
 	public static IPeaksMSD readPeaks(Reader reader) throws IOException, ParseException {
 
 		PeaksMSD result = new PeaksMSD();
-		try (CSVParser parser = new CSVParser(reader, CSVFormat.EXCEL.withHeader(HEADERS).withSkipHeaderRecord())) {
+		try (CSVParser parser = CSVParser.parse(reader, CSVFormat.EXCEL.builder().setHeader(HEADERS).setSkipHeaderRecord(true).get())) {
 			NumberFormat nf;
 			synchronized(NUMBER_FORMAT) {
 				nf = (NumberFormat)NUMBER_FORMAT.clone();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/core/ChromatogramReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/core/ChromatogramReader.java
@@ -83,7 +83,7 @@ public class ChromatogramReader extends AbstractChromatogramMSDReader implements
 			String zeroMarker = PreferenceSupplier.getImportZeroMarker();
 			zeroMarker = zeroMarker.startsWith(ZERO_VALUE) ? zeroMarker : ZERO_VALUE;
 			char delimiter = PreferenceSupplier.getImportDelimiter().getCharacter();
-			CSVParser csvParser = new CSVParser(fileReader, CSVFormat.newFormat(delimiter).withHeader());
+			CSVParser csvParser = CSVParser.parse(fileReader, CSVFormat.newFormat(delimiter).builder().setHeader().get());
 			chromatogram = new VendorChromatogram();
 			if(!overview) {
 				/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.apache.poi;bundle-version="4.1.1",
  org.apache.poi.ooxml;bundle-version="4.1.1",
  org.apache.poi.ooxml.schemas;bundle-version="4.1.1",
- org.apache.commons.csv;bundle-version="1.8.0"
+ org.apache.commons.commons-csv;bundle-version="1.8.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.xxd.process.supplier.pca.core,

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/PcaExtractionFileLongText.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/PcaExtractionFileLongText.java
@@ -141,7 +141,7 @@ public class PcaExtractionFileLongText implements IExtractionData {
 					/*
 					 * Data
 					 */
-					CSVParser parser = new CSVParser(reader, CSVFormat.TDF.withHeader());
+					CSVParser parser = CSVParser.parse(reader, CSVFormat.TDF.builder().setHeader().get());
 					for(CSVRecord record : parser.getRecords()) {
 						int size = record.size();
 						if(size == 7) {
@@ -183,7 +183,7 @@ public class PcaExtractionFileLongText implements IExtractionData {
 					/*
 					 * Data
 					 */
-					CSVParser parser = new CSVParser(reader, CSVFormat.TDF.withHeader());
+					CSVParser parser = CSVParser.parse(reader, CSVFormat.TDF.builder().setHeader().get());
 					for(CSVRecord record : parser.getRecords()) {
 						int size = record.size();
 						if(size == 7) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/PcaExtractionFileText.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/PcaExtractionFileText.java
@@ -119,7 +119,7 @@ public class PcaExtractionFileText implements IExtractionData {
 					/*
 					 * Data
 					 */
-					CSVParser parser = new CSVParser(reader, CSVFormat.TDF.withHeader());
+					CSVParser parser = CSVParser.parse(reader, CSVFormat.TDF.builder().setHeader().get());
 					Map<Integer, String> indexMap = extractIndexMap(parser);
 					for(CSVRecord record : parser.getRecords()) {
 						/*

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -47,11 +47,11 @@
 		<unit id="org.eclipse.nebula.widgets.richtext.feature.feature.group"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/oomph/simrel-orbit/2023-06"/>
+		<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2025-06"/>
 		<unit id="org.apache.poi"/>
 		<unit id="org.apache.poi.ooxml"/>
 		<unit id="org.apache.poi.ooxml.schemas"/>
-		<unit id="org.apache.commons.csv"/>
+		<unit id="org.apache.commons.commons-csv"/>
 		<unit id="org.apache.commons.math3"/>
 		<unit id="org.apache.xmlbeans"/>
 	</location>

--- a/chemclipse/sites/chemclipse/category.xml
+++ b/chemclipse/sites/chemclipse/category.xml
@@ -15,6 +15,6 @@
       </description>
    </category-def>
    <repository-reference location="https://download.eclipse.org/releases/2025-06/" enabled="true" />
-   <repository-reference location="https://download.eclipse.org/oomph/simrel-orbit/2023-06/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2025-06" enabled="true" />
    <repository-reference location="https://download.eclipse.org/nebula/updates/release/3.1.1/" enabled="true" />
 </site>


### PR DESCRIPTION
Updating to 2025-06 official orbit p2 repo (instead of some oomph repo). Updated to the new commons-csv symbolic name and adjust code to not use newly deprecated constructs.