### PR TITLE
Add database reference ID and RI to Peaks Identifications Report

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/AbstractReport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/AbstractReport.java
@@ -28,7 +28,7 @@ public abstract class AbstractReport extends AbstractChromatogramReportGenerator
 	public IProcessingInfo<File> report(File file, boolean append, List<IChromatogram> chromatograms, IChromatogramReportSettings settings, IProgressMonitor monitor) {
 
 		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
-		processingInfo.addErrorMessage("ChemClipse Chromatogram Report", "Please override this method");
+		processingInfo.addErrorMessage("Chromatogram Report", "Please override this method");
 		return processingInfo;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/AbstractReport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/AbstractReport.java
@@ -20,17 +20,11 @@ import org.eclipse.chemclipse.chromatogram.xxd.report.chromatogram.AbstractChrom
 import org.eclipse.chemclipse.chromatogram.xxd.report.settings.IChromatogramReportSettings;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 public abstract class AbstractReport extends AbstractChromatogramReportGenerator {
 
-	public IProcessingInfo<File> report(File file, boolean append, List<IChromatogram> chromatograms, IChromatogramReportSettings settings, IProgressMonitor monitor) {
-
-		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
-		processingInfo.addErrorMessage("Chromatogram Report", "Please override this method");
-		return processingInfo;
-	}
+	abstract IProcessingInfo<File> report(File file, boolean append, List<IChromatogram> chromatograms, IChromatogramReportSettings settings, IProgressMonitor monitor);
 
 	@Override
 	public IProcessingInfo<File> generate(File file, boolean append, IChromatogram chromatogram, IChromatogramReportSettings settings, IProgressMonitor monitor) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/Report1.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/Report1.java
@@ -35,7 +35,7 @@ public class Report1 extends AbstractReport {
 
 		file = SpecificationValidator.validateSpecification(file);
 		IProcessingInfo<File> processingInfo = super.validate(file);
-		//
+
 		if(!processingInfo.hasErrorMessages()) {
 			if(settings instanceof ReportSettings1 reportSettings) {
 				ReportWriter1 chromatogramReport = new ReportWriter1();
@@ -44,13 +44,13 @@ public class Report1 extends AbstractReport {
 					processingInfo.setProcessingResult(file);
 				} catch(IOException e) {
 					logger.warn(e);
-					processingInfo.addErrorMessage("Chromatogram Report", "The report couldn't be created. An error occured.");
+					processingInfo.addErrorMessage("Chromatogram Report", "The report couldn't be created. An error occured.", e);
 				}
 			} else {
 				logger.warn("The settings are not of type: " + ReportSettings1.class);
 			}
 		}
-		//
+
 		return processingInfo;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/Report1.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/Report1.java
@@ -44,7 +44,7 @@ public class Report1 extends AbstractReport {
 					processingInfo.setProcessingResult(file);
 				} catch(IOException e) {
 					logger.warn(e);
-					processingInfo.addErrorMessage("ChemClipse Chromatogram Report", "The report couldn't be created. An error occured.");
+					processingInfo.addErrorMessage("Chromatogram Report", "The report couldn't be created. An error occured.");
 				}
 			} else {
 				logger.warn("The settings are not of type: " + ReportSettings1.class);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/Report2.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/Report2.java
@@ -44,7 +44,7 @@ public class Report2 extends AbstractReport {
 					processingInfo.setProcessingResult(file);
 				} catch(IOException e) {
 					logger.warn(e);
-					processingInfo.addErrorMessage("ChemClipse Chromatogram Report", "The report couldn't be created. An error occured.");
+					processingInfo.addErrorMessage("Chromatogram Report", "The report couldn't be created. An error occured.");
 				}
 			} else {
 				logger.warn("The settings are not of type: " + ReportSettings2.class);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/Report2.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/Report2.java
@@ -35,7 +35,7 @@ public class Report2 extends AbstractReport {
 
 		file = SpecificationValidator.validateSpecification(file);
 		IProcessingInfo<File> processingInfo = super.validate(file);
-		//
+
 		if(!processingInfo.hasErrorMessages()) {
 			if(settings instanceof ReportSettings2 reportSettings) {
 				ReportWriter2 chromatogramReport = new ReportWriter2();
@@ -44,7 +44,7 @@ public class Report2 extends AbstractReport {
 					processingInfo.setProcessingResult(file);
 				} catch(IOException e) {
 					logger.warn(e);
-					processingInfo.addErrorMessage("Chromatogram Report", "The report couldn't be created. An error occured.");
+					processingInfo.addErrorMessage("Chromatogram Report", "The report couldn't be created. An error occured.", e);
 				}
 			} else {
 				logger.warn("The settings are not of type: " + ReportSettings2.class);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/Report3.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/Report3.java
@@ -35,7 +35,7 @@ public class Report3 extends AbstractReport {
 
 		file = SpecificationValidator.validateSpecification(file);
 		IProcessingInfo<File> processingInfo = super.validate(file);
-		//
+
 		if(!processingInfo.hasErrorMessages()) {
 			if(settings instanceof ReportSettings3 reportSettings) {
 				try {
@@ -44,7 +44,7 @@ public class Report3 extends AbstractReport {
 					processingInfo.setProcessingResult(file);
 				} catch(IOException e) {
 					logger.warn(e);
-					processingInfo.addErrorMessage("Quantitation Report", "The report couldn't be created. An error occured.");
+					processingInfo.addErrorMessage("Quantitation Report", "The report couldn't be created. An error occured.", e);
 				}
 			} else {
 				logger.warn("The settings are not of type: " + ReportSettings3.class);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/Report3.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/Report3.java
@@ -44,7 +44,7 @@ public class Report3 extends AbstractReport {
 					processingInfo.setProcessingResult(file);
 				} catch(IOException e) {
 					logger.warn(e);
-					processingInfo.addErrorMessage("ChemClipse Quantitation Report", "The report couldn't be created. An error occured.");
+					processingInfo.addErrorMessage("Quantitation Report", "The report couldn't be created. An error occured.");
 				}
 			} else {
 				logger.warn("The settings are not of type: " + ReportSettings3.class);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/Report4.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/Report4.java
@@ -35,7 +35,7 @@ public class Report4 extends AbstractReport {
 
 		file = SpecificationValidator.validateSpecification(file);
 		IProcessingInfo<File> processingInfo = super.validate(file);
-		//
+
 		if(!processingInfo.hasErrorMessages()) {
 			if(settings instanceof ReportSettings4) {
 				ReportWriter4 chromatogramReport = new ReportWriter4();
@@ -44,13 +44,13 @@ public class Report4 extends AbstractReport {
 					processingInfo.setProcessingResult(file);
 				} catch(IOException e) {
 					logger.warn(e);
-					processingInfo.addErrorMessage("Chromatogram Report", "The report couldn't be created. An error occured.");
+					processingInfo.addErrorMessage("Chromatogram Report", "The report couldn't be created. An error occured.", e);
 				}
 			} else {
 				logger.warn("The settings are not of type: " + ReportSettings4.class);
 			}
 		}
-		//
+
 		return processingInfo;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/Report4.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/core/Report4.java
@@ -44,7 +44,7 @@ public class Report4 extends AbstractReport {
 					processingInfo.setProcessingResult(file);
 				} catch(IOException e) {
 					logger.warn(e);
-					processingInfo.addErrorMessage("ChemClipse Chromatogram Report", "The report couldn't be created. An error occured.");
+					processingInfo.addErrorMessage("Chromatogram Report", "The report couldn't be created. An error occured.");
 				}
 			} else {
 				logger.warn("The settings are not of type: " + ReportSettings4.class);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/io/ReportWriter1.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/io/ReportWriter1.java
@@ -62,11 +62,11 @@ public class ReportWriter1 {
 	private static final String RESULTS_DELIMITER = "---";
 	private static final String NO_VALUE = "--";
 	private static final String HORIZONTAL_RULE = "------------------------------";
-	//
+
 	private PeakQuantitationsExtractor peakQuantitationsExtractor = new PeakQuantitationsExtractor();
 	private DecimalFormat decimalFormat = ValueFormat.getDecimalFormatEnglish("0.0####");
 	private DateFormat dateFormat = ValueFormat.getDateFormatEnglish();
-	//
+
 	private IonAbundanceComparator ionComparator = new IonAbundanceComparator(SortOrder.DESC);
 	private PeakRetentionTimeComparator peakComparator = new PeakRetentionTimeComparator(SortOrder.ASC);
 
@@ -76,7 +76,7 @@ public class ReportWriter1 {
 			printWriter.println("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
 			printWriter.println("ASCII Report");
 			printWriter.println("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
-			//
+
 			for(IChromatogram chromatogram : chromatograms) {
 				printHeader(printWriter, chromatogram, monitor);
 				reportChromatogram(printWriter, chromatogram, monitor);
@@ -98,7 +98,7 @@ public class ReportWriter1 {
 		} else {
 			printHeaderLine(printWriter, "Date", "");
 		}
-		//
+
 		printHeaderLine(printWriter, "Info", chromatogramOverview.getShortInfo());
 		printHeaderLine(printWriter, "Misc", chromatogramOverview.getMiscInfo());
 		printHeaderLine(printWriter, "Misc (separated)", chromatogramOverview.getMiscInfoSeparated());
@@ -116,7 +116,7 @@ public class ReportWriter1 {
 		for(Map.Entry<String, String> entry : chromatogramOverview.getHeaderDataMap().entrySet()) {
 			printHeaderLine(printWriter, entry.getKey(), entry.getValue());
 		}
-		//
+
 		printWriter.println(HORIZONTAL_RULE);
 	}
 
@@ -141,7 +141,7 @@ public class ReportWriter1 {
 		 */
 		List<IPeak> peaks = new ArrayList<>(chromatogram.getPeaks());
 		Collections.sort(peaks, peakComparator);
-		//
+
 		printWriter.println("");
 		printWriter.println("NAME: " + chromatogram.getName());
 		printWriter.println("TYPE: " + getChromatogramType(chromatogram));
@@ -275,7 +275,7 @@ public class ReportWriter1 {
 		if(peak instanceof IChromatogramPeak reportedPeak) {
 			chromatogramPeak = reportedPeak;
 		}
-		//
+
 		printWriter.print("[" + number + "]");
 		printWriter.print(DELIMITER);
 		printWriter.print(decimalFormat.format(peakModel.getRetentionTimeAtPeakMaximum() / IChromatogramOverview.MINUTE_CORRELATION_FACTOR));
@@ -457,7 +457,7 @@ public class ReportWriter1 {
 				return true;
 			}
 		}
-		//
+
 		return false;
 	}
 
@@ -505,6 +505,10 @@ public class ReportWriter1 {
 		printWriter.print("Miscellaneous");
 		printWriter.print(DELIMITER);
 		printWriter.print("Comments");
+		printWriter.print(DELIMITER);
+		printWriter.print("Reference ID");
+		printWriter.print(DELIMITER);
+		printWriter.print("RI");
 		printWriter.println("");
 	}
 
@@ -552,6 +556,10 @@ public class ReportWriter1 {
 			printWriter.print(libraryInformation.getMiscellaneous());
 			printWriter.print(DELIMITER);
 			printWriter.print(libraryInformation.getComments());
+			printWriter.print(DELIMITER);
+			printWriter.print(libraryInformation.getReferenceIdentifier());
+			printWriter.print(DELIMITER);
+			printWriter.print(decimalFormat.format(libraryInformation.getRetentionIndex()));
 			printWriter.println("");
 		}
 	}


### PR DESCRIPTION
The reference ID is important when processing this further to exactly match the hit by ID instead of trying to parse the compound name. The RI from the database entry is essential when generating potential matches without comparing mass spectra but rather by retention indices. It is also helpful when comparing MSD chromatograms though.