### PR TITLE
PCA, allow group names as column labels in feature table

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/support/FeatureColumnLabels.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/support/FeatureColumnLabels.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Lorenz Gerber - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.process.supplier.pca.ui.support;
+
+import org.eclipse.chemclipse.support.text.ILabel;
+
+public enum FeatureColumnLabels implements ILabel {
+
+	SAMPLENAMES("Sample Names"), //
+	GROUPNAMES("Group Names");
+
+	private String label = "";
+
+	FeatureColumnLabels(String label) {
+
+		this.label = label;
+	}
+
+	public String label() {
+
+		return label;
+	}
+
+	public static String[][] getOptions() {
+
+		return ILabel.getOptions(values());
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedFeatureListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedFeatureListUI.java
@@ -49,6 +49,7 @@ import org.eclipse.chemclipse.xxd.process.supplier.pca.model.FeatureDataMatrix;
 import org.eclipse.chemclipse.xxd.process.supplier.pca.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.xxd.process.supplier.pca.ui.Activator;
 import org.eclipse.chemclipse.xxd.process.supplier.pca.ui.preferences.PreferencePage;
+import org.eclipse.chemclipse.xxd.process.supplier.pca.ui.support.FeatureColumnLabels;
 import org.eclipse.chemclipse.xxd.process.supplier.pca.ui.support.FeatureMode;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -196,8 +197,9 @@ public class ExtendedFeatureListUI extends Composite implements IExtendedPartUI 
 		GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
 		gridData.horizontalAlignment = SWT.END;
 		composite.setLayoutData(gridData);
-		composite.setLayout(new GridLayout(8, false));
+		composite.setLayout(new GridLayout(9, false));
 		//
+		createComboViewerColumnLabels(composite);
 		createComboViewerFeatureMode(composite);
 		buttonToolbarInfo = createButtonToggleToolbar(composite, toolbarInfo, IMAGE_INFO, TOOLTIP_INFO);
 		buttonToolbarSearch = createButtonToggleToolbar(composite, toolbarSearch, IMAGE_SEARCH, TOOLTIP_SEARCH);
@@ -511,6 +513,50 @@ public class ExtendedFeatureListUI extends Composite implements IExtendedPartUI 
 		//
 		comboViewer.setInput(FeatureMode.values());
 		comboViewer.setSelection(new StructuredSelection(FeatureMode.ORIGINAL));
+		//
+		comboViewerFeatureMode.set(comboViewer);
+	}
+
+	private void createComboViewerColumnLabels(Composite parent) {
+
+		ComboViewer comboViewer = new EnhancedComboViewer(parent, SWT.READ_ONLY);
+		comboViewer.setContentProvider(ArrayContentProvider.getInstance());
+		comboViewer.setLabelProvider(new AbstractLabelProvider() {
+
+			@Override
+			public String getText(Object element) {
+
+				if(element instanceof FeatureColumnLabels featureColumnLabel) {
+					return featureColumnLabel.label();
+				}
+				return null;
+			}
+		});
+		Combo combo = comboViewer.getCombo();
+		combo.setToolTipText("Select Column Label");
+		combo.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+		combo.addSelectionListener(new SelectionAdapter() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+
+				Object object = comboViewer.getStructuredSelection().getFirstElement();
+				if(object instanceof FeatureColumnLabels featureColumnLabel) {
+					if(evaluationPCA != null) {
+						if(featureColumnLabel.equals(FeatureColumnLabels.SAMPLENAMES)) {
+							listControl.get().setColumnLabels(FeatureColumnLabels.SAMPLENAMES);
+							updateInput();
+						} else {
+							listControl.get().setColumnLabels(FeatureColumnLabels.GROUPNAMES);
+							updateInput();
+						}
+					}
+				}
+			}
+		});
+		//
+		comboViewer.setInput(FeatureColumnLabels.values());
+		comboViewer.setSelection(new StructuredSelection(FeatureColumnLabels.SAMPLENAMES));
 		//
 		comboViewerFeatureMode.set(comboViewer);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/FeatureListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/FeatureListUI.java
@@ -26,6 +26,7 @@ import org.eclipse.chemclipse.xxd.process.supplier.pca.ui.internal.provider.Feat
 import org.eclipse.chemclipse.xxd.process.supplier.pca.ui.internal.provider.FeatureLabelProvider;
 import org.eclipse.chemclipse.xxd.process.supplier.pca.ui.internal.provider.FeatureListFilter;
 import org.eclipse.chemclipse.xxd.process.supplier.pca.ui.internal.provider.VisualSelectionFilter;
+import org.eclipse.chemclipse.xxd.process.supplier.pca.ui.support.FeatureColumnLabels;
 import org.eclipse.chemclipse.xxd.process.supplier.pca.ui.support.FeatureMode;
 import org.eclipse.jface.viewers.ITableLabelProvider;
 import org.eclipse.jface.viewers.TableViewerColumn;
@@ -47,6 +48,7 @@ public class FeatureListUI extends ExtendedTableViewer {
 	//
 	private IUpdateListener updateListener = null;
 	private FeatureMode featureMode = FeatureMode.ORIGINAL;
+	private FeatureColumnLabels columnLabels = FeatureColumnLabels.SAMPLENAMES;
 
 	public FeatureListUI(Composite parent, int style) {
 
@@ -103,6 +105,11 @@ public class FeatureListUI extends ExtendedTableViewer {
 		this.featureMode = featureMode;
 	}
 
+	public void setColumnLabels(FeatureColumnLabels labels) {
+
+		this.columnLabels = labels;
+	}
+
 	private void createColumnsDefault() {
 
 		if(featureMode.equals(FeatureMode.ORIGINAL)) {
@@ -125,7 +132,12 @@ public class FeatureListUI extends ExtendedTableViewer {
 		 * Labels and bounds
 		 */
 		String variableName = featureDataMatrix.getVariableName();
-		List<String> sampleNames = featureDataMatrix.getSampleNames();
+		List<String> columnNames;
+		if(columnLabels.equals(FeatureColumnLabels.SAMPLENAMES)) {
+			columnNames = featureDataMatrix.getSampleNames();
+		} else {
+			columnNames = featureDataMatrix.getGroupNames();
+		}
 		//
 		List<String> titleList = new ArrayList<>();
 		List<Integer> boundList = new ArrayList<>();
@@ -147,7 +159,7 @@ public class FeatureListUI extends ExtendedTableViewer {
 		/*
 		 * Sample labels
 		 */
-		for(String sampleName : sampleNames) {
+		for(String sampleName : columnNames) {
 			titleList.add(sampleName);
 			boundList.add(FeatureLabelProvider.BOUND_SAMPLE);
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/AbstractProcessorMultivariateAanalysis.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/core/AbstractProcessorMultivariateAanalysis.java
@@ -62,8 +62,10 @@ public abstract class AbstractProcessorMultivariateAanalysis {
 		 * Samples
 		 */
 		List<String> sampleNames = new ArrayList<>();
+		List<String> groupNames = new ArrayList<>();
 		for(ISample sample : samples) {
 			sampleNames.add(sample.getSampleName());
+			groupNames.add(sample.getGroupName());
 		}
 		/*
 		 * variable.getClassification() //
@@ -91,7 +93,7 @@ public abstract class AbstractProcessorMultivariateAanalysis {
 			}
 		}
 		//
-		evaluationPCA.setFeatureDataMatrix(new FeatureDataMatrix(sampleNames, features));
+		evaluationPCA.setFeatureDataMatrix(new FeatureDataMatrix(sampleNames, groupNames, features));
 	}
 
 	protected <V extends IVariable, S extends ISample> Map<S, double[]> extractData(ISamples<V, S> samples, Algorithm algorithm, IAnalysisSettings settings, boolean[] isSelectedVariable) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/model/FeatureDataMatrix.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/src/org/eclipse/chemclipse/xxd/process/supplier/pca/model/FeatureDataMatrix.java
@@ -20,10 +20,12 @@ public class FeatureDataMatrix {
 
 	private List<String> sampleNames = new ArrayList<>();
 	private List<Feature> features = new ArrayList<>();
+	private List<String> groupNames = new ArrayList<>();
 
-	public FeatureDataMatrix(List<String> sampleNames, List<Feature> features) {
+	public FeatureDataMatrix(List<String> sampleNames, List<String> groupNames, List<Feature> features) {
 
 		this.sampleNames = sampleNames;
+		this.groupNames = groupNames;
 		this.features = features;
 	}
 
@@ -41,6 +43,11 @@ public class FeatureDataMatrix {
 	public List<String> getSampleNames() {
 
 		return Collections.unmodifiableList(sampleNames);
+	}
+
+	public List<String> getGroupNames() {
+
+		return groupNames;
 	}
 
 	public List<Feature> getFeatures() {


### PR DESCRIPTION
Groups are readily used for OPLS separation, hence group names in the feature table simplify for result inspection.