### PR TITLE
Don't build JavaDoc in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,4 @@ jobs:
         MAVEN_ARGS: "--batch-mode --no-transfer-progress -Dstyle.color=always"
       run: |
         source $HOME/.sdkman/bin/sdkman-init.sh
-        mvn -f chemclipse/releng/org.eclipse.chemclipse.aggregator/pom.xml -T 1C verify -Pci -Pjavadoc
+        mvn -f chemclipse/releng/org.eclipse.chemclipse.aggregator/pom.xml -T 1C verify -Pci


### PR DESCRIPTION
because it is surprisingly slow.