### PR TITLE
Set focus on file item so the whole dialog can be finished via keyboard

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/methods/WidgetItem.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/methods/WidgetItem.java
@@ -395,6 +395,7 @@ public class WidgetItem {
 		text.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, true));
 		text.setText(AbstractProcessSettings.getCleanedFileValue(getValueAsString()));
 		text.addModifyListener(e -> currentSelection = new File(text.getText()));
+		text.setFocus();
 
 		Button button = new Button(composite, SWT.PUSH);
 		button.setText(" ... ");
@@ -403,8 +404,6 @@ public class WidgetItem {
 
 			@Override
 			public void widgetSelected(SelectionEvent e) {
-
-				text.setFocus();
 
 				boolean filechooser;
 				int style;
@@ -491,7 +490,7 @@ public class WidgetItem {
 				}
 			}
 		});
-		//
+
 		return composite;
 	}
 


### PR DESCRIPTION
https://github.com/eclipse-chemclipse/chemclipse/pull/2150 worked on Linux with @KDE so you can hit <kbd>⏎</kbd> and finish a settings dialog with keyboard alone. This is now confirmed to work on Windows.