### PR TITLE
Add NMR spectrum as container.

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter.supplier.nmrml/src/org/eclipse/chemclipse/nmr/converter/supplier/nmrml/converter/ScanImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter.supplier.nmrml/src/org/eclipse/chemclipse/nmr/converter/supplier/nmrml/converter/ScanImportConverter.java
@@ -22,11 +22,13 @@ import org.eclipse.chemclipse.model.core.IComplexSignalMeasurement;
 import org.eclipse.chemclipse.nmr.converter.core.AbstractScanImportConverter;
 import org.eclipse.chemclipse.nmr.converter.core.IScanImportConverter;
 import org.eclipse.chemclipse.nmr.converter.supplier.nmrml.io.ScanReaderVersion100;
+import org.eclipse.chemclipse.nmr.model.core.ISpectrumNMR;
+import org.eclipse.chemclipse.nmr.model.core.SpectrumNMR;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class ScanImportConverter extends AbstractScanImportConverter<Collection<IComplexSignalMeasurement<?>>> implements IScanImportConverter<Collection<IComplexSignalMeasurement<?>>> {
+public class ScanImportConverter extends AbstractScanImportConverter implements IScanImportConverter {
 
 	public ScanImportConverter() {
 
@@ -34,9 +36,9 @@ public class ScanImportConverter extends AbstractScanImportConverter<Collection<
 	}
 
 	@Override
-	public IProcessingInfo<Collection<IComplexSignalMeasurement<?>>> convert(File file, IProgressMonitor monitor) {
+	public IProcessingInfo<ISpectrumNMR> convert(File file, IProgressMonitor monitor) {
 
-		IProcessingInfo<Collection<IComplexSignalMeasurement<?>>> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<ISpectrumNMR> processingInfo = new ProcessingInfo<>();
 		try {
 			final FileReader fileReader = new FileReader(file);
 			final char[] charBuffer = new char[500];
@@ -46,8 +48,10 @@ public class ScanImportConverter extends AbstractScanImportConverter<Collection<
 			final String header = new String(charBuffer);
 			if(header.contains("nmrML")) {
 				ScanReaderVersion100 scanReader = new ScanReaderVersion100();
-				Collection<IComplexSignalMeasurement<?>> result = scanReader.read(file, monitor);
-				processingInfo.setProcessingResult(result);
+				Collection<IComplexSignalMeasurement<?>> complexSignalMeasurement = scanReader.read(file, monitor);
+				ISpectrumNMR spectrumNMR = new SpectrumNMR();
+				spectrumNMR.setComplexSignalMeasurements(complexSignalMeasurement);
+				processingInfo.setProcessingResult(spectrumNMR);
 			} else {
 				throw new UnknownVersionException();
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter/src/org/eclipse/chemclipse/nmr/converter/core/AbstractScanImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter/src/org/eclipse/chemclipse/nmr/converter/core/AbstractScanImportConverter.java
@@ -14,5 +14,5 @@ package org.eclipse.chemclipse.nmr.converter.core;
 
 import org.eclipse.chemclipse.converter.core.AbstractImportConverter;
 
-public abstract class AbstractScanImportConverter<T> extends AbstractImportConverter implements IScanImportConverter<T> {
+public abstract class AbstractScanImportConverter extends AbstractImportConverter implements IScanImportConverter {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter/src/org/eclipse/chemclipse/nmr/converter/core/IScanImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter/src/org/eclipse/chemclipse/nmr/converter/core/IScanImportConverter.java
@@ -16,10 +16,11 @@ package org.eclipse.chemclipse.nmr.converter.core;
 import java.io.File;
 
 import org.eclipse.chemclipse.converter.core.IImportConverter;
+import org.eclipse.chemclipse.nmr.model.core.ISpectrumNMR;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public interface IScanImportConverter<T> extends IImportConverter {
+public interface IScanImportConverter extends IImportConverter {
 
-	IProcessingInfo<T> convert(File file, IProgressMonitor monitor);
+	IProcessingInfo<ISpectrumNMR> convert(File file, IProgressMonitor monitor);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter/src/org/eclipse/chemclipse/nmr/converter/core/ScanConverterNMR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter/src/org/eclipse/chemclipse/nmr/converter/core/ScanConverterNMR.java
@@ -15,8 +15,6 @@
 package org.eclipse.chemclipse.nmr.converter.core;
 
 import java.io.File;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.chemclipse.converter.core.Converter;
@@ -29,7 +27,7 @@ import org.eclipse.chemclipse.converter.scan.ScanConverterSupport;
 import org.eclipse.chemclipse.converter.scan.ScanSupplier;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IComplexSignalMeasurement;
-import org.eclipse.chemclipse.model.core.IMeasurement;
+import org.eclipse.chemclipse.nmr.model.core.ISpectrumNMR;
 import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
@@ -52,14 +50,14 @@ public class ScanConverterNMR {
 
 	}
 
-	public static IProcessingInfo<IMeasurement> convert(final File file, final String converterId, final IProgressMonitor monitor) {
+	public static IProcessingInfo<ISpectrumNMR> convert(final File file, final String converterId, final IProgressMonitor monitor) {
 
-		IProcessingInfo<IMeasurement> processingInfo;
+		IProcessingInfo<ISpectrumNMR> processingInfo;
 		/*
 		 * Do not use a safe runnable here, because an object must
 		 * be returned or null.
 		 */
-		IScanImportConverter<IMeasurement> importConverter = getScanImportConverter(converterId);
+		IScanImportConverter importConverter = getScanImportConverter(converterId);
 		if(importConverter != null) {
 			processingInfo = importConverter.convert(file, monitor);
 		} else {
@@ -68,44 +66,31 @@ public class ScanConverterNMR {
 		return processingInfo;
 	}
 
-	@SuppressWarnings("unchecked")
-	public static IProcessingInfo<Collection<IComplexSignalMeasurement<?>>> convert(final File file, final IProgressMonitor monitor) {
+	public static IProcessingInfo<ISpectrumNMR> convert(final File file, final IProgressMonitor monitor) {
 
-		IProcessingInfo<Collection<IComplexSignalMeasurement<?>>> error = getProcessingError(file);
 		IScanConverterSupport converterSupport = getScanConverterSupport();
 		try {
 			List<String> availableConverterIds = converterSupport.getAvailableConverterIds(file);
 			SubMonitor subMonitor = SubMonitor.convert(monitor, availableConverterIds.size());
 			for(String converterId : availableConverterIds) {
-				IScanImportConverter<?> importConverter = getScanImportConverter(converterId);
+				IScanImportConverter importConverter = getScanImportConverter(converterId);
 				if(importConverter != null) {
-					IProcessingInfo<?> processingInfo = importConverter.convert(file, subMonitor.split(1));
+					IProcessingInfo<ISpectrumNMR> processingInfo = importConverter.convert(file, subMonitor.split(1));
 					if(processingInfo != null) {
-						if(processingInfo.hasErrorMessages()) {
-							error.addMessages(processingInfo);
-						} else {
-							Object object = processingInfo.getProcessingResult();
-							if(object instanceof IComplexSignalMeasurement<?> measurement) {
-								ProcessingInfo<Collection<IComplexSignalMeasurement<?>>> info = new ProcessingInfo<>();
-								info.setProcessingResult(Collections.singleton(measurement));
-								info.addMessages(processingInfo);
-								return info;
-							} else if(object instanceof Collection<?> collection) {
-								ProcessingInfo<Collection<IComplexSignalMeasurement<?>>> info = new ProcessingInfo<>();
-								info.setProcessingResult((Collection<IComplexSignalMeasurement<?>>)collection);
-								info.addMessages(processingInfo);
-								return info;
-							}
+						if(!processingInfo.hasErrorMessages()) {
+							return processingInfo;
 						}
 					}
 				}
 			}
 		} catch(NoConverterAvailableException e) {
+			logger.info(e);
 		}
-		return error;
+
+		return getProcessingError(file);
 	}
 
-	public static IProcessingInfo<Void> export(final File file, final IComplexSignalMeasurement<?> measurement, final String converterId, final IProgressMonitor monitor) {
+	public static IProcessingInfo<?> export(final File file, final IComplexSignalMeasurement<?> measurement, final String converterId, final IProgressMonitor monitor) {
 
 		try {
 			IScanExportConverter exportConverter = getScanExportConverter(converterId);
@@ -122,15 +107,14 @@ public class ScanConverterNMR {
 		}
 	}
 
-	@SuppressWarnings("unchecked")
-	private static <T> IScanImportConverter<T> getScanImportConverter(final String converterId) {
+	private static IScanImportConverter getScanImportConverter(final String converterId) {
 
 		IConfigurationElement element;
 		element = getConfigurationElement(converterId);
-		IScanImportConverter<T> instance = null;
+		IScanImportConverter instance = null;
 		if(element != null) {
 			try {
-				instance = (IScanImportConverter<T>)element.createExecutableExtension(Converter.IMPORT_CONVERTER);
+				instance = (IScanImportConverter)element.createExecutableExtension(Converter.IMPORT_CONVERTER);
 			} catch(CoreException e) {
 				logger.error(e);
 			}
@@ -220,9 +204,9 @@ public class ScanConverterNMR {
 		return fileContentMatcher;
 	}
 
-	private static <T> IProcessingInfo<T> getProcessingError(File file) {
+	private static IProcessingInfo<ISpectrumNMR> getProcessingError(File file) {
 
-		IProcessingInfo<T> processingInfo = new ProcessingInfo<>();
+		IProcessingInfo<ISpectrumNMR> processingInfo = new ProcessingInfo<>();
 		processingInfo.addErrorMessage("Scan Converter", "No suitable converter was found for: " + file);
 		return processingInfo;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.model/src/org/eclipse/chemclipse/nmr/model/core/ISpectrumNMR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.model/src/org/eclipse/chemclipse/nmr/model/core/ISpectrumNMR.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.nmr.model.core;
+
+import java.util.Collection;
+
+import org.eclipse.chemclipse.model.core.IComplexSignalMeasurement;
+import org.eclipse.chemclipse.model.core.IMeasurementInfo;
+
+public interface ISpectrumNMR extends IMeasurementInfo {
+
+	Collection<IComplexSignalMeasurement<?>> getComplexSignalMeasurements();
+
+	void setComplexSignalMeasurements(Collection<IComplexSignalMeasurement<?>> complexSignalMeasurements);
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.model/src/org/eclipse/chemclipse/nmr/model/core/SpectrumNMR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.model/src/org/eclipse/chemclipse/nmr/model/core/SpectrumNMR.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.nmr.model.core;
+
+import java.util.Collection;
+
+import org.eclipse.chemclipse.model.core.AbstractMeasurementInfo;
+import org.eclipse.chemclipse.model.core.IComplexSignalMeasurement;
+
+public class SpectrumNMR extends AbstractMeasurementInfo implements ISpectrumNMR {
+
+	private static final long serialVersionUID = 4818664376666278484L;
+
+	private Collection<IComplexSignalMeasurement<?>> complexSignalMeasurements;
+
+	@Override
+	public Collection<IComplexSignalMeasurement<?>> getComplexSignalMeasurements() {
+
+		return complexSignalMeasurements;
+	}
+
+	@Override
+	public void setComplexSignalMeasurements(Collection<IComplexSignalMeasurement<?>> complexSignalMeasurements) {
+
+		this.complexSignalMeasurements = complexSignalMeasurements;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.processing.supplier.base.ui/src/org/eclipse/chemclipse/nmr/processing/supplier/base/ui/NMRDataListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.processing.supplier.base.ui/src/org/eclipse/chemclipse/nmr/processing/supplier/base/ui/NMRDataListUI.java
@@ -25,6 +25,7 @@ import java.util.function.Consumer;
 import org.eclipse.chemclipse.model.core.IComplexSignalMeasurement;
 import org.eclipse.chemclipse.model.types.DataType;
 import org.eclipse.chemclipse.nmr.converter.core.ScanConverterNMR;
+import org.eclipse.chemclipse.nmr.model.core.ISpectrumNMR;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.chemclipse.processing.ui.support.ProcessingInfoPartSupport;
@@ -142,8 +143,8 @@ public class NMRDataListUI extends DataListUI {
 
 				SubMonitor subMonitor = SubMonitor.convert(monitor, "Loading Files", newFiles.size() * 100);
 				for(File file : newFiles) {
-					IProcessingInfo<Collection<IComplexSignalMeasurement<?>>> convert = ScanConverterNMR.convert(file, subMonitor.split(100));
-					Collection<IComplexSignalMeasurement<?>> result = convert.getProcessingResult();
+					IProcessingInfo<ISpectrumNMR> convert = ScanConverterNMR.convert(file, subMonitor.split(100));
+					Collection<IComplexSignalMeasurement<?>> result = convert.getProcessingResult().getComplexSignalMeasurements();
 					filesMap.put(file, new MeasurementLoadResult(file, result));
 					if(subMonitor.isCanceled()) {
 						throw new InterruptedException("canceled");

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartNMR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartNMR.java
@@ -113,7 +113,7 @@ public class ChartNMR extends LineChart {
 							try {
 								dialog.run(true, true, monitor -> {
 
-									IProcessingInfo<Void> export = ScanConverterNMR.export(file, measurementSupplier.get(), supplier.getId(), monitor);
+									IProcessingInfo<?> export = ScanConverterNMR.export(file, measurementSupplier.get(), supplier.getId(), monitor);
 									ProcessingInfoPartSupport.getInstance().update(export);
 								});
 							} catch(InvocationTargetException e) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ScanEditorNMR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ScanEditorNMR.java
@@ -39,6 +39,7 @@ import org.eclipse.chemclipse.nmr.model.core.FilteredFIDMeasurement;
 import org.eclipse.chemclipse.nmr.model.core.FilteredSpectrumMeasurement;
 import org.eclipse.chemclipse.nmr.model.core.IMeasurementFID;
 import org.eclipse.chemclipse.nmr.model.core.ISpectrumMeasurement;
+import org.eclipse.chemclipse.nmr.model.core.ISpectrumNMR;
 import org.eclipse.chemclipse.nmr.model.selection.DataNMRSelection;
 import org.eclipse.chemclipse.nmr.model.selection.IDataNMRSelection;
 import org.eclipse.chemclipse.processing.ProcessorFactory;
@@ -176,8 +177,8 @@ public class ScanEditorNMR implements IScanEditorNMR {
 			try {
 				dialog.run(true, false, monitor -> {
 
-					IProcessingInfo<Collection<IComplexSignalMeasurement<?>>> convert = ScanConverterNMR.convert(file, monitor);
-					Collection<IComplexSignalMeasurement<?>> result = convert.getProcessingResult();
+					IProcessingInfo<ISpectrumNMR> convert = ScanConverterNMR.convert(file, monitor);
+					Collection<IComplexSignalMeasurement<?>> result = convert.getProcessingResult().getComplexSignalMeasurements();
 					if(result != null) {
 						selection = new DataNMRSelection();
 						for(IComplexSignalMeasurement<?> measurement : result) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/nmr/converter/supplier/jcampdx/converter/ScanImportConverterNMR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/nmr/converter/supplier/jcampdx/converter/ScanImportConverterNMR.java
@@ -14,16 +14,19 @@ package org.eclipse.chemclipse.nmr.converter.supplier.jcampdx.converter;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IComplexSignalMeasurement;
 import org.eclipse.chemclipse.nmr.converter.core.AbstractScanImportConverter;
 import org.eclipse.chemclipse.nmr.converter.core.IScanImportConverter;
 import org.eclipse.chemclipse.nmr.converter.supplier.jcampdx.io.ScanReaderNMR;
+import org.eclipse.chemclipse.nmr.model.core.ISpectrumNMR;
+import org.eclipse.chemclipse.nmr.model.core.SpectrumNMR;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class ScanImportConverterNMR extends AbstractScanImportConverter<IComplexSignalMeasurement<?>> implements IScanImportConverter<IComplexSignalMeasurement<?>> {
+public class ScanImportConverterNMR extends AbstractScanImportConverter implements IScanImportConverter {
 
 	private static final Logger logger = Logger.getLogger(ScanImportConverterNMR.class);
 
@@ -33,14 +36,16 @@ public class ScanImportConverterNMR extends AbstractScanImportConverter<IComplex
 	}
 
 	@Override
-	public IProcessingInfo<IComplexSignalMeasurement<?>> convert(File file, IProgressMonitor monitor) {
+	public IProcessingInfo<ISpectrumNMR> convert(File file, IProgressMonitor monitor) {
 
-		IProcessingInfo<IComplexSignalMeasurement<?>> processingInfo = super.validate(file);
+		IProcessingInfo<ISpectrumNMR> processingInfo = super.validate(file);
 		if(!processingInfo.hasErrorMessages()) {
 			ScanReaderNMR scanReader = new ScanReaderNMR();
 			try {
-				IComplexSignalMeasurement<?> result = scanReader.read(file, monitor);
-				processingInfo.setProcessingResult(result);
+				IComplexSignalMeasurement<?> complexSignalMeasurement = scanReader.read(file, monitor);
+				ISpectrumNMR spectrumNMR = new SpectrumNMR();
+				spectrumNMR.setComplexSignalMeasurements(Collections.singleton(complexSignalMeasurement));
+				processingInfo.setProcessingResult(spectrumNMR);
 			} catch(IOException e) {
 				logger.warn(e);
 			}

--- a/chemclipse/tests/org.eclipse.chemclipse.nmr.converter.supplier.nmrml.fragment.test/src/org/eclipse/chemclipse/nmr/converter/supplier/nmrml/MMBBI_10M12_CE01_1a_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.nmr.converter.supplier.nmrml.fragment.test/src/org/eclipse/chemclipse/nmr/converter/supplier/nmrml/MMBBI_10M12_CE01_1a_ITest.java
@@ -17,10 +17,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
-import java.util.Collection;
 
 import org.eclipse.chemclipse.model.core.IComplexSignalMeasurement;
 import org.eclipse.chemclipse.nmr.converter.supplier.nmrml.converter.ScanImportConverter;
+import org.eclipse.chemclipse.nmr.model.core.ISpectrumNMR;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Before;
@@ -28,14 +28,14 @@ import org.junit.Test;
 
 public class MMBBI_10M12_CE01_1a_ITest {
 
-	private Collection<IComplexSignalMeasurement<?>> spectrumNMR;
+	private ISpectrumNMR spectrumNMR;
 
 	@Before
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.MMBBI_10M12_CE01_1a));
 		ScanImportConverter importConverter = new ScanImportConverter();
-		IProcessingInfo<Collection<IComplexSignalMeasurement<?>>> processingInfo = importConverter.convert(file, new NullProgressMonitor());
+		IProcessingInfo<ISpectrumNMR> processingInfo = importConverter.convert(file, new NullProgressMonitor());
 		spectrumNMR = processingInfo.getProcessingResult();
 	}
 
@@ -43,13 +43,13 @@ public class MMBBI_10M12_CE01_1a_ITest {
 	public void testLoading() {
 
 		assertNotNull(spectrumNMR);
-		assertFalse(spectrumNMR.isEmpty());
+		assertFalse(spectrumNMR.getComplexSignalMeasurements().isEmpty());
 	}
 
 	@Test
 	public void testMeasuremnt() {
 
-		IComplexSignalMeasurement<?> measurement = spectrumNMR.iterator().next();
+		IComplexSignalMeasurement<?> measurement = spectrumNMR.getComplexSignalMeasurements().iterator().next();
 		assertEquals("mica", measurement.getOperator());
 		assertEquals(8459, measurement.getSignals().size());
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/BrukerAFFN_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/BrukerAFFN_ITest.java
@@ -19,6 +19,7 @@ import java.io.File;
 
 import org.eclipse.chemclipse.model.core.IComplexSignalMeasurement;
 import org.eclipse.chemclipse.nmr.converter.supplier.jcampdx.converter.ScanImportConverterNMR;
+import org.eclipse.chemclipse.nmr.model.core.ISpectrumNMR;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Before;
@@ -33,8 +34,8 @@ public class BrukerAFFN_ITest {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.REAL_SPECTRUM_ASCII_FREE_FORMAT_NUMERIC));
 		ScanImportConverterNMR importConverter = new ScanImportConverterNMR();
-		IProcessingInfo<IComplexSignalMeasurement<?>> processingInfo = importConverter.convert(file, new NullProgressMonitor());
-		complexSignalMeasurement = processingInfo.getProcessingResult();
+		IProcessingInfo<ISpectrumNMR> processingInfo = importConverter.convert(file, new NullProgressMonitor());
+		complexSignalMeasurement = processingInfo.getProcessingResult().getComplexSignalMeasurements().iterator().next();
 	}
 
 	@Test


### PR DESCRIPTION
To bring it in line with the rest of the spectroscopy API where the spectrum is the container. This introduces type safety to the processing result and avoids generic placeholders in return types.