### PR TITLE
Try to improve backfolding performance

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/ChromatogramFilterMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/ChromatogramFilterMSD.java
@@ -90,7 +90,7 @@ public class ChromatogramFilterMSD extends AbstractChromatogramFilterMSD {
 			supplierMassSpectrum = chromatogram.getSupplierScan(scan);
 			supplierMassSpectrum.removeAllIons();
 			for(IIon ion : massSpectrum.getIons()) {
-				supplierMassSpectrum.addIon(ion);
+				supplierMassSpectrum.addIon(ion, false);
 			}
 		}
 	}


### PR DESCRIPTION
[BackfoldingFilter_1_ITest](https://ci.eclipse.org/chemclipse/job/chemclipse/job/develop/4215/testReport/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.core/BackfoldingFilter_1_ITest/testApplyFilter_1/history/) takes 2 minutes on the Eclipse infrastructure to run. I can't reproduce the slowness locally however I have a hunch that `addIons` is slow as in https://github.com/eclipse-chemclipse/chemclipse/pull/1900. In fact we don't need to check if the ion already exists in the mass spectrum because we just cleared it and are re-adding the backfolded ones.