### PR TITLE
Add queued web nucleotide BLAST

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/META-INF/MANIFEST.MF
@@ -12,7 +12,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
  com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.6.2",
  org.eclipse.chemclipse.wsd.model;bundle-version="0.9.0",
- org.eclipse.chemclipse.chromatogram.wsd.identifier;bundle-version="0.9.0"
+ org.eclipse.chemclipse.chromatogram.wsd.identifier;bundle-version="0.9.0",
+ org.apache.httpcomponents.client5.httpclient5;bundle-version="5.4.4",
+ org.apache.httpcomponents.core5.httpcore5;bundle-version="5.3.4"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: ChemClipse
 Bundle-ActivationPolicy: lazy

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/plugin.xml
@@ -5,10 +5,20 @@
          point="org.eclipse.chemclipse.chromatogram.wsd.identifier.chromatogramIdentifier">
       <ChromatogramIdentificationSupplier
             description="Run a local BLAST nucleotide search."
-            id="org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn"
-            identifier="org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.core.ChromatogramIdentifier"
-            identifierName="Local Nucleotide BLAST"
-            identifierSettings="org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings.IdentifierSettings">
+            id="org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.local"
+            identifier="org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.core.ChromatogramIdentifierLocal"
+            identifierName="Nucleotide BLAST (Local)"
+            identifierSettings="org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings.LocalIdentifierSettings">
+      </ChromatogramIdentificationSupplier>
+   </extension>
+   <extension
+         point="org.eclipse.chemclipse.chromatogram.wsd.identifier.chromatogramIdentifier">
+      <ChromatogramIdentificationSupplier
+            description="Run a BLAST nucleotide search on a web server."
+            id="org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.web"
+            identifier="org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.core.ChromatogramIdentifierWeb"
+            identifierName="Nucleotide BLAST (Web)"
+            identifierSettings="org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings.WebIdentifierSettings">
       </ChromatogramIdentificationSupplier>
    </extension>
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/core/ChromatogramIdentifierLocal.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/core/ChromatogramIdentifierLocal.java
@@ -18,13 +18,13 @@ import org.eclipse.chemclipse.chromatogram.wsd.identifier.chromatogram.AbstractC
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.chromatogram.IChromatogramIdentifierSettings;
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.io.LocalNucleotideBLAST;
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.preferences.PreferenceSupplier;
-import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings.IdentifierSettings;
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings.LocalIdentifierSettings;
 import org.eclipse.chemclipse.model.identifier.IChromatogramIdentificationResult;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.model.core.selection.IChromatogramSelectionWSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class ChromatogramIdentifier extends AbstractChromatogramIdentifier {
+public class ChromatogramIdentifierLocal extends AbstractChromatogramIdentifier {
 
 	private static final String DESCRIPTION = "Nucleotide BLAST";
 
@@ -33,7 +33,7 @@ public class ChromatogramIdentifier extends AbstractChromatogramIdentifier {
 
 		IProcessingInfo<IChromatogramIdentificationResult> processingInfo = validate(chromatogramSelection, chromatogramIdentifierSettings);
 		if(!processingInfo.hasErrorMessages()) {
-			if(chromatogramIdentifierSettings instanceof IdentifierSettings settings) {
+			if(chromatogramIdentifierSettings instanceof LocalIdentifierSettings settings) {
 				try {
 					LocalNucleotideBLAST.run(chromatogramSelection.getChromatogram(), settings);
 					processingInfo.addInfoMessage(DESCRIPTION, "The chromatogram has been identified.");

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/core/ChromatogramIdentifierWeb.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/core/ChromatogramIdentifierWeb.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.core;
+
+import java.io.IOException;
+
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.chromatogram.AbstractChromatogramIdentifier;
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.chromatogram.IChromatogramIdentifierSettings;
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.io.WebNucleotideBLAST;
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.preferences.PreferenceSupplier;
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings.WebIdentifierSettings;
+import org.eclipse.chemclipse.model.identifier.IChromatogramIdentificationResult;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.wsd.model.core.selection.IChromatogramSelectionWSD;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+public class ChromatogramIdentifierWeb extends AbstractChromatogramIdentifier {
+
+	private static final String DESCRIPTION = "Nucleotide BLAST";
+
+	@Override
+	public IProcessingInfo<IChromatogramIdentificationResult> identify(IChromatogramSelectionWSD chromatogramSelection, IChromatogramIdentifierSettings chromatogramIdentifierSettings, IProgressMonitor monitor) {
+
+		IProcessingInfo<IChromatogramIdentificationResult> processingInfo = validate(chromatogramSelection, chromatogramIdentifierSettings);
+		if(!processingInfo.hasErrorMessages()) {
+			if(chromatogramIdentifierSettings instanceof WebIdentifierSettings settings) {
+				try {
+					WebNucleotideBLAST.run(chromatogramSelection.getChromatogram(), settings);
+					processingInfo.addInfoMessage(DESCRIPTION, "The chromatogram has been identified.");
+				} catch(IOException e) {
+					processingInfo.addErrorMessage(DESCRIPTION, "Failed to identify chromatogram.", e);
+				} catch(InterruptedException e) {
+					processingInfo.addErrorMessage(DESCRIPTION, "Process interrupted.", e);
+					Thread.currentThread().interrupt();
+				}
+			}
+		}
+		return processingInfo;
+	}
+
+	@Override
+	public IProcessingInfo<IChromatogramIdentificationResult> identify(IChromatogramSelectionWSD chromatogramSelection, IProgressMonitor monitor) {
+
+		IChromatogramIdentifierSettings identifierSettings = PreferenceSupplier.getIdentifierSettings();
+		return identify(chromatogramSelection, identifierSettings, monitor);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/AbstractNucleotideBLAST.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/AbstractNucleotideBLAST.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.io;
+
+import java.io.IOException;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.xml.v1.BlastOutput;
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.xml.v1.Hit;
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.xml.v1.Hsp;
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.xml.v1.Iteration;
+import org.eclipse.chemclipse.model.identifier.ComparisonResult;
+import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
+import org.eclipse.chemclipse.model.identifier.LibraryInformation;
+import org.eclipse.chemclipse.model.implementation.IdentificationTarget;
+import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
+import org.xml.sax.SAXException;
+
+import jakarta.xml.bind.JAXBException;
+
+public abstract class AbstractNucleotideBLAST {
+
+	public static void transferTargets(IChromatogramWSD chromatogram, BlastOutput blastOutput) throws SAXException, IOException, JAXBException, ParserConfigurationException {
+
+		for(Iteration iteration : blastOutput.getIterations().getIteration()) {
+			for(Hit hit : iteration.getHits().getHit()) {
+				ILibraryInformation libraryInformation = new LibraryInformation();
+				libraryInformation.setName(hit.getDef());
+				libraryInformation.setDatabase(blastOutput.getDb());
+				libraryInformation.setMiscellaneous(hit.getId());
+				libraryInformation.setComments(hit.getAccession());
+				for(Hsp hsp : hit.getHsps().getHsp()) {
+					ComparisonResult comparisionResult = new ComparisonResult((float)hsp.getBitScore(), (float)hsp.getScore(), (float)hsp.getEvalue(), hsp.getIdentity().floatValue()); // TODO: wrong model
+					IdentificationTarget identificationTarget = new IdentificationTarget(libraryInformation, comparisionResult);
+					identificationTarget.setIdentifier(blastOutput.getVersion());
+					chromatogram.getTargets().add(identificationTarget);
+				}
+			}
+		}
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/LocalNucleotideBLAST.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/LocalNucleotideBLAST.java
@@ -13,6 +13,7 @@
 package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.io;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -21,25 +22,19 @@ import java.io.PrintWriter;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.xml.v1.BlastOutput;
-import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.xml.v1.Hit;
-import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.xml.v1.Hsp;
-import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.xml.v1.Iteration;
-import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings.IdentifierSettings;
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings.LocalIdentifierSettings;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.model.identifier.ComparisonResult;
-import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
-import org.eclipse.chemclipse.model.identifier.LibraryInformation;
-import org.eclipse.chemclipse.model.implementation.IdentificationTarget;
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import jakarta.xml.bind.JAXBException;
 
-public class LocalNucleotideBLAST {
+public class LocalNucleotideBLAST extends AbstractNucleotideBLAST {
 
 	private static final Logger logger = Logger.getLogger(LocalNucleotideBLAST.class);
 
-	public static void run(IChromatogramWSD chromatogram, IdentifierSettings settings) throws IOException, InterruptedException {
+	public static void run(IChromatogramWSD chromatogram, LocalIdentifierSettings settings) throws IOException, InterruptedException {
 
 		File fasta = File.createTempFile(chromatogram.getSampleName() + "_", ".fsa");
 		writeFASTA(chromatogram, fasta);
@@ -50,7 +45,9 @@ public class LocalNucleotideBLAST {
 		int exitCode = process.waitFor();
 		if(exitCode == 0) {
 			try {
-				transferTargets(chromatogram, xml);
+				InputSource inputSource = new InputSource(new FileInputStream(xml));
+				BlastOutput blastOutput = XmlReaderVersion1.getBlastOutput(inputSource);
+				transferTargets(chromatogram, blastOutput);
 			} catch(SAXException | IOException | JAXBException
 					| ParserConfigurationException e) {
 				logger.error(e);
@@ -70,7 +67,7 @@ public class LocalNucleotideBLAST {
 		}
 	}
 
-	private static ProcessBuilder buildProcess(IdentifierSettings settings, File fasta, File xml) {
+	private static ProcessBuilder buildProcess(LocalIdentifierSettings settings, File fasta, File xml) {
 
 		ProcessBuilder processBuilder = new ProcessBuilder("blastn");
 		processBuilder.command().add("-db");
@@ -103,25 +100,5 @@ public class LocalNucleotideBLAST {
 				logger.error(new String(b, off, len));
 			}
 		};
-	}
-
-	private static void transferTargets(IChromatogramWSD chromatogram, File xml) throws SAXException, IOException, JAXBException, ParserConfigurationException {
-
-		BlastOutput blastOutput = XmlReaderVersion1.getBlastOutput(xml);
-		for(Iteration iteration : blastOutput.getIterations().getIteration()) {
-			for(Hit hit : iteration.getHits().getHit()) {
-				ILibraryInformation libraryInformation = new LibraryInformation();
-				libraryInformation.setName(hit.getDef());
-				libraryInformation.setDatabase(blastOutput.getDb());
-				libraryInformation.setMiscellaneous(hit.getId());
-				libraryInformation.setComments(hit.getAccession());
-				for(Hsp hsp : hit.getHsps().getHsp()) {
-					ComparisonResult comparisionResult = new ComparisonResult((float)hsp.getBitScore(), (float)hsp.getScore(), (float)hsp.getEvalue(), hsp.getIdentity().floatValue()); // TODO: wrong model
-					IdentificationTarget identificationTarget = new IdentificationTarget(libraryInformation, comparisionResult);
-					identificationTarget.setIdentifier(blastOutput.getVersion());
-					chromatogram.getTargets().add(identificationTarget);
-				}
-			}
-		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/WebNucleotideBLAST.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/WebNucleotideBLAST.java
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.io;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.BasicHttpClientResponseHandler;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.xml.v1.BlastOutput;
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings.Task;
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings.WebIdentifierSettings;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import jakarta.xml.bind.JAXBException;
+
+public class WebNucleotideBLAST extends AbstractNucleotideBLAST {
+
+	private static final Logger logger = Logger.getLogger(WebNucleotideBLAST.class);
+
+	public static void run(IChromatogramWSD chromatogram, WebIdentifierSettings settings) throws IOException, InterruptedException {
+
+		String postData = buildPostData(settings, getFASTA(chromatogram)).toString();
+		try (CloseableHttpClient client = HttpClients.createDefault()) {
+			String rid = submitSearch(client, settings, postData);
+			if(rid != null) {
+				String xml = retrieveXML(client, rid, settings);
+				try {
+					InputSource inputSource = new InputSource(new StringReader(xml));
+					BlastOutput blastOutput = XmlReaderVersion1.getBlastOutput(inputSource);
+					transferTargets(chromatogram, blastOutput);
+				} catch(SAXException | IOException | JAXBException
+						| ParserConfigurationException e) {
+					logger.error(e);
+					throw new IOException("Failed to read XML.");
+				}
+			}
+		}
+	}
+
+	/**
+	 * @return the response ID
+	 */
+	private static String submitSearch(CloseableHttpClient client, WebIdentifierSettings settings, String postData) throws InterruptedException, IOException {
+
+		HttpPost request = new HttpPost(settings.getEndpoint());
+		request.setEntity(new StringEntity(postData, ContentType.APPLICATION_FORM_URLENCODED));
+		BasicHttpClientResponseHandler handler = new BasicHttpClientResponseHandler();
+		return parseQueuedBlastInfo(client.execute(request, handler));
+	}
+
+	private static String parseQueuedBlastInfo(String response) throws InterruptedException {
+
+		int rtoe = 10;
+		String qBlastInfo = regexExtract(response, "<!--QBlastInfoBegin(.*?)QBlastInfoEnd\\s*-->", Pattern.DOTALL);
+		if(qBlastInfo != null) {
+			String rtoeStr = regexExtract(qBlastInfo, "RTOE = ([^\n\r]*)", 0);
+			if(rtoeStr != null && !rtoeStr.trim().isEmpty()) {
+				rtoe = Integer.parseInt(rtoeStr.trim());
+				Thread.sleep(rtoe * 1000L);
+			}
+			String rid = regexExtract(qBlastInfo, "RID = ([^\n\r]*)", 0);
+			return rid.trim();
+		} else {
+			logger.error("QBlastInfo not found");
+		}
+		return null;
+	}
+
+	private static StringBuilder buildPostData(WebIdentifierSettings settings, String fasta) {
+
+		StringBuilder stringBuilder = new StringBuilder("CMD=Put");
+		stringBuilder.append("&PROGRAM=");
+		stringBuilder.append(getProgram(settings));
+		stringBuilder.append("&DATABASE=");
+		stringBuilder.append(settings.getDatabase());
+		stringBuilder.append("&QUERY=");
+		stringBuilder.append(fasta);
+		return stringBuilder;
+	}
+
+	private static String getProgram(WebIdentifierSettings settings) {
+
+		if(settings.getTask() == Task.MEGABLAST) {
+			return "blastn&MEGABLAST=on";
+		}
+		return settings.getTask().value();
+	}
+
+	private static String regexExtract(String input, String patternStr, int flags) {
+
+		Pattern pattern = Pattern.compile(patternStr, flags);
+		Matcher matcher = pattern.matcher(input);
+		if(matcher.find()) {
+			return matcher.group(1);
+		}
+		return null;
+	}
+
+	private static String getFASTA(IChromatogramWSD chromatogram) {
+
+		StringBuilder stringBuilder = new StringBuilder("> " + chromatogram.getSampleName() + "\n");
+		stringBuilder.append(chromatogram.getMiscInfo());
+		return URLEncoder.encode(stringBuilder.toString(), StandardCharsets.UTF_8);
+	}
+
+	private static String retrieveXML(CloseableHttpClient client, String rid, WebIdentifierSettings settings) throws IOException, InterruptedException {
+
+		while(true) {
+			Thread.sleep(5000);
+			String pollResponse = "";
+			BasicHttpClientResponseHandler handler = new BasicHttpClientResponseHandler();
+			String pollRequest = settings.getEndpoint() + "?CMD=Get&FORMAT_OBJECT=SearchInfo&RID=" + rid;
+			pollResponse = client.execute(new HttpGet(pollRequest), handler);
+
+			if(pollResponse.matches("(?s).*\\s+Status=WAITING.*")) {
+				continue;
+			}
+
+			if(pollResponse.matches("(?s).*\\s+Status=FAILED.*")) {
+				logger.error("Search " + rid + " failed.");
+			}
+
+			if(pollResponse.matches("(?s).*\\s+Status=UNKNOWN.*")) {
+				logger.error("Search " + rid + " expired.");
+			}
+
+			if(pollResponse.matches("(?s).*\\s+Status=READY.*")) {
+				if(pollResponse.matches("(?s).*\\s+ThereAreHits=yes.*")) {
+					break;
+				} else {
+					logger.error("No hits found.");
+				}
+			}
+
+			logger.error("Unknown error.");
+		}
+
+		BasicHttpClientResponseHandler handler = new BasicHttpClientResponseHandler();
+		String getRequest = settings.getEndpoint() + "?CMD=Get&FORMAT_TYPE=XML&RID=" + rid;
+		return client.execute(new HttpGet(getRequest), handler);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/XmlReaderVersion1.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/XmlReaderVersion1.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.io;
 
-import java.io.File;
 import java.io.IOException;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -23,6 +22,7 @@ import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.xml.v1.ObjectFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import jakarta.xml.bind.JAXBContext;
@@ -31,13 +31,13 @@ import jakarta.xml.bind.Unmarshaller;
 
 public class XmlReaderVersion1 {
 
-	public static BlastOutput getBlastOutput(File file) throws SAXException, IOException, JAXBException, ParserConfigurationException {
+	public static BlastOutput getBlastOutput(InputSource inputSource) throws SAXException, IOException, JAXBException, ParserConfigurationException {
 
 		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
 		documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-		Document document = documentBuilder.parse(file);
+		Document document = documentBuilder.parse(inputSource);
 
 		JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
 		Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
@@ -45,5 +45,4 @@ public class XmlReaderVersion1 {
 		NodeList topNode = document.getElementsByTagName("BlastOutput");
 		return (BlastOutput)unmarshaller.unmarshal(topNode.item(0));
 	}
-
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/preferences/PreferenceSupplier.java
@@ -14,7 +14,7 @@ package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.prefe
 
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.chromatogram.IChromatogramIdentifierSettings;
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.Activator;
-import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings.IdentifierSettings;
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings.LocalIdentifierSettings;
 import org.eclipse.chemclipse.support.preferences.AbstractPreferenceSupplier;
 import org.eclipse.chemclipse.support.preferences.IPreferenceSupplier;
 
@@ -47,13 +47,13 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 
 	public static IChromatogramIdentifierSettings getIdentifierSettings() {
 
-		IdentifierSettings settings = new IdentifierSettings();
+		LocalIdentifierSettings settings = new LocalIdentifierSettings();
 		settings.setDatabase(getDatabase());
 		initialize(settings);
 		return settings;
 	}
 
-	private static void initialize(IdentifierSettings settings) {
+	private static void initialize(LocalIdentifierSettings settings) {
 
 		settings.setDatabase(INSTANCE().get(P_DATABASE, DEF_DATABASE));
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/LocalIdentifierSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/LocalIdentifierSettings.java
@@ -26,9 +26,9 @@ import org.eclipse.chemclipse.support.settings.FileSettingProperty.DialogType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
-public class IdentifierSettings extends AbstractIdentifierSettingsWSD implements IChromatogramIdentifierSettings {
+public class LocalIdentifierSettings extends AbstractIdentifierSettingsWSD implements IChromatogramIdentifierSettings {
 
-	private static final Logger logger = Logger.getLogger(IdentifierSettings.class);
+	private static final Logger logger = Logger.getLogger(LocalIdentifierSettings.class);
 
 	@JsonProperty(value = "Database Folder", defaultValue = "")
 	@JsonPropertyDescription("Select the located where update_blastdb downloaded the databases to.")
@@ -84,7 +84,7 @@ public class IdentifierSettings extends AbstractIdentifierSettingsWSD implements
 
 		String content;
 		try {
-			content = new String(IdentifierSettings.class.getResourceAsStream(file).readAllBytes());
+			content = new String(LocalIdentifierSettings.class.getResourceAsStream(file).readAllBytes());
 		} catch(Exception e) {
 			content = doi;
 			logger.warn(e);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/WebIdentifierSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/WebIdentifierSettings.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.chromatogram.IChromatogramIdentifierSettings;
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.settings.AbstractIdentifierSettingsWSD;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+public class WebIdentifierSettings extends AbstractIdentifierSettingsWSD implements IChromatogramIdentifierSettings {
+
+	private static final Logger logger = Logger.getLogger(WebIdentifierSettings.class);
+
+	@JsonProperty(value = "Endpoint", defaultValue = "https://blast.ncbi.nlm.nih.gov/blast/Blast.cgi")
+	@JsonPropertyDescription("Select the web server to query against.")
+	private String endpoint = "https://blast.ncbi.nlm.nih.gov/blast/Blast.cgi";
+
+	@JsonProperty(value = "Database", defaultValue = "nt")
+	@JsonPropertyDescription(value = "Select the database to search.")
+	private String database = "nt";
+
+	@JsonProperty(value = "Task", defaultValue = "blastn")
+	private Task task = Task.BLASTN;
+
+	public String getEndpoint() {
+
+		return endpoint;
+	}
+
+	public void setEndPoint(String endpoint) {
+
+		this.endpoint = endpoint;
+	}
+
+	public String getDatabase() {
+
+		return database;
+	}
+
+	public void setDatabase(String database) {
+
+		this.database = database;
+	}
+
+	public Task getTask() {
+
+		return task;
+	}
+
+	public void setTask(Task task) {
+
+		this.task = task;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		List<LiteratureReference> literatureReferences = new ArrayList<>();
+		literatureReferences.add(createLiteratureReference("csp_7_203.ris", "10.1089/10665270050081478"));
+		return literatureReferences;
+	}
+
+	private static LiteratureReference createLiteratureReference(String file, String doi) {
+
+		String content;
+		try {
+			content = new String(WebIdentifierSettings.class.getResourceAsStream(file).readAllBytes());
+		} catch(Exception e) {
+			content = doi;
+			logger.warn(e);
+		}
+		return new LiteratureReference(content);
+	}
+}


### PR DESCRIPTION
This uses the [Common URL API](https://blast.ncbi.nlm.nih.gov/doc/blast-help/urlapi.html#urlapi) to do queued web based BLAST searches. It has the upside of not requiring any setup or powerful hardware. However you have to wait in line especially on the frequently used public servers.