### PR TITLE
PCA, fix update highlighted features in feature table

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/parts/FeatureTablePart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/parts/FeatureTablePart.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import org.eclipse.chemclipse.xxd.process.supplier.pca.model.EvaluationPCA;
 import org.eclipse.chemclipse.xxd.process.supplier.pca.ui.swt.ExtendedFeatureListUI;
+import org.eclipse.e4.ui.di.Focus;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 
@@ -29,6 +30,13 @@ public class FeatureTablePart extends AbstractPartPCA<ExtendedFeatureListUI> {
 	public FeatureTablePart(Composite parent) {
 
 		super(parent);
+	}
+
+	@Focus
+	private void onFocus() {
+
+		super.setFocus();
+		getControl().updateSelection();
 	}
 
 	@Override
@@ -49,6 +57,13 @@ public class FeatureTablePart extends AbstractPartPCA<ExtendedFeatureListUI> {
 				Object object = objects.get(0);
 				if(object instanceof EvaluationPCA evaluationPCA) {
 					getControl().setInput(evaluationPCA);
+					return true;
+				}
+			} else if(isUpdateResultEvent(topic)) {
+				Object object = objects.get(0);
+				if(object instanceof EvaluationPCA evaluationPCA) {
+					getControl().setInput(evaluationPCA);
+					getControl().updateSelection();
 					return true;
 				}
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedFeatureListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedFeatureListUI.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -133,6 +134,36 @@ public class ExtendedFeatureListUI extends Composite implements IExtendedPartUI 
 			this.evaluationPCA = evaluationPCA;
 			updateInput(true);
 		}
+	}
+
+	public void updateSelection() {
+
+		DataUpdateSupport dataUpdateSupport = Activator.getDefault().getDataUpdateSupport();
+		List<Object> objects = dataUpdateSupport.getUpdates(getLastTopic(dataUpdateSupport.getTopics()));
+		if(!objects.isEmpty()) {
+			Object object = objects.get(0);
+			ArrayList<Feature> features = new ArrayList<>();
+			if(object instanceof Object[] values) {
+				int length = values.length;
+				for(int i = 0; i < length; i++) {
+					if(values[i] instanceof Feature feature) {
+						features.add(feature);
+					}
+				}
+			}
+			UpdateNotifierUI.update(Display.getDefault(), IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_PLOT_VARIABLE, features.toArray());
+		}
+	}
+
+	private String getLastTopic(List<String> topics) {
+
+		Collections.reverse(topics);
+		for(String topic : topics) {
+			if(topic.equals(IChemClipseEvents.TOPIC_PCA_UPDATE_HIGHLIGHT_PLOT_VARIABLE)) {
+				return topic;
+			}
+		}
+		return "";
 	}
 
 	private boolean doUpdate(EvaluationPCA evaluationPCA) {


### PR DESCRIPTION
When the Feature Table has not been used yet, but features have been highlighted in the loading plot, the same features shall be highlighted in the Feature Table when it's opened and later when it gets focus.