### PR TITLE
Update to 2025-09 release

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
@@ -25,14 +25,6 @@
          version="0.0.0"/>
 
    <includes
-         id="org.eclipse.emf.common"
-         version="0.0.0"/>
-
-   <includes
-         id="org.eclipse.emf.ecore"
-         version="0.0.0"/>
-
-   <includes
          id="org.eclipse.equinox.p2.core.feature"
          version="0.0.0"/>
 
@@ -46,14 +38,6 @@
 
    <includes
          id="org.eclipse.rcp"
-         version="0.0.0"/>
-
-   <includes
-         id="org.eclipse.ecf.core.feature"
-         version="0.0.0"/>
-
-   <includes
-         id="org.eclipse.ecf.filetransfer.feature"
          version="0.0.0"/>
 
    <includes

--- a/chemclipse/plugins/org.eclipse.chemclipse.container/src/org/eclipse/chemclipse/container/support/FileContainerCache.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.container/src/org/eclipse/chemclipse/container/support/FileContainerCache.java
@@ -16,7 +16,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.eclipse.chemclipse.container.definition.Container;
 import org.eclipse.chemclipse.container.definition.IFileContentProvider;
 import org.eclipse.chemclipse.converter.core.IMagicNumberMatcher;
@@ -54,7 +54,7 @@ public class FileContainerCache {
 	public IFileContentProvider getFileContentProvider(File file) {
 
 		for(FileContainer fileContainer : fileContainers) {
-			if(StringUtils.endsWithIgnoreCase(file.getName(), fileContainer.getFileExtension())) {
+			if(Strings.CI.endsWith(file.getName(), fileContainer.getFileExtension())) {
 				IMagicNumberMatcher magicNumberMatcher = fileContainer.getMagicNumberMatcher();
 				if(magicNumberMatcher != null) {
 					if(magicNumberMatcher.checkFileFormat(file)) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/csv/core/PCRExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/csv/core/PCRExportConverter.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.pcr.converter.core.AbstractPlateExportConverter;
 import org.eclipse.chemclipse.pcr.converter.core.IPlateExportConverter;
@@ -122,7 +122,7 @@ public class PCRExportConverter extends AbstractPlateExportConverter implements 
 
 		csvPrinter.print(HeaderMessages.sample);
 		ChannelMappings channelMappings = PreferenceSupplier.getChannelMappings();
-		List<ChannelMapping> targetMappings = channelMappings.stream().filter(m -> StringUtils.equalsIgnoreCase(targetSubset, m.getSubset())).collect(Collectors.toList());
+		List<ChannelMapping> targetMappings = channelMappings.stream().filter(m -> Strings.CI.equals(targetSubset, m.getSubset())).collect(Collectors.toList());
 		List<ChannelMapping> sortedMappings = targetMappings.stream().sorted(Comparator.comparing(ChannelMapping::getChannel)).collect(Collectors.toList());
 		for(ChannelMapping sortedMapping : sortedMappings) {
 			csvPrinter.print(sortedMapping.getLabel());
@@ -134,12 +134,12 @@ public class PCRExportConverter extends AbstractPlateExportConverter implements 
 		WellMappings wellMapings = PreferenceSupplier.getWellMappings();
 		VirtualChannels virtualChannels = PreferenceSupplier.getVirtualChannels();
 		for(VirtualChannel virtualChannel : virtualChannels) {
-			if(!StringUtils.equalsIgnoreCase(targetSubset, virtualChannel.getSubset())) {
+			if(!Strings.CI.equals(targetSubset, virtualChannel.getSubset())) {
 				continue;
 			}
 			Map<Integer, IChannel> targetChannels = new HashMap<>();
 			for(IWell well : wells) {
-				if(!StringUtils.equalsIgnoreCase(targetSubset, well.getSampleSubset())) {
+				if(!Strings.CI.equals(targetSubset, well.getSampleSubset())) {
 					continue;
 				}
 				Pattern pattern = Pattern.compile(virtualChannel.getSample(), Pattern.CASE_INSENSITIVE);
@@ -170,9 +170,9 @@ public class PCRExportConverter extends AbstractPlateExportConverter implements 
 				continue;
 			}
 			for(IWell well : wells) {
-				if(StringUtils.equalsIgnoreCase(targetSubset, well.getSampleSubset())) {
+				if(Strings.CI.equals(targetSubset, well.getSampleSubset())) {
 					for(WellMapping wellMapping : wellMapings) {
-						if(!StringUtils.equalsIgnoreCase(targetSubset, wellMapping.getSubset())) {
+						if(!Strings.CI.equals(targetSubset, wellMapping.getSubset())) {
 							continue;
 						}
 						Pattern pattern = Pattern.compile(wellMapping.getSample(), Pattern.CASE_INSENSITIVE);
@@ -218,9 +218,9 @@ public class PCRExportConverter extends AbstractPlateExportConverter implements 
 		generateVirtualChannels(sortedWells, targetSubset);
 		WellMappings wellMapings = PreferenceSupplier.getWellMappings();
 		for(IWell well : sortedWells) {
-			if(StringUtils.equalsIgnoreCase(targetSubset, well.getSampleSubset())) {
+			if(Strings.CI.equals(targetSubset, well.getSampleSubset())) {
 				for(WellMapping wellMapping : wellMapings) {
-					if(!StringUtils.equalsIgnoreCase(targetSubset, wellMapping.getSubset())) {
+					if(!Strings.CI.equals(targetSubset, wellMapping.getSubset())) {
 						continue;
 					}
 					Pattern pattern = Pattern.compile(wellMapping.getSample(), Pattern.CASE_INSENSITIVE);

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -28,7 +28,7 @@
 	<unit id="org.apache.httpcomponents.httpclient"/>
 	<unit id="org.apache.httpcomponents.httpcore"/>
 	<unit id="org.eclipse.jdt.junit5.runtime"/>
-	<repository location="https://download.eclipse.org/releases/2025-06/"/>
+	<repository location="https://download.eclipse.org/releases/2025-09/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<repository location="https://download.eclipse.org/cbi/updates/license/"/>
@@ -55,7 +55,7 @@
 		<unit id="org.apache.xmlbeans"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2025-06"/>
+		<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2025-09"/>
 		<unit id="org.apache.commons.commons-csv"/>
 		<unit id="org.apache.commons.math3"/>
 	</location>

--- a/chemclipse/sites/chemclipse/category.xml
+++ b/chemclipse/sites/chemclipse/category.xml
@@ -11,8 +11,8 @@
          Update site for derivative products.
       </description>
    </category-def>
-   <repository-reference location="https://download.eclipse.org/releases/2025-06/" enabled="true" />
-   <repository-reference location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2025-06" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/releases/2025-09/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2025-09" enabled="true" />
    <repository-reference location="https://download.eclipse.org/oomph/simrel-orbit/release/4.28.0" enabled="true" />
    <repository-reference location="https://download.eclipse.org/nebula/updates/release/3.1.1/" enabled="true" />
 </site>


### PR DESCRIPTION
* Do not include EMF/ECF features in chemclipse feature. Platform doesn't do so anymore as it's not needed and thus they are no longer included chemclipse's target platform and just created extra churn and more artifacts needlessly pushed to end users.
* Fixed deprecation warnings coming from updates commons-lang.
