### PR TITLE
Revert "Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.11.2 to 3.11.3 in /chemclipse"

### DIFF
--- a/chemclipse/pom.xml
+++ b/chemclipse/pom.xml
@@ -259,7 +259,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>3.11.3</version>
+						<version>3.11.2</version>
 						<executions>
 							<execution>
 								<id>attach-javadocs</id>


### PR DESCRIPTION
Reverts eclipse-chemclipse/chemclipse#2409 again https://github.com/eclipse-chemclipse/chemclipse/commit/c676a57ce44c5dae98adcc56ed5ab4cf3cd5181f because it has added a regression in https://github.com/apache/maven-javadoc-plugin/pull/1217.