### PR TITLE
Add method to determine the trace type of a given text input.

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/traces/TraceFactory.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/traces/TraceFactory.java
@@ -37,12 +37,49 @@ public class TraceFactory {
 	private static final Pattern PATTERN_GENERIC_DIGITS = Pattern.compile("(\\d+\\.?\\d+)(.*)");
 	private static final Pattern PATTERN_TANDEM_MSD = Pattern.compile("(\\d+)(\\s+>\\s+)(\\d+\\.?\\d?)(\\s+@)(\\d+)(.*)");
 
-	public static boolean isTraceDefinition(String content) {
+	public static boolean isTraceDefinition(String line) {
 
 		/*
 		 * TODO
 		 */
-		return content.contains(ITrace.INFIX_RANGE_STANDARD) || content.contains(ITrace.INFIX_RANGE_SIMPLE);
+		return line.contains(ITrace.INFIX_RANGE_STANDARD) || line.contains(ITrace.INFIX_RANGE_SIMPLE);
+	}
+
+	/**
+	 * Determine the trace type (TraceHighResMSD, TraceGenericDelta, TraceTandemMSD or TraceGeneric) by the given line.
+	 * May return null.
+	 * 
+	 * @param content
+	 * @return Class<? extends ITrace>
+	 */
+	public static Class<? extends ITrace> determineTraceType(String line) {
+
+		Class<? extends ITrace> clazz = null;
+		if(line != null) {
+			/*
+			 * Drill down from specific trace to generic definitions.
+			 */
+			String trace = line.trim();
+			if(!trace.isEmpty()) {
+				if(trace.contains(ITrace.INFIX_RANGE_STANDARD) || trace.contains(ITrace.INFIX_RANGE_SIMPLE)) {
+					if(trace.contains(ITrace.POSTFIX_UNIT_PPM)) {
+						clazz = TraceHighResMSD.class;
+					} else {
+						/*
+						 * We can't differentiate both types here:
+						 * TraceHighResMSD or TraceHighResWSD
+						 */
+						clazz = TraceGenericDelta.class;
+					}
+				} else if(trace.contains("@")) {
+					clazz = TraceTandemMSD.class;
+				} else {
+					clazz = TraceGeneric.class;
+				}
+			}
+		}
+
+		return clazz;
 	}
 
 	public static <T extends ITrace> List<T> parseTraces(String content, Class<T> clazz) {

--- a/chemclipse/tests/org.eclipse.chemclipse.support.fragment.test/src/org/eclipse/chemclipse/support/traces/TraceFactory_01_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.support.fragment.test/src/org/eclipse/chemclipse/support/traces/TraceFactory_01_Test.java
@@ -1,0 +1,216 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Philip Wenig - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.support.traces;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class TraceFactory_01_Test {
+
+	@Test
+	public void test01() {
+
+		assertEquals(null, TraceFactory.determineTraceType(null));
+	}
+
+	@Test
+	public void test02() {
+
+		assertEquals(null, TraceFactory.determineTraceType(""));
+	}
+
+	@Test
+	public void test03() {
+
+		assertEquals(null, TraceFactory.determineTraceType("  "));
+	}
+
+	@Test
+	public void test04() {
+
+		assertEquals(TraceTandemMSD.class, TraceFactory.determineTraceType("139 > 111.0 @12"));
+	}
+
+	@Test
+	public void test05() {
+
+		assertEquals(TraceTandemMSD.class, TraceFactory.determineTraceType("139 > 111.0 @12 (x5.8)"));
+	}
+
+	@Test
+	public void test06() {
+
+		assertEquals(TraceHighResMSD.class, TraceFactory.determineTraceType("400.01627±10ppm"));
+	}
+
+	@Test
+	public void test07() {
+
+		assertEquals(TraceHighResMSD.class, TraceFactory.determineTraceType("400.01627±10ppm (x4.7)"));
+	}
+
+	@Test
+	public void test08() {
+
+		assertEquals(TraceGenericDelta.class, TraceFactory.determineTraceType("400.01627±0.02"));
+	}
+
+	@Test
+	public void test09() {
+
+		assertEquals(TraceGenericDelta.class, TraceFactory.determineTraceType("400.01627±0.02 (x2.9)"));
+	}
+
+	@Test
+	public void test10() {
+
+		assertEquals(TraceGenericDelta.class, TraceFactory.determineTraceType("400.01627+-0.02"));
+	}
+
+	@Test
+	public void test11() {
+
+		assertEquals(TraceGenericDelta.class, TraceFactory.determineTraceType("400.01627+-0.02 (x2.9)"));
+	}
+
+	@Test
+	public void test12() {
+
+		assertEquals(TraceHighResMSD.class, TraceFactory.determineTraceType("400.01627+-10ppm"));
+	}
+
+	@Test
+	public void test13() {
+
+		assertEquals(TraceHighResMSD.class, TraceFactory.determineTraceType("400.01627+-10ppm (x4.7)"));
+	}
+
+	@Test
+	public void test14() {
+
+		assertEquals(TraceGenericDelta.class, TraceFactory.determineTraceType("400.01627±0.02"));
+	}
+
+	@Test
+	public void test15() {
+
+		assertEquals(TraceGenericDelta.class, TraceFactory.determineTraceType("400.01627±0.02 (x2.9)"));
+	}
+
+	@Test
+	public void test16() {
+
+		assertEquals(TraceGenericDelta.class, TraceFactory.determineTraceType("400.01627+-0.02"));
+	}
+
+	@Test
+	public void test17() {
+
+		assertEquals(TraceGenericDelta.class, TraceFactory.determineTraceType("400.01627+-0.02 (x2.9)"));
+	}
+
+	@Test
+	public void test18() {
+
+		assertEquals(TraceGeneric.class, TraceFactory.determineTraceType("0 - 0"));
+	}
+
+	@Test
+	public void test19() {
+
+		assertEquals(TraceGeneric.class, TraceFactory.determineTraceType("55 - 120"));
+	}
+
+	@Test
+	public void test20() {
+
+		assertEquals(TraceGeneric.class, TraceFactory.determineTraceType("18 28 32 84 207"));
+	}
+
+	@Test
+	public void test21() {
+
+		/*
+		 * Invalid (mixed space and range)
+		 * But it can't be validated here. It will be validated when parsing traces
+		 */
+		assertEquals(TraceGeneric.class, TraceFactory.determineTraceType("18 28 32 55 - 65 84 207"));
+	}
+
+	@Test
+	public void test22() {
+
+		assertEquals(TraceGeneric.class, TraceFactory.determineTraceType("69"));
+	}
+
+	@Test
+	public void test23() {
+
+		assertEquals(TraceGeneric.class, TraceFactory.determineTraceType("69.5"));
+	}
+
+	@Test
+	public void test24() {
+
+		assertEquals(TraceGeneric.class, TraceFactory.determineTraceType("79 (x10.5)"));
+	}
+
+	@Test
+	public void test25() {
+
+		assertEquals(TraceGeneric.class, TraceFactory.determineTraceType("79 (x8)"));
+	}
+
+	@Test
+	public void test26() {
+
+		assertEquals(TraceGeneric.class, TraceFactory.determineTraceType("79.4 (x8))"));
+	}
+
+	@Test
+	public void test27() {
+
+		assertEquals(TraceGeneric.class, TraceFactory.determineTraceType("427.240"));
+	}
+
+	@Test
+	public void test28() {
+
+		assertEquals(TraceGeneric.class, TraceFactory.determineTraceType("279.092 (x5.3)"));
+	}
+
+	@Test
+	public void test29() {
+
+		assertEquals(TraceGeneric.class, TraceFactory.determineTraceType("200"));
+	}
+
+	@Test
+	public void test30() {
+
+		assertEquals(TraceGeneric.class, TraceFactory.determineTraceType("427.240"));
+	}
+
+	@Test
+	public void test31() {
+
+		assertEquals(TraceGeneric.class, TraceFactory.determineTraceType("279.092 (x5.3)"));
+	}
+
+	@Test
+	public void test32() {
+
+		assertEquals(TraceGeneric.class, TraceFactory.determineTraceType("1801 (x1.6)"));
+	}
+}


### PR DESCRIPTION
Traces shall be used in a generic way, but dependent on the underlying chromatogram type, e.g. TandemMS or HighResMS might be forced to be used.