### PR TITLE
Don't persist the session subtract mass spectrum

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.logging;bundle-version="0.8.0",
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
  org.eclipse.chemclipse.chromatogram.filter;bundle-version="0.8.0",
- com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.7.1"
+ com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.7.1",
+ org.eclipse.e4.core.contexts;bundle-version="1.13.100"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.calculator,

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/calculator/SubtractCalculator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/calculator/SubtractCalculator.java
@@ -26,10 +26,13 @@ import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.msd.model.core.AbstractIon;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
-import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.msd.model.xic.IExtractedIonSignal;
+import org.eclipse.e4.core.contexts.EclipseContextFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.osgi.framework.FrameworkUtil;
 
 public class SubtractCalculator {
 
@@ -44,16 +47,10 @@ public class SubtractCalculator {
 	 */
 	public void subtractPeakMassSpectraFromChromatogramSelection(IChromatogramSelectionMSD chromatogramSelection, ChromatogramFilterSettings filterSettings) {
 
-		/*
-		 * Test if null.
-		 */
 		if(chromatogramSelection == null || chromatogramSelection.getChromatogram() == null || filterSettings == null) {
 			return;
 		}
-		/*
-		 * The mass spectrum must be not null.
-		 */
-		IScanMSD massSpectrum = filterSettings.getSubtractMassSpectrum();
+		IScanMSD massSpectrum = getContextSubtractMassSpectrum();
 		if(massSpectrum == null) {
 			logger.warn("The mass spectrum must be not null.");
 			return;
@@ -96,16 +93,10 @@ public class SubtractCalculator {
 	 */
 	public void subtractPeakMassSpectra(List<IPeakMSD> peaks, PeakFilterSettings peakFilterSettings) {
 
-		/*
-		 * Test if null.
-		 */
 		if(peaks == null || peaks.isEmpty() || peakFilterSettings == null) {
 			return;
 		}
-		/*
-		 * The mass spectrum must be not null.
-		 */
-		IScanMSD massSpectrum = peakFilterSettings.getSubtractMassSpectrum();
+		IScanMSD massSpectrum = getContextSubtractMassSpectrum();
 		if(massSpectrum == null) {
 			logger.warn("The mass spectrum must be not null.");
 			return;
@@ -131,20 +122,10 @@ public class SubtractCalculator {
 
 	public void subtractMassSpectra(List<IScanMSD> massSpectra, MassSpectrumFilterSettings massSpectrumFilterSettings) {
 
-		/*
-		 * Test if null.
-		 */
 		if(massSpectra == null || massSpectra.isEmpty() || massSpectrumFilterSettings == null) {
 			return;
 		}
-		/*
-		 * The mass spectrum must be not null.
-		 */
-		IScanMSD massSpectrum = massSpectrumFilterSettings.getSubtractMassSpectrum();
-		if(massSpectrum == null) {
-			logger.warn("The mass spectrum must be not null.");
-			return;
-		}
+		IScanMSD massSpectrum = getContextSubtractMassSpectrum();
 		boolean useNominalMasses = massSpectrumFilterSettings.isUseNominalMasses();
 		boolean useNormalize = massSpectrumFilterSettings.isNormalize();
 		Map<Double, Float> subtractMassSpectrumMap = getMassSpectrumMap(massSpectrum, useNominalMasses, useNormalize);
@@ -154,6 +135,15 @@ public class SubtractCalculator {
 		for(IScanMSD targetMassSpectrum : massSpectra) {
 			adjustIntensityValues(targetMassSpectrum, subtractMassSpectrumMap, useNominalMasses, useNormalize);
 		}
+	}
+
+	private IScanMSD getContextSubtractMassSpectrum() {
+
+		IEclipseContext context = EclipseContextFactory.getServiceContext(FrameworkUtil.getBundle(this.getClass()).getBundleContext());
+		if(context.get("SessionSubtractMassSpectrum") instanceof IScanMSD scanMSD) {
+			return scanMSD;
+		}
+		return null;
 	}
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/preferences/PreferenceSupplier.java
@@ -47,30 +47,27 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static ChromatogramFilterSettings getFilterSettings() {
 
 		ChromatogramFilterSettings subtractFilterSettingsChromatogram = new ChromatogramFilterSettings();
-		subtractFilterSettingsChromatogram.setSubtractMassSpectrum(PreferenceSupplierMSD.getSessionSubtractMassSpectrumAsString());
 		subtractFilterSettingsChromatogram.setUseNominalMasses(PreferenceSupplierMSD.isUseNominalMZ());
 		subtractFilterSettingsChromatogram.setUseNormalize(PreferenceSupplierMSD.isUseNormalizedScan());
-		//
+
 		return subtractFilterSettingsChromatogram;
 	}
 
 	public static PeakFilterSettings getPeakFilterSettings() {
 
 		PeakFilterSettings peakFilterSettings = new PeakFilterSettings();
-		peakFilterSettings.setSubtractMassSpectrum(PreferenceSupplierMSD.getSessionSubtractMassSpectrumAsString());
 		peakFilterSettings.setUseNominalMasses(PreferenceSupplierMSD.isUseNominalMZ());
 		peakFilterSettings.setUseNormalize(PreferenceSupplierMSD.isUseNormalizedScan());
-		//
+
 		return peakFilterSettings;
 	}
 
 	public static MassSpectrumFilterSettings getMassSpectrumFilterSettings() {
 
 		MassSpectrumFilterSettings massSpectrumFilterSettings = new MassSpectrumFilterSettings();
-		massSpectrumFilterSettings.setSubtractMassSpectrum(PreferenceSupplierMSD.getSessionSubtractMassSpectrumAsString());
 		massSpectrumFilterSettings.setUseNominalMasses(PreferenceSupplierMSD.isUseNominalMZ());
 		massSpectrumFilterSettings.setUseNormalize(PreferenceSupplierMSD.isUseNormalizedScan());
-		//
+
 		return massSpectrumFilterSettings;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/settings/ChromatogramFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/settings/ChromatogramFilterSettings.java
@@ -13,32 +13,18 @@
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.settings;
 
 import org.eclipse.chemclipse.chromatogram.filter.settings.AbstractChromatogramFilterSettings;
-import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 public class ChromatogramFilterSettings extends AbstractChromatogramFilterSettings {
 
-	@JsonProperty(value = "Subtract Mass Spectrum", defaultValue = "18:200;28:1000;32:500")
-	@JsonPropertyDescription(value = "This is the mass spectrum used for subtraction.")
-	private String subtractMassSpectrum = "18:200;28:1000;32:500";
 	@JsonProperty(value = "Use Nominal Mass", defaultValue = "true")
 	@JsonPropertyDescription(value = "Use the nominal mass schema.")
 	private boolean useNominalMasses = true;
 	@JsonProperty(value = "Normalize Data", defaultValue = "true")
 	@JsonPropertyDescription(value = "Normalize the intensities.")
 	private boolean useNormalize = true;
-
-	public void setSubtractMassSpectrum(String subtractMassSpectrum) {
-
-		this.subtractMassSpectrum = subtractMassSpectrum;
-	}
-
-	public IScanMSD getSubtractMassSpectrum() {
-
-		return org.eclipse.chemclipse.msd.model.preferences.PreferenceSupplier.getMassSpectrum(subtractMassSpectrum);
-	}
 
 	public boolean isUseNominalMasses() {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/settings/MassSpectrumFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/settings/MassSpectrumFilterSettings.java
@@ -16,17 +16,12 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.msd.filter.settings.AbstractMassSpectrumFilterSettings;
-import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 public class MassSpectrumFilterSettings extends AbstractMassSpectrumFilterSettings {
-
-	@JsonProperty(value = "Subtract Mass Spectrum", defaultValue = "18:200;28:1000;32:500")
-	@JsonPropertyDescription(value = "This is the mass spectrum used for subtraction.")
-	private String subtractMassSpectrum = "18:200;28:1000;32:500";
 
 	@JsonProperty(value = "Use Nominal Mass", defaultValue = "true")
 	@JsonPropertyDescription(value = "Use the nominal mass schema.")
@@ -35,16 +30,6 @@ public class MassSpectrumFilterSettings extends AbstractMassSpectrumFilterSettin
 	@JsonProperty(value = "Normalize Data", defaultValue = "true")
 	@JsonPropertyDescription(value = "Normalize the intensities.")
 	private boolean useNormalize = true;
-
-	public void setSubtractMassSpectrum(String subtractMassSpectrum) {
-
-		this.subtractMassSpectrum = subtractMassSpectrum;
-	}
-
-	public IScanMSD getSubtractMassSpectrum() {
-
-		return org.eclipse.chemclipse.msd.model.preferences.PreferenceSupplier.getMassSpectrum(subtractMassSpectrum);
-	}
 
 	public boolean isUseNominalMasses() {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/settings/PeakFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/settings/PeakFilterSettings.java
@@ -13,32 +13,18 @@
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.settings;
 
 import org.eclipse.chemclipse.chromatogram.filter.settings.AbstractPeakFilterSettings;
-import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 public class PeakFilterSettings extends AbstractPeakFilterSettings {
 
-	@JsonProperty(value = "Subtract Mass Spectrum", defaultValue = "18:200;28:1000;32:500")
-	@JsonPropertyDescription(value = "This is the mass spectrum used for subtraction.")
-	private String subtractMassSpectrum = "18:200;28:1000;32:500";
 	@JsonProperty(value = "Use Nominal Mass", defaultValue = "true")
 	@JsonPropertyDescription(value = "Use the nominal mass schema.")
 	private boolean useNominalMasses = true;
 	@JsonProperty(value = "Normalize Data", defaultValue = "true")
 	@JsonPropertyDescription(value = "Normalize the intensities.")
 	private boolean useNormalize = true;
-
-	public void setSubtractMassSpectrum(String subtractMassSpectrum) {
-
-		this.subtractMassSpectrum = subtractMassSpectrum;
-	}
-
-	public IScanMSD getSubtractMassSpectrum() {
-
-		return org.eclipse.chemclipse.msd.model.preferences.PreferenceSupplier.getMassSpectrum(subtractMassSpectrum);
-	}
 
 	public boolean isUseNominalMasses() {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/Activator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/Activator.java
@@ -16,7 +16,6 @@ import org.eclipse.chemclipse.msd.model.core.support.IMarkedIon;
 import org.eclipse.chemclipse.msd.model.core.support.IMarkedIons;
 import org.eclipse.chemclipse.msd.model.core.support.MarkedIon;
 import org.eclipse.chemclipse.msd.model.core.support.MarkedIons;
-import org.eclipse.chemclipse.msd.model.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.support.settings.serialization.JSONSerialization;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
@@ -40,7 +39,6 @@ public class Activator implements BundleActivator {
 		JSONSerialization.addMapping(IMarkedIons.class, MarkedIons.class);
 		JSONSerialization.addMapping(IMarkedIon.class, MarkedIon.class);
 		Activator.context = bundleContext;
-		PreferenceSupplier.loadSessionSubtractMassSpectrum();
 	}
 
 	/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/preferences/PreferenceSupplier.java
@@ -26,9 +26,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 
 	public static final int MIN_TRACES = 1;
 	public static final int MAX_TRACES = Integer.MAX_VALUE;
-	//
-	public static final String P_SUBTRACT_MASS_SPECTRUM = "subtractMassSpectrum";
-	public static final String DEF_SUBTRACT_MASS_SPECTRUM = "18:200;28:1000;32:500";
+
 	public static final String P_USE_NOMINAL_MZ = "useNominalMZ";
 	public static final boolean DEF_USE_NOMINAL_MZ = true;
 	public static final String P_USE_NORMALIZED_SCAN = "useNormalizedScan";
@@ -41,13 +39,9 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final int DEF_COPY_TRACES_CLIPBOARD = 5;
 	public static final String P_DELETE_TARGETS_OPTIMIZE_SCAN = "deleteTargetsOptimizeScan";
 	public static final boolean DEF_DELETE_TARGETS_OPTIMIZE_SCAN = true;
-	//
+
 	private static final String DELIMITER_ION_ABUNDANCE = ":";
 	private static final String DELIMITER_IONS = ";";
-	/*
-	 * It is the mass spectrum that is used only by the session.
-	 */
-	private static IScanMSD sessionSubtractMassSpectrum;
 
 	public static IPreferenceSupplier INSTANCE() {
 
@@ -63,44 +57,12 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	@Override
 	public void initializeDefaults() {
 
-		putDefault(P_SUBTRACT_MASS_SPECTRUM, DEF_SUBTRACT_MASS_SPECTRUM);
 		putDefault(P_USE_NOMINAL_MZ, Boolean.toString(DEF_USE_NOMINAL_MZ));
 		putDefault(P_USE_NORMALIZED_SCAN, Boolean.toString(DEF_USE_NORMALIZED_SCAN));
 		putDefault(P_CALCULATION_TYPE, DEF_CALCULATION_TYPE);
 		putDefault(P_USE_PEAKS_INSTEAD_OF_SCANS, Boolean.toString(DEF_USE_PEAKS_INSTEAD_OF_SCANS));
 		putDefault(P_COPY_TRACES_CLIPBOARD, Integer.toString(DEF_COPY_TRACES_CLIPBOARD));
 		putDefault(P_DELETE_TARGETS_OPTIMIZE_SCAN, DEF_DELETE_TARGETS_OPTIMIZE_SCAN);
-	}
-
-	public static void loadSessionSubtractMassSpectrum() {
-
-		IScanMSD subtractMassSpectrum = getSubtractMassSpectrum();
-		setSessionSubtractMassSpectrum(subtractMassSpectrum);
-	}
-
-	public static void storeSessionSubtractMassSpectrum() {
-
-		setSubtractMassSpectrum(sessionSubtractMassSpectrum);
-	}
-
-	/**
-	 * Returns the session subtract mass spectrum, which is used by the filter.
-	 * 
-	 * @return {@link IScanMSD}
-	 */
-	public static IScanMSD getSessionSubtractMassSpectrum() {
-
-		return sessionSubtractMassSpectrum;
-	}
-
-	/**
-	 * Sets the session mass spectrum, which is used by the filter.
-	 * 
-	 * @param subtractMassSpectrum
-	 */
-	public static void setSessionSubtractMassSpectrum(IScanMSD subtractMassSpectrum) {
-
-		sessionSubtractMassSpectrum = subtractMassSpectrum;
 	}
 
 	public static boolean isUseNominalMZ() {
@@ -121,11 +83,6 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static void setUseNormalizedScan(boolean useNormalizedScan) {
 
 		INSTANCE().putBoolean(P_USE_NORMALIZED_SCAN, useNormalizedScan);
-	}
-
-	public static String getSessionSubtractMassSpectrumAsString() {
-
-		return INSTANCE().get(P_SUBTRACT_MASS_SPECTRUM, DEF_SUBTRACT_MASS_SPECTRUM);
 	}
 
 	public static void setCalculationType(CalculationType calculationType) {
@@ -201,15 +158,5 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static boolean isDeleteTargetsOptimizeScan() {
 
 		return INSTANCE().getBoolean(P_DELETE_TARGETS_OPTIMIZE_SCAN);
-	}
-
-	private static IScanMSD getSubtractMassSpectrum() {
-
-		return getMassSpectrum(INSTANCE().get(P_SUBTRACT_MASS_SPECTRUM, DEF_SUBTRACT_MASS_SPECTRUM));
-	}
-
-	private static void setSubtractMassSpectrum(IScanMSD massSpectrum) {
-
-		INSTANCE().put(P_SUBTRACT_MASS_SPECTRUM, getMassSpectrum(massSpectrum));
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/support/SubtractSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/support/SubtractSupport.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.ux.extension.xxd.ui.internal.support;
+
+import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.calculator.SubtractCalculator;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.e4.core.contexts.EclipseContextFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.osgi.framework.FrameworkUtil;
+
+public class SubtractSupport {
+
+	public static IScanMSD getSessionSubtractMassSpectrum() {
+
+		IEclipseContext context = EclipseContextFactory.getServiceContext(FrameworkUtil.getBundle(SubtractCalculator.class).getBundleContext());
+		if(context.get("SessionSubtractMassSpectrum") instanceof IScanMSD scanMSD) {
+			return scanMSD;
+		}
+		return null;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/SubtractScanPart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/SubtractScanPart.java
@@ -15,12 +15,11 @@ package org.eclipse.chemclipse.ux.extension.xxd.ui.parts;
 import java.util.List;
 
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
-import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.chemclipse.ux.extension.ui.parts.AbstractPart;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
-import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.preferences.PreferenceSupplierModelMSD;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.support.SubtractSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedSubtractScanUI;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
@@ -54,8 +53,7 @@ public class SubtractScanPart extends AbstractPart<ExtendedSubtractScanUI> {
 			} else {
 				Object object = objects.get(0);
 				if(IChemClipseEvents.TOPIC_UPDATE_SESSION_SUBTRACT_MASS_SPECTRUM.equals(topic)) {
-					IScanMSD scanMSD = PreferenceSupplierModelMSD.getSessionSubtractMassSpectrum();
-					getControl().update(scanMSD);
+					getControl().update(SubtractSupport.getSessionSubtractMassSpectrum());
 					/*
 					 * Additionally try to get the latest chromatogram selection.
 					 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferencePageSubtract.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferencePageSubtract.java
@@ -14,7 +14,6 @@ package org.eclipse.chemclipse.ux.extension.xxd.ui.preferences;
 
 import org.eclipse.chemclipse.model.support.CalculationType;
 import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpinnerFieldEditor;
-import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.TextFieldEditor;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.preferences.PreferenceSupplierModelMSD;
 import org.eclipse.jface.preference.BooleanFieldEditor;
@@ -33,6 +32,7 @@ public class PreferencePageSubtract extends FieldEditorPreferencePage implements
 		setDescription("");
 	}
 
+	@Override
 	public void createFieldEditors() {
 
 		addField(new BooleanFieldEditor(PreferenceSupplierModelMSD.P_USE_NOMINAL_MZ, "Use nominal m/z", getFieldEditorParent()));
@@ -40,10 +40,10 @@ public class PreferencePageSubtract extends FieldEditorPreferencePage implements
 		addField(new ComboFieldEditor(PreferenceSupplierModelMSD.P_CALCULATION_TYPE, "Calculation Type", CalculationType.getOptions(), getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplierModelMSD.P_USE_PEAKS_INSTEAD_OF_SCANS, "Use peaks instead of scans", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplierModelMSD.P_DELETE_TARGETS_OPTIMIZE_SCAN, "Delete Targets (Optimize Scan)", getFieldEditorParent()));
-		addField(new TextFieldEditor(PreferenceSupplierModelMSD.P_SUBTRACT_MASS_SPECTRUM, "Subtract mass spectrum", getFieldEditorParent()));
 		addField(new SpinnerFieldEditor(PreferenceSupplierModelMSD.P_COPY_TRACES_CLIPBOARD, "Copy Traces", PreferenceSupplierModelMSD.MIN_TRACES, PreferenceSupplierModelMSD.MAX_TRACES, getFieldEditorParent()));
 	}
 
+	@Override
 	public void init(IWorkbench workbench) {
 
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedCombinedScanUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedCombinedScanUI.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.calculator.SubtractCalculator;
 import org.eclipse.chemclipse.converter.exceptions.NoConverterAvailableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogram;
@@ -46,10 +47,13 @@ import org.eclipse.chemclipse.ux.extension.ui.swt.IExtendedPartUI;
 import org.eclipse.chemclipse.ux.extension.ui.swt.ISettingsHandler;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.preferences.PreferenceSupplierModelMSD;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.support.SubtractSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageScans;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageSubtract;
 import org.eclipse.chemclipse.vsd.model.core.selection.IChromatogramSelectionVSD;
 import org.eclipse.chemclipse.vsd.model.support.FilterSupportVSD;
+import org.eclipse.e4.core.contexts.EclipseContextFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.services.events.IEventBroker;
 import org.eclipse.jface.preference.IPreferencePage;
 import org.eclipse.swt.SWT;
@@ -68,6 +72,7 @@ import org.eclipse.swt.widgets.TabItem;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.osgi.framework.FrameworkUtil;
 
 public class ExtendedCombinedScanUI extends Composite implements IExtendedPartUI {
 
@@ -372,7 +377,7 @@ public class ExtendedCombinedScanUI extends Composite implements IExtendedPartUI
 				if(combinedScan instanceof ICombinedMassSpectrum combinedMassSpectrum) {
 					boolean useNormalize = PreferenceSupplierModelMSD.isUseNormalizedScan();
 					CalculationType calculationType = PreferenceSupplierModelMSD.getCalculationType();
-					IScanMSD massSpectrum1 = PreferenceSupplierModelMSD.getSessionSubtractMassSpectrum();
+					IScanMSD massSpectrum1 = SubtractSupport.getSessionSubtractMassSpectrum();
 					IScanMSD massSpectrum2 = combinedMassSpectrum;
 					IScanMSD subtractMassSpectrum = FilterSupport.getCombinedMassSpectrum(massSpectrum1, massSpectrum2, null, useNormalize, calculationType);
 					saveSessionMassSpectrum(e.display, subtractMassSpectrum);
@@ -389,9 +394,9 @@ public class ExtendedCombinedScanUI extends Composite implements IExtendedPartUI
 	 */
 	private void saveSessionMassSpectrum(Display display, IScanMSD scanMSD) {
 
-		PreferenceSupplierModelMSD.setSessionSubtractMassSpectrum(scanMSD);
-		PreferenceSupplierModelMSD.storeSessionSubtractMassSpectrum();
-		//
+		IEclipseContext context = EclipseContextFactory.getServiceContext(FrameworkUtil.getBundle(SubtractCalculator.class).getBundleContext());
+		context.set("SessionSubtractMassSpectrum", scanMSD);
+
 		if(display != null) {
 			fireUpdateEvent(display);
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedComparisonScanUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedComparisonScanUI.java
@@ -65,6 +65,8 @@ import org.eclipse.chemclipse.vsd.model.core.IScanVSD;
 import org.eclipse.chemclipse.wsd.model.core.IScanWSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.e4.core.contexts.EclipseContextFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.di.Focus;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.preference.IPreferencePage;
@@ -99,6 +101,7 @@ import org.eclipse.swtchart.extensions.core.IExtendedChart;
 import org.eclipse.swtchart.extensions.core.ISecondaryAxisSettings;
 import org.eclipse.swtchart.extensions.core.RangeRestriction;
 import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.osgi.framework.FrameworkUtil;
 
 import jakarta.inject.Inject;
 
@@ -681,7 +684,8 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 		MassSpectrumFilterSettings settings = new MassSpectrumFilterSettings();
 		settings.setUseNominalMasses(PreferenceSupplierModelMSD.isUseNominalMZ());
 		settings.setUseNormalize(PreferenceSupplierModelMSD.isUseNormalizedScan());
-		settings.setSubtractMassSpectrum(PreferenceSupplierModelMSD.getMassSpectrum(scanReference));
+		IEclipseContext context = EclipseContextFactory.getServiceContext(FrameworkUtil.getBundle(SubtractCalculator.class).getBundleContext());
+		context.set("SessionSubtractMassSpectrum", scanReference);
 		/*
 		 * Subtract
 		 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanChartUI.java
@@ -55,6 +55,8 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.ScanDataSupport
 import org.eclipse.chemclipse.ux.extension.xxd.ui.wizards.SubtractScanWizard;
 import org.eclipse.chemclipse.vsd.model.core.IScanVSD;
 import org.eclipse.chemclipse.wsd.model.core.IScanWSD;
+import org.eclipse.e4.core.contexts.EclipseContextFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.di.Focus;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.IPreferencePage;
@@ -76,6 +78,7 @@ import org.eclipse.swtchart.IAxis;
 import org.eclipse.swtchart.Range;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.osgi.framework.FrameworkUtil;
 
 public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 
@@ -524,7 +527,8 @@ public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 		MassSpectrumFilterSettings settings = new MassSpectrumFilterSettings();
 		settings.setUseNominalMasses(PreferenceSupplierModelMSD.isUseNominalMZ());
 		settings.setUseNormalize(PreferenceSupplierModelMSD.isUseNormalizedScan());
-		settings.setSubtractMassSpectrum(PreferenceSupplierModelMSD.getMassSpectrum(scanSubtract));
+		IEclipseContext context = EclipseContextFactory.getServiceContext(FrameworkUtil.getBundle(SubtractCalculator.class).getBundleContext());
+		context.set("SessionSubtractMassSpectrum", scanSubtract);
 		/*
 		 * Subtract
 		 */
@@ -544,7 +548,7 @@ public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 				logger.warn(e);
 			}
 		}
-		//
+
 		return optimizedMassSpectrum;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSubtractScanUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSubtractScanUI.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.calculator.SubtractCalculator;
 import org.eclipse.chemclipse.converter.exceptions.NoConverterAvailableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
@@ -36,11 +37,14 @@ import org.eclipse.chemclipse.swt.ui.notifier.UpdateNotifierUI;
 import org.eclipse.chemclipse.ux.extension.ui.swt.IExtendedPartUI;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.preferences.PreferenceSupplierModelMSD;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.support.SubtractSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageScans;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageSubtract;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.runnables.LibraryServiceRunnable;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.e4.core.contexts.EclipseContextFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.di.Focus;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.swt.SWT;
@@ -58,6 +62,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.TabFolder;
 import org.eclipse.swt.widgets.TabItem;
+import org.osgi.framework.FrameworkUtil;
 
 import jakarta.inject.Inject;
 
@@ -121,7 +126,6 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 		createToolbarMain(composite);
 		createScanTabFolderSection(composite);
 
-		loadSessionMassSpectrum(composite.getDisplay());
 		updateWidgets();
 	}
 
@@ -207,7 +211,7 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 					/*
 					 * Add the selected scan to the session MS.
 					 */
-					IScanMSD massSpectrum1 = PreferenceSupplierModelMSD.getSessionSubtractMassSpectrum();
+					IScanMSD massSpectrum1 = SubtractSupport.getSessionSubtractMassSpectrum();
 					CalculationType calculationType = PreferenceSupplierModelMSD.getCalculationType();
 					IRegularMassSpectrum massSpectrum2 = chromatogramSelectionMSD.getSelectedScan();
 					boolean useNormalize = PreferenceSupplierModelMSD.isUseNormalizedScan();
@@ -234,7 +238,7 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 					boolean useNormalize = PreferenceSupplierModelMSD.isUseNormalizedScan();
 					CalculationType calculationType = PreferenceSupplierModelMSD.getCalculationType();
 					boolean usePeaksInsteadOfScans = PreferenceSupplierModelMSD.isUsePeaksInsteadOfScans();
-					IScanMSD massSpectrum1 = PreferenceSupplierModelMSD.getSessionSubtractMassSpectrum();
+					IScanMSD massSpectrum1 = SubtractSupport.getSessionSubtractMassSpectrum();
 					IScanMSD massSpectrum2 = FilterSupport.getCombinedMassSpectrum(chromatogramSelectionMSD, null, useNormalize, calculationType, usePeaksInsteadOfScans);
 					IScanMSD subtractMassSpectrum = FilterSupport.getCombinedMassSpectrum(massSpectrum1, massSpectrum2, null, useNormalize, calculationType);
 					saveSessionMassSpectrum(e.display, subtractMassSpectrum);
@@ -388,12 +392,6 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 		updateWidgets();
 	}
 
-	private void loadSessionMassSpectrum(Display display) {
-
-		PreferenceSupplierModelMSD.loadSessionSubtractMassSpectrum();
-		fireUpdateEvent(display);
-	}
-
 	/**
 	 * If the display is set to null, no event is fired.
 	 * 
@@ -402,8 +400,8 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 	 */
 	private void saveSessionMassSpectrum(Display display, IScanMSD scanMSD) {
 
-		PreferenceSupplierModelMSD.setSessionSubtractMassSpectrum(scanMSD);
-		PreferenceSupplierModelMSD.storeSessionSubtractMassSpectrum();
+		IEclipseContext context = EclipseContextFactory.getServiceContext(FrameworkUtil.getBundle(SubtractCalculator.class).getBundleContext());
+		context.set("SessionSubtractMassSpectrum", scanMSD);
 
 		if(display != null) {
 			fireUpdateEvent(display);


### PR DESCRIPTION
This avoids I/O when initializing the model bundle. Furthermore, it won't display data from previous sessions when reloading the application.