### PR TITLE
Fix a null reference exception in mzXML reader

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion20.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion20.java
@@ -135,6 +135,9 @@ public class ChromatogramReaderVersion20 extends AbstractChromatogramReaderVersi
 				 * Get the ions.
 				 */
 				Peaks peaks = scan.getPeaks();
+				if(peaks == null) {
+					continue;
+				}
 				ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
 				/*
 				 * Byte Order

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion21.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion21.java
@@ -135,6 +135,9 @@ public class ChromatogramReaderVersion21 extends AbstractChromatogramReaderVersi
 				 * Get the ions.
 				 */
 				Peaks peaks = scan.getPeaks();
+				if(peaks == null) {
+					continue;
+				}
 				ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
 				/*
 				 * Byte Order

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion22.java
@@ -135,6 +135,9 @@ public class ChromatogramReaderVersion22 extends AbstractChromatogramReaderVersi
 				 * Get the ions.
 				 */
 				Peaks peaks = scan.getPeaks();
+				if(peaks == null) {
+					continue;
+				}
 				ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
 				/*
 				 * Byte Order

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion30.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion30.java
@@ -138,6 +138,9 @@ public class ChromatogramReaderVersion30 extends AbstractChromatogramReaderVersi
 				 * Get the ions.
 				 */
 				for(Peaks peaks : scan.getPeaks()) {
+					if(peaks == null) {
+						continue;
+					}
 					ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
 					/*
 					 * Compression

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion31.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion31.java
@@ -138,6 +138,9 @@ public class ChromatogramReaderVersion31 extends AbstractChromatogramReaderVersi
 				 * Get the ions.
 				 */
 				for(Peaks peaks : scan.getPeaks()) {
+					if(peaks == null) {
+						continue;
+					}
 					ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
 					/*
 					 * Compression

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion32.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion32.java
@@ -141,6 +141,9 @@ public class ChromatogramReaderVersion32 extends AbstractChromatogramReaderVersi
 				 * Get the ions.
 				 */
 				for(Peaks peaks : scan.getPeaks()) {
+					if(peaks == null) {
+						continue;
+					}
 					ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
 					/*
 					 * Compression

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v32/model/Scan.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v32/model/Scan.java
@@ -17,6 +17,8 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.datatype.Duration;
+
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
@@ -25,7 +27,6 @@ import jakarta.xml.bind.annotation.XmlElements;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
-import javax.xml.datatype.Duration;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "", propOrder = {"scanOrigin", "precursorMz", "maldi", "peaks", "nameValueAndComment", "scan"})
@@ -36,56 +37,81 @@ public class Scan implements Serializable {
 	private List<ScanOrigin> scanOrigin;
 	private List<PrecursorMz> precursorMz;
 	private Maldi maldi;
+
 	@XmlElement(required = true, nillable = true)
 	private List<Peaks> peaks;
+
 	@XmlElements({@XmlElement(name = "nameValue", type = NameValue.class), @XmlElement(name = "comment", type = String.class)})
 	private List<Serializable> nameValueAndComment;
+
 	private List<Scan> scan;
+
 	@XmlAttribute(name = "num", required = true)
 	@XmlSchemaType(name = "positiveInteger")
 	private BigInteger num;
+
 	@XmlAttribute(name = "msLevel", required = true)
 	@XmlSchemaType(name = "positiveInteger")
 	private BigInteger msLevel;
+
 	@XmlAttribute(name = "peaksCount", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger peaksCount;
+
 	@XmlAttribute(name = "polarity")
 	private String polarity;
+
 	@XmlAttribute(name = "scanType")
 	private String scanType;
+
 	@XmlAttribute(name = "filterLine")
 	private String filterLine;
+
 	@XmlAttribute(name = "centroided")
 	private Boolean centroided;
+
 	@XmlAttribute(name = "deisotoped")
 	private Boolean deisotoped;
+
 	@XmlAttribute(name = "chargeDeconvoluted")
 	private Boolean chargeDeconvoluted;
+
 	@XmlAttribute(name = "retentionTime")
 	private Duration retentionTime;
+
 	@XmlAttribute(name = "ionisationEnergy")
 	private Float ionisationEnergy;
+
 	@XmlAttribute(name = "collisionEnergy")
 	private Float collisionEnergy;
+
 	@XmlAttribute(name = "cidGasPressure")
 	private Float cidGasPressure;
+
 	@XmlAttribute(name = "startMz")
 	private Float startMz;
+
 	@XmlAttribute(name = "endMz")
 	private Float endMz;
+
 	@XmlAttribute(name = "lowMz")
 	private Float lowMz;
+
 	@XmlAttribute(name = "highMz")
 	private Float highMz;
+
 	@XmlAttribute(name = "basePeakMz")
 	private Float basePeakMz;
+
 	@XmlAttribute(name = "basePeakIntensity")
 	private Float basePeakIntensity;
+
 	@XmlAttribute(name = "totIonCurrent")
 	private Float totIonCurrent;
+
 	@XmlAttribute(name = "msInstrumentID")
 	private Integer msInstrumentID;
+
 	@XmlAttribute(name = "compensationVoltage")
 	private Float compensationVoltage;
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/TestPathHelper.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/TestPathHelper.java
@@ -18,4 +18,5 @@ public class TestPathHelper extends PathResolver {
 	 * IMPORT
 	 */
 	public static final String TESTFILE_IMPORT_TINY1_MZXML20 = "testData/files/import/tiny1.mzXML2.0.mzxml";
+	public static final String TESTFILE_IMPORT_TINY_MZXML30 = "testData/files/import/tiny3.0.mzXML";
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramImportConverterTinyMzXML30_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramImportConverterTinyMzXML30_ITest.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzxml.converter;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.TestPathHelper;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorChromatogram;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorScan;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorChromatogram;
+import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.chemclipse.msd.model.core.IIonTransition;
+import org.eclipse.chemclipse.msd.model.core.Polarity;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ChromatogramImportConverterTinyMzXML30_ITest {
+
+	private static IVendorChromatogram chromatogram;
+
+	@BeforeClass
+	public static void setUp() throws Exception {
+
+		File importFile = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_TINY_MZXML30));
+		ChromatogramImportConverter converter = new ChromatogramImportConverter();
+		IProcessingInfo<IChromatogramMSD> processingInfo = converter.convert(importFile, new NullProgressMonitor());
+		chromatogram = (VendorChromatogram)processingInfo.getProcessingResult();
+	}
+
+	@Test
+	public void testInstrument() {
+
+		assertEquals("ThermoFinnigan LCQ Deca", chromatogram.getInstrument());
+		assertEquals("ESI", chromatogram.getIonisation());
+		assertEquals("Ion Trap", chromatogram.getMassAnalyzer());
+		assertEquals("EMT", chromatogram.getMassDetector());
+		assertEquals("Xcalibur 1.3 alpha 8", chromatogram.getSoftware());
+	}
+
+	@Test
+	public void testEditHistory() {
+
+		assertEquals("conversion", chromatogram.getEditHistory().get(0).getDescription());
+		assertEquals("ReAdW.exe 1.2", chromatogram.getEditHistory().get(0).getEditor());
+	}
+
+	@Test
+	public void testNumberOfScans() {
+
+		assertEquals("NumberOfScans", 2, chromatogram.getNumberOfScans());
+	}
+
+	@Test
+	public void testFirstScan() {
+
+		IVendorScan massSpectrum = (IVendorScan)chromatogram.getScan(1);
+		assertEquals("Ions", 977, massSpectrum.getNumberOfIons());
+		assertEquals("Polarity", Polarity.POSITIVE, massSpectrum.getPolarity());
+		assertEquals(353430, massSpectrum.getRetentionTime());
+	}
+
+	@Test
+	public void testSecondScan() {
+
+		IVendorScan massSpectrum = (IVendorScan)chromatogram.getScan(2);
+		assertEquals((short)2, massSpectrum.getMassSpectrometer());
+		assertEquals("Ions", 43, massSpectrum.getNumberOfIons());
+		assertEquals("Polarity", Polarity.POSITIVE, massSpectrum.getPolarity());
+		assertEquals(356680, massSpectrum.getRetentionTime());
+
+		IIonTransition ionTransition = massSpectrum.getIons().iterator().next().getIonTransition();
+		assertEquals(35, ionTransition.getCollisionEnergy(), 0);
+		assertEquals(445, ionTransition.getQ1Ion());
+		assertEquals(-2.0, ionTransition.getQ3Ion(), 0);
+	}
+}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/testData/files/import/tiny3.0.mzXML
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/testData/files/import/tiny3.0.mzXML
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<mzXML
+ xmlns="http://sashimi.sourceforge.net/schema_revision/mzXML_3.0"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://sashimi.sourceforge.net/schema_revision/mzXML_3.0 http://sashimi.sourceforge.net/schema_revision/mzXML_3.0/mzXML_idx_3.0.xsd">
+ <msRun scanCount="3113"
+        startTime="PT5.0005S"
+        endTime="PT119.982S">
+  <parentFile fileName="file://PROTEOMICSDEV01/Inetpub/wwwroot/ISB/data/class/day1/runsearch/ICAT_test4.RAW"
+              fileType="RAWData"
+              fileSha1="71be39fb2700ab2f3c8b2234b91274968b6899b1"/>
+  <msInstrument msInstrumentID="1">
+	<msManufacturer category="msManufacturer" value="ThermoFinnigan"/>
+  <msModel category="msModel" value="LCQ Deca"/>
+ 	<msIonisation category="msIonisation" value="ESI"/>
+	<msMassAnalyzer category="msMassAnalyzer" value="Ion Trap"/>
+	<msDetector category="msDetector" value="EMT"/>
+    <software type="acquisition"
+              name="Xcalibur"
+              version="1.3 alpha 8"/>
+  </msInstrument>
+  <dataProcessing centroided="0">
+    <software type="conversion"
+              name="ReAdW.exe"
+              version="1.2"/>
+  </dataProcessing>
+  <scan num="1"
+        msLevel="1"
+        peaksCount="1313"
+        polarity="+"
+        scanType="Full"
+        retentionTime="PT353.43S"
+        lowMz="400.39"
+        highMz="1795.56"
+        basePeakMz="445.347"
+        basePeakIntensity="120053"
+        totIonCurrent="1.66755e+007">
+    <peaks precision="32"
+           byteOrder="network"
+           contentType="m/z-int"
+           compressionType="zlib"
+           compressedLen="782">eJylzskRUEEIBNAJjdAmNELzoBx89VtG5ULRK31+Tp/f5/7aFfjibnDv2ZOrz1779SW9eTPmdMA33unA+4e89/Q0u9hbj3nbP7Pt17f9kfrtae7R6fMf8ZmU61Zvnri95iSdPVuue+M33fT5R7rFU86B3/KTLukT7vwt/jqpP+FJN7uCvsO96ba/kj7xd8G37bz6mjv5a+lLPvP7fM/gBW5/6ttyb+DFky5NBV9x34An3XZv+NbXbHPE9aV8+xMur87cZqe8G3TbH/bq68Crc1KPvLnNnXwzxX7t9bb/VT97+jvwKa/Ak978RtfozNGnzjv11PkedeKppwIub37qu9yp/3Dbn3LtTbj98v6x5aV8ffrv+Z4tT7859rz6K/DFbc6MutRjzgHXJ7/dW06f79Hnlp+pkH/h021/seUddemPtNV525/41D9Ti++13zz1he6GveU64g2eegdvduLtu+Bzpxz/UJfytz82n33i9ovbm/jUZ/4NeAVcnzr/sDf1zKiXT75a8D7fIz+3/cl/4M3xH3P0zb7sLS/pks/8u/DiqT/5nPlH/zaj64DLu1OO/bXgadIf4vJb733k0x/uyUn/iaf/3PZPjj779aVJPZu/4dUV9/CbT968hM/W7x+J9x+3Pf7h6P9XXS93ymvuTVds/eq3fveMPdtfh/v1L/kKuPp0b/kzqWfr1ZfyOuhe/9Jvftqpx7yk17fd6a8Ze7dJuc3edOmfpGt08uKJ93bss9epJTf9kXzFnf7QfwOuz3/sF5e3f7Y9db5n6+1FVwv+v33y9iXdTLOTP+Wbm3Zzm1Potlz5lJd8qe+A69v+cr/me9vrXWz94m55/3Kb673h9hz4pK/z5zF37rvcKeeC2z93s9XdgMunHnl75FNf6m92cSd/0t2Ay2/bvw63Ov8RT/1pzNdXAXf7z4x/vfaYZ27SmedOfv957ZupoDP3wM/WX2z7HHXJ51/2Jp254vqLO/1RbHO2O+ENbs+ma+6z8OLmq0s7/bP9Ze/wFz5tdSlXnz1Ows37AU1Iy5A=
+    </peaks>
+  </scan>
+  <scan num="2"
+        msLevel="2"
+        peaksCount="43"
+        polarity="+"
+        scanType="Full"
+        retentionTime="PT356.68S"
+        collisionEnergy="35"
+        lowMz="223.089"
+        highMz="531.078"
+        basePeakMz="428.905"
+        basePeakIntensity="301045"
+        totIonCurrent="764637">
+    <precursorMz precursorIntensity="120053">445.3466797</precursorMz>
+    <peaks precision="32"
+           byteOrder="network"
+           contentType="m/z-int"
+           compressionType="zlib"
+           compressedLen="55">eJw7wAABDQzYAbr4ARzyB9DoBhw0OnDAYQ66uAOaPDqNbh6x7kC3DxeA6UO3D10cxgcA3f0RQQ==</peaks>
+  </scan>
+ </msRun>
+  <index name="scan">
+    <offset id="1">1209</offset>
+    <offset id="2">2577</offset>
+  </index>
+  <indexOffset>31713417</indexOffset>
+  <sha1>e83e234ed25a2e675ad8a3fbcd56f16585a237c2</sha1>
+</mzXML>


### PR DESCRIPTION
https://github.com/eclipse-chemclipse/chemclipse/blob/9834cac9095d3acd871bb812ab12493eba638325/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/v32/model/Scan.java#L39-L40

is a required field that can also be null, which is a bit confusing.