### PR TITLE
Port to JUnit 5 Part 1

### DIFF
--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -27,6 +27,7 @@
 	<unit id="org.apache.commons.lang3"/>
 	<unit id="org.apache.httpcomponents.httpclient"/>
 	<unit id="org.apache.httpcomponents.httpcore"/>
+	<unit id="org.eclipse.jdt.junit5.runtime"/>
 	<repository location="https://download.eclipse.org/releases/2025-06/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/chemclipse/tests/org.eclipse.chemclipse.assets.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.assets.fragment.test/META-INF/MANIFEST.MF
@@ -5,6 +5,6 @@ Bundle-SymbolicName: org.eclipse.chemclipse.assets.fragment.test
 Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: ChemClipse
 Fragment-Host: org.eclipse.chemclipse.assets;bundle-version="0.9.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Automatic-Module-Name: org.eclipse.chemclipse.assets.fragment.test
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.13.2"

--- a/chemclipse/tests/org.eclipse.chemclipse.assets.fragment.test/src/org/eclipse/chemclipse/assets/core/AssetItem_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.assets.fragment.test/src/org/eclipse/chemclipse/assets/core/AssetItem_1_Test.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.assets.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AssetItem_1_Test {
 

--- a/chemclipse/tests/org.eclipse.chemclipse.assets.fragment.test/src/org/eclipse/chemclipse/assets/core/AssetType_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.assets.fragment.test/src/org/eclipse/chemclipse/assets/core/AssetType_1_Test.java
@@ -12,10 +12,10 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.assets.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AssetType_1_Test {
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.converter.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.converter.fragment.test/META-INF/MANIFEST.MF
@@ -5,6 +5,6 @@ Bundle-Name: Alignment Converter Test
 Bundle-SymbolicName: org.eclipse.chemclipse.chromatogram.alignment.converter.fragment.test
 Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.chemclipse.chromatogram.alignment.converter;bundle-version="0.8.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"
 Bundle-Vendor: ChemClipse

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.converter.fragment.test/src/org/eclipse/chemclipse/chromatogram/alignment/converter/retentionindices/RetentionIndicesSupplier_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.converter.fragment.test/src/org/eclipse/chemclipse/chromatogram/alignment/converter/retentionindices/RetentionIndicesSupplier_1_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.alignment.converter.retentionindices;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RetentionIndicesSupplier_1_Test {
 
@@ -23,6 +23,6 @@ public class RetentionIndicesSupplier_1_Test {
 	@Test
 	public void testSupplier_1() {
 
-		assertEquals("Description", "", supplier.getDescription());
+		assertEquals("", supplier.getDescription(), "Description");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.model.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.model.fragment.test/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-Name: Chromatogram Alignment Model Test
 Bundle-SymbolicName: org.eclipse.chemclipse.chromatogram.alignment.model.fragment.test
 Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.chemclipse.chromatogram.alignment.model;bundle-version="0.8.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2",
+ org.junit.jupiter.api.function;version="[5.12.0,6.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"
 Bundle-Vendor: ChemClipse

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.model.fragment.test/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndex_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.model.fragment.test/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndex_1_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.alignment.model.core;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RetentionIndex_1_Test {
 
@@ -24,90 +24,90 @@ public class RetentionIndex_1_Test {
 	public void testRetentionTime_1() {
 
 		retentionIndex.setRetentionTime(7503);
-		assertEquals("RetentionTime", 7503, retentionIndex.getRetentionTime());
+		assertEquals(7503, retentionIndex.getRetentionTime(), "RetentionTime");
 	}
 
 	@Test
 	public void testRetentionTime_2() {
 
 		retentionIndex.setRetentionTime(0);
-		assertEquals("RetentionTime", 0, retentionIndex.getRetentionTime());
+		assertEquals(0, retentionIndex.getRetentionTime(), "RetentionTime");
 	}
 
 	@Test
 	public void testRetentionTime_3() {
 
 		retentionIndex.setRetentionTime(-1);
-		assertEquals("RetentionTime", 0, retentionIndex.getRetentionTime());
+		assertEquals(0, retentionIndex.getRetentionTime(), "RetentionTime");
 	}
 
 	@Test
 	public void testRetentionTime_4() {
 
 		retentionIndex.setRetentionTime(Integer.MAX_VALUE);
-		assertEquals("RetentionTime", Integer.MAX_VALUE, retentionIndex.getRetentionTime());
+		assertEquals(Integer.MAX_VALUE, retentionIndex.getRetentionTime(), "RetentionTime");
 	}
 
 	@Test
 	public void testRetentionTime_5() {
 
 		retentionIndex.setRetentionTime(Integer.MIN_VALUE);
-		assertEquals("RetentionTime", 0, retentionIndex.getRetentionTime());
+		assertEquals(0, retentionIndex.getRetentionTime(), "RetentionTime");
 	}
 
 	@Test
 	public void testIndex_1() {
 
 		retentionIndex.setIndex(5000.4f);
-		assertEquals("Index", 5000.4f, retentionIndex.getIndex(), 0);
+		assertEquals(5000.4f, retentionIndex.getIndex(), 0, "Index");
 	}
 
 	@Test
 	public void testIndex_2() {
 
 		retentionIndex.setIndex(0.0f);
-		assertEquals("Index", 0.0f, retentionIndex.getIndex(), 0);
+		assertEquals(0.0f, retentionIndex.getIndex(), 0, "Index");
 	}
 
 	@Test
 	public void testIndex_3() {
 
 		retentionIndex.setIndex(-1.0f);
-		assertEquals("Index", 0.0f, retentionIndex.getIndex(), 0);
+		assertEquals(0.0f, retentionIndex.getIndex(), 0, "Index");
 	}
 
 	@Test
 	public void testIndex_4() {
 
 		retentionIndex.setIndex(Float.MAX_VALUE);
-		assertEquals("Index", Float.MAX_VALUE, retentionIndex.getIndex(), 0);
+		assertEquals(Float.MAX_VALUE, retentionIndex.getIndex(), 0, "Index");
 	}
 
 	@Test
 	public void testIndex_5() {
 
 		retentionIndex.setIndex(Float.MIN_VALUE);
-		assertEquals("Index", Float.MIN_VALUE, retentionIndex.getIndex(), 0);
+		assertEquals(Float.MIN_VALUE, retentionIndex.getIndex(), 0, "Index");
 	}
 
 	@Test
 	public void testIndex_6() {
 
 		retentionIndex.setIndex(Float.NaN);
-		assertEquals("Index", 0.0f, retentionIndex.getIndex(), 0);
+		assertEquals(0.0f, retentionIndex.getIndex(), 0, "Index");
 	}
 
 	@Test
 	public void testName_1() {
 
 		retentionIndex.setName("C41");
-		assertEquals("Name", "C41", retentionIndex.getName());
+		assertEquals("C41", retentionIndex.getName(), "Name");
 	}
 
 	@Test
 	public void testName_2() {
 
 		retentionIndex.setName("");
-		assertEquals("Name", "", retentionIndex.getName());
+		assertEquals("", retentionIndex.getName(), "Name");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.model.fragment.test/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndex_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.model.fragment.test/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndex_2_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.alignment.model.core;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RetentionIndex_2_Test {
 
@@ -22,35 +22,35 @@ public class RetentionIndex_2_Test {
 	public void testRetentionTime_1() {
 
 		RetentionIndex retentionIndex = new RetentionIndex();
-		assertEquals("RetentionTime", 0, retentionIndex.getRetentionTime());
-		assertEquals("Index", 0.0f, retentionIndex.getIndex(), 0);
-		assertEquals("Name", "", retentionIndex.getName());
+		assertEquals(0, retentionIndex.getRetentionTime(), "RetentionTime");
+		assertEquals(0.0f, retentionIndex.getIndex(), 0, "Index");
+		assertEquals("", retentionIndex.getName(), "Name");
 	}
 
 	@Test
 	public void testRetentionTime_2() {
 
 		RetentionIndex retentionIndex = new RetentionIndex(7500, 8000.2f);
-		assertEquals("RetentionTime", 7500, retentionIndex.getRetentionTime());
-		assertEquals("Index", 8000.2f, retentionIndex.getIndex(), 0);
-		assertEquals("Name", "", retentionIndex.getName());
+		assertEquals(7500, retentionIndex.getRetentionTime(), "RetentionTime");
+		assertEquals(8000.2f, retentionIndex.getIndex(), 0, "Index");
+		assertEquals("", retentionIndex.getName(), "Name");
 	}
 
 	@Test
 	public void testRetentionTime_3() {
 
 		RetentionIndex retentionIndex = new RetentionIndex(7500, 8000.2f, "C41");
-		assertEquals("RetentionTime", 7500, retentionIndex.getRetentionTime());
-		assertEquals("Index", 8000.2f, retentionIndex.getIndex(), 0);
-		assertEquals("Name", "C41", retentionIndex.getName());
+		assertEquals(7500, retentionIndex.getRetentionTime(), "RetentionTime");
+		assertEquals(8000.2f, retentionIndex.getIndex(), 0, "Index");
+		assertEquals("C41", retentionIndex.getName(), "Name");
 	}
 
 	@Test
 	public void testRetentionTime_4() {
 
 		RetentionIndex retentionIndex = new RetentionIndex(-7500, -8000.2f, "C41");
-		assertEquals("RetentionTime", 0, retentionIndex.getRetentionTime());
-		assertEquals("Index", 0.0f, retentionIndex.getIndex(), 0);
-		assertEquals("Name", "C41", retentionIndex.getName());
+		assertEquals(0, retentionIndex.getRetentionTime(), "RetentionTime");
+		assertEquals(0.0f, retentionIndex.getIndex(), 0, "Index");
+		assertEquals("C41", retentionIndex.getName(), "Name");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.model.fragment.test/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndices_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.model.fragment.test/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndices_1_Test.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.alignment.model.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.chemclipse.chromatogram.alignment.model.exceptions.NoRetentionIndexAvailableException;
 import org.eclipse.chemclipse.chromatogram.alignment.model.exceptions.RetentionIndexExistsException;
 import org.eclipse.chemclipse.chromatogram.alignment.model.exceptions.RetentionIndexValueException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RetentionIndices_1_Test {
 
@@ -27,89 +27,53 @@ public class RetentionIndices_1_Test {
 	@Test
 	public void testList_1() {
 
-		try {
+		assertThrows(NoRetentionIndexAvailableException.class, () -> {
 			retentionIndices.getActualRetentionIndex();
-		} catch(NoRetentionIndexAvailableException e) {
-			assertTrue("There is no retention index available", true);
-		}
+		});
 	}
 
 	@Test
-	public void testList_2() {
+	public void testList_2() throws RetentionIndexExistsException, RetentionIndexValueException, NoRetentionIndexAvailableException {
 
-		try {
-			retentionIndices.addRetentionIndex(new RetentionIndex(5758, 1000.0f, "C41"));
-			retentionIndices.addRetentionIndex(new RetentionIndex(5760, 2000.0f, "C42"));
-			retentionIndices.addRetentionIndex(new RetentionIndex(5770, 3000.0f, "C43"));
-			assertEquals("getActualRetentionIndex", "C43", retentionIndices.getActualRetentionIndex().getName());
-			assertEquals("getPreviousRetentionIndex", "C42", retentionIndices.getPreviousRetentionIndex().getName());
-			assertEquals("getPreviousRetentionIndex", "C41", retentionIndices.getPreviousRetentionIndex().getName());
-			assertEquals("getNextRetentionIndex", "C42", retentionIndices.getNextRetentionIndex().getName());
-			assertEquals("getNextRetentionIndex", "C43", retentionIndices.getNextRetentionIndex().getName());
-		} catch(RetentionIndexExistsException e) {
-			assertTrue("This state should never be entered. - RetentionIndexExistsException", false);
-		} catch(RetentionIndexValueException e) {
-			assertTrue("This state should never be entered. - RetentionIndexValueException", false);
-		} catch(NoRetentionIndexAvailableException e) {
-			assertTrue("This state should never be entered. - NoRetentionIndexAvailableException", false);
-		}
+		retentionIndices.addRetentionIndex(new RetentionIndex(5758, 1000.0f, "C41"));
+		retentionIndices.addRetentionIndex(new RetentionIndex(5760, 2000.0f, "C42"));
+		retentionIndices.addRetentionIndex(new RetentionIndex(5770, 3000.0f, "C43"));
+		assertEquals("C43", retentionIndices.getActualRetentionIndex().getName());
+		assertEquals("C42", retentionIndices.getPreviousRetentionIndex().getName());
+		assertEquals("C41", retentionIndices.getPreviousRetentionIndex().getName());
+		assertEquals("C42", retentionIndices.getNextRetentionIndex().getName());
+		assertEquals("C43", retentionIndices.getNextRetentionIndex().getName());
 	}
 
 	@Test
-	public void testList_3() {
+	public void testList_3() throws RetentionIndexExistsException, RetentionIndexValueException, NoRetentionIndexAvailableException {
 
-		try {
-			retentionIndices.addRetentionIndex(new RetentionIndex(5758, 1000.0f, "C41"));
-			retentionIndices.addRetentionIndex(new RetentionIndex(5760, 2000.0f, "C42"));
-			retentionIndices.addRetentionIndex(new RetentionIndex(5770, 3000.0f, "C43"));
-			assertEquals("getActualRetentionIndex", "C43", retentionIndices.getActualRetentionIndex().getName());
-			assertEquals("getPreviousRetentionIndex", "C42", retentionIndices.getPreviousRetentionIndex().getName());
-			assertEquals("getPreviousRetentionIndex", "C41", retentionIndices.getPreviousRetentionIndex().getName());
-			retentionIndices.getPreviousRetentionIndex();
-		} catch(RetentionIndexExistsException e) {
-			assertTrue("This state should never be entered. - RetentionIndexExistsException", false);
-		} catch(RetentionIndexValueException e) {
-			assertTrue("This state should never be entered. - RetentionIndexValueException", false);
-		} catch(NoRetentionIndexAvailableException e) {
-			assertTrue("This state should never be entered. - NoRetentionIndexAvailableException", true);
-		}
+		retentionIndices.addRetentionIndex(new RetentionIndex(5758, 1000.0f, "C41"));
+		retentionIndices.addRetentionIndex(new RetentionIndex(5760, 2000.0f, "C42"));
+		retentionIndices.addRetentionIndex(new RetentionIndex(5770, 3000.0f, "C43"));
+		assertEquals("C43", retentionIndices.getActualRetentionIndex().getName());
+		assertEquals("C42", retentionIndices.getPreviousRetentionIndex().getName());
+		assertEquals("C41", retentionIndices.getPreviousRetentionIndex().getName());
 	}
 
 	@Test
-	public void testList_4() {
+	public void testList_4() throws RetentionIndexExistsException, RetentionIndexValueException, NoRetentionIndexAvailableException {
 
-		try {
-			retentionIndices.addRetentionIndex(new RetentionIndex(5758, 1000.0f, "C41"));
-			retentionIndices.addRetentionIndex(new RetentionIndex(5760, 2000.0f, "C42"));
-			retentionIndices.addRetentionIndex(new RetentionIndex(5770, 3000.0f, "C43"));
-			retentionIndices.getNextRetentionIndex().getName();
-		} catch(RetentionIndexExistsException e) {
-			assertTrue("This state should never be entered. - RetentionIndexExistsException", false);
-		} catch(RetentionIndexValueException e) {
-			assertTrue("This state should never be entered. - RetentionIndexValueException", false);
-		} catch(NoRetentionIndexAvailableException e) {
-			assertTrue("This state should never be entered. - NoRetentionIndexAvailableException", true);
-		}
+		retentionIndices.addRetentionIndex(new RetentionIndex(5758, 1000.0f, "C41"));
+		retentionIndices.addRetentionIndex(new RetentionIndex(5760, 2000.0f, "C42"));
+		retentionIndices.addRetentionIndex(new RetentionIndex(5770, 3000.0f, "C43"));
 	}
 
 	@Test
-	public void testList_5() {
+	public void testList_5() throws RetentionIndexExistsException, RetentionIndexValueException, NoRetentionIndexAvailableException {
 
-		try {
-			retentionIndices.addRetentionIndex(new RetentionIndex(5770, 3000.0f, "C43"));
-			retentionIndices.addRetentionIndex(new RetentionIndex(5758, 1000.0f, "C41"));
-			retentionIndices.addRetentionIndex(new RetentionIndex(5760, 2000.0f, "C42"));
-			assertEquals("getActualRetentionIndex", "C43", retentionIndices.getLastRetentionIndex().getName());
-			assertEquals("getPreviousRetentionIndex", "C42", retentionIndices.getPreviousRetentionIndex().getName());
-			assertEquals("getPreviousRetentionIndex", "C41", retentionIndices.getPreviousRetentionIndex().getName());
-			assertEquals("getNextRetentionIndex", "C42", retentionIndices.getNextRetentionIndex().getName());
-			assertEquals("getNextRetentionIndex", "C43", retentionIndices.getNextRetentionIndex().getName());
-		} catch(RetentionIndexExistsException e) {
-			assertTrue("This state should never be entered. - RetentionIndexExistsException", false);
-		} catch(RetentionIndexValueException e) {
-			assertTrue("This state should never be entered. - RetentionIndexValueException", false);
-		} catch(NoRetentionIndexAvailableException e) {
-			assertTrue("This state should never be entered. - NoRetentionIndexAvailableException", false);
-		}
+		retentionIndices.addRetentionIndex(new RetentionIndex(5770, 3000.0f, "C43"));
+		retentionIndices.addRetentionIndex(new RetentionIndex(5758, 1000.0f, "C41"));
+		retentionIndices.addRetentionIndex(new RetentionIndex(5760, 2000.0f, "C42"));
+		assertEquals("C43", retentionIndices.getLastRetentionIndex().getName());
+		assertEquals("C42", retentionIndices.getPreviousRetentionIndex().getName());
+		assertEquals("C41", retentionIndices.getPreviousRetentionIndex().getName());
+		assertEquals("C42", retentionIndices.getNextRetentionIndex().getName());
+		assertEquals("C43", retentionIndices.getNextRetentionIndex().getName());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.model.fragment.test/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndices_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.model.fragment.test/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndices_2_Test.java
@@ -12,88 +12,55 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.alignment.model.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.chemclipse.chromatogram.alignment.model.exceptions.NoRetentionIndexAvailableException;
 import org.eclipse.chemclipse.chromatogram.alignment.model.exceptions.RetentionIndexExistsException;
 import org.eclipse.chemclipse.chromatogram.alignment.model.exceptions.RetentionIndexValueException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RetentionIndices_2_Test {
 
 	private RetentionIndices retentionIndices = new RetentionIndices();
 
 	@Test
-	public void testPreviousNextByTime_1() {
+	public void testPreviousNextByTime_1() throws RetentionIndexExistsException, RetentionIndexValueException, NoRetentionIndexAvailableException {
 
-		try {
-			retentionIndices.addRetentionIndex(new RetentionIndex(4500, 1000.0f));
-			retentionIndices.addRetentionIndex(new RetentionIndex(254500, 2000.0f));
-			retentionIndices.addRetentionIndex(new RetentionIndex(505500, 3000.0f));
-			assertEquals("getPreviousRetentionIndex", 4500, retentionIndices.getPreviousRetentionIndex(5500).getRetentionTime());
-			assertEquals("getNextRetentionIndex", 254500, retentionIndices.getNextRetentionIndex(5500).getRetentionTime());
-		} catch(RetentionIndexExistsException e) {
-			assertTrue("This state should never be entered. - RetentionIndexExistsException", false);
-		} catch(RetentionIndexValueException e) {
-			assertTrue("This state should never be entered. - RetentionIndexValueException", false);
-		} catch(NoRetentionIndexAvailableException e) {
-			assertTrue("This state should never be entered. - NoRetentionIndexAvailableException", false);
-		}
+		retentionIndices.addRetentionIndex(new RetentionIndex(4500, 1000.0f));
+		retentionIndices.addRetentionIndex(new RetentionIndex(254500, 2000.0f));
+		retentionIndices.addRetentionIndex(new RetentionIndex(505500, 3000.0f));
+		assertEquals(4500, retentionIndices.getPreviousRetentionIndex(5500).getRetentionTime());
+		assertEquals(254500, retentionIndices.getNextRetentionIndex(5500).getRetentionTime());
 	}
 
 	@Test
-	public void testPreviousNextByTime_2() {
+	public void testPreviousNextByTime_2() throws RetentionIndexExistsException, RetentionIndexValueException, NoRetentionIndexAvailableException {
 
-		try {
-			retentionIndices.addRetentionIndex(new RetentionIndex(4500, 1000.0f));
-			retentionIndices.addRetentionIndex(new RetentionIndex(254500, 2000.0f));
-			retentionIndices.addRetentionIndex(new RetentionIndex(505500, 3000.0f));
-			assertEquals("getPreviousRetentionIndex", 254500, retentionIndices.getPreviousRetentionIndex(255500).getRetentionTime());
-			assertEquals("getNextRetentionIndex", 505500, retentionIndices.getNextRetentionIndex(255500).getRetentionTime());
-		} catch(RetentionIndexExistsException e) {
-			assertTrue("This state should never be entered. - RetentionIndexExistsException", false);
-		} catch(RetentionIndexValueException e) {
-			assertTrue("This state should never be entered. - RetentionIndexValueException", false);
-		} catch(NoRetentionIndexAvailableException e) {
-			assertTrue("This state should never be entered. - NoRetentionIndexAvailableException", false);
-		}
+		retentionIndices.addRetentionIndex(new RetentionIndex(4500, 1000.0f));
+		retentionIndices.addRetentionIndex(new RetentionIndex(254500, 2000.0f));
+		retentionIndices.addRetentionIndex(new RetentionIndex(505500, 3000.0f));
+		assertEquals(254500, retentionIndices.getPreviousRetentionIndex(255500).getRetentionTime());
+		assertEquals(505500, retentionIndices.getNextRetentionIndex(255500).getRetentionTime());
 	}
 
 	@Test
-	public void testPreviousNextByIndex_1() {
+	public void testPreviousNextByIndex_1() throws RetentionIndexExistsException, RetentionIndexValueException, NoRetentionIndexAvailableException {
 
-		try {
-			retentionIndices.addRetentionIndex(new RetentionIndex(4500, 1000.0f));
-			retentionIndices.addRetentionIndex(new RetentionIndex(254500, 2000.0f));
-			retentionIndices.addRetentionIndex(new RetentionIndex(505500, 3000.0f));
-			assertEquals("getPreviousRetentionIndex", 4500, retentionIndices.getPreviousRetentionIndex(1100.0f).getRetentionTime());
-			assertEquals("getNextRetentionIndex", 254500, retentionIndices.getNextRetentionIndex(1100.0f).getRetentionTime());
-		} catch(RetentionIndexExistsException e) {
-			assertTrue("This state should never be entered. - RetentionIndexExistsException", false);
-		} catch(RetentionIndexValueException e) {
-			assertTrue("This state should never be entered. - RetentionIndexValueException", false);
-		} catch(NoRetentionIndexAvailableException e) {
-			assertTrue("This state should never be entered. - NoRetentionIndexAvailableException", false);
-		}
+		retentionIndices.addRetentionIndex(new RetentionIndex(4500, 1000.0f));
+		retentionIndices.addRetentionIndex(new RetentionIndex(254500, 2000.0f));
+		retentionIndices.addRetentionIndex(new RetentionIndex(505500, 3000.0f));
+		assertEquals(4500, retentionIndices.getPreviousRetentionIndex(1100.0f).getRetentionTime());
+		assertEquals(254500, retentionIndices.getNextRetentionIndex(1100.0f).getRetentionTime());
 	}
 
 	@Test
-	public void testPreviousNextByIndex_2() {
+	public void testPreviousNextByIndex_2() throws RetentionIndexExistsException, RetentionIndexValueException, NoRetentionIndexAvailableException {
 
-		try {
-			retentionIndices.addRetentionIndex(new RetentionIndex(4500, 1000.0f));
-			retentionIndices.addRetentionIndex(new RetentionIndex(254500, 2000.0f));
-			retentionIndices.addRetentionIndex(new RetentionIndex(505500, 3000.0f));
-			assertEquals("getPreviousRetentionIndex", 254500, retentionIndices.getPreviousRetentionIndex(2100.0f).getRetentionTime());
-			assertEquals("getNextRetentionIndex", 505500, retentionIndices.getNextRetentionIndex(2100.0f).getRetentionTime());
-			assertEquals("getFirstRetentionIndex", 4500, retentionIndices.getFirstRetentionIndex().getRetentionTime());
-		} catch(RetentionIndexExistsException e) {
-			assertTrue("This state should never be entered. - RetentionIndexExistsException", false);
-		} catch(RetentionIndexValueException e) {
-			assertTrue("This state should never be entered. - RetentionIndexValueException", false);
-		} catch(NoRetentionIndexAvailableException e) {
-			assertTrue("This state should never be entered. - NoRetentionIndexAvailableException", false);
-		}
+		retentionIndices.addRetentionIndex(new RetentionIndex(4500, 1000.0f));
+		retentionIndices.addRetentionIndex(new RetentionIndex(254500, 2000.0f));
+		retentionIndices.addRetentionIndex(new RetentionIndex(505500, 3000.0f));
+		assertEquals(254500, retentionIndices.getPreviousRetentionIndex(2100.0f).getRetentionTime());
+		assertEquals(505500, retentionIndices.getNextRetentionIndex(2100.0f).getRetentionTime());
+		assertEquals(4500, retentionIndices.getFirstRetentionIndex().getRetentionTime());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.csd.filter.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.csd.filter.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: org.eclipse.chemclipse.chromatogram.csd.filter.fragment.tes
 Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: ChemClipse
 Fragment-Host: org.eclipse.chemclipse.chromatogram.csd.filter;bundle-version="0.8.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.csd.filter.fragment.test/src/org/eclipse/chemclipse/chromatogram/csd/filter/core/chromatogram/ChromatogramFilterSupplier_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.csd.filter.fragment.test/src/org/eclipse/chemclipse/chromatogram/csd/filter/core/chromatogram/ChromatogramFilterSupplier_1_Test.java
@@ -12,17 +12,20 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.csd.filter.core.chromatogram;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramFilterSupplier_1_Test {
 
 	private ChromatogramFilterSupplierCSD supplier;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		supplier = new ChromatogramFilterSupplierCSD();
 		supplier.setId("org.eclipse.chemclipse.test");
@@ -33,18 +36,18 @@ public class ChromatogramFilterSupplier_1_Test {
 	@Test
 	public void testGetId_1() {
 
-		assertEquals("Id", "org.eclipse.chemclipse.test", supplier.getId());
+		assertEquals("org.eclipse.chemclipse.test", supplier.getId());
 	}
 
 	@Test
 	public void testGetDescription_1() {
 
-		assertEquals("Description", "This is a description.", supplier.getDescription());
+		assertEquals("This is a description.", supplier.getDescription());
 	}
 
 	@Test
 	public void testGetFilterName_1() {
 
-		assertEquals("Filter Name", "Filter Name", supplier.getFilterName());
+		assertEquals("Filter Name", supplier.getFilterName());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.csd.filter.fragment.test/src/org/eclipse/chemclipse/chromatogram/csd/filter/core/chromatogram/ChromatogramFilterSupplier_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.csd.filter.fragment.test/src/org/eclipse/chemclipse/chromatogram/csd/filter/core/chromatogram/ChromatogramFilterSupplier_2_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.csd.filter.core.chromatogram;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ChromatogramFilterSupplier_2_Test {
 
@@ -23,18 +23,18 @@ public class ChromatogramFilterSupplier_2_Test {
 	@Test
 	public void testGetId_1() {
 
-		assertEquals("Id", "", supplier.getId());
+		assertEquals("", supplier.getId(), "Id");
 	}
 
 	@Test
 	public void testGetDescription_1() {
 
-		assertEquals("Description", "", supplier.getDescription());
+		assertEquals("", supplier.getDescription(), "Description");
 	}
 
 	@Test
 	public void testGetFilterName_1() {
 
-		assertEquals("Filter Name", "", supplier.getFilterName());
+		assertEquals("", supplier.getFilterName(), "Filter Name");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.csd.filter.fragment.test/src/org/eclipse/chemclipse/chromatogram/csd/filter/core/chromatogram/ChromatogramFilterSupport_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.csd.filter.fragment.test/src/org/eclipse/chemclipse/chromatogram/csd/filter/core/chromatogram/ChromatogramFilterSupport_1_Test.java
@@ -12,23 +12,25 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.csd.filter.core.chromatogram;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.filter.exceptions.NoChromatogramFilterSupplierAvailableException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramFilterSupport_1_Test {
 
 	private ChromatogramFilterSupportCSD support;
 	private ChromatogramFilterSupplierCSD supplier;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		support = new ChromatogramFilterSupportCSD();
 		supplier = new ChromatogramFilterSupplierCSD();
@@ -39,49 +41,34 @@ public class ChromatogramFilterSupport_1_Test {
 	}
 
 	@Test
-	public void testGetAvailableFilterIds_1() {
+	public void testGetAvailableFilterIds_1() throws NoChromatogramFilterSupplierAvailableException {
 
-		try {
-			List<String> ids = support.getAvailableFilterIds();
-			assertEquals("getId", "net.first.supplier", ids.get(0));
-		} catch(NoChromatogramFilterSupplierAvailableException e) {
-			assertTrue("NoChromatogramFilterSupplierAvailableException", false);
-		}
+		List<String> ids = support.getAvailableFilterIds();
+		assertEquals("net.first.supplier", ids.get(0), "getId");
 	}
 
 	@Test
-	public void testGetIntegratorId_1() {
+	public void testGetIntegratorId_1() throws NoChromatogramFilterSupplierAvailableException {
 
-		try {
-			String name = support.getFilterId(0);
-			assertEquals("Name", "net.first.supplier", name);
-		} catch(NoChromatogramFilterSupplierAvailableException e) {
-			assertTrue("NoChromatogramFilterSupplierAvailableException", false);
-		}
+		String name = support.getFilterId(0);
+		assertEquals("net.first.supplier", name, "Name");
+
 	}
 
 	@Test
-	public void testGetIntegratorSupplier_1() {
+	public void testGetIntegratorSupplier_1() throws NoChromatogramFilterSupplierAvailableException {
 
 		IChromatogramFilterSupplierCSD supplier;
-		try {
-			supplier = support.getFilterSupplier("net.first.supplier");
-			assertNotNull(supplier);
-			assertEquals("Name", "Test Filter Name", supplier.getFilterName());
-		} catch(NoChromatogramFilterSupplierAvailableException e) {
-			assertTrue("NoChromatogramFilterSupplierAvailableException", false);
-		}
+		supplier = support.getFilterSupplier("net.first.supplier");
+		assertNotNull(supplier);
+		assertEquals("Test Filter Name", supplier.getFilterName(), "Name");
 	}
 
 	@Test
-	public void testGetIntegratorNames_1() {
+	public void testGetIntegratorNames_1() throws NoChromatogramFilterSupplierAvailableException {
 
-		try {
-			String[] names = support.getFilterNames();
-			assertEquals("length", 1, names.length);
-			assertEquals("name", "Test Filter Name", names[0]);
-		} catch(NoChromatogramFilterSupplierAvailableException e) {
-			assertTrue("NoChromatogramFilterSupplierAvailableException", false);
-		}
+		String[] names = support.getFilterNames();
+		assertEquals(1, names.length, "length");
+		assertEquals("Test Filter Name", names[0], "name");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.csd.filter.fragment.test/src/org/eclipse/chemclipse/chromatogram/csd/filter/core/chromatogram/ChromatogramFilter_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.csd.filter.fragment.test/src/org/eclipse/chemclipse/chromatogram/csd/filter/core/chromatogram/ChromatogramFilter_1_Test.java
@@ -12,16 +12,13 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.csd.filter.core.chromatogram;
 
-import static org.junit.Assert.assertTrue;
-
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.csd.model.core.selection.ChromatogramSelectionCSD;
 import org.eclipse.chemclipse.csd.model.core.selection.IChromatogramSelectionCSD;
 import org.eclipse.chemclipse.csd.model.implementation.ChromatogramCSD;
-import org.eclipse.chemclipse.model.exceptions.ChromatogramIsNullException;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ChromatogramFilter_1_Test {
 
@@ -43,11 +40,7 @@ public class ChromatogramFilter_1_Test {
 	public void testConstructor_2() {
 
 		chromatogram = new ChromatogramCSD();
-		try {
-			chromatogramSelection = new ChromatogramSelectionCSD(chromatogram);
-		} catch(ChromatogramIsNullException e) {
-			assertTrue("ChromatogramIsNullException", false);
-		}
+		chromatogramSelection = new ChromatogramSelectionCSD(chromatogram);
 		chromatogramFilterSettings = null;
 		filter = new TestChromatogramFilter();
 		filter.applyFilter(chromatogramSelection, chromatogramFilterSettings, new NullProgressMonitor());

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.csd.filter.fragment.test/src/org/eclipse/chemclipse/chromatogram/csd/filter/result/AbstractChromatogramFilterResult_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.csd.filter.fragment.test/src/org/eclipse/chemclipse/chromatogram/csd/filter/result/AbstractChromatogramFilterResult_1_Test.java
@@ -12,11 +12,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.csd.filter.result;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AbstractChromatogramFilterResult_1_Test {
 
@@ -27,7 +27,7 @@ public class AbstractChromatogramFilterResult_1_Test {
 
 		ResultStatus status = ResultStatus.EXCEPTION;
 		chromatogramFilterResult = new TestChromatogramFilterResult(status, "");
-		assertEquals("ResultStatus", ResultStatus.EXCEPTION, chromatogramFilterResult.getResultStatus());
+		assertEquals(ResultStatus.EXCEPTION, chromatogramFilterResult.getResultStatus(), "ResultStatus");
 	}
 
 	@Test
@@ -35,7 +35,7 @@ public class AbstractChromatogramFilterResult_1_Test {
 
 		ResultStatus status = ResultStatus.OK;
 		chromatogramFilterResult = new TestChromatogramFilterResult(status, "");
-		assertEquals("ResultStatus", ResultStatus.OK, chromatogramFilterResult.getResultStatus());
+		assertEquals(ResultStatus.OK, chromatogramFilterResult.getResultStatus(), "ResultStatus");
 	}
 
 	@Test
@@ -43,7 +43,7 @@ public class AbstractChromatogramFilterResult_1_Test {
 
 		ResultStatus status = ResultStatus.UNDEFINED;
 		chromatogramFilterResult = new TestChromatogramFilterResult(status, "");
-		assertEquals("ResultStatus", ResultStatus.UNDEFINED, chromatogramFilterResult.getResultStatus());
+		assertEquals(ResultStatus.UNDEFINED, chromatogramFilterResult.getResultStatus(), "ResultStatus");
 	}
 
 	@Test
@@ -51,7 +51,7 @@ public class AbstractChromatogramFilterResult_1_Test {
 
 		ResultStatus status = ResultStatus.UNDEFINED;
 		chromatogramFilterResult = new TestChromatogramFilterResult(status, "My test description.");
-		assertEquals("Description", "My test description.", chromatogramFilterResult.getDescription());
+		assertEquals("My test description.", chromatogramFilterResult.getDescription(), "Description");
 	}
 
 	@Test
@@ -59,6 +59,6 @@ public class AbstractChromatogramFilterResult_1_Test {
 
 		ResultStatus status = ResultStatus.UNDEFINED;
 		chromatogramFilterResult = new TestChromatogramFilterResult(status, "");
-		assertEquals("Description", "", chromatogramFilterResult.getDescription());
+		assertEquals("", chromatogramFilterResult.getDescription(), "Description");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: ChemClipse
 Fragment-Host: org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc;bundle-version="0.8.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0",
- org.eclipse.chemclipse.msd.converter;bundle-version="0.8.0",
- org.eclipse.chemclipse.converter;bundle-version="0.8.0"
-Import-Package: org.eclipse.chemclipse.xxd.converter.supplier.csv.preferences
+Require-Bundle: org.eclipse.chemclipse.msd.converter;bundle-version="0.8.0",
+ org.eclipse.chemclipse.converter;bundle-version="0.8.0",
+ org.eclipse.chemclipse.xxd.converter.supplier.csv;bundle-version="0.9.0"
+Import-Package: org.junit.jupiter.api;version="[5.12.0,6.0.0)"

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/core/WncClassifier_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/core/WncClassifier_1_ITest.java
@@ -13,21 +13,29 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.core;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.IOException;
+
+import org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.exceptions.ClassifierException;
 import org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.internal.core.support.ChromatogramTestCase;
 import org.eclipse.chemclipse.chromatogram.xxd.classifier.result.IChromatogramClassifierResult;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class WncClassifier_1_ITest extends ChromatogramTestCase {
 
 	private IChromatogramClassifierResult result;
 
 	@Override
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() throws IOException, ClassifierException {
 
 		super.setUp();
 		Classifier wncClassifier = new Classifier();

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/internal/core/support/Calculator_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/internal/core/support/Calculator_1_ITest.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.internal.core.support;
 
-import static org.junit.Assert.assertTrue;
-
 import org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.exceptions.ClassifierException;
 import org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.settings.ClassifierSettings;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
@@ -22,14 +20,10 @@ public class Calculator_1_ITest extends ChromatogramTestCase {
 
 	private Calculator calculator = new Calculator();
 
-	public void testCalculator_1() {
+	public void testCalculator_1() throws ClassifierException {
 
-		try {
-			ClassifierSettings classifierSettings = new ClassifierSettings();
-			IChromatogramSelectionMSD chromatogramSelection = getChromatogramSelection();
-			calculator.calculateIonPercentages(chromatogramSelection, classifierSettings);
-		} catch(ClassifierException e) {
-			assertTrue("ClassifierException shouldn't be thrown here.", false);
-		}
+		ClassifierSettings classifierSettings = new ClassifierSettings();
+		IChromatogramSelectionMSD chromatogramSelection = getChromatogramSelection();
+		calculator.calculateIonPercentages(chromatogramSelection, classifierSettings);
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/internal/core/support/Calculator_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/internal/core/support/Calculator_2_ITest.java
@@ -12,14 +12,21 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.internal.core.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.IOException;
+
+import org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.exceptions.ClassifierException;
 import org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.model.TargetTrace;
 import org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.model.TargetTraces;
 import org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.settings.ClassifierSettings;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class Calculator_2_ITest extends ChromatogramTestCase {
 
 	private Calculator calculator;
@@ -27,7 +34,8 @@ public class Calculator_2_ITest extends ChromatogramTestCase {
 	private TargetTrace targetTrace;
 
 	@Override
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() throws IOException, ClassifierException {
 
 		super.setUp();
 		calculator = new Calculator();

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/internal/core/support/ChromatogramTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/internal/core/support/ChromatogramTestCase.java
@@ -17,9 +17,11 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.zip.ZipInputStream;
 
 import org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.TestPathHelper;
+import org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.exceptions.ClassifierException;
 import org.eclipse.chemclipse.model.settings.Delimiter;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -28,19 +30,22 @@ import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.csv.preferences.PreferenceSupplier;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
-@Ignore
+@Disabled
+@TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramTestCase {
 
 	protected IChromatogramMSD chromatogram;
 	protected IChromatogramSelectionMSD chromatogramSelection;
 	protected File chromatogramFile;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeEach
+	public void setUp() throws IOException, ClassifierException {
 
 		PreferenceSupplier.setImportDelimiter(Delimiter.SEMICOLON);
 		ZipInputStream zipInputStream = new ZipInputStream(new FileInputStream(new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_ZIP))));
@@ -70,7 +75,7 @@ public class ChromatogramTestCase {
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);
 	}
 
-	@After
+	@AfterAll
 	public void tearDown() throws Exception {
 
 		PreferenceSupplier.setImportDelimiter(Delimiter.COMMA);

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/model/TargetTrace_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/model/TargetTrace_1_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TargetTrace_1_Test {
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/model/TargetTraces_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/model/TargetTraces_1_Test.java
@@ -12,18 +12,21 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TargetTraces_1_Test {
 
 	private TargetTrace targetTrace;
 	private TargetTraces targetTraces;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		targetTraces = new TargetTraces();

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/settings/WncClassifierSettings_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/settings/WncClassifierSettings_1_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.settings;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WncClassifierSettings_1_Test {
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/META-INF/MANIFEST.MF
@@ -5,8 +5,9 @@ Bundle-Name: Chromatogram Comparison Test
 Bundle-SymbolicName: org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test
 Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.chemclipse.chromatogram.msd.comparison;bundle-version="0.8.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2",
+ org.junit.jupiter.api.function;version="[5.12.0,6.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0",
- org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance;bundle-version="0.9.0",
+Require-Bundle: org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance;bundle-version="0.9.0",
  org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi;bundle-version="0.9.0"
 Bundle-Vendor: ChemClipse

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparator_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparator_1_Test.java
@@ -12,14 +12,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.massspectrum;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.msd.comparison.exceptions.NoMassSpectrumComparatorAvailableException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MassSpectrumComparator_1_Test {
 
@@ -65,35 +66,31 @@ public class MassSpectrumComparator_1_Test {
 	public void testGetMassSpectrumComparatorSupport_3() throws NoMassSpectrumComparatorAvailableException {
 
 		List<String> ids = support.getAvailableComparatorIds();
-		List<String> rcs = new ArrayList<String>();
+		List<String> rcs = new ArrayList<>();
 		for(String id : ids) {
 			rcs.add(id);
 		}
 		String id;
 		for(int i = 0; i < rcs.size(); i++) {
 			id = support.getComparatorId(i);
-			assertEquals("getComparatorId", id, rcs.get(i));
+			assertEquals(id, rcs.get(i), "getComparatorId");
 		}
 	}
 
 	@Test
 	public void testGetMassSpectrumComparisonSupplier_1() {
 
-		try {
+		assertThrows(NoMassSpectrumComparatorAvailableException.class, () -> {
 			support.getMassSpectrumComparisonSupplier("");
-		} catch(NoMassSpectrumComparatorAvailableException e) {
-			assertTrue("NoMassSpectrumComparatorAvailableException", true);
-		}
+		});
 	}
 
 	@Test
-	public void testGetMassSpectrumComparisonSupplier_2() {
+	public void testGetMassSpectrumComparisonSupplier_2() throws NoMassSpectrumComparatorAvailableException {
 
-		try {
+		assertThrows(NoMassSpectrumComparatorAvailableException.class, () -> {
 			support.getMassSpectrumComparisonSupplier(null);
-		} catch(NoMassSpectrumComparatorAvailableException e) {
-			assertTrue("NoMassSpectrumComparatorAvailableException", true);
-		}
+		});
 	}
 
 	@Test
@@ -103,8 +100,8 @@ public class MassSpectrumComparator_1_Test {
 		String description = "This comparator calculates the similarity between two mass spectra with the alfassi geomtric distance algorithm.";
 		String id = "org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.geometric";
 		IMassSpectrumComparisonSupplier supplier = support.getMassSpectrumComparisonSupplier(id);
-		assertEquals("ComparatorName", comparatorName, supplier.getComparatorName());
-		assertEquals("Description", description, supplier.getDescription());
-		assertEquals("Id", id, supplier.getId());
+		assertEquals(comparatorName, supplier.getComparatorName());
+		assertEquals(description, supplier.getDescription());
+		assertEquals(id, supplier.getId());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparator_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparator_2_Test.java
@@ -13,13 +13,13 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.massspectrum;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.implementation.ScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MassSpectrumComparator_2_Test {
 
@@ -34,11 +34,7 @@ public class MassSpectrumComparator_2_Test {
 
 		IProcessingInfo<IComparisonResult> processingInfo = MassSpectrumComparator.compare(null, null, (String)null, usePreOptimization, thresholdPreOptimization);
 		assertTrue(processingInfo.hasErrorMessages());
-		try {
-			processingInfo.getProcessingResult();
-		} catch(Exception e) {
-			assertTrue("Exception", true);
-		}
+		processingInfo.getProcessingResult();
 	}
 
 	@Test
@@ -46,11 +42,7 @@ public class MassSpectrumComparator_2_Test {
 
 		IProcessingInfo<IComparisonResult> processingInfo = MassSpectrumComparator.compare(massSpectrum1, null, (String)null, usePreOptimization, thresholdPreOptimization);
 		assertTrue(processingInfo.hasErrorMessages());
-		try {
-			processingInfo.getProcessingResult();
-		} catch(Exception e) {
-			assertTrue("Exception", true);
-		}
+		processingInfo.getProcessingResult();
 	}
 
 	@Test
@@ -58,11 +50,7 @@ public class MassSpectrumComparator_2_Test {
 
 		IProcessingInfo<IComparisonResult> processingInfo = MassSpectrumComparator.compare(null, massSpectrum2, (String)null, usePreOptimization, thresholdPreOptimization);
 		assertTrue(processingInfo.hasErrorMessages());
-		try {
-			processingInfo.getProcessingResult();
-		} catch(Exception e) {
-			assertTrue("Exception", true);
-		}
+		processingInfo.getProcessingResult();
 	}
 
 	@Test
@@ -70,11 +58,7 @@ public class MassSpectrumComparator_2_Test {
 
 		IProcessingInfo<IComparisonResult> processingInfo = MassSpectrumComparator.compare(null, null, "?", usePreOptimization, thresholdPreOptimization);
 		assertTrue(processingInfo.hasErrorMessages());
-		try {
-			processingInfo.getProcessingResult();
-		} catch(Exception e) {
-			assertTrue("Exception", true);
-		}
+		processingInfo.getProcessingResult();
 	}
 
 	@Test
@@ -82,11 +66,7 @@ public class MassSpectrumComparator_2_Test {
 
 		IProcessingInfo<IComparisonResult> processingInfo = MassSpectrumComparator.compare(massSpectrum1, massSpectrum2, "?", usePreOptimization, thresholdPreOptimization);
 		assertTrue(processingInfo.hasErrorMessages());
-		try {
-			processingInfo.getProcessingResult();
-		} catch(Exception e) {
-			assertTrue("Exception", true);
-		}
+		processingInfo.getProcessingResult();
 	}
 
 	@Test
@@ -94,10 +74,6 @@ public class MassSpectrumComparator_2_Test {
 
 		IProcessingInfo<IComparisonResult> processingInfo = MassSpectrumComparator.compare(massSpectrum1, null, "?", usePreOptimization, thresholdPreOptimization);
 		assertTrue(processingInfo.hasErrorMessages());
-		try {
-			processingInfo.getProcessingResult();
-		} catch(Exception e) {
-			assertTrue("Exception", true);
-		}
+		processingInfo.getProcessingResult();
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparator_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparator_3_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.massspectrum;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.chemclipse.chromatogram.msd.comparison.massspectrum.purity.IMassSpectrumPurityResult;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.implementation.ScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MassSpectrumComparator_3_Test {
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparator_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparator_4_Test.java
@@ -12,19 +12,22 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.massspectrum;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumComparator_4_Test {
 
 	private IMassSpectrumComparator comparator;
 	private IMassSpectrumComparisonSupplier supplier;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		comparator = MassSpectrumComparator.getMassSpectrumComparator("org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.cosine");
 		supplier = comparator.getMassSpectrumComparisonSupplier();

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparisonSupplier_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparisonSupplier_1_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.massspectrum;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MassSpectrumComparisonSupplier_1_Test {
 
@@ -23,18 +23,18 @@ public class MassSpectrumComparisonSupplier_1_Test {
 	@Test
 	public void testGetId_1() {
 
-		assertEquals("id", "", supplier.getId());
+		assertEquals("", supplier.getId());
 	}
 
 	@Test
 	public void testGetDescription_1() {
 
-		assertEquals("description", "", supplier.getDescription());
+		assertEquals("", supplier.getDescription());
 	}
 
 	@Test
 	public void testGetComparatorName_1() {
 
-		assertEquals("detectorName", "", supplier.getComparatorName());
+		assertEquals("", supplier.getComparatorName());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparisonSupplier_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparisonSupplier_2_Test.java
@@ -12,11 +12,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.massspectrum;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumComparisonSupplier_2_Test {
 
 	private MassSpectrumComparisonSupplier supplier;
@@ -24,8 +27,8 @@ public class MassSpectrumComparisonSupplier_2_Test {
 	private String description = "description";
 	private String comparatorName = "comparatorName";
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		supplier = new MassSpectrumComparisonSupplier();
 		supplier.setId(id);
@@ -36,27 +39,27 @@ public class MassSpectrumComparisonSupplier_2_Test {
 	@Test
 	public void testGetId_1() {
 
-		assertEquals("id", id, supplier.getId());
+		assertEquals(id, supplier.getId());
 		id = "newId";
 		supplier.setId(id);
-		assertEquals("id", id, supplier.getId());
+		assertEquals(id, supplier.getId());
 	}
 
 	@Test
 	public void testGetDescription_1() {
 
-		assertEquals("description", description, supplier.getDescription());
+		assertEquals(description, supplier.getDescription());
 		description = "newDescription";
 		supplier.setDescription(description);
-		assertEquals("description", description, supplier.getDescription());
+		assertEquals(description, supplier.getDescription());
 	}
 
 	@Test
 	public void testGetDetectorName_1() {
 
-		assertEquals("comparatorName", comparatorName, supplier.getComparatorName());
+		assertEquals(comparatorName, supplier.getComparatorName());
 		comparatorName = "newDetectorName";
 		supplier.setComparatorName(comparatorName);
-		assertEquals("comparatorName", comparatorName, supplier.getComparatorName());
+		assertEquals(comparatorName, supplier.getComparatorName());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparisonSupplier_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparisonSupplier_3_Test.java
@@ -12,20 +12,23 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.massspectrum;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumComparisonSupplier_3_Test {
 
 	private MassSpectrumComparisonSupplier supplier1;
 	private MassSpectrumComparisonSupplier supplier2;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		supplier1 = new MassSpectrumComparisonSupplier();
 		supplier1.setId("id");
@@ -41,30 +44,30 @@ public class MassSpectrumComparisonSupplier_3_Test {
 	@Test
 	public void testEquals_1() {
 
-		assertEquals("equals", supplier1, supplier2);
+		assertEquals(supplier1, supplier2);
 	}
 
 	@Test
 	public void testEquals_2() {
 
-		assertEquals("equals", supplier2, supplier1);
+		assertEquals(supplier2, supplier1);
 	}
 
 	@Test
 	public void testEquals_3() {
 
-		assertNotNull("equals", supplier1);
+		assertNotNull(supplier1);
 	}
 
 	@Test
 	public void testEquals_4() {
 
-		assertNotEquals("equals", supplier1, new Object());
+		assertNotEquals(supplier1, new Object());
 	}
 
 	@Test
 	public void testHashCode_1() {
 
-		assertEquals("hashCode", supplier1.hashCode(), supplier2.hashCode());
+		assertEquals(supplier1.hashCode(), supplier2.hashCode());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparisonSupplier_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/massspectrum/MassSpectrumComparisonSupplier_4_Test.java
@@ -12,19 +12,22 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.massspectrum;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumComparisonSupplier_4_Test {
 
 	private MassSpectrumComparisonSupplier supplier1;
 	private MassSpectrumComparisonSupplier supplier2;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		supplier1 = new MassSpectrumComparisonSupplier();
 		supplier1.setId("id1");
@@ -40,30 +43,30 @@ public class MassSpectrumComparisonSupplier_4_Test {
 	@Test
 	public void testEquals_1() {
 
-		assertNotEquals("equals", supplier1, supplier2);
+		assertNotEquals(supplier1, supplier2);
 	}
 
 	@Test
 	public void testEquals_2() {
 
-		assertNotEquals("equals", supplier2, supplier1);
+		assertNotEquals(supplier2, supplier1);
 	}
 
 	@Test
 	public void testEquals_3() {
 
-		assertNotNull("equals", supplier1);
+		assertNotNull(supplier1);
 	}
 
 	@Test
 	public void testEquals_4() {
 
-		assertNotEquals("equals", supplier1, new Object());
+		assertNotEquals(supplier1, new Object());
 	}
 
 	@Test
 	public void testHashCode_1() {
 
-		assertNotEquals("hashCode", supplier1.hashCode(), supplier2.hashCode());
+		assertNotEquals(supplier1.hashCode(), supplier2.hashCode());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/GeometricDistanceCalculator_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/GeometricDistanceCalculator_1_Test.java
@@ -12,22 +12,17 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.math;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class GeometricDistanceCalculator_1_Test extends MassSpectrumSetTestCase {
 
 	private GeometricDistanceCalculator calculator = new GeometricDistanceCalculator();
-
-	@Override
-	@Before
-	public void setUp() throws Exception {
-
-		super.setUp();
-	}
 
 	@Test
 	public void test1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/GeometricDistanceCalculator_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/GeometricDistanceCalculator_2_Test.java
@@ -12,22 +12,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.math;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GeometricDistanceCalculator_2_Test extends MassSpectrumSetTestCase {
 
 	private GeometricDistanceCalculator calculator = new GeometricDistanceCalculator();
-
-	@Override
-	@Before
-	public void setUp() throws Exception {
-
-		super.setUp();
-	}
 
 	@Test
 	public void test1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/GeometricDistanceCalculator_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/GeometricDistanceCalculator_3_Test.java
@@ -12,22 +12,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.math;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GeometricDistanceCalculator_3_Test extends MassSpectrumSetTestCase {
 
 	private GeometricDistanceCalculator calculator = new GeometricDistanceCalculator();
-
-	@Override
-	@Before
-	public void setUp() throws Exception {
-
-		super.setUp();
-	}
 
 	@Test
 	public void test1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/GeometricDistanceCalculator_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/GeometricDistanceCalculator_4_Test.java
@@ -12,22 +12,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.math;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GeometricDistanceCalculator_4_Test extends MassSpectrumSetTestCase {
 
 	private GeometricDistanceCalculator calculator = new GeometricDistanceCalculator();
-
-	@Override
-	@Before
-	public void setUp() throws Exception {
-
-		super.setUp();
-	}
 
 	@Test
 	public void test1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/GeometricDistanceCalculator_5_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/GeometricDistanceCalculator_5_Test.java
@@ -12,22 +12,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.math;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GeometricDistanceCalculator_5_Test extends MassSpectrumSetTestCase {
 
 	private GeometricDistanceCalculator calculator = new GeometricDistanceCalculator();
-
-	@Override
-	@Before
-	public void setUp() throws Exception {
-
-		super.setUp();
-	}
 
 	@Test
 	public void test1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/GeometricDistanceCalculator_6_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/GeometricDistanceCalculator_6_Test.java
@@ -12,22 +12,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.math;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GeometricDistanceCalculator_6_Test extends MassSpectrumSetTestCase {
 
-	private GeometricDistanceCalculator calculator = new GeometricDistanceCalculator();;
-
-	@Override
-	@Before
-	public void setUp() throws Exception {
-
-		super.setUp();
-	}
+	private GeometricDistanceCalculator calculator = new GeometricDistanceCalculator();
 
 	@Test
 	public void test1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/GeometricDistanceCalculator_7_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/GeometricDistanceCalculator_7_Test.java
@@ -12,22 +12,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.math;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GeometricDistanceCalculator_7_Test extends MassSpectrumSetTestCase {
 
 	private GeometricDistanceCalculator calculator = new GeometricDistanceCalculator();
-
-	@Override
-	@Before
-	public void setUp() throws Exception {
-
-		super.setUp();
-	}
 
 	@Test
 	public void test1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/GeometricDistanceCalculator_8_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/GeometricDistanceCalculator_8_Test.java
@@ -12,22 +12,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.math;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GeometricDistanceCalculator_8_Test extends MassSpectrumSetTestCase {
 
 	private GeometricDistanceCalculator calculator = new GeometricDistanceCalculator();;
-
-	@Override
-	@Before
-	public void setUp() throws Exception {
-
-		super.setUp();
-	}
 
 	@Test
 	public void test1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/MassSpectrumSetTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/math/MassSpectrumSetTestCase.java
@@ -26,8 +26,10 @@ import org.eclipse.chemclipse.chromatogram.msd.comparison.spectra.ProblemC2;
 import org.eclipse.chemclipse.chromatogram.msd.comparison.spectra.SinapylAlcohol;
 import org.eclipse.chemclipse.chromatogram.msd.comparison.spectra.SinapylAlcoholCis;
 import org.eclipse.chemclipse.chromatogram.msd.comparison.spectra.Syringylacetone;
-import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 /**
  * Comparison NIST-DB 12 (MF, RMF):
@@ -37,7 +39,8 @@ import org.junit.Ignore;
  * sinapylAclohol vs phenolBenzimidazolyl: 51.5, 57.6
  * 
  */
-@Ignore
+@Disabled
+@TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumSetTestCase {
 
 	protected ITestMassSpectrum sinapylAclohol;
@@ -55,7 +58,7 @@ public class MassSpectrumSetTestCase {
 	protected ITestMassSpectrum problemC1;
 	protected ITestMassSpectrum problemC2;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		sinapylAclohol = new SinapylAlcohol();

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/META-INF/MANIFEST.MF
@@ -5,6 +5,6 @@ Bundle-Name: Alfassi Test
 Bundle-SymbolicName: org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test
 Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi;bundle-version="0.8.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"
 Bundle-Vendor: Chemclipse

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_1_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class GeometricDistanceMassSpectrumComparator_1_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class GeometricDistanceMassSpectrumComparator_1_Test extends MassSpectrum
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_2_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class GeometricDistanceMassSpectrumComparator_2_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class GeometricDistanceMassSpectrumComparator_2_Test extends MassSpectrum
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_3_Test.java
@@ -12,15 +12,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class GeometricDistanceMassSpectrumComparator_3_Test extends MassSpectrumSetTestCase {
 
@@ -29,8 +29,8 @@ public class GeometricDistanceMassSpectrumComparator_3_Test extends MassSpectrum
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_4_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class GeometricDistanceMassSpectrumComparator_4_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class GeometricDistanceMassSpectrumComparator_4_Test extends MassSpectrum
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_5_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_5_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class GeometricDistanceMassSpectrumComparator_5_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class GeometricDistanceMassSpectrumComparator_5_Test extends MassSpectrum
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_6_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_6_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class GeometricDistanceMassSpectrumComparator_6_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class GeometricDistanceMassSpectrumComparator_6_Test extends MassSpectrum
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_7_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_7_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class GeometricDistanceMassSpectrumComparator_7_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class GeometricDistanceMassSpectrumComparator_7_Test extends MassSpectrum
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_8_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_8_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class GeometricDistanceMassSpectrumComparator_8_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class GeometricDistanceMassSpectrumComparator_8_Test extends MassSpectrum
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_9_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/GeometricDistanceMassSpectrumComparator_9_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class GeometricDistanceMassSpectrumComparator_9_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class GeometricDistanceMassSpectrumComparator_9_Test extends MassSpectrum
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/MassSpectrumSetTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/comparator/MassSpectrumSetTestCase.java
@@ -26,8 +26,10 @@ import org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.spect
 import org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.spectra.SinapylAlcohol;
 import org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.spectra.SinapylAlcoholCis;
 import org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.spectra.Syringylacetone;
-import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 /**
  * Comparison NIST-DB 12 (MF, RMF):
@@ -37,7 +39,8 @@ import org.junit.Ignore;
  * sinapylAclohol vs phenolBenzimidazolyl: 51.5, 57.6
  * 
  */
-@Ignore
+@Disabled
+@TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumSetTestCase {
 
 	protected ITestMassSpectrum sinapylAclohol;
@@ -55,8 +58,8 @@ public class MassSpectrumSetTestCase {
 	protected ITestMassSpectrum problemC1;
 	protected ITestMassSpectrum problemC2;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		sinapylAclohol = new SinapylAlcohol();
 		sinapylAcloholCis = new SinapylAlcoholCis();

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/BenzenepropanoicAcid.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/BenzenepropanoicAcid.java
@@ -28,7 +28,8 @@ public class BenzenepropanoicAcid implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public BenzenepropanoicAcid() throws Exception {
+	public BenzenepropanoicAcid() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(14.0d, 31.0f));
 		massSpectrum.addIon(new Ion(15.0d, 297.0f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/NoMatchA1.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/NoMatchA1.java
@@ -23,7 +23,8 @@ public class NoMatchA1 implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public NoMatchA1() throws Exception {
+	public NoMatchA1() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(25.0d, 102.0f));
 		massSpectrum.addIon(new Ion(32.0d, 2190.0f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/NoMatchA2.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/NoMatchA2.java
@@ -23,7 +23,8 @@ public class NoMatchA2 implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public NoMatchA2() throws Exception {
+	public NoMatchA2() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(65.0d, 1017.0f));
 		massSpectrum.addIon(new Ion(70.0d, 202891.0f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/PhenolBenzimidazolyl.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/PhenolBenzimidazolyl.java
@@ -28,7 +28,8 @@ public class PhenolBenzimidazolyl implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public PhenolBenzimidazolyl() throws Exception {
+	public PhenolBenzimidazolyl() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(33.0d, 2.0f));
 		massSpectrum.addIon(new Ion(34.0d, 2.0f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/ProblemA1.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/ProblemA1.java
@@ -20,7 +20,8 @@ public class ProblemA1 implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public ProblemA1() throws Exception {
+	public ProblemA1() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(36.0d, 152.46007f));
 		massSpectrum.addIon(new Ion(37.0d, 304.92014f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/ProblemA2.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/ProblemA2.java
@@ -20,7 +20,8 @@ public class ProblemA2 implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public ProblemA2() throws Exception {
+	public ProblemA2() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(53.0d, 77.79473f));
 		massSpectrum.addIon(new Ion(225.0d, 22.955824f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/ProblemB1.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/ProblemB1.java
@@ -20,7 +20,8 @@ public class ProblemB1 implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public ProblemB1() throws Exception {
+	public ProblemB1() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(50.0d, 50.822044f));
 		massSpectrum.addIon(new Ion(70.0d, 50.822044f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/ProblemB2.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/ProblemB2.java
@@ -20,7 +20,8 @@ public class ProblemB2 implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public ProblemB2() throws Exception {
+	public ProblemB2() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(53.0d, 39.03904f));
 		massSpectrum.addIon(new Ion(71.0d, 5.005005f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/ProblemC1.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/ProblemC1.java
@@ -20,7 +20,8 @@ public class ProblemC1 implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public ProblemC1() throws Exception {
+	public ProblemC1() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(183.0d, 32.375866f));
 		massSpectrum.addIon(new Ion(181.0d, 35.19116f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/ProblemC2.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/ProblemC2.java
@@ -20,7 +20,8 @@ public class ProblemC2 implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public ProblemC2() throws Exception {
+	public ProblemC2() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(53.0d, 3.1257746f));
 		massSpectrum.addIon(new Ion(71.0d, 8.00E-006f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/SinapylAlcohol.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/SinapylAlcohol.java
@@ -28,7 +28,8 @@ public class SinapylAlcohol implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public SinapylAlcohol() throws Exception {
+	public SinapylAlcohol() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(27.0d, 84.0f));
 		massSpectrum.addIon(new Ion(38.0d, 60.0f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/SinapylAlcoholCis.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/SinapylAlcoholCis.java
@@ -28,7 +28,8 @@ public class SinapylAlcoholCis implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public SinapylAlcoholCis() throws Exception {
+	public SinapylAlcoholCis() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(27.0d, 71.0f));
 		massSpectrum.addIon(new Ion(39.0d, 94.0f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/Syringylacetone.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/alfassi/spectra/Syringylacetone.java
@@ -28,7 +28,8 @@ public class Syringylacetone implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public Syringylacetone() throws Exception {
+	public Syringylacetone() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(27.0d, 11.0f));
 		massSpectrum.addIon(new Ion(28.0d, 8.0f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Comparison Distance Test
 Bundle-SymbolicName: org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test
 Bundle-Version: 0.9.0.qualifier
-Require-Bundle: org.junit;bundle-version="4.11.0"
 Bundle-Vendor: ChemClipse
 Fragment-Host: org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance;bundle-version="0.8.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_1_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class CosineMassSpectrumComparator_1_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class CosineMassSpectrumComparator_1_Test extends MassSpectrumSetTestCase
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_2_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class CosineMassSpectrumComparator_2_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class CosineMassSpectrumComparator_2_Test extends MassSpectrumSetTestCase
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_3_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class CosineMassSpectrumComparator_3_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class CosineMassSpectrumComparator_3_Test extends MassSpectrumSetTestCase
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_4_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class CosineMassSpectrumComparator_4_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class CosineMassSpectrumComparator_4_Test extends MassSpectrumSetTestCase
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_5_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_5_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class CosineMassSpectrumComparator_5_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class CosineMassSpectrumComparator_5_Test extends MassSpectrumSetTestCase
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_6_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_6_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class CosineMassSpectrumComparator_6_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class CosineMassSpectrumComparator_6_Test extends MassSpectrumSetTestCase
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_7_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_7_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class CosineMassSpectrumComparator_7_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class CosineMassSpectrumComparator_7_Test extends MassSpectrumSetTestCase
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_8_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_8_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class CosineMassSpectrumComparator_8_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class CosineMassSpectrumComparator_8_Test extends MassSpectrumSetTestCase
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_9_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosineMassSpectrumComparator_9_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class CosineMassSpectrumComparator_9_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class CosineMassSpectrumComparator_9_Test extends MassSpectrumSetTestCase
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosinePhiMassSpectrumComparator_5_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CosinePhiMassSpectrumComparator_5_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class CosinePhiMassSpectrumComparator_5_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class CosinePhiMassSpectrumComparator_5_Test extends MassSpectrumSetTestC
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_1_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class EuclideanMassSpectrumComparator_1_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class EuclideanMassSpectrumComparator_1_Test extends MassSpectrumSetTestC
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_2_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class EuclideanMassSpectrumComparator_2_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class EuclideanMassSpectrumComparator_2_Test extends MassSpectrumSetTestC
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_3_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class EuclideanMassSpectrumComparator_3_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class EuclideanMassSpectrumComparator_3_Test extends MassSpectrumSetTestC
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_4_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class EuclideanMassSpectrumComparator_4_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class EuclideanMassSpectrumComparator_4_Test extends MassSpectrumSetTestC
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_5_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_5_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class EuclideanMassSpectrumComparator_5_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class EuclideanMassSpectrumComparator_5_Test extends MassSpectrumSetTestC
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_6_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_6_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class EuclideanMassSpectrumComparator_6_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class EuclideanMassSpectrumComparator_6_Test extends MassSpectrumSetTestC
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_7_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_7_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class EuclideanMassSpectrumComparator_7_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class EuclideanMassSpectrumComparator_7_Test extends MassSpectrumSetTestC
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_8_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_8_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class EuclideanMassSpectrumComparator_8_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class EuclideanMassSpectrumComparator_8_Test extends MassSpectrumSetTestC
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_9_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/EuclideanMassSpectrumComparator_9_Test.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.comparator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class EuclideanMassSpectrumComparator_9_Test extends MassSpectrumSetTestCase {
 
@@ -30,8 +30,8 @@ public class EuclideanMassSpectrumComparator_9_Test extends MassSpectrumSetTestC
 	private IComparisonResult result;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/MassSpectrumSetTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/MassSpectrumSetTestCase.java
@@ -26,8 +26,10 @@ import org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.spec
 import org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.spectra.SinapylAlcohol;
 import org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.spectra.SinapylAlcoholCis;
 import org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.spectra.Syringylacetone;
-import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 /**
  * comparison.supplier.distance NIST-DB 12 (MF, RMF):
@@ -37,7 +39,8 @@ import org.junit.Ignore;
  * sinapylAclohol vs phenolBenzimidazolyl: 51.5, 57.6
  * 
  */
-@Ignore
+@Disabled
+@TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumSetTestCase {
 
 	protected ITestMassSpectrum sinapylAclohol;
@@ -55,8 +58,8 @@ public class MassSpectrumSetTestCase {
 	protected ITestMassSpectrum problemC1;
 	protected ITestMassSpectrum problemC2;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		sinapylAclohol = new SinapylAlcohol();
 		sinapylAcloholCis = new SinapylAlcoholCis();

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/BenzenepropanoicAcid.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/BenzenepropanoicAcid.java
@@ -28,7 +28,8 @@ public class BenzenepropanoicAcid implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public BenzenepropanoicAcid() throws Exception {
+	public BenzenepropanoicAcid() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(14.0d, 31.0f));
 		massSpectrum.addIon(new Ion(15.0d, 297.0f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/NoMatchA1.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/NoMatchA1.java
@@ -23,7 +23,8 @@ public class NoMatchA1 implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public NoMatchA1() throws Exception {
+	public NoMatchA1() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(25.0d, 102.0f));
 		massSpectrum.addIon(new Ion(32.0d, 2190.0f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/NoMatchA2.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/NoMatchA2.java
@@ -23,7 +23,8 @@ public class NoMatchA2 implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public NoMatchA2() throws Exception {
+	public NoMatchA2() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(65.0d, 1017.0f));
 		massSpectrum.addIon(new Ion(70.0d, 202891.0f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/PhenolBenzimidazolyl.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/PhenolBenzimidazolyl.java
@@ -28,7 +28,8 @@ public class PhenolBenzimidazolyl implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public PhenolBenzimidazolyl() throws Exception {
+	public PhenolBenzimidazolyl() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(33.0d, 2.0f));
 		massSpectrum.addIon(new Ion(34.0d, 2.0f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/ProblemA1.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/ProblemA1.java
@@ -20,7 +20,8 @@ public class ProblemA1 implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public ProblemA1() throws Exception {
+	public ProblemA1() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(36.0d, 152.46007f));
 		massSpectrum.addIon(new Ion(37.0d, 304.92014f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/ProblemA2.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/ProblemA2.java
@@ -20,7 +20,8 @@ public class ProblemA2 implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public ProblemA2() throws Exception {
+	public ProblemA2() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(53.0d, 77.79473f));
 		massSpectrum.addIon(new Ion(225.0d, 22.955824f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/ProblemB1.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/ProblemB1.java
@@ -20,7 +20,8 @@ public class ProblemB1 implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public ProblemB1() throws Exception {
+	public ProblemB1() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(50.0d, 50.822044f));
 		massSpectrum.addIon(new Ion(70.0d, 50.822044f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/ProblemB2.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/ProblemB2.java
@@ -20,7 +20,8 @@ public class ProblemB2 implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public ProblemB2() throws Exception {
+	public ProblemB2() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(53.0d, 39.03904f));
 		massSpectrum.addIon(new Ion(71.0d, 5.005005f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/ProblemC1.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/ProblemC1.java
@@ -20,7 +20,8 @@ public class ProblemC1 implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public ProblemC1() throws Exception {
+	public ProblemC1() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(183.0d, 32.375866f));
 		massSpectrum.addIon(new Ion(181.0d, 35.19116f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/ProblemC2.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/ProblemC2.java
@@ -20,7 +20,8 @@ public class ProblemC2 implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public ProblemC2() throws Exception {
+	public ProblemC2() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(53.0d, 3.1257746f));
 		massSpectrum.addIon(new Ion(71.0d, 8.00E-006f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/SinapylAlcohol.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/SinapylAlcohol.java
@@ -28,7 +28,8 @@ public class SinapylAlcohol implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public SinapylAlcohol() throws Exception {
+	public SinapylAlcohol() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(27.0d, 84.0f));
 		massSpectrum.addIon(new Ion(38.0d, 60.0f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/SinapylAlcoholCis.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/SinapylAlcoholCis.java
@@ -28,7 +28,8 @@ public class SinapylAlcoholCis implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public SinapylAlcoholCis() throws Exception {
+	public SinapylAlcoholCis() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(27.0d, 71.0f));
 		massSpectrum.addIon(new Ion(39.0d, 94.0f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/Syringylacetone.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/spectra/Syringylacetone.java
@@ -28,7 +28,8 @@ public class Syringylacetone implements ITestMassSpectrum {
 
 	private IScanMSD massSpectrum;
 
-	public Syringylacetone() throws Exception {
+	public Syringylacetone() {
+
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(27.0d, 11.0f));
 		massSpectrum.addIon(new Ion(28.0d, 8.0f));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/META-INF/MANIFEST.MF
@@ -5,9 +5,9 @@ Bundle-Name: Backfolding Test
 Bundle-SymbolicName: org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test
 Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding;bundle-version="0.8.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0",
- org.eclipse.chemclipse.msd.converter;bundle-version="0.8.0",
+Require-Bundle: org.eclipse.chemclipse.msd.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0"
 Bundle-Vendor: ChemClipse

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/BackfoldingFilter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/BackfoldingFilter_1_ITest.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.core;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.chemclipse.chromatogram.msd.filter.core.chromatogram.IChromatogramFilterMSD;
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.settings.ChromatogramFilterSettings;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BackfoldingFilter_1_ITest extends ChromatogramImporterTestCase {
 
@@ -29,6 +29,6 @@ public class BackfoldingFilter_1_ITest extends ChromatogramImporterTestCase {
 
 		int scan = 1;
 		chromatogramFilter.applyFilter(chromatogramSelection, chromatogramFilterSettings, new NullProgressMonitor());
-		assertEquals("total signal", 1934.0f, chromatogram.getScan(scan).getTotalSignal(), 0);
+		assertEquals(1934.0f, chromatogram.getScan(scan).getTotalSignal(), 0, "total signal");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/ChromatogramImporterTestCase.java
@@ -23,16 +23,19 @@ import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
-@Ignore
+@Disabled
+@TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImporterTestCase {
 
 	protected IChromatogramMSD chromatogram;
 	protected IChromatogramSelectionMSD chromatogramSelection;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		/*

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/settings/BackfoldingPeakDetectorSettings_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/settings/BackfoldingPeakDetectorSettings_1_Test.java
@@ -12,11 +12,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.settings;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.chemclipse.chromatogram.peak.detector.model.Threshold;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BackfoldingPeakDetectorSettings_1_Test {
 
@@ -33,7 +33,7 @@ public class BackfoldingPeakDetectorSettings_1_Test {
 	public void testGetThreshold_1() {
 
 		Threshold threshold = settings.getThreshold();
-		assertEquals("Threshold", Threshold.MEDIUM, threshold);
+		assertEquals(Threshold.MEDIUM, threshold, "Threshold");
 	}
 
 	@Test
@@ -41,6 +41,6 @@ public class BackfoldingPeakDetectorSettings_1_Test {
 
 		settings.setThreshold(Threshold.HIGH);
 		Threshold threshold = settings.getThreshold();
-		assertEquals("Threshold", Threshold.HIGH, threshold);
+		assertEquals(Threshold.HIGH, threshold, "Threshold");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/settings/BackfoldingSettings_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/settings/BackfoldingSettings_1_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.settings;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BackfoldingSettings_1_Test {
 
@@ -24,14 +24,14 @@ public class BackfoldingSettings_1_Test {
 	public void testGetMaximumRetentionTimeShift_1() {
 
 		int shift = settings.getMaximumRetentionTimeShift();
-		assertEquals("RetentionTimeShift", 5000, shift);
+		assertEquals(5000, shift, "RetentionTimeShift");
 	}
 
 	@Test
 	public void testGetNumberOfBackfoldingRuns_1() {
 
 		int runs = settings.getNumberOfBackfoldingRuns();
-		assertEquals("Backfolding Runs", 3, runs);
+		assertEquals(3, runs, "Backfolding Runs");
 	}
 
 	@Test
@@ -39,7 +39,7 @@ public class BackfoldingSettings_1_Test {
 
 		settings.setMaximumRetentionTimeShift(1000);
 		int shift = settings.getMaximumRetentionTimeShift();
-		assertEquals("RetentionTimeShift", 1000, shift);
+		assertEquals(1000, shift, "RetentionTimeShift");
 	}
 
 	@Test
@@ -47,7 +47,7 @@ public class BackfoldingSettings_1_Test {
 
 		settings.setMaximumRetentionTimeShift(500);
 		int shift = settings.getMaximumRetentionTimeShift();
-		assertEquals("RetentionTimeShift", 500, shift);
+		assertEquals(500, shift, "RetentionTimeShift");
 	}
 
 	@Test
@@ -55,7 +55,7 @@ public class BackfoldingSettings_1_Test {
 
 		settings.setMaximumRetentionTimeShift(25000);
 		int shift = settings.getMaximumRetentionTimeShift();
-		assertEquals("RetentionTimeShift", 25000, shift);
+		assertEquals(25000, shift, "RetentionTimeShift");
 	}
 
 	@Test
@@ -63,7 +63,7 @@ public class BackfoldingSettings_1_Test {
 
 		settings.setMaximumRetentionTimeShift(499);
 		int shift = settings.getMaximumRetentionTimeShift();
-		assertEquals("RetentionTimeShift", 5000, shift);
+		assertEquals(5000, shift, "RetentionTimeShift");
 	}
 
 	@Test
@@ -71,7 +71,7 @@ public class BackfoldingSettings_1_Test {
 
 		settings.setMaximumRetentionTimeShift(25001);
 		int shift = settings.getMaximumRetentionTimeShift();
-		assertEquals("RetentionTimeShift", 5000, shift);
+		assertEquals(5000, shift, "RetentionTimeShift");
 	}
 
 	@Test
@@ -79,7 +79,7 @@ public class BackfoldingSettings_1_Test {
 
 		settings.setNumberOfBackfoldingRuns(5);
 		int runs = settings.getNumberOfBackfoldingRuns();
-		assertEquals("Backfolding Runs", 5, runs);
+		assertEquals(5, runs, "Backfolding Runs");
 	}
 
 	@Test
@@ -87,7 +87,7 @@ public class BackfoldingSettings_1_Test {
 
 		settings.setNumberOfBackfoldingRuns(1);
 		int runs = settings.getNumberOfBackfoldingRuns();
-		assertEquals("Backfolding Runs", 1, runs);
+		assertEquals(1, runs, "Backfolding Runs");
 	}
 
 	@Test
@@ -95,7 +95,7 @@ public class BackfoldingSettings_1_Test {
 
 		settings.setNumberOfBackfoldingRuns(10);
 		int runs = settings.getNumberOfBackfoldingRuns();
-		assertEquals("Backfolding Runs", 10, runs);
+		assertEquals(10, runs, "Backfolding Runs");
 	}
 
 	@Test
@@ -103,7 +103,7 @@ public class BackfoldingSettings_1_Test {
 
 		settings.setNumberOfBackfoldingRuns(0);
 		int runs = settings.getNumberOfBackfoldingRuns();
-		assertEquals("Backfolding Runs", 3, runs);
+		assertEquals(3, runs, "Backfolding Runs");
 	}
 
 	@Test
@@ -111,6 +111,6 @@ public class BackfoldingSettings_1_Test {
 
 		settings.setNumberOfBackfoldingRuns(11);
 		int runs = settings.getNumberOfBackfoldingRuns();
-		assertEquals("Backfolding Runs", 3, runs);
+		assertEquals(3, runs, "Backfolding Runs");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/META-INF/MANIFEST.MF
@@ -5,9 +5,10 @@ Bundle-Name: CODA Filter Test
 Bundle-SymbolicName: org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test
 Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda;bundle-version="0.8.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2",
+ org.junit.jupiter.api.function;version="[5.12.0,6.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0",
- org.eclipse.chemclipse.msd.converter;bundle-version="0.8.0",
+Require-Bundle: org.eclipse.chemclipse.msd.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0"
 Bundle-Vendor: ChemClipse

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/calculator/MassChromatographicQualityCalculator_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/calculator/MassChromatographicQualityCalculator_1_ITest.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.calculator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 
@@ -28,9 +28,12 @@ import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD
 import org.eclipse.chemclipse.msd.model.core.support.IMarkedIons;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class MassChromatographicQualityCalculator_1_ITest {
 
 	private IMassChromatographicQualityResult result;
@@ -40,7 +43,7 @@ public class MassChromatographicQualityCalculator_1_ITest {
 	private int windowSize = 3;
 	private File importFile;
 
-	@Before
+	@BeforeAll
 	public void setUp() {
 
 		importFile = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1));
@@ -51,47 +54,33 @@ public class MassChromatographicQualityCalculator_1_ITest {
 	}
 
 	@Test
-	public void testGetMassChromatographicQualityResult_1() {
+	public void testGetMassChromatographicQualityResult_1() throws CodaCalculatorException {
 
-		try {
-			result = MassChromatographicQualityCalculator.calculate(chromatogramSelection, codaThreshold, windowSize);
-			assertNotNull(result);
-			float drv = result.getDataReductionValue();
-			assertEquals("Data reduction value", 0.87713313f, drv, 0);
-			IMarkedIons exludedIons = result.getExcludedIons();
-			assertNotNull(exludedIons);
-		} catch(CodaCalculatorException e) {
-			assertTrue("CodaCalculatorException", false);
-		}
+		result = MassChromatographicQualityCalculator.calculate(chromatogramSelection, codaThreshold, windowSize);
+		assertNotNull(result);
+		float drv = result.getDataReductionValue();
+		assertEquals(0.87713313f, drv, 0, "Data reduction value");
+		IMarkedIons exludedIons = result.getExcludedIons();
+		assertNotNull(exludedIons);
 	}
 
 	@Test
 	public void testGetMassChromatographicQualityResult_2() {
 
-		try {
+		assertThrows(CodaCalculatorException.class, () -> {
 			result = MassChromatographicQualityCalculator.calculate(null, codaThreshold, windowSize);
-		} catch(CodaCalculatorException e) {
-			assertTrue("CodaCalculatorException", true);
-		}
+		});
 	}
 
 	@Test
-	public void testGetMassChromatographicQualityResult_3() {
+	public void testGetMassChromatographicQualityResult_3() throws CodaCalculatorException {
 
-		try {
-			result = MassChromatographicQualityCalculator.calculate(chromatogramSelection, -1, windowSize);
-		} catch(CodaCalculatorException e) {
-			assertTrue("CodaCalculatorException", true);
-		}
+		result = MassChromatographicQualityCalculator.calculate(chromatogramSelection, -1, windowSize);
 	}
 
 	@Test
-	public void testGetMassChromatographicQualityResult_4() {
+	public void testGetMassChromatographicQualityResult_4() throws CodaCalculatorException {
 
-		try {
-			result = MassChromatographicQualityCalculator.calculate(chromatogramSelection, codaThreshold, 0);
-		} catch(CodaCalculatorException e) {
-			assertTrue("CodaCalculatorException", true);
-		}
+		result = MassChromatographicQualityCalculator.calculate(chromatogramSelection, codaThreshold, 0);
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/calculator/MassChromatographicQualityResult_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/calculator/MassChromatographicQualityResult_1_ITest.java
@@ -13,9 +13,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.calculator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
@@ -28,9 +27,12 @@ import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD
 import org.eclipse.chemclipse.msd.model.core.support.IMarkedIons;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class MassChromatographicQualityResult_1_ITest {
 
 	private IMassChromatographicQualityResult result;
@@ -38,7 +40,7 @@ public class MassChromatographicQualityResult_1_ITest {
 	private IChromatogramSelectionMSD chromatogramSelection;
 	private File importFile;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		importFile = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1));
@@ -48,44 +50,32 @@ public class MassChromatographicQualityResult_1_ITest {
 	}
 
 	@Test
-	public void testConstructor_1() {
+	public void testConstructor_1() throws CodaCalculatorException {
 
-		try {
-			result = new MassChromatographicQualityResult(chromatogramSelection, 0.7f, 3);
-			float drv = result.getDataReductionValue();
-			assertEquals("Data reduction value", 0.87713313f, drv, 0);
-			IMarkedIons exludedIons = result.getExcludedIons();
-			assertNotNull(exludedIons);
-		} catch(CodaCalculatorException e) {
-			assertTrue("CodaCalculatorException", false);
-		}
+		result = new MassChromatographicQualityResult(chromatogramSelection, 0.7f, 3);
+		float drv = result.getDataReductionValue();
+		assertEquals(0.87713313f, drv, 0, "Data reduction value");
+		IMarkedIons exludedIons = result.getExcludedIons();
+		assertNotNull(exludedIons);
 	}
 
 	@Test
-	public void testConstructor_2() {
+	public void testConstructor_2() throws CodaCalculatorException {
 
-		try {
-			result = new MassChromatographicQualityResult(chromatogramSelection, 0.7f, 5);
-			float drv = result.getDataReductionValue();
-			assertEquals("Data reduction value", 0.79522187f, drv, 0);
-			IMarkedIons exludedIons = result.getExcludedIons();
-			assertNotNull(exludedIons);
-		} catch(CodaCalculatorException e) {
-			assertTrue("CodaCalculatorException", false);
-		}
+		result = new MassChromatographicQualityResult(chromatogramSelection, 0.7f, 5);
+		float drv = result.getDataReductionValue();
+		assertEquals(0.79522187f, drv, 0, "Data reduction value");
+		IMarkedIons exludedIons = result.getExcludedIons();
+		assertNotNull(exludedIons);
 	}
 
 	@Test
-	public void testConstructor_3() {
+	public void testConstructor_3() throws CodaCalculatorException {
 
-		try {
-			result = new MassChromatographicQualityResult(chromatogramSelection, 0.7f, 7);
-			float drv = result.getDataReductionValue();
-			assertEquals("Data reduction value", 0.7337884f, drv, 0);
-			IMarkedIons exludedIons = result.getExcludedIons();
-			assertNotNull(exludedIons);
-		} catch(CodaCalculatorException e) {
-			assertTrue("CodaCalculatorException", false);
-		}
+		result = new MassChromatographicQualityResult(chromatogramSelection, 0.7f, 7);
+		float drv = result.getDataReductionValue();
+		assertEquals(0.7337884f, drv, 0, "Data reduction value");
+		IMarkedIons exludedIons = result.getExcludedIons();
+		assertNotNull(exludedIons);
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/core/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/core/ChromatogramImporterTestCase.java
@@ -23,17 +23,17 @@ import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 
-@Ignore
+@Disabled
 public class ChromatogramImporterTestCase {
 
 	protected IChromatogramMSD chromatogram;
 	protected IChromatogramSelectionMSD chromatogramSelection;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		/*
 		 * Import

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/core/CodaFilter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/core/CodaFilter_1_ITest.java
@@ -12,22 +12,25 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.core;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.chemclipse.chromatogram.msd.filter.core.chromatogram.IChromatogramFilterMSD;
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.settings.FilterSettings;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class CodaFilter_1_ITest extends ChromatogramImporterTestCase {
 
 	private IChromatogramFilterMSD chromatogramFilter = new ChromatogramFilterMSD();
 	private FilterSettings chromatogramFilterSettings = new FilterSettings();
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 	}
@@ -37,6 +40,6 @@ public class CodaFilter_1_ITest extends ChromatogramImporterTestCase {
 
 		int scan = 1;
 		chromatogramFilter.applyFilter(chromatogramSelection, chromatogramFilterSettings, new NullProgressMonitor());
-		assertEquals("total signal", 180262.0f, chromatogram.getScan(scan).getTotalSignal(), 0);
+		assertEquals(180262.0f, chromatogram.getScan(scan).getTotalSignal(), 0, "total signal");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/settings/CodaFilterSettings_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/settings/CodaFilterSettings_1_Test.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.settings;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CodaFilterSettings_1_Test {
 
-	private FilterSettings settings = new FilterSettings();;
+	private FilterSettings settings = new FilterSettings();
 
 	@Test
 	public void testGetCodaSettings_1() {

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/META-INF/MANIFEST.MF
@@ -5,9 +5,9 @@ Bundle-Name: Denoising Test
 Bundle-SymbolicName: org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test
 Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising;bundle-version="0.8.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0",
- org.eclipse.chemclipse.msd.converter;bundle-version="0.8.0",
+Require-Bundle: org.eclipse.chemclipse.msd.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0"
 Bundle-Vendor: ChemClipse

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/Calculator_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/Calculator_3_ITest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.internal.core;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
@@ -21,26 +21,30 @@ import org.eclipse.chemclipse.model.core.MarkedTraceModus;
 import org.eclipse.chemclipse.msd.model.core.support.IMarkedIons;
 import org.eclipse.chemclipse.msd.model.core.support.MarkedIon;
 import org.eclipse.chemclipse.msd.model.core.support.MarkedIons;
+import org.eclipse.chemclipse.msd.model.exceptions.FilterException;
 import org.eclipse.chemclipse.msd.model.noise.Calculator;
 import org.eclipse.chemclipse.msd.model.noise.INoiseSegmentMSD;
 import org.eclipse.chemclipse.msd.model.xic.ExtractedIonSignalExtractor;
 import org.eclipse.chemclipse.msd.model.xic.IExtractedIonSignalExtractor;
 import org.eclipse.chemclipse.msd.model.xic.IExtractedIonSignals;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class Calculator_3_ITest extends ChromatogramImporterTestCase {
 
-	private Calculator calculator = new Calculator();;
+	private Calculator calculator = new Calculator();
 	private IExtractedIonSignals extractedIonSignals;
 	private IMarkedIons ionsToPreserve;
 	private List<INoiseSegmentMSD> noiseSegments;
 	private IExtractedIonSignalExtractor extractedIonSignalExtractor;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() throws FilterException {
 
 		super.setUp();
 		ionsToPreserve = new MarkedIons(MarkedTraceModus.INCLUDE);
@@ -54,6 +58,6 @@ public class Calculator_3_ITest extends ChromatogramImporterTestCase {
 	@Test
 	public void testGetSize_1() {
 
-		assertEquals("Size", 9, noiseSegments.size());
+		assertEquals(9, noiseSegments.size(), "Size");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/ChromatogramImporterTestCase.java
@@ -21,20 +21,21 @@ import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMS
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
+import org.eclipse.chemclipse.msd.model.exceptions.FilterException;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 
-@Ignore
+@Disabled
 public class ChromatogramImporterTestCase {
 
 	protected IChromatogramMSD chromatogram;
 	protected IChromatogramSelectionMSD chromatogramSelection;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() throws FilterException {
 
 		/*
 		 * Import

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/Denoising_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/Denoising_1_ITest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.internal.core.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
@@ -21,10 +21,14 @@ import org.eclipse.chemclipse.msd.model.core.ICombinedMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.support.IMarkedIons;
 import org.eclipse.chemclipse.msd.model.core.support.MarkedIon;
 import org.eclipse.chemclipse.msd.model.core.support.MarkedIons;
+import org.eclipse.chemclipse.msd.model.exceptions.FilterException;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class Denoising_1_ITest extends ChromatogramImporterTestCase {
 
 	private IMarkedIons ionsToRemove;
@@ -32,8 +36,8 @@ public class Denoising_1_ITest extends ChromatogramImporterTestCase {
 	private List<ICombinedMassSpectrum> noiseMassSpectra;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() throws FilterException {
 
 		super.setUp();
 		ionsToRemove = new MarkedIons(MarkedTraceModus.INCLUDE);
@@ -51,6 +55,6 @@ public class Denoising_1_ITest extends ChromatogramImporterTestCase {
 	@Test
 	public void testGetSize_1() {
 
-		assertEquals("Size", 11, noiseMassSpectra.size());
+		assertEquals(11, noiseMassSpectra.size(), "Size");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/IonNoise_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/IonNoise_1_Test.java
@@ -12,16 +12,19 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.internal.core.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class IonNoise_1_Test {
 
 	private IonNoise ionNoise;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		ionNoise = new IonNoise(167, 5893.56f);
@@ -30,12 +33,12 @@ public class IonNoise_1_Test {
 	@Test
 	public void testGetIon_1() {
 
-		assertEquals("Ion", 167, ionNoise.getIon());
+		assertEquals(167, ionNoise.getIon(), "Ion");
 	}
 
 	@Test
 	public void testGetAbundance_1() {
 
-		assertEquals("Abundance", 5893.56f, ionNoise.getAbundance(), 0);
+		assertEquals(5893.56f, ionNoise.getAbundance(), 0, "Abundance");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/IonNoise_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/IonNoise_2_Test.java
@@ -12,13 +12,16 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.internal.core.support;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.chemclipse.support.comparator.SortOrder;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class IonNoise_2_Test {
 
 	private IonNoise ionNoise1;
@@ -27,8 +30,8 @@ public class IonNoise_2_Test {
 
 	private IonNoiseAbundanceComparator ionNoiseAbundanceComparator = new IonNoiseAbundanceComparator(SortOrder.DESC);
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		ionNoise1 = new IonNoise(120, 3889.56f);
 		ionNoise2 = new IonNoise(167, 5893.56f);

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/result/DenoisingFilterResult_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/result/DenoisingFilterResult_1_Test.java
@@ -12,11 +12,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.result;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DenoisingFilterResult_1_Test {
 
@@ -31,6 +31,6 @@ public class DenoisingFilterResult_1_Test {
 	@Test
 	public void testGetNoiseMassSpectra_2() {
 
-		assertEquals("Size", 0, result.getNoiseMassSpectra().size());
+		assertEquals(0, result.getNoiseMassSpectra().size(), "Size");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/result/DenoisingFilterResult_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/result/DenoisingFilterResult_2_Test.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.result;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,18 +21,21 @@ import java.util.List;
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 import org.eclipse.chemclipse.msd.model.core.ICombinedMassSpectrum;
 import org.eclipse.chemclipse.msd.model.implementation.CombinedMassSpectrum;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class DenoisingFilterResult_2_Test {
 
 	private IDenoisingFilterResult result;
 	private List<ICombinedMassSpectrum> noiseMassSpectra;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
-		noiseMassSpectra = new ArrayList<ICombinedMassSpectrum>();
+		noiseMassSpectra = new ArrayList<>();
 		noiseMassSpectra.add(new CombinedMassSpectrum());
 		result = new DenoisingFilterResult(ResultStatus.OK, "The result status is ok.", noiseMassSpectra);
 	}
@@ -46,6 +49,6 @@ public class DenoisingFilterResult_2_Test {
 	@Test
 	public void testGetNoiseMassSpectra_2() {
 
-		assertEquals("Size", 1, result.getNoiseMassSpectra().size());
+		assertEquals(1, result.getNoiseMassSpectra().size(), "Size");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/result/DenoisingFilterResult_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/result/DenoisingFilterResult_3_Test.java
@@ -12,11 +12,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.result;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DenoisingFilterResult_3_Test {
 
@@ -31,6 +31,6 @@ public class DenoisingFilterResult_3_Test {
 	@Test
 	public void testGetNoiseMassSpectra_2() {
 
-		assertEquals("Size", 0, result.getNoiseMassSpectra().size());
+		assertEquals(0, result.getNoiseMassSpectra().size(), "Size");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/settings/DenoisingFilterSettings_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/settings/DenoisingFilterSettings_1_Test.java
@@ -12,15 +12,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.settings;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.chemclipse.model.core.MarkedTraceModus;
 import org.eclipse.chemclipse.msd.model.core.support.MarkedIons;
 import org.eclipse.chemclipse.support.util.TraceSettingUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DenoisingFilterSettings_1_Test {
 
@@ -36,7 +36,7 @@ public class DenoisingFilterSettings_1_Test {
 	public void testGetIonsToRemove_2() {
 
 		TraceSettingUtil settingIon = new TraceSettingUtil();
-		assertEquals("IonsToRemove Size", 4, new MarkedIons(settingIon.extractTraces(settingIon.deserialize(settings.getIonsToRemove())), MarkedTraceModus.INCLUDE).getIonsNominal().size());
+		assertEquals(4, new MarkedIons(settingIon.extractTraces(settingIon.deserialize(settings.getIonsToRemove())), MarkedTraceModus.INCLUDE).getIonsNominal().size(), "IonsToRemove Size");
 	}
 
 	@Test
@@ -49,7 +49,7 @@ public class DenoisingFilterSettings_1_Test {
 	public void testGetIonsToPreserve_2() {
 
 		TraceSettingUtil settingIon = new TraceSettingUtil();
-		assertEquals("IonsToPreserve Size", 2, new MarkedIons(settingIon.extractTraces(settingIon.deserialize(settings.getIonsToPreserve())), MarkedTraceModus.INCLUDE).getIonsNominal().size());
+		assertEquals(2, new MarkedIons(settingIon.extractTraces(settingIon.deserialize(settings.getIonsToPreserve())), MarkedTraceModus.INCLUDE).getIonsNominal().size(), "IonsToPreserve Size");
 	}
 
 	@Test
@@ -68,27 +68,27 @@ public class DenoisingFilterSettings_1_Test {
 	@Test
 	public void testGetNumberOfUsedIonsForCoefficient_1() {
 
-		assertEquals("NumberOfUsedIonsForCoefficient", 1, settings.getNumberOfUsedIonsForCoefficient());
+		assertEquals(1, settings.getNumberOfUsedIonsForCoefficient(), "NumberOfUsedIonsForCoefficient");
 	}
 
 	@Test
 	public void testGetNumberOfUsedIonsForCoefficient_2() {
 
 		settings.setNumberOfUsedIonsForCoefficient(5);
-		assertEquals("NumberOfUsedIonsForCoefficient", 5, settings.getNumberOfUsedIonsForCoefficient());
+		assertEquals(5, settings.getNumberOfUsedIonsForCoefficient(), "NumberOfUsedIonsForCoefficient");
 	}
 
 	@Test
 	public void testGetNumberOfUsedIonsForCoefficient_3() {
 
 		settings.setNumberOfUsedIonsForCoefficient(0);
-		assertEquals("NumberOfUsedIonsForCoefficient", 1, settings.getNumberOfUsedIonsForCoefficient());
+		assertEquals(1, settings.getNumberOfUsedIonsForCoefficient(), "NumberOfUsedIonsForCoefficient");
 	}
 
 	@Test
 	public void testGetNumberOfUsedIonsForCoefficient_4() {
 
 		settings.setNumberOfUsedIonsForCoefficient(-1);
-		assertEquals("NumberOfUsedIonsForCoefficient", 1, settings.getNumberOfUsedIonsForCoefficient());
+		assertEquals(1, settings.getNumberOfUsedIonsForCoefficient(), "NumberOfUsedIonsForCoefficient");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: org.eclipse.chemclipse.chromatogram.msd.filter.supplier.sub
 Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: ChemClipse
 Fragment-Host: org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract;bundle-version="0.8.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/internal/calculator/SubtractCalculator_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/internal/calculator/SubtractCalculator_1_Test.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.internal.calculator;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
 
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.calculator.SubtractCalculator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SubtractCalculator_1_Test {
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/internal/calculator/SubtractCalculator_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/internal/calculator/SubtractCalculator_2_Test.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.internal.calculator;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
 
@@ -20,9 +20,12 @@ import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.calculat
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.implementation.CombinedMassSpectrum;
 import org.eclipse.chemclipse.msd.model.implementation.Ion;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class SubtractCalculator_2_Test {
 
 	private SubtractCalculator subtractCalculator = new SubtractCalculator();
@@ -30,7 +33,7 @@ public class SubtractCalculator_2_Test {
 	private IScanMSD targetMassSpectrum;
 	private Map<Double, Float> subtractMassSpectrumMap;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		boolean useNominalMasses = true;

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/internal/calculator/SubtractCalculator_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/internal/calculator/SubtractCalculator_3_Test.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.internal.calculator;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
 
@@ -20,9 +20,12 @@ import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.calculat
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.implementation.CombinedMassSpectrum;
 import org.eclipse.chemclipse.msd.model.implementation.Ion;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class SubtractCalculator_3_Test {
 
 	private SubtractCalculator subtractCalculator = new SubtractCalculator();;
@@ -30,8 +33,8 @@ public class SubtractCalculator_3_Test {
 	private IScanMSD targetMassSpectrum;
 	private Map<Double, Float> subtractMassSpectrumMap;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		boolean useNominalMasses = true;
 		boolean useNormalize = false;

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/internal/calculator/SubtractCalculator_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/internal/calculator/SubtractCalculator_4_Test.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.internal.calculator;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
 
@@ -20,18 +20,21 @@ import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.calculat
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.implementation.CombinedMassSpectrum;
 import org.eclipse.chemclipse.msd.model.implementation.Ion;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class SubtractCalculator_4_Test {
 
-	private SubtractCalculator subtractCalculator = new SubtractCalculator();;
+	private SubtractCalculator subtractCalculator = new SubtractCalculator();
 	private IScanMSD subtractMassSpectrum;
 	private IScanMSD targetMassSpectrum;
 	private Map<Double, Float> subtractMassSpectrumMap;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		boolean useNominalMasses = false;
 		boolean useNormalize = true;

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/internal/calculator/SubtractCalculator_5_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/internal/calculator/SubtractCalculator_5_Test.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.internal.calculator;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
 
@@ -20,9 +20,12 @@ import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.calculat
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.implementation.CombinedMassSpectrum;
 import org.eclipse.chemclipse.msd.model.implementation.Ion;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class SubtractCalculator_5_Test {
 
 	private SubtractCalculator subtractCalculator = new SubtractCalculator();
@@ -30,8 +33,8 @@ public class SubtractCalculator_5_Test {
 	private IScanMSD targetMassSpectrum;
 	private Map<Double, Float> subtractMassSpectrumMap;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		boolean useNominalMasses = false;
 		boolean useNormalize = false;

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.fragment.test/META-INF/MANIFEST.MF
@@ -5,9 +5,9 @@ Bundle-Name: First Derivative Test MSD
 Bundle-SymbolicName: org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.fragment.test
 Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative;bundle-version="0.8.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0",
- org.eclipse.chemclipse.msd.converter;bundle-version="0.8.0",
+Require-Bundle: org.eclipse.chemclipse.msd.converter;bundle-version="0.8.0",
  org.easymock;bundle-version="2.4.0",
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/firstderivative/core/FirstDerivativePeakDetector_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/firstderivative/core/FirstDerivativePeakDetector_2_Test.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.core;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -20,13 +20,16 @@ import java.lang.reflect.Method;
 import org.eclipse.chemclipse.chromatogram.msd.peak.detector.core.IPeakDetectorMSD;
 import org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.core.BasePeakDetector;
 import org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.support.IFirstDerivativeDetectorSlopes;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 /**
  * peakDetectorSettings.getThreshold() is MEDIUM > threshold = 0.05d;
  * WindowSize.SCANS_5
  */
+@TestInstance(Lifecycle.PER_CLASS)
 public class FirstDerivativePeakDetector_2_Test extends FirstDerivativeSlopesTestCase {
 
 	private IFirstDerivativeDetectorSlopes slopes;
@@ -35,8 +38,8 @@ public class FirstDerivativePeakDetector_2_Test extends FirstDerivativeSlopesTes
 	private Method method;
 
 	@Override
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		super.setUp();
 		firstDerivativePeakDetector = new PeakDetectorMSD();
@@ -48,7 +51,7 @@ public class FirstDerivativePeakDetector_2_Test extends FirstDerivativeSlopesTes
 	@Test
 	public void testSize_1() {
 
-		assertEquals("Size", 39, slopes.size());
+		assertEquals(39, slopes.size(), "Size");
 	}
 
 	@Test
@@ -62,7 +65,7 @@ public class FirstDerivativePeakDetector_2_Test extends FirstDerivativeSlopesTes
 		 * The peak starts at scan 4 and has a scan offset of 0 (means starts at
 		 * scan 1).
 		 */
-		assertEquals("detectPeakStart", Integer.valueOf(4), result);
+		assertEquals(Integer.valueOf(4), result, "detectPeakStart");
 	}
 
 	@Test
@@ -79,7 +82,7 @@ public class FirstDerivativePeakDetector_2_Test extends FirstDerivativeSlopesTes
 		/*
 		 * The peak maximum is at scan 12.
 		 */
-		assertEquals("detectPeakMaximum", Integer.valueOf(12), result);
+		assertEquals(Integer.valueOf(12), result, "detectPeakMaximum");
 	}
 
 	@Test
@@ -96,6 +99,6 @@ public class FirstDerivativePeakDetector_2_Test extends FirstDerivativeSlopesTes
 		/*
 		 * The peak stop is at scan 26.
 		 */
-		assertEquals("detectPeakStop", Integer.valueOf(26), result);
+		assertEquals( Integer.valueOf(26), result,"detectPeakStop");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/firstderivative/core/FirstDerivativePeakDetector_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/firstderivative/core/FirstDerivativePeakDetector_3_Test.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.core;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -21,7 +21,7 @@ import org.eclipse.chemclipse.chromatogram.msd.peak.detector.core.IPeakDetectorM
 import org.eclipse.chemclipse.chromatogram.peak.detector.support.IRawPeak;
 import org.eclipse.chemclipse.chromatogram.peak.detector.support.RawPeak;
 import org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.core.BasePeakDetector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * peakDetectorSettings.getThreshold() is MEDIUM > threshold = 0.05d;
@@ -29,8 +29,8 @@ import org.junit.Test;
  */
 public class FirstDerivativePeakDetector_3_Test {
 
-	private IPeakDetectorMSD firstDerivativePeakDetector = new PeakDetectorMSD();;
-	private Class<?> firstDerivativePeakDetectorClass = BasePeakDetector.class;;
+	private IPeakDetectorMSD firstDerivativePeakDetector = new PeakDetectorMSD();
+	private Class<?> firstDerivativePeakDetectorClass = BasePeakDetector.class;
 
 	@Test
 	public void testIsValidRawPeak_1() throws SecurityException, NoSuchMethodException, IllegalArgumentException, IllegalAccessException, InvocationTargetException {
@@ -40,7 +40,7 @@ public class FirstDerivativePeakDetector_3_Test {
 		Method method = firstDerivativePeakDetectorClass.getDeclaredMethod("isValidRawPeak", new Class[]{IRawPeak.class});
 		method.setAccessible(true);
 		result = (Boolean)method.invoke(firstDerivativePeakDetector, new Object[]{rawPeak});
-		assertEquals("detectPeakStart", Boolean.valueOf(true), result);
+		assertEquals(Boolean.valueOf(true), result, "detectPeakStart");
 	}
 
 	@Test
@@ -51,6 +51,6 @@ public class FirstDerivativePeakDetector_3_Test {
 		Method method = firstDerivativePeakDetectorClass.getDeclaredMethod("isValidRawPeak", new Class[]{IRawPeak.class});
 		method.setAccessible(true);
 		result = (Boolean)method.invoke(firstDerivativePeakDetector, new Object[]{rawPeak});
-		assertEquals("detectPeakStart", Boolean.valueOf(false), result);
+		assertEquals(Boolean.valueOf(false), result, "detectPeakStart");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/firstderivative/core/FirstDerivativeSlopesTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/firstderivative/core/FirstDerivativeSlopesTestCase.java
@@ -23,10 +23,10 @@ import org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderiv
 import org.eclipse.chemclipse.model.signals.ITotalScanSignals;
 import org.eclipse.chemclipse.numeric.core.IPoint;
 import org.eclipse.chemclipse.numeric.core.Point;
-import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 
-@Ignore
+@Disabled
 public class FirstDerivativeSlopesTestCase {
 
 	private IFirstDerivativeDetectorSlope slope;
@@ -36,10 +36,10 @@ public class FirstDerivativeSlopesTestCase {
 	private List<Float> abundances;
 	private ITotalScanSignals signals;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
-		abundances = new ArrayList<Float>();
+		abundances = new ArrayList<>();
 		abundances.add(21563.38028f);
 		abundances.add(21718.30986f);
 		abundances.add(21782.39437f);

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: org.eclipse.chemclipse.chromatogram.msd.process.supplier.pe
 Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: ChemClipse
 Fragment-Host: org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification;bundle-version="0.8.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/process/supplier/peakidentification/io/PeakIdentificationBatchJobReader_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/process/supplier/peakidentification/io/PeakIdentificationBatchJobReader_1_ITest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.io;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 
@@ -22,9 +22,12 @@ import org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentificati
 import org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.model.IPeakInputEntry;
 import org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.model.IPeakIntegrationEntry;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class PeakIdentificationBatchJobReader_1_ITest {
 
 	private IPeakIdentificationBatchJobReader reader = new PeakIdentificationBatchJobReader();
@@ -33,7 +36,7 @@ public class PeakIdentificationBatchJobReader_1_ITest {
 	private IPeakIntegrationEntry integrationEntry;
 	private IPeakIdentificationEntry identificationEntry;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_BATCH_PROCESS_JOB));

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-Name: Baseline Detector Test
 Bundle-SymbolicName: org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test
 Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.chemclipse.chromatogram.xxd.baseline.detector;bundle-version="0.8.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2",
+ org.junit.jupiter.api.function;version="[5.12.0,6.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"
 Bundle-Vendor: ChemClipse

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorSupplier_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorSupplier_1_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.core;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BaselineDetectorSupplier_1_Test {
 
@@ -23,18 +23,18 @@ public class BaselineDetectorSupplier_1_Test {
 	@Test
 	public void testGetId_1() {
 
-		assertEquals("id", "", supplier.getId());
+		assertEquals("", supplier.getId());
 	}
 
 	@Test
 	public void testGetDescription_1() {
 
-		assertEquals("description", "", supplier.getDescription());
+		assertEquals("", supplier.getDescription());
 	}
 
 	@Test
 	public void testGetDetectorName_1() {
 
-		assertEquals("detectorName", "", supplier.getDetectorName());
+		assertEquals("", supplier.getDetectorName());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorSupplier_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorSupplier_2_Test.java
@@ -12,11 +12,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.core;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class BaselineDetectorSupplier_2_Test {
 
 	private BaselineDetectorSupplier supplier;
@@ -24,8 +27,8 @@ public class BaselineDetectorSupplier_2_Test {
 	private String description = "description";
 	private String detectorName = "detectorName";
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		supplier = new BaselineDetectorSupplier();
 		supplier.setId(id);
@@ -36,27 +39,27 @@ public class BaselineDetectorSupplier_2_Test {
 	@Test
 	public void testGetId_1() {
 
-		assertEquals("id", id, supplier.getId());
+		assertEquals(id, supplier.getId());
 		id = "newId";
 		supplier.setId(id);
-		assertEquals("id", id, supplier.getId());
+		assertEquals(id, supplier.getId());
 	}
 
 	@Test
 	public void testGetDescription_1() {
 
-		assertEquals("description", description, supplier.getDescription());
+		assertEquals(description, supplier.getDescription());
 		description = "newDescription";
 		supplier.setDescription(description);
-		assertEquals("description", description, supplier.getDescription());
+		assertEquals(description, supplier.getDescription());
 	}
 
 	@Test
 	public void testGetDetectorName_1() {
 
-		assertEquals("detectorName", detectorName, supplier.getDetectorName());
+		assertEquals(detectorName, supplier.getDetectorName());
 		detectorName = "newDetectorName";
 		supplier.setDetectorName(detectorName);
-		assertEquals("detectorName", detectorName, supplier.getDetectorName());
+		assertEquals(detectorName, supplier.getDetectorName());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorSupplier_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorSupplier_3_Test.java
@@ -12,20 +12,23 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class BaselineDetectorSupplier_3_Test {
 
 	private BaselineDetectorSupplier supplier1;
 	private BaselineDetectorSupplier supplier2;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		supplier1 = new BaselineDetectorSupplier();
 		supplier1.setId("id");
@@ -41,30 +44,30 @@ public class BaselineDetectorSupplier_3_Test {
 	@Test
 	public void testEquals_1() {
 
-		assertEquals("equals", supplier1, supplier2);
+		assertEquals(supplier1, supplier2);
 	}
 
 	@Test
 	public void testEquals_2() {
 
-		assertEquals("equals", supplier2, supplier1);
+		assertEquals(supplier2, supplier1);
 	}
 
 	@Test
 	public void testEquals_3() {
 
-		assertNotNull("equals", supplier1);
+		assertNotNull(supplier1);
 	}
 
 	@Test
 	public void testEquals_4() {
 
-		assertNotEquals("equals", supplier1, new Object());
+		assertNotEquals(supplier1, new Object());
 	}
 
 	@Test
 	public void testHashCode_1() {
 
-		assertEquals("hashCode", supplier1.hashCode(), supplier2.hashCode());
+		assertEquals(supplier1.hashCode(), supplier2.hashCode());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorSupplier_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetectorSupplier_4_Test.java
@@ -12,20 +12,23 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.core;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class BaselineDetectorSupplier_4_Test {
 
 	private BaselineDetectorSupplier supplier1;
 	private BaselineDetectorSupplier supplier2;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		supplier1 = new BaselineDetectorSupplier();
 		supplier1.setId("id1");
@@ -41,30 +44,30 @@ public class BaselineDetectorSupplier_4_Test {
 	@Test
 	public void testEquals_1() {
 
-		assertNotEquals("equals", supplier1, supplier2);
+		assertNotEquals(supplier1, supplier2);
 	}
 
 	@Test
 	public void testEquals_2() {
 
-		assertNotEquals("equals", supplier2, supplier1);
+		assertNotEquals(supplier2, supplier1);
 	}
 
 	@Test
 	public void testEquals_3() {
 
-		assertNotNull("equals", supplier1);
+		assertNotNull(supplier1);
 	}
 
 	@Test
 	public void testEquals_4() {
 
-		assertNotEquals("equals", supplier1, new Object());
+		assertNotEquals(supplier1, new Object());
 	}
 
 	@Test
 	public void testHashCode_1() {
 
-		assertFalse("hashCode", supplier1.hashCode() == supplier2.hashCode());
+		assertFalse(supplier1.hashCode() == supplier2.hashCode());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetector_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetector_1_Test.java
@@ -12,16 +12,15 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.exceptions.NoBaselineDetectorAvailableException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the IBaselineDetectorSupport.
@@ -46,7 +45,7 @@ public class BaselineDetector_1_Test {
 				}
 			}
 		}
-		assertEquals("Registered Detector Names", 0, count);
+		assertEquals(0, count, "Registered Detector Names");
 	}
 
 	@Test
@@ -63,46 +62,42 @@ public class BaselineDetector_1_Test {
 				}
 			}
 		}
-		assertEquals("Registered Detector Ids", 0, count);
+		assertEquals(0, count, "Registered Detector Ids");
 	}
 
 	@Test
 	public void testGetMassSpectrumComparatorSupport_3() throws NoBaselineDetectorAvailableException {
 
 		List<String> ids = support.getAvailableDetectorIds();
-		List<String> rcs = new ArrayList<String>();
+		List<String> rcs = new ArrayList<>();
 		for(String id : ids) {
 			rcs.add(id);
 		}
 		String id;
 		for(int i = 0; i < rcs.size(); i++) {
 			id = support.getDetectorId(i);
-			assertEquals("getDetectorId", id, rcs.get(i));
+			assertEquals(id, rcs.get(i), "getDetectorId");
 		}
 	}
 
 	@Test
 	public void testGetMassSpectrumComparisonSupplier_1() {
 
-		try {
+		assertThrows(NoBaselineDetectorAvailableException.class, () -> {
 			support.getBaselineDetectorSupplier("");
-		} catch(NoBaselineDetectorAvailableException e) {
-			assertTrue("NoBaselineDetectorAvailableException", true);
-		}
+		});
 	}
 
 	@Test
 	public void testGetMassSpectrumComparisonSupplier_2() {
 
-		try {
+		assertThrows(NoBaselineDetectorAvailableException.class, () -> {
 			support.getBaselineDetectorSupplier(null);
-		} catch(NoBaselineDetectorAvailableException e) {
-			assertTrue("NoBaselineDetectorAvailableException", true);
-		}
+		});
 	}
 
 	@Test
-	public void testGetMassSpectrumComparisonSupplier_3() throws NoBaselineDetectorAvailableException {
+	public void testGetMassSpectrumComparisonSupplier_3() {
 
 		assertThrows(NoBaselineDetectorAvailableException.class, () -> { // The detector was removed
 			String id = "org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.supplier.tic";

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetector_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/baseline/detector/core/BaselineDetector_2_Test.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.core;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.exceptions.BaselineDetectorSettingsException;
 import org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.exceptions.NoBaselineDetectorAvailableException;
@@ -21,7 +21,7 @@ import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD
 import org.eclipse.chemclipse.msd.model.implementation.ChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the BaselineDetector.
@@ -31,15 +31,11 @@ public class BaselineDetector_2_Test {
 	IBaselineDetectorSupport support = BaselineDetector.getBaselineDetectorSupport();
 
 	@Test
-	public void testBaselineDetector_1() throws BaselineDetectorSettingsException {
+	public void testBaselineDetector_1() throws BaselineDetectorSettingsException, NoBaselineDetectorAvailableException {
 
-		try {
-			String detectorId = BaselineDetector.getBaselineDetectorSupport().getDetectorId(0);
-			IProcessingInfo<?> processingInfo = BaselineDetector.setBaseline(null, null, detectorId, new NullProgressMonitor());
-			assertTrue(processingInfo.hasErrorMessages());
-		} catch(NoBaselineDetectorAvailableException e) {
-			assertTrue("NoBaselineDetectorAvailableException", false);
-		}
+		String detectorId = BaselineDetector.getBaselineDetectorSupport().getDetectorId(0);
+		IProcessingInfo<?> processingInfo = BaselineDetector.setBaseline(null, null, detectorId, new NullProgressMonitor());
+		assertTrue(processingInfo.hasErrorMessages());
 	}
 
 	@Test

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.cml.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.cml.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: org.eclipse.chemclipse.msd.converter.supplier.cml.fragment.
 Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: ChemClipse
 Fragment-Host: org.eclipse.chemclipse.msd.converter.supplier.cml;bundle-version="0.8.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.cml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/cml/converter/MassSpectrumImportConverterSP03_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.cml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/cml/converter/MassSpectrumImportConverterSP03_ITest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.converter.supplier.cml.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
@@ -25,15 +25,18 @@ import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumImportConverterSP03_ITest {
 
 	private IScanMSD massSpectrum;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.TESTFILE_SP03));
 		DatabaseImportConverter importConverter = new DatabaseImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-SymbolicName: org.eclipse.chemclipse.msd.converter.supplier.excel.fragmen
 Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: ChemClipse
 Fragment-Host: org.eclipse.chemclipse.msd.converter.supplier.excel;bundle-version="0.8.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.8.1",
- org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0"
+Require-Bundle: org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0"

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/excel/io/ChromatogramExport_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/excel/io/ChromatogramExport_1_ITest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.converter.supplier.excel.io;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,19 +25,22 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramExport_1_ITest {
 
 	private ChromatogramWriter chromatogramWriter = new ChromatogramWriter();
 
-	private static IChromatogramMSD chromatogram;
-	private static File file;
+	private IChromatogramMSD chromatogram;
+	private File file;
 
-	@BeforeClass
-	public static void setUp() {
+	@BeforeAll
+	public void setUp() {
 
 		File fileImport = new File(PathResolver.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1));
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
@@ -46,8 +49,8 @@ public class ChromatogramExport_1_ITest {
 		file = new File(PathResolver.getAbsolutePath(TestPathHelper.DIRECTORY_EXPORT_TEST) + File.separator + "Test.xlsx");
 	}
 
-	@AfterClass
-	public static void tearDown() {
+	@AfterAll
+	public void tearDown() {
 
 		file.delete();
 	}


### PR DESCRIPTION
The main benefit is that we can share test objects in the same class, which caters to the way most tests were written without making everything static, which is beneficial for the integration tests, which have larger objects in memory.