### PR TITLE
Remove runtime requirement on org.osgi.service.component.annotations

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.filter/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.filter/META-INF/MANIFEST.MF
@@ -18,6 +18,5 @@ Export-Package: org.eclipse.chemclipse.chromatogram.csd.filter.core.chromatogram
  org.eclipse.chemclipse.chromatogram.csd.filter.core.peak,
  org.eclipse.chemclipse.chromatogram.csd.filter.exceptions
 Bundle-ActivationPolicy: lazy
-Import-Package: org.eclipse.chemclipse.support.settings.parser,
- org.osgi.service.component.annotations
+Import-Package: org.eclipse.chemclipse.support.settings.parser
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.csd.filter.core.chromatogram.ChromatogramFilterCSDProcessSupplier.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/META-INF/MANIFEST.MF
@@ -18,6 +18,5 @@ Export-Package: org.eclipse.chemclipse.chromatogram.csd.identifier.impl,
  org.eclipse.chemclipse.chromatogram.csd.identifier.peak,
  org.eclipse.chemclipse.chromatogram.csd.identifier.settings,
  org.eclipse.chemclipse.chromatogram.csd.identifier.support
-Import-Package: org.eclipse.chemclipse.support.settings.parser,
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: org.eclipse.chemclipse.support.settings.parser
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.csd.identifier.peak.PeakIdentifierCSDProcessTypeSupplier.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.firstderivative/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.firstderivative/META-INF/MANIFEST.MF
@@ -26,5 +26,4 @@ Export-Package: org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.f
  org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.firstderivative.settings
 Bundle-Vendor: ChemClipse
 Import-Package: com.fasterxml.jackson.databind.annotation;version="2.9.93",
- org.apache.commons.lang3;version="3.1.0",
- org.osgi.service.component.annotations;version="1.2.0"
+ org.apache.commons.lang3;version="3.1.0"

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector/META-INF/MANIFEST.MF
@@ -14,8 +14,7 @@ Require-Bundle: org.eclipse.core.runtime,
 Bundle-Vendor: ChemClipse
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: org.eclipse.chemclipse.support.settings.parser,
- org.osgi.framework;version="1.3.0",
- org.osgi.service.component.annotations;version="1.2.0"
+ org.osgi.framework;version="1.3.0"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.chromatogram.csd.peak.detector.core,
  org.eclipse.chemclipse.chromatogram.csd.peak.detector.settings

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/META-INF/MANIFEST.MF
@@ -26,7 +26,6 @@ Export-Package: org.eclipse.chemclipse.chromatogram.filter.core.chromatogram,
  org.eclipse.chemclipse.chromatogram.filter.impl.settings,
  org.eclipse.chemclipse.chromatogram.filter.result,
  org.eclipse.chemclipse.chromatogram.filter.settings
-Import-Package: org.osgi.service.component.annotations;version="1.2.0"
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.ChromatogramFilterProcessSupplier.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.filter.range.ChromatogramFilterResetRange.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.filter.range.ChromatogramFilterSelectRange.xml,

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/META-INF/MANIFEST.MF
@@ -21,4 +21,3 @@ Export-Package: org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremov
  org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover.preferences,
  org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover.settings
 Bundle-Vendor: ChemClipse
-Import-Package: org.osgi.service.component.annotations;version="[1.2.0,2.0.0)"

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass/META-INF/MANIFEST.MF
@@ -20,7 +20,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass.filter,
  org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass.preferences
-Import-Package: org.osgi.service.component.annotations;version="[1.2.0,2.0.0)"
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass.core.CutOffScanFilter.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass.core.HighPassIonsFilter.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass.core.LowPassIonsFilter.xml,

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/META-INF/MANIFEST.MF
@@ -25,8 +25,7 @@ Export-Package: org.eclipse.chemclipse.chromatogram.msd.filter.core.chromatogram
  org.eclipse.chemclipse.chromatogram.msd.filter.result,
  org.eclipse.chemclipse.chromatogram.msd.filter.settings
 Bundle-Vendor: ChemClipse
-Import-Package: org.eclipse.chemclipse.support.settings.parser,
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: org.eclipse.chemclipse.support.settings.parser
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.filter.core.chromatogram.ChromatogramFilterMSDProcessSupplier.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.filter.core.massspectrum.MassSpectrumFilterProcessSupplier.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.filter.core.massspectrum.PeakMassSpectrumFilterProcessTypeSupplier.xml,

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/META-INF/MANIFEST.MF
@@ -25,7 +25,6 @@ Export-Package: org.eclipse.chemclipse.chromatogram.msd.identifier.chromatogram,
  org.eclipse.chemclipse.chromatogram.msd.identifier.settings,
  org.eclipse.chemclipse.chromatogram.msd.identifier.support
 Bundle-Vendor: ChemClipse
-Import-Package: org.osgi.service.component.annotations;version="1.2.0"
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.identifier.chromatogram.ChromatogramIdentifierProcessTypeSupplier.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.MassSpectrumIdentifierProcessTypeSupplier.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.identifier.massspectrum.StandaloneMassSpectrumIdentifierProcessTypeSupplier.xml,

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative/META-INF/MANIFEST.MF
@@ -26,5 +26,4 @@ Export-Package: org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.f
  org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.preferences,
  org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.settings
 Bundle-Vendor: ChemClipse
-Import-Package: com.fasterxml.jackson.databind.annotation;version="2.9.93",
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: com.fasterxml.jackson.databind.annotation;version="2.9.93"

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/META-INF/MANIFEST.MF
@@ -21,6 +21,5 @@ Import-Package: com.fasterxml.jackson.annotation;version="2.9.2",
  org.eclipse.chemclipse.model.types,
  org.eclipse.chemclipse.numeric.statistics,
  org.eclipse.chemclipse.support.settings,
- org.eclipse.chemclipse.support.settings.parser,
- org.osgi.service.component.annotations;version="1.2.0"
+ org.eclipse.chemclipse.support.settings.parser
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.msd.peak.detector.core.PeakDetectorMSDProcessTypeSupplier.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.vsd.peak.detector/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.vsd.peak.detector/META-INF/MANIFEST.MF
@@ -16,6 +16,5 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
  org.eclipse.chemclipse.vsd.model;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Import-Package: org.osgi.framework;version="1.3.0",
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: org.osgi.framework;version="1.3.0"
 Bundle-ActivationPolicy: lazy

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.filter/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.filter/META-INF/MANIFEST.MF
@@ -19,7 +19,6 @@ Export-Package: org.eclipse.chemclipse.chromatogram.wsd.filter.core.chromatogram
  org.eclipse.chemclipse.chromatogram.wsd.filter.core.peak,
  org.eclipse.chemclipse.chromatogram.wsd.filter.exceptions
 Bundle-ActivationPolicy: lazy
-Import-Package: org.eclipse.chemclipse.support.settings.parser,
- org.osgi.service.component.annotations
+Import-Package: org.eclipse.chemclipse.support.settings.parser
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.wsd.filter.core.chromatogram.ChromatogramFilterWSDProcessSupplier.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.wsd.filter.processors.WaveSpectrumSignalRemover.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/META-INF/MANIFEST.MF
@@ -21,8 +21,7 @@ Export-Package: org.eclipse.chemclipse.chromatogram.wsd.identifier.chromatogram,
  org.eclipse.chemclipse.chromatogram.wsd.identifier.settings,
  org.eclipse.chemclipse.chromatogram.wsd.identifier.support,
  org.eclipse.chemclipse.chromatogram.wsd.identifier.wavespectrum
-Import-Package: org.eclipse.chemclipse.support.settings.parser,
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: org.eclipse.chemclipse.support.settings.parser
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.wsd.identifier.chromatogram.ChromatogramIdentifierProcessTypeSupplier.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.wsd.identifier.peak.PeakIdentifierWSDProcessTypeSupplier.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.wsd.identifier.wavespectrum.WaveSpectrumIdentifierProcessTypeSupplier.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector.supplier.firstderivative/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector.supplier.firstderivative/META-INF/MANIFEST.MF
@@ -26,5 +26,4 @@ Export-Package: org.eclipse.chemclipse.chromatogram.wsd.peak.detector.supplier.f
  org.eclipse.chemclipse.chromatogram.wsd.peak.detector.supplier.firstderivative.settings
 Bundle-Vendor: ChemClipse
 Import-Package: com.fasterxml.jackson.databind.annotation;version="2.9.93",
- org.apache.commons.lang3;version="3.1.0",
- org.osgi.service.component.annotations;version="1.2.0"
+ org.apache.commons.lang3;version="3.1.0"

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/META-INF/MANIFEST.MF
@@ -14,8 +14,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.support;bundle-version="0.8.0"
 Bundle-Vendor: ChemClipse
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Import-Package: org.osgi.framework;version="1.3.0",
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: org.osgi.framework;version="1.3.0"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.chromatogram.wsd.peak.detector.core,
  org.eclipse.chemclipse.chromatogram.wsd.peak.detector.settings

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/META-INF/MANIFEST.MF
@@ -20,6 +20,5 @@ Export-Package: org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.core,
  org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.exceptions,
  org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.settings
 Bundle-Vendor: ChemClipse
-Import-Package: org.eclipse.chemclipse.support.settings.parser,
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: org.eclipse.chemclipse.support.settings.parser
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.core.BaselineDetectorProcessTypeSupplier.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/META-INF/MANIFEST.MF
@@ -39,7 +39,6 @@ Bundle-ActivationPolicy: lazy
 Bundle-Localization: OSGI-INF/l10n/bundle
 Import-Package: jakarta.annotation;version="2.1.1",
  jakarta.inject;version="[2.0.0,3.0.0]",
- org.osgi.service.component.annotations;version="[1.2.0,2.0.0)",
  org.osgi.service.event;version="1.3.0"
 Export-Package: org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui.dialogs,
  org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui.swt

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/META-INF/MANIFEST.MF
@@ -22,6 +22,5 @@ Export-Package: org.eclipse.chemclipse.chromatogram.xxd.calculator.core.chromato
  org.eclipse.chemclipse.chromatogram.xxd.calculator.preferences,
  org.eclipse.chemclipse.chromatogram.xxd.calculator.settings
 Import-Package: com.fasterxml.jackson.annotation;version="2.9.2",
- com.fasterxml.jackson.databind.annotation;version="2.9.2",
- org.osgi.service.component.annotations;version="1.2.0"
+ com.fasterxml.jackson.databind.annotation;version="2.9.2"
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.xxd.calculator.core.chromatogram.ChromatogramCalculatorProcessTypeSupplier.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.classifier/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.classifier/META-INF/MANIFEST.MF
@@ -16,6 +16,5 @@ Export-Package: org.eclipse.chemclipse.chromatogram.xxd.classifier.core,
  org.eclipse.chemclipse.chromatogram.xxd.classifier.exceptions,
  org.eclipse.chemclipse.chromatogram.xxd.classifier.result,
  org.eclipse.chemclipse.chromatogram.xxd.classifier.settings
-Import-Package: org.eclipse.chemclipse.support.settings.parser,
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: org.eclipse.chemclipse.support.settings.parser
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.xxd.classifier.core.ChromatogramClassifierProcessTypeSupport.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/META-INF/MANIFEST.MF
@@ -29,7 +29,6 @@ Export-Package: org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzky
  org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.settings
 Import-Package: org.eclipse.chemclipse.chromatogram.wsd.filter.core.chromatogram,
  org.eclipse.chemclipse.wsd.model.core,
- org.eclipse.chemclipse.wsd.model.core.selection,
- org.osgi.service.component.annotations;version="1.2.0"
+ org.eclipse.chemclipse.wsd.model.core.selection
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.core.ChromatogramFilterVSD.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.core.SavitzkyGolaySmoothingFilter.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/META-INF/MANIFEST.MF
@@ -20,8 +20,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.numeric;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
-Import-Package: org.osgi.service.component.annotations;version="1.2.0",
- org.osgi.service.event;version="[1.0.0,2.0.0)"
+Import-Package: org.osgi.service.event;version="[1.0.0,2.0.0)"
 Export-Package: org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.core,
  org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.model,
  org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.preferences,

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.ui/META-INF/MANIFEST.MF
@@ -25,8 +25,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.chemclipse.swt.ui;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
-Import-Package: org.osgi.service.component.annotations;version="[1.2.0,2.0.0)",
- org.osgi.service.event;version="1.3.0"
+Import-Package: org.osgi.service.event;version="1.3.0"
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.ui.services.ScanIdentifierService.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.ui.services.ScanIdentifierServiceCSD.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.ui.services.ScanIdentifierServiceMSD.xml,

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier/META-INF/MANIFEST.MF
@@ -18,5 +18,4 @@ Require-Bundle: org.eclipse.core.runtime,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: ChemClipse
-Import-Package: org.osgi.service.component.annotations;version="1.2.0"
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.xxd.identifier.chromatogram.ChromatogramIdentifierProcessTypeSupplier.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/META-INF/MANIFEST.MF
@@ -27,8 +27,7 @@ Export-Package: org.eclipse.chemclipse.chromatogram.xxd.integrator.core.chromato
  org.eclipse.chemclipse.chromatogram.xxd.integrator.result,
  org.eclipse.chemclipse.chromatogram.xxd.integrator.support
 Bundle-Vendor: ChemClipse
-Import-Package: org.eclipse.chemclipse.support.settings.parser,
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: org.eclipse.chemclipse.support.settings.parser
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.xxd.integrator.core.chromatogram.ChromatogramIntegratorProcessTypeSupplier.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.xxd.integrator.core.combined.CombinedIntegratorProcessTypeSupplier.xml,
  OSGI-INF/org.eclipse.chemclipse.chromatogram.xxd.integrator.core.peaks.PeakIntegratorProcessTypeSupplier.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative/META-INF/MANIFEST.MF
@@ -25,6 +25,5 @@ Export-Package: org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.f
  org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.preferences
 Bundle-Vendor: ChemClipse
 Import-Package: com.fasterxml.jackson.databind.annotation;version="2.9.93",
- org.apache.commons.lang3;version="3.1.0",
- org.osgi.service.component.annotations;version="1.2.0"
+ org.apache.commons.lang3;version="3.1.0"
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.services.FirstDerivativeMaximaService.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation/META-INF/MANIFEST.MF
@@ -15,6 +15,5 @@ Bundle-Vendor: ChemClipse
 Export-Package: org.eclipse.chemclipse.chromatogram.xxd.quantitation.core,
  org.eclipse.chemclipse.chromatogram.xxd.quantitation.exceptions,
  org.eclipse.chemclipse.chromatogram.xxd.quantitation.settings
-Import-Package: org.eclipse.chemclipse.support.settings.parser,
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: org.eclipse.chemclipse.support.settings.parser
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.xxd.quantitation.core.PeakQuantifierProcessTypeSupplier.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/META-INF/MANIFEST.MF
@@ -20,6 +20,5 @@ Export-Package: org.eclipse.chemclipse.chromatogram.xxd.report.chromatogram,
  org.eclipse.chemclipse.chromatogram.xxd.report.preferences,
  org.eclipse.chemclipse.chromatogram.xxd.report.settings,
  org.eclipse.chemclipse.chromatogram.xxd.report.support
-Import-Package: com.fasterxml.jackson.annotation,
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: com.fasterxml.jackson.annotation
 Service-Component: OSGI-INF/org.eclipse.chemclipse.chromatogram.xxd.report.core.ChromatogramReportsProcessSupplier.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/META-INF/MANIFEST.MF
@@ -35,7 +35,6 @@ Export-Package: org.eclipse.chemclipse.converter.chromatogram,
  org.eclipse.chemclipse.converter.support
 Import-Package: com.fasterxml.jackson.annotation;version="2.9.2",
  jakarta.xml.bind,
- jakarta.xml.bind.annotation,
- org.osgi.service.component.annotations;version="1.2.0"
+ jakarta.xml.bind.annotation
 Service-Component: OSGI-INF/org.eclipse.chemclipse.converter.methods.MethodProcessTypeSupplier.xml
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter/META-INF/MANIFEST.MF
@@ -17,6 +17,5 @@ Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.csd.converter.chromatogram,
  org.eclipse.chemclipse.csd.converter.io,
  org.eclipse.chemclipse.csd.converter.support
-Import-Package: org.eclipse.chemclipse.support.settings.parser,
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: org.eclipse.chemclipse.support.settings.parser
 Service-Component: OSGI-INF/org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSDProcessTypeSupplier.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.fsd.converter/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.fsd.converter/META-INF/MANIFEST.MF
@@ -16,6 +16,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.fsd.converter.chromatogram,
  org.eclipse.chemclipse.fsd.converter.core
-Import-Package: org.eclipse.chemclipse.support.settings.parser,
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: org.eclipse.chemclipse.support.settings.parser
 Service-Component: OSGI-INF/org.eclipse.chemclipse.fsd.converter.chromatogram.ChromatogramConverterFSDProcessTypeSupplier.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/META-INF/MANIFEST.MF
@@ -64,7 +64,6 @@ Export-Package: org.eclipse.chemclipse.model.baseline,
  org.eclipse.chemclipse.model.updates,
  org.eclipse.chemclipse.model.validators,
  org.eclipse.chemclipse.model.wavelengths
-Import-Package: org.osgi.service.component.annotations;version="1.2.0"
 Service-Component: OSGI-INF/org.eclipse.chemclipse.model.service.ColumnMappingSerializationService.xml,
  OSGI-INF/org.eclipse.chemclipse.model.service.TimeRangesSerializationService.xml,
  OSGI-INF/org.eclipse.chemclipse.model.supplier.IMeasurementFilterProcessTypeSupplier.xml,

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak.ui/META-INF/MANIFEST.MF
@@ -16,7 +16,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.chemclipse.swt.ui;bundle-version="0.9.0",
  org.eclipse.chemclipse.xxd.process.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Import-Package: org.osgi.service.component.annotations;version="[1.2.0,2.0.0)",
- org.osgi.service.event;version="1.3.0" 
+Import-Package: org.osgi.service.event;version="1.3.0" 
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/org.eclipse.chemclipse.msd.classifier.supplier.molpeak.ui.services.ScanIdentifierServiceMSD.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/META-INF/MANIFEST.MF
@@ -18,7 +18,6 @@ Require-Bundle: org.eclipse.core.runtime,
  com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.9.9",
  org.apache.commons.commons-io;bundle-version="2.11.0"
 Bundle-ActivationPolicy: lazy
-Import-Package: org.osgi.service.component.annotations;version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: ChemClipse
 Export-Package: org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.misc,

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/META-INF/MANIFEST.MF
@@ -24,8 +24,7 @@ Export-Package: org.eclipse.chemclipse.msd.converter.chromatogram,
  org.eclipse.chemclipse.msd.converter.peak,
  org.eclipse.chemclipse.msd.converter.preferences,
  org.eclipse.chemclipse.msd.converter.support
-Import-Package: com.fasterxml.jackson.annotation;version="2.9.2",
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: com.fasterxml.jackson.annotation;version="2.9.2"
 Service-Component: OSGI-INF/org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSDProcessTypeSupplier.xml,
  OSGI-INF/org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSDProcessTypeSupplier.xml,
  OSGI-INF/org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSDSupplierContext.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist.ui/META-INF/MANIFEST.MF
@@ -17,7 +17,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.chemclipse.xxd.process.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
-Import-Package: org.osgi.service.component.annotations;version="[1.2.0,2.0.0)",
- org.osgi.service.event;version="1.3.0" 
+Import-Package: org.osgi.service.event;version="1.3.0" 
 Service-Component: OSGI-INF/org.eclipse.chemclipse.msd.identifier.supplier.nist.ui.services.ScanIdentifierInstallationService.xml,
  OSGI-INF/org.eclipse.chemclipse.msd.identifier.supplier.nist.ui.services.ScanIdentifierSettingsService.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/META-INF/MANIFEST.MF
@@ -36,6 +36,5 @@ Export-Package: org.eclipse.chemclipse.msd.model.core,
  org.eclipse.chemclipse.msd.model.support,
  org.eclipse.chemclipse.msd.model.util,
  org.eclipse.chemclipse.msd.model.xic
-Import-Package: org.osgi.service.component.annotations;version="1.2.0"
 Automatic-Module-Name: org.eclipse.chemclipse.msd.model
 Service-Component: OSGI-INF/org.eclipse.chemclipse.msd.model.system.ModelProcessorMSD.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.peak.detector.supplier.firstderivative/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.peak.detector.supplier.firstderivative/META-INF/MANIFEST.MF
@@ -24,5 +24,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.core
 Bundle-Vendor: ChemClipse
 Import-Package: com.fasterxml.jackson.databind.annotation;version="2.9.93",
- org.apache.commons.lang3;version="3.1.0",
- org.osgi.service.component.annotations;version="1.2.0"
+ org.apache.commons.lang3;version="3.1.0"

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.processing.supplier.base/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.processing.supplier.base/META-INF/MANIFEST.MF
@@ -17,8 +17,7 @@ Require-Bundle: org.eclipse.core.runtime,
  wrapped.org.ejml.ejml-core;bundle-version="0.43.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
-Import-Package: com.fasterxml.jackson.annotation;version="[2.18.0,3.0.0)",
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: com.fasterxml.jackson.annotation;version="[2.18.0,3.0.0)"
 Export-Package: org.eclipse.chemclipse.nmr.processing.apodization,
  org.eclipse.chemclipse.nmr.processing.digitalfilter,
  org.eclipse.chemclipse.nmr.processing.ft,

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/META-INF/MANIFEST.MF
@@ -122,7 +122,6 @@ Bundle-ActivationPolicy: lazy
 Import-Package: jakarta.annotation;version="2.1.1",
  jakarta.inject;version="2.0.1",
  org.eclipse.chemclipse.rcp.app.ui.handlers,
- org.osgi.service.component.annotations;version="1.2.0",
  org.osgi.service.event;version="[1.0.0,2.0.0)"
 Service-Component: OSGI-INF/org.eclipse.chemclipse.ux.extension.xxd.ui.editors.EditorProcessTypeSupplier.xml,
  OSGI-INF/org.eclipse.chemclipse.ux.extension.xxd.ui.filter.ChromatogramFilterAdjust.xml,

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/META-INF/MANIFEST.MF
@@ -18,6 +18,5 @@ Export-Package: org.eclipse.chemclipse.wsd.converter,
  org.eclipse.chemclipse.wsd.converter.chromatogram,
  org.eclipse.chemclipse.wsd.converter.core,
  org.eclipse.chemclipse.wsd.converter.io
-Import-Package: org.eclipse.chemclipse.support.settings.parser,
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: org.eclipse.chemclipse.support.settings.parser
 Service-Component: OSGI-INF/org.eclipse.chemclipse.wsd.converter.chromatogram.ChromatogramConverterWSDProcessTypeSupplier.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.classification.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.classification.ui/META-INF/MANIFEST.MF
@@ -24,6 +24,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.core.commands.common,
  org.eclipse.jface.viewers,
- org.osgi.service.component.annotations;version="[1.2.0,2.0.0)",
  org.osgi.service.event;version="[1.0.0,2.0.0)"
 Service-Component: OSGI-INF/org.eclipse.chemclipse.xxd.classification.ui.services.ClassificationDictionaryAnnotationService.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.classification/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.classification/META-INF/MANIFEST.MF
@@ -17,8 +17,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Import-Package: com.fasterxml.jackson.annotation;version="2.12.1",
  com.fasterxml.jackson.core;version="2.12.1",
- com.fasterxml.jackson.databind;version="2.12.1",
- org.osgi.service.component.annotations;version="1.2.0"
+ com.fasterxml.jackson.databind;version="2.12.1"
 Service-Component: OSGI-INF/org.eclipse.chemclipse.xxd.classification.filter.ClassificationAddFilter.xml,
  OSGI-INF/org.eclipse.chemclipse.xxd.classification.filter.ClassificationAssignFilter.xml,
  OSGI-INF/org.eclipse.chemclipse.xxd.classification.filter.ClassificationRemoveFilter.xml,

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/META-INF/MANIFEST.MF
@@ -24,7 +24,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.apache.commons.csv;bundle-version="1.8.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
-Import-Package: org.osgi.service.component.annotations;version="1.2.0"
 Export-Package: org.eclipse.chemclipse.xxd.converter.supplier.csv.core,
  org.eclipse.chemclipse.xxd.converter.supplier.csv.io.core,
  org.eclipse.chemclipse.xxd.converter.supplier.csv.preferences,

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/META-INF/MANIFEST.MF
@@ -33,6 +33,5 @@ Export-Package: org.eclipse.chemclipse.csd.converter.supplier.ocx.converter,
  org.eclipse.chemclipse.xxd.converter.supplier.ocx.preferences,
  org.eclipse.chemclipse.xxd.converter.supplier.ocx.settings,
  org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions
-Import-Package: org.osgi.service.component.annotations;version="1.2.0"
 Service-Component: OSGI-INF/org.eclipse.chemclipse.xxd.converter.supplier.ocx.ChromatogramProcedure.xml,
  OSGI-INF/org.eclipse.chemclipse.xxd.converter.supplier.ocx.system.ConverterProcessSupplier.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/META-INF/MANIFEST.MF
@@ -50,7 +50,6 @@ Export-Package: org.eclipse.chemclipse.xxd.filter.peaks,
  org.eclipse.chemclipse.xxd.filter.peaks.settings,
  org.eclipse.chemclipse.xxd.filter.preferences,
  org.eclipse.chemclipse.xxd.filter.support
-Import-Package: org.osgi.service.component.annotations;version="1.2.0"
 Service-Component: OSGI-INF/org.eclipse.chemclipse.xxd.filter.chromatogram.IntensityCutOffFilter.xml,
  OSGI-INF/org.eclipse.chemclipse.xxd.filter.chromatogram.MeasurementResultsFilter.xml,
  OSGI-INF/org.eclipse.chemclipse.xxd.filter.chromatogram.ShiftIntensityFilter.xml,

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.model/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.model/META-INF/MANIFEST.MF
@@ -13,5 +13,4 @@ Require-Bundle: org.eclipse.core.runtime,
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.xxd.model.quantitation
-Import-Package: com.google.common.collect,
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: com.google.common.collect

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/META-INF/MANIFEST.MF
@@ -47,8 +47,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.help
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: jakarta.annotation;version="2.1.1",
- jakarta.inject;version="2.0.1",
- org.osgi.service.component.annotations;version="1.2.0"
+ jakarta.inject;version="2.0.1"
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/org.eclipse.chemclipse.xxd.process.supplier.pca.ui.quickstart.FileTileDefinition.xml,
  OSGI-INF/org.eclipse.chemclipse.xxd.process.supplier.pca.ui.quickstart.FilesLongFormatTileDefinition.xml,

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/META-INF/MANIFEST.MF
@@ -31,4 +31,3 @@ Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.xxd.process.comparators,
  org.eclipse.chemclipse.xxd.process.files,
  org.eclipse.chemclipse.xxd.process.support
-Import-Package: org.osgi.service.component.annotations;version="1.2.0"


### PR DESCRIPTION
These are needed only at build time for DS xml files generation and both Tycho and PDE will handle setting it up proper without needless explicit runtime dependency.