### PR TITLE
Fix menu element references

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/fragment.e4xmi
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/fragment.e4xmi
@@ -77,13 +77,13 @@
       <children xsi:type="advanced:Placeholder" xmi:id="_BNUDUMxsEeOp3IEcthiWqQ" elementId="org.eclipse.chemclipse.ux.extension.ui.part.welcomeView" ref="_sEZv4MxrEeOp3IEcthiWqQ" closeable="true"/>
     </elements>
   </fragments>
-  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_O4wL0ENPEeaHxO-Ahlk0cA" featurename="children" parentElementId="org.eclipse.chemclipse.rcp.app.ui.menu.main" positionInList="after:org.eclipse.chemclipse.ux.extension.ui.menu">
-    <elements xsi:type="menu:Menu" xmi:id="_mMBv8ENNEeaHxO-Ahlk0cA" elementId="org.eclipse.chemclipse.ux.extension.ui.spectra.menu" label="%Spectrum" mnemonics="">
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_O4wL0ENPEeaHxO-Ahlk0cA" featurename="children" parentElementId="org.eclipse.chemclipse.rcp.app.ui.menu.main" positionInList="after:org.eclipse.chemclipse.ux.extension.ui.menu.chromatogram">
+    <elements xsi:type="menu:Menu" xmi:id="_mMBv8ENNEeaHxO-Ahlk0cA" elementId="org.eclipse.chemclipse.ux.extension.ui.menu.spectrum" label="%Spectrum" mnemonics="">
       <children xsi:type="menu:Menu" xmi:id="_16DXMPB9Eeev9sLsv2ZXcQ" elementId="org.eclipse.chemclipse.ux.extension.ui.menu.spectrum.baselinecorrection" label="%BaselineCorrection"/>
       <children xsi:type="menu:Menu" xmi:id="_GRIXQBDTEei3erbzL7KMaw" elementId="org.eclipse.chemclipse.ux.extension.ui.menu.spectrum.filter" label="%Filter"/>
     </elements>
   </fragments>
-  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_9O66YK1-EeeOj_frlqyeaw" featurename="children" parentElementId="org.eclipse.chemclipse.rcp.app.ui.menu.main" positionInList="after:org.eclipse.chemclipse.ux.extension.ui.menu">
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_9O66YK1-EeeOj_frlqyeaw" featurename="children" parentElementId="org.eclipse.chemclipse.rcp.app.ui.menu.main" positionInList="after:org.eclipse.chemclipse.ux.extension.ui.menu.spectrum">
     <elements xsi:type="menu:Menu" xmi:id="_9qTloDL-EeKMEOdllHiEaA" elementId="org.eclipse.chemclipse.ux.extension.ui.menu.process" label="%Processors"/>
   </fragments>
   <fragments xsi:type="fragment:StringModelFragment" xmi:id="_QC5CoLiaEeu05KeOzWexnw" featurename="children" parentElementId="org.eclipse.chemclipse.rcp.app.ui.menu.file" positionInList="after:org.eclipse.chemclipse.rcp.app.ui.menuseparator.close">


### PR DESCRIPTION
Fixes two warnings

> Could not find element with Id 'org.eclipse.chemclipse.ux.extension.ui.menu' in 'org.eclipse.chemclipse.rcp.app.ui.menu.main'

and inconsistent naming.