### PR TITLE
Label the comparison scan legend

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -30,10 +30,12 @@ jobs:
       - name: Find changed Java files
         id: changed
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          CHANGED_FILES=$(git diff --name-status origin/${{ github.event.pull_request.base.ref }} | grep -E '^[AM]' | awk '{print $2}')
-          echo "java=$(echo "$CHANGED_FILES" | grep '\.java$' || true | tr '\n' ' ')" >> $GITHUB_OUTPUT
+          CHANGED_FILES=$(gh pr view ${{ github.event.pull_request.number }} --json files --jq '.files[].path')
+          JAVA_FILES=$(echo "$CHANGED_FILES" | grep '\.java$' || true)
+          echo "java=$(echo "$JAVA_FILES" | tr '\n' ' ')" >> $GITHUB_OUTPUT
 
       - name: Check year in license header
         shell: bash

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/support/charts/ScanChartSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/support/charts/ScanChartSupport.java
@@ -48,16 +48,16 @@ public class ScanChartSupport {
 	private IonValueComparator ionValueComparator = new IonValueComparator(SortOrder.ASC);
 	private WavelengthValueComparator wavelengthValueComparator = new WavelengthValueComparator(SortOrder.ASC);
 
-	public IBarSeriesData getBarSeriesData(IScan scan, String postfix, boolean mirrored) {
+	public IBarSeriesData getBarSeriesData(IScan scan, String label, boolean mirrored) {
 
-		ISeriesData seriesData = getSeriesData(scan, postfix, mirrored);
+		ISeriesData seriesData = getSeriesData(scan, label, mirrored);
 		IBarSeriesData barSeriesData = new BarSeriesData(seriesData);
 		return barSeriesData;
 	}
 
-	public ILineSeriesData getLineSeriesData(IScan scan, String postfix, boolean mirrored) {
+	public ILineSeriesData getLineSeriesData(IScan scan, String label, boolean mirrored) {
 
-		ISeriesData seriesData = getSeriesData(scan, postfix, mirrored);
+		ISeriesData seriesData = getSeriesData(scan, label, mirrored);
 		ILineSeriesData lineSeriesData = new LineSeriesData(seriesData);
 		return lineSeriesData;
 	}
@@ -120,14 +120,15 @@ public class ScanChartSupport {
 		return lineSeriesData;
 	}
 
-	private ISeriesData getSeriesData(IScan scan, String postfix, boolean mirrored) {
+	private ISeriesData getSeriesData(IScan scan, String label, boolean mirrored) {
 
 		double[] xSeries;
 		double[] ySeries;
-		String scanNumber = (scan.getScanNumber() > 0 ? Integer.toString(scan.getScanNumber()) : "--");
-		String id = "Scan " + scanNumber;
-		if(!"".equals(postfix)) {
-			id += " " + postfix;
+
+		String id = label;
+		if(id == null || id.isEmpty()) {
+			String scanNumber = (scan.getScanNumber() > 0 ? Integer.toString(scan.getScanNumber()) : "--");
+			id = "Scan " + scanNumber;
 		}
 		/*
 		 * Sort the scan data, otherwise the line chart could be odd.

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedComparisonScanUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedComparisonScanUI.java
@@ -359,8 +359,8 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 			int molWeightUnknown = getMolWeight(textWeightUnknownControl);
 			int molWeightReference = getMolWeight(textWeightReferenceControl);
 			BaseChart baseChart = scanChartUI.getBaseChart();
-			baseChart.shiftSeries("Scan -- scan1", IExtendedChart.X_AXIS, -molWeightUnknown);
-			baseChart.shiftSeries("Scan -- scan2", IExtendedChart.X_AXIS, -molWeightReference);
+			baseChart.shiftSeries(ScanChartUI.LABEL_SCAN1, IExtendedChart.X_AXIS, -molWeightUnknown);
+			baseChart.shiftSeries(ScanChartUI.LABEL_SCAN2, IExtendedChart.X_AXIS, -molWeightReference);
 			scanChartUI.adjustRange(true);
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
@@ -70,6 +70,9 @@ import org.eclipse.swtchart.extensions.linecharts.ILineSeriesSettings;
 
 public class ScanChartUI extends ScrollableChart {
 
+	public static final String LABEL_SCAN1 = "Unknown";
+	public static final String LABEL_SCAN2 = "Reference";
+
 	private static final int LENGTH_HINT_DATA_POINTS = 5000;
 	private static final int COMPRESS_TO_LENGTH = Integer.MAX_VALUE;
 
@@ -195,6 +198,7 @@ public class ScanChartUI extends ScrollableChart {
 		addSeriesLabelMarker(labelPaintListenerY);
 	}
 
+	@Override
 	public void setChartType(ChartType chartType) {
 
 		super.setChartType(chartType);
@@ -255,8 +259,6 @@ public class ScanChartUI extends ScrollableChart {
 			modifyChart(mirrored);
 			modifyChart(scan1, scan2);
 
-			String labelScan1 = "scan1";
-			String labelScan2 = "scan2";
 			IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
 			Color colorScan1 = Colors.getColor(preferenceStore.getString(PreferenceSupplier.P_COLOR_SCAN_1));
 			Color colorScan2 = Colors.getColor(preferenceStore.getString(PreferenceSupplier.P_COLOR_SCAN_2));
@@ -264,8 +266,8 @@ public class ScanChartUI extends ScrollableChart {
 			if(usedSignalType.equals(SignalType.PROFILE)) {
 				setChartType(ChartType.LINE);
 				List<ILineSeriesData> lineSeriesDataList = new ArrayList<>();
-				ILineSeriesData lineSeriesDataScan1 = scanChartSupport.getLineSeriesData(scan1, labelScan1, false);
-				ILineSeriesData lineSeriesDataScan2 = scanChartSupport.getLineSeriesData(scan2, labelScan2, mirrored);
+				ILineSeriesData lineSeriesDataScan1 = scanChartSupport.getLineSeriesData(scan1, LABEL_SCAN1, false);
+				ILineSeriesData lineSeriesDataScan2 = scanChartSupport.getLineSeriesData(scan2, LABEL_SCAN2, mirrored);
 				lineSeriesDataScan1.getSettings().setLineColor(colorScan1);
 				lineSeriesDataScan2.getSettings().setLineColor(colorScan2);
 				lineSeriesDataList.add(lineSeriesDataScan1);
@@ -274,8 +276,8 @@ public class ScanChartUI extends ScrollableChart {
 			} else {
 				setChartType(ChartType.BAR);
 				List<IBarSeriesData> barSeriesDataList = new ArrayList<>();
-				IBarSeriesData barSeriesDataScan1 = scanChartSupport.getBarSeriesData(scan1, labelScan1, false);
-				IBarSeriesData barSeriesDataScan2 = scanChartSupport.getBarSeriesData(scan2, labelScan2, mirrored);
+				IBarSeriesData barSeriesDataScan1 = scanChartSupport.getBarSeriesData(scan1, LABEL_SCAN1, false);
+				IBarSeriesData barSeriesDataScan2 = scanChartSupport.getBarSeriesData(scan2, LABEL_SCAN2, mirrored);
 				IBarSeriesSettings barSeriesSettings1 = barSeriesDataScan1.getSettings();
 				IBarSeriesSettings barSeriesSettings2 = barSeriesDataScan2.getSettings();
 				barSeriesSettings1.setBarColor(colorScan1);


### PR DESCRIPTION
`Reference` vs. `Unknown` is nicer than `Scan -- scan1` and `Scan -- scan2`. Use scan number only as fallback.

<img width="1920" height="1080" alt="grafik" src="https://github.com/user-attachments/assets/12155b33-cd59-4f5a-a910-691b944781a9" />
