### PR TITLE
Fixed help button not always displaying content

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/IExtendedPartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/IExtendedPartUI.java
@@ -119,7 +119,7 @@ public interface IExtendedPartUI {
 		return button;
 	}
 
-	default Button createButtonHelp(Composite parent) {
+	default Button createButtonHelp(Composite parent, String context) {
 
 		/*
 		 * Validated SWT.PUSH - no toggle
@@ -132,10 +132,10 @@ public interface IExtendedPartUI {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 
-				PlatformUI.getWorkbench().getHelpSystem().displayDynamicHelp();
+				PlatformUI.getWorkbench().getHelpSystem().displayHelp(context);
 			}
 		});
-		//
+
 		return button;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramIndicesUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramIndicesUI.java
@@ -85,15 +85,14 @@ public class ExtendedChromatogramIndicesUI extends Composite implements IExtende
 		GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
 		gridData.horizontalAlignment = SWT.END;
 		composite.setLayoutData(gridData);
-		composite.setLayout(new GridLayout(6, false));
-		//
+		composite.setLayout(new GridLayout(5, false));
+
 		createButtonToggleToolbarInfo(composite);
 		createButtonToggleToolbarSearch(composite);
 		createButtonToggleToolbarEdit(composite);
 		createButtonSave(composite);
-		createButtonHelp(composite);
 		createButtonSettings(composite);
-		//
+
 		return composite;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramOverlayUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramOverlayUI.java
@@ -241,7 +241,7 @@ public class ExtendedChromatogramOverlayUI extends Composite implements IExtende
 		createResetButton(composite);
 		createNewOverlayPartButton(composite);
 		createToggleGridButton(composite);
-		createButtonHelp(composite);
+		createButtonHelp(composite, HelpContext.CHROMATOGRAM_OVERLAY);
 		createSettingsButton(composite);
 
 		return composite;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
@@ -266,7 +266,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 		createScanIdentifierUI(composite);
 		createButtonReset(composite);
 		createButtonSave(composite);
-		createButtonHelp(composite);
+		createButtonHelp(composite, HelpContext.PEAK_SCAN_LIST);
 		createButtonSettings(composite);
 
 		toolbarMain.set(composite);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedTargetsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedTargetsUI.java
@@ -234,7 +234,7 @@ public class ExtendedTargetsUI extends Composite implements IExtendedPartUI {
 		createButtonToggleToolbarSearch(composite);
 		createButtonToggleToolbarEdit(composite);
 		createButtonDeleteAll(composite);
-		createButtonHelp(composite);
+		createButtonHelp(composite, HelpContext.TARGETS);
 		createButtonSettings(composite);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -1278,7 +1278,7 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 		createButtonToggleChartGrid(composite);
 		createToggleChartSeriesLegendButton(composite);
 		createButtonReset(composite);
-		createButtonHelp(composite);
+		createButtonHelp(composite, HelpContext.CHROMATOGRAM_EDITOR);
 		createButtonSettings(composite);
 
 		toolbarMainControl.set(composite);
@@ -1436,7 +1436,7 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 
 	private void createButtonSettings(Composite parent) {
 
-		createSettingsButton(parent, getPreferencePagesSupplier(), (ISettingsHandler) display -> applySettings(display), false);
+		createSettingsButton(parent, getPreferencePagesSupplier(), (ISettingsHandler)display -> applySettings(display), false);
 	}
 
 	private Supplier<List<Class<? extends IPreferencePage>>> getPreferencePagesSupplier() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedLoadingsPlot.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedLoadingsPlot.java
@@ -138,7 +138,7 @@ public class ExtendedLoadingsPlot extends Composite implements IExtendedPartUI {
 		//
 		createPrincipalComponentUI(composite);
 		createSettingsButton(composite);
-		createButtonHelp(composite);
+		createButtonHelp(composite, HelpContext.LOADINGS_PLOT);
 	}
 
 	private void createPlot(Composite parent) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedScorePlot2D.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedScorePlot2D.java
@@ -143,7 +143,7 @@ public class ExtendedScorePlot2D extends Composite implements IExtendedPartUI {
 		createPrincipalComponentUI(composite);
 		createButtonReset(composite);
 		createSettingsButton(composite);
-		createButtonHelp(composite);
+		createButtonHelp(composite, HelpContext.SCORE_PLOT);
 	}
 
 	private void createScorePlot(Composite parent) {


### PR DESCRIPTION
Its reliance on the dynamic help (currently selected UI element) was twitchy with it not working properly most of the time. This now always loads the context we want when pressing the :grey_question: button.