### PR TITLE
Don't load the previous session subtract mass spectrum

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/Activator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/Activator.java
@@ -16,7 +16,6 @@ import org.eclipse.chemclipse.msd.model.core.support.IMarkedIon;
 import org.eclipse.chemclipse.msd.model.core.support.IMarkedIons;
 import org.eclipse.chemclipse.msd.model.core.support.MarkedIon;
 import org.eclipse.chemclipse.msd.model.core.support.MarkedIons;
-import org.eclipse.chemclipse.msd.model.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.support.settings.serialization.JSONSerialization;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
@@ -40,7 +39,6 @@ public class Activator implements BundleActivator {
 		JSONSerialization.addMapping(IMarkedIons.class, MarkedIons.class);
 		JSONSerialization.addMapping(IMarkedIon.class, MarkedIon.class);
 		Activator.context = bundleContext;
-		PreferenceSupplier.loadSessionSubtractMassSpectrum();
 	}
 
 	/*


### PR DESCRIPTION
This avoids I/O when initializing the model bundle. Furthermore, it won't display data from previous sessions when reloading the application.