### PR TITLE
Remove manual Equinox dependencies

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
@@ -385,14 +385,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.p2.publisher"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.publisher.eclipse"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.osgi.compatibility.state"
          version="0.0.0"/>
 

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
@@ -257,59 +257,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.concurrent"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.event"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.artifact.repository"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.core"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.director"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.engine"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.garbagecollector"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.jarprocessor"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.metadata"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.metadata.repository"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.operations"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.repository"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.transport.ecf"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.preferences"
          version="0.0.0"/>
 
    <plugin
@@ -437,27 +385,11 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.frameworkadmin"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.frameworkadmin.equinox"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.p2.publisher"
          version="0.0.0"/>
 
    <plugin
          id="org.eclipse.equinox.p2.publisher.eclipse"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.touchpoint.eclipse"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.simpleconfigurator.manipulator"
          version="0.0.0"/>
 
    <plugin


### PR DESCRIPTION
They are already included by `org.eclipse.equinox.p2.core.feature` and `org.eclipse.equinox.p2.extras.feature`.