### PR TITLE
Make msd.converter.supplier test catch dependency problems too

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.excel/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.excel/META-INF/MANIFEST.MF
@@ -17,7 +17,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
  org.apache.poi;bundle-version="4.1.1",
  org.apache.poi.ooxml;bundle-version="4.1.1",
- org.apache.poi.ooxml.schemas;bundle-version="4.1.1"
+ org.apache.poi.ooxml.schemas;bundle-version="4.1.1",
+ org.apache.commons.commons-compress,
+ org.apache.xmlbeans
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.msd.converter.supplier.excel.converter,

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/META-INF/MANIFEST.MF
@@ -8,7 +8,4 @@ Bundle-Vendor: ChemClipse
 Fragment-Host: org.eclipse.chemclipse.msd.converter.supplier.excel;bundle-version="0.8.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.junit;bundle-version="4.8.1",
- org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0",
- org.apache.commons.commons-collections4;bundle-version="4.4.0",
- org.apache.commons.commons-compress;bundle-version="1.22.0",
- org.apache.xmlbeans;bundle-version="3.1.0"
+ org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0"

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/excel/io/ChromatogramExport_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/excel/io/ChromatogramExport_1_ITest.java
@@ -12,34 +12,33 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.converter.supplier.excel.io;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.converter.supplier.excel.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.excel.TestPathHelper;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.junit.Before;
+import org.junit.Test;
 
 public class ChromatogramExport_1_ITest extends ChromatogramReaderTestCase {
 
 	private ChromatogramWriter chromatogramWriter;
 
-	@Override
-	protected void setUp() throws Exception {
-
+	@Before
+	public void setUp() throws Exception {
 		pathImport = PathResolver.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
 		chromatogramWriter = new ChromatogramWriter();
 		super.setUp();
 	}
 
-	public void testExport_1() {
-
-		try {
-			new File(TestPathHelper.DIRECTORY_EXPORT_TEST).mkdirs();
-			File file = new File(PathResolver.getAbsolutePath(TestPathHelper.DIRECTORY_EXPORT_TEST) + File.separator + "Test.xlsx");
-			chromatogramWriter.writeChromatogram(file, chromatogram, new NullProgressMonitor());
-			assertTrue(file.length() > 0);
-			file.delete();
-		} catch(Exception e) {
-			assertTrue("Exception", false);
-		}
+	@Test
+	public void testExport_1() throws Exception {
+		new File(TestPathHelper.DIRECTORY_EXPORT_TEST).mkdirs();
+		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.DIRECTORY_EXPORT_TEST) + File.separator + "Test.xlsx");
+		chromatogramWriter.writeChromatogram(file, chromatogram, new NullProgressMonitor());
+		assertTrue(file.length() > 0);
+		file.delete();
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/excel/io/ChromatogramReaderTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/excel/io/ChromatogramReaderTestCase.java
@@ -20,33 +20,26 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Ignore;
+import org.junit.After;
+import org.junit.Before;
 
-import junit.framework.TestCase;
-
-@Ignore
-public class ChromatogramReaderTestCase extends TestCase {
+public abstract class ChromatogramReaderTestCase {
 
 	protected IChromatogramMSD chromatogram;
 	protected String pathImport;
 	protected File fileImport;
 
-	@Override
-	protected void setUp() throws Exception {
-
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		fileImport = new File(this.pathImport);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-
+	@After
+	public void tearDown() throws Exception {
 		pathImport = null;
 		fileImport = null;
 		chromatogram = null;
-
-		super.tearDown();
 	}
 }


### PR DESCRIPTION
Test fragment shouldn't add extra dependencies that are needed at runtime but not for the sake of writing the test case itself. That should help in catching dependency resolving problems (at least in some cases as what PDE resolves from target platform and what is in the product can still differe significantly).
Changed the test to now swallow the exception (via assertTrue("Exception", false);) but rather let the test method throw the exception so JUnit gives the whole stacktrace in the case of assertion failure.
Migrated to JUnit 4 while at it.
Driven by https://github.com/eclipse-chemclipse/chemclipse/issues/2300 not being catched by the test.