### PR TITLE
Remove manual web help dependencies

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
@@ -125,10 +125,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.core.net"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.ui.net"
          version="0.0.0"/>
 
@@ -269,26 +265,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.http.jetty"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.http.registry"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.http.servlet"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.jsp.jasper"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.jsp.jasper.registry"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.p2.artifact.repository"
          version="0.0.0"/>
 
@@ -341,31 +317,11 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.security"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.security.ui"
          version="0.0.0"/>
 
    <plugin
          id="org.eclipse.equinox.simpleconfigurator"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.help"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.help.base"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.help.ui"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.help.webapp"
          version="0.0.0"/>
 
    <plugin


### PR DESCRIPTION
`org.eclipse.help` already contains them. This is a follow-up to https://github.com/eclipse-chemclipse/chemclipse/pull/2260 which auto-includes dependencies.