### PR TITLE
Fix MS/MS for mzXML version 2

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ByteReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ByteReader.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Philip Wenig - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+
+public class ByteReader {
+
+	public static double[] readValues(byte[] bytes, String byteOrder, BigInteger precision) {
+
+		ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+		/*
+		 * Byte Order
+		 */
+		if(byteOrder != null && byteOrder.equals("network")) {
+			byteBuffer.order(ByteOrder.BIG_ENDIAN);
+		} else {
+			byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+		}
+		/*
+		 * Precision
+		 */
+		double[] values;
+
+		if(precision != null && precision.intValue() == 64) {
+			DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
+			values = new double[doubleBuffer.capacity()];
+			for(int index = 0; index < doubleBuffer.capacity(); index++) {
+				values[index] = doubleBuffer.get(index);
+			}
+		} else {
+			FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
+			values = new double[floatBuffer.capacity()];
+			for(int index = 0; index < floatBuffer.capacity(); index++) {
+				values[index] = floatBuffer.get(index);
+			}
+		}
+
+		return values;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion20.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion20.java
@@ -14,11 +14,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.DoubleBuffer;
-import java.nio.FloatBuffer;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -65,7 +60,7 @@ public class ChromatogramReaderVersion20 extends AbstractChromatogramReaderVersi
 	public IChromatogramMSD read(File file, IProgressMonitor monitor) throws IOException {
 
 		IVendorChromatogram chromatogram = null;
-
+		MsRun msRun = null;
 		try {
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
@@ -74,115 +69,7 @@ public class ChromatogramReaderVersion20 extends AbstractChromatogramReaderVersi
 
 			JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
 			Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
-			MsRun msrun = (MsRun)unmarshaller.unmarshal(nodeList.item(0));
-
-			chromatogram = new VendorChromatogram();
-			boolean isTandemMeasurement = isTandemMeasurement(msrun);
-			int cycleNumber = isTandemMeasurement ? 1 : 0;
-
-			MsInstrument instrument = msrun.getMsInstrument();
-			if(instrument != null) {
-				chromatogram.setInstrument(instrument.getMsManufacturer().getTheValue() + " " + instrument.getMsModel().getTheValue());
-				chromatogram.setIonisation(instrument.getMsIonisation().getTheValue());
-				chromatogram.setMassAnalyzer(instrument.getMsMassAnalyzer().getTheValue());
-				chromatogram.setMassDetector(instrument.getMsDetector().getTheValue());
-				Software software = instrument.getSoftware();
-				if(software != null) {
-					chromatogram.setSoftware(software.getName() + " " + software.getVersion());
-				}
-			}
-			for(DataProcessing processing : msrun.getDataProcessing()) {
-				Software software = processing.getSoftware();
-				chromatogram.getEditHistory().add(new EditInformation(software.getType(), software.getName() + " " + software.getVersion()));
-			}
-			List<Scan> scans = msrun.getScan();
-			monitor.beginTask(ConverterMessages.readScans, scans.size());
-			for(Scan scan : scans) {
-				/*
-				 * Get the mass spectra.
-				 */
-				IVendorScan massSpectrum = new VendorScan();
-				int retentionTime = scan.getRetentionTime().multiply(1000).getSeconds(); // milliseconds
-				massSpectrum.setRetentionTime(retentionTime);
-				/*
-				 * Polarity
-				 */
-				String polarity = scan.getPolarity();
-				if(polarity != null) {
-					if(polarity.equals("+")) {
-						massSpectrum.setPolarity(Polarity.POSITIVE);
-					} else if(polarity.equals("-")) {
-						massSpectrum.setPolarity(Polarity.NEGATIVE);
-					}
-				}
-				// MS, MS/MS
-				short msLevel = scan.getMsLevel().shortValue();
-				massSpectrum.setMassSpectrometer(msLevel);
-
-				if(!scan.getPrecursorMz().isEmpty()) {
-					PrecursorMz precursor = scan.getPrecursorMz().get(0);
-					massSpectrum.setPrecursorIon(precursor.getValue());
-				}
-
-				if(msLevel < 2) {
-					cycleNumber++;
-				}
-				if(cycleNumber >= 1) {
-					massSpectrum.setCycleNumber(cycleNumber);
-				}
-				massSpectrum.setRetentionTime(retentionTime);
-				/*
-				 * Get the ions.
-				 */
-				Peaks peaks = scan.getPeaks();
-				if(peaks == null) {
-					continue;
-				}
-				ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
-				/*
-				 * Byte Order
-				 */
-				String byteOrder = peaks.getByteOrder();
-				if(byteOrder != null && byteOrder.equals("network")) {
-					byteBuffer.order(ByteOrder.BIG_ENDIAN);
-				} else {
-					byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
-				}
-				/*
-				 * Precision
-				 */
-				double[] values;
-				BigInteger precision = peaks.getPrecision();
-				if(precision != null && precision.intValue() == 64) {
-					DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
-					values = new double[doubleBuffer.capacity()];
-					for(int index = 0; index < doubleBuffer.capacity(); index++) {
-						values[index] = doubleBuffer.get(index);
-					}
-				} else {
-					FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
-					values = new double[floatBuffer.capacity()];
-					for(int index = 0; index < floatBuffer.capacity(); index++) {
-						values[index] = floatBuffer.get(index);
-					}
-				}
-				for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
-					/*
-					 * Get m/z and intensity (m/z-int)
-					 */
-					double mz = values[peakIndex];
-					float intensity = (float)values[peakIndex + 1];
-					if(msLevel >= 2) {
-						IIonTransition ionTransition = new IonTransition(massSpectrum.getPrecursorIon(), mz, scan.getCollisionEnergy(), 1, 1, 0);
-						massSpectrum.addIon(new VendorIon(mz, intensity, ionTransition), false);
-						chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
-					} else {
-						massSpectrum.addIon(new VendorIon(mz, intensity), false);
-					}
-				}
-				chromatogram.addScan(massSpectrum);
-				monitor.worked(1);
-			}
+			msRun = (MsRun)unmarshaller.unmarshal(nodeList.item(0));
 		} catch(SAXException e) {
 			logger.warn(e);
 		} catch(JAXBException e) {
@@ -190,14 +77,123 @@ public class ChromatogramReaderVersion20 extends AbstractChromatogramReaderVersi
 		} catch(ParserConfigurationException e) {
 			logger.warn(e);
 		}
+
+		chromatogram = new VendorChromatogram();
+		boolean isTandemMeasurement = isTandemMeasurement(msRun);
+		int cycleNumber = isTandemMeasurement ? 1 : 0;
+
+		MsInstrument instrument = msRun.getMsInstrument();
+		if(instrument != null) {
+			chromatogram.setInstrument(instrument.getMsManufacturer().getTheValue() + " " + instrument.getMsModel().getTheValue());
+			chromatogram.setIonisation(instrument.getMsIonisation().getTheValue());
+			chromatogram.setMassAnalyzer(instrument.getMsMassAnalyzer().getTheValue());
+			chromatogram.setMassDetector(instrument.getMsDetector().getTheValue());
+			Software software = instrument.getSoftware();
+			if(software != null) {
+				chromatogram.setSoftware(software.getName() + " " + software.getVersion());
+			}
+		}
+
+		for(DataProcessing processing : msRun.getDataProcessing()) {
+			Software software = processing.getSoftware();
+			chromatogram.getEditHistory().add(new EditInformation(software.getType(), software.getName() + " " + software.getVersion()));
+		}
+
+		readScans(msRun, cycleNumber, chromatogram, monitor);
+
 		chromatogram.setConverterId("");
 		chromatogram.setFile(file);
+
 		return chromatogram;
 	}
 
-	private boolean isTandemMeasurement(MsRun msrun) {
+	private void readScans(MsRun msRun, int cycleNumber, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
 
-		for(Scan scan : msrun.getScan()) {
+		List<Scan> scans = msRun.getScan();
+		monitor.beginTask(ConverterMessages.readScans, scans.size());
+		for(Scan scan : scans) {
+			IVendorScan massSpectrum = readScan(scan, chromatogram);
+			massSpectrum.setCycleNumber(cycleNumber);
+			chromatogram.addScan(massSpectrum);
+			for(Scan embeddedScan : scan.getScan()) {
+				IVendorScan embeddedMassSpectrum = readScan(embeddedScan, chromatogram);
+				embeddedMassSpectrum.setCycleNumber(cycleNumber);
+				chromatogram.addScan(embeddedMassSpectrum);
+			}
+			cycleNumber++;
+			monitor.worked(1);
+		}
+	}
+
+	private IVendorScan readScan(Scan scan, IChromatogramMSD chromatogram) {
+
+		IVendorScan massSpectrum = new VendorScan();
+
+		setRetentionTime(scan, massSpectrum);
+		setPolarity(scan, massSpectrum);
+
+		// MS, MS/MS
+		massSpectrum.setMassSpectrometer(scan.getMsLevel().shortValue());
+
+		if(!scan.getPrecursorMz().isEmpty()) {
+			PrecursorMz precursor = scan.getPrecursorMz().get(0);
+			massSpectrum.setPrecursorIon(precursor.getValue());
+		}
+
+		Peaks peaks = scan.getPeaks();
+		if(peaks == null) {
+			return massSpectrum;
+		}
+		/*
+		 * Get the ions.
+		 */
+		double[] values = ByteReader.readValues(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision());
+		readIons(values, scan, massSpectrum, chromatogram);
+
+		return massSpectrum;
+	}
+
+	private void readIons(double[] values, Scan scan, IVendorScan massSpectrum, IChromatogramMSD chromatogram) {
+
+		for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
+			/*
+			 * Get m/z and intensity (m/z-int)
+			 */
+			double mz = values[peakIndex];
+			float intensity = (float)values[peakIndex + 1];
+			if(massSpectrum.getMassSpectrometer() >= 2) {
+				float collisionEnergy = scan.getCollisionEnergy() != null ? scan.getCollisionEnergy().floatValue() : 0f;
+				IIonTransition ionTransition = new IonTransition(massSpectrum.getPrecursorIon(), mz, collisionEnergy, 1, 1, 0);
+				massSpectrum.addIon(new VendorIon(mz, intensity, ionTransition), false);
+				chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
+			} else {
+				massSpectrum.addIon(new VendorIon(mz, intensity), false);
+			}
+		}
+
+	}
+
+	private void setRetentionTime(Scan scan, IVendorScan massSpectrum) {
+
+		int retentionTime = scan.getRetentionTime().multiply(1000).getSeconds(); // milliseconds
+		massSpectrum.setRetentionTime(retentionTime);
+	}
+
+	private void setPolarity(Scan scan, IVendorScan massSpectrum) {
+
+		String polarity = scan.getPolarity();
+		if(polarity != null) {
+			if(polarity.equals("+")) {
+				massSpectrum.setPolarity(Polarity.POSITIVE);
+			} else if(polarity.equals("-")) {
+				massSpectrum.setPolarity(Polarity.NEGATIVE);
+			}
+		}
+	}
+
+	private boolean isTandemMeasurement(MsRun msRun) {
+
+		for(Scan scan : msRun.getScan()) {
 			if(scan.getMsLevel().shortValue() > 1) {
 				return true;
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion21.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion21.java
@@ -14,11 +14,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.DoubleBuffer;
-import java.nio.FloatBuffer;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -65,7 +60,7 @@ public class ChromatogramReaderVersion21 extends AbstractChromatogramReaderVersi
 	public IChromatogramMSD read(File file, IProgressMonitor monitor) throws IOException {
 
 		IVendorChromatogram chromatogram = null;
-
+		MsRun msRun = null;
 		try {
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
@@ -74,116 +69,7 @@ public class ChromatogramReaderVersion21 extends AbstractChromatogramReaderVersi
 
 			JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
 			Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
-			MsRun msrun = (MsRun)unmarshaller.unmarshal(nodeList.item(0));
-
-			chromatogram = new VendorChromatogram();
-			boolean isTandemMeasurement = isTandemMeasurement(msrun);
-			int cycleNumber = isTandemMeasurement ? 1 : 0;
-
-			MsInstrument instrument = msrun.getMsInstrument();
-			if(instrument != null) {
-				chromatogram.setInstrument(instrument.getMsManufacturer().getTheValue() + " " + instrument.getMsModel().getTheValue());
-				chromatogram.setIonisation(instrument.getMsIonisation().getTheValue());
-				chromatogram.setMassAnalyzer(instrument.getMsMassAnalyzer().getTheValue());
-				chromatogram.setMassDetector(instrument.getMsDetector().getTheValue());
-				Software software = instrument.getSoftware();
-				if(software != null) {
-					chromatogram.setSoftware(software.getName() + " " + software.getVersion());
-				}
-			}
-			for(DataProcessing processing : msrun.getDataProcessing()) {
-				Software software = processing.getSoftware();
-				chromatogram.getEditHistory().add(new EditInformation(software.getType(), software.getName() + " " + software.getVersion()));
-			}
-			List<Scan> scans = msrun.getScan();
-			monitor.beginTask(ConverterMessages.readScans, scans.size());
-			for(Scan scan : scans) {
-				/*
-				 * Get the mass spectra.
-				 */
-				IVendorScan massSpectrum = new VendorScan();
-				int retentionTime = scan.getRetentionTime().multiply(1000).getSeconds(); // milliseconds
-				massSpectrum.setRetentionTime(retentionTime);
-				/*
-				 * Polarity
-				 */
-				String polarity = scan.getPolarity();
-				if(polarity != null) {
-					if(polarity.equals("+")) {
-						massSpectrum.setPolarity(Polarity.POSITIVE);
-					} else if(polarity.equals("-")) {
-						massSpectrum.setPolarity(Polarity.NEGATIVE);
-					}
-				}
-				// MS, MS/MS
-				short msLevel = scan.getMsLevel().shortValue();
-				massSpectrum.setMassSpectrometer(msLevel);
-
-				if(!scan.getPrecursorMz().isEmpty()) {
-					PrecursorMz precursor = scan.getPrecursorMz().get(0);
-					massSpectrum.setPrecursorIon(precursor.getValue());
-				}
-
-				if(msLevel < 2) {
-					cycleNumber++;
-				}
-				if(cycleNumber >= 1) {
-					massSpectrum.setCycleNumber(cycleNumber);
-				}
-				massSpectrum.setRetentionTime(retentionTime);
-				/*
-				 * Get the ions.
-				 */
-				Peaks peaks = scan.getPeaks();
-				if(peaks == null) {
-					continue;
-				}
-				ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
-				/*
-				 * Byte Order
-				 */
-				String byteOrder = peaks.getByteOrder();
-				if(byteOrder != null && byteOrder.equals("network")) {
-					byteBuffer.order(ByteOrder.BIG_ENDIAN);
-				} else {
-					byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
-				}
-				/*
-				 * Precision
-				 */
-				double[] values;
-				BigInteger precision = peaks.getPrecision();
-				if(precision != null && precision.intValue() == 64) {
-					DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
-					values = new double[doubleBuffer.capacity()];
-					for(int index = 0; index < doubleBuffer.capacity(); index++) {
-						values[index] = doubleBuffer.get(index);
-					}
-				} else {
-					FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
-					values = new double[floatBuffer.capacity()];
-					for(int index = 0; index < floatBuffer.capacity(); index++) {
-						values[index] = floatBuffer.get(index);
-					}
-				}
-				for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
-					/*
-					 * Get m/z and intensity (m/z-int)
-					 */
-					double mz = values[peakIndex];
-					float intensity = (float)values[peakIndex + 1];
-					if(msLevel >= 2) {
-						float collisionEnergy = scan.getCollisionEnergy() != null ? scan.getCollisionEnergy().floatValue() : 0f;
-						IIonTransition ionTransition = new IonTransition(massSpectrum.getPrecursorIon(), mz, collisionEnergy, 1, 1, 0);
-						massSpectrum.addIon(new VendorIon(mz, intensity, ionTransition), false);
-						chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
-					} else {
-						massSpectrum.addIon(new VendorIon(mz, intensity), false);
-					}
-				}
-				chromatogram.addScan(massSpectrum);
-				monitor.worked(1);
-			}
+			msRun = (MsRun)unmarshaller.unmarshal(nodeList.item(0));
 		} catch(SAXException e) {
 			logger.warn(e);
 		} catch(JAXBException e) {
@@ -191,14 +77,123 @@ public class ChromatogramReaderVersion21 extends AbstractChromatogramReaderVersi
 		} catch(ParserConfigurationException e) {
 			logger.warn(e);
 		}
+
+		chromatogram = new VendorChromatogram();
+		boolean isTandemMeasurement = isTandemMeasurement(msRun);
+		int cycleNumber = isTandemMeasurement ? 1 : 0;
+
+		MsInstrument instrument = msRun.getMsInstrument();
+		if(instrument != null) {
+			chromatogram.setInstrument(instrument.getMsManufacturer().getTheValue() + " " + instrument.getMsModel().getTheValue());
+			chromatogram.setIonisation(instrument.getMsIonisation().getTheValue());
+			chromatogram.setMassAnalyzer(instrument.getMsMassAnalyzer().getTheValue());
+			chromatogram.setMassDetector(instrument.getMsDetector().getTheValue());
+			Software software = instrument.getSoftware();
+			if(software != null) {
+				chromatogram.setSoftware(software.getName() + " " + software.getVersion());
+			}
+		}
+
+		for(DataProcessing processing : msRun.getDataProcessing()) {
+			Software software = processing.getSoftware();
+			chromatogram.getEditHistory().add(new EditInformation(software.getType(), software.getName() + " " + software.getVersion()));
+		}
+
+		readScans(msRun, cycleNumber, chromatogram, monitor);
+
 		chromatogram.setConverterId("");
 		chromatogram.setFile(file);
+
 		return chromatogram;
 	}
 
-	private boolean isTandemMeasurement(MsRun msrun) {
+	private void readScans(MsRun msRun, int cycleNumber, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
 
-		for(Scan scan : msrun.getScan()) {
+		List<Scan> scans = msRun.getScan();
+		monitor.beginTask(ConverterMessages.readScans, scans.size());
+		for(Scan scan : scans) {
+			IVendorScan massSpectrum = readScan(scan, chromatogram);
+			massSpectrum.setCycleNumber(cycleNumber);
+			chromatogram.addScan(massSpectrum);
+			for(Scan embeddedScan : scan.getScan()) {
+				IVendorScan embeddedMassSpectrum = readScan(embeddedScan, chromatogram);
+				embeddedMassSpectrum.setCycleNumber(cycleNumber);
+				chromatogram.addScan(embeddedMassSpectrum);
+			}
+			cycleNumber++;
+			monitor.worked(1);
+		}
+	}
+
+	private IVendorScan readScan(Scan scan, IChromatogramMSD chromatogram) {
+
+		IVendorScan massSpectrum = new VendorScan();
+
+		setRetentionTime(scan, massSpectrum);
+		setPolarity(scan, massSpectrum);
+
+		// MS, MS/MS
+		massSpectrum.setMassSpectrometer(scan.getMsLevel().shortValue());
+
+		if(!scan.getPrecursorMz().isEmpty()) {
+			PrecursorMz precursor = scan.getPrecursorMz().get(0);
+			massSpectrum.setPrecursorIon(precursor.getValue());
+		}
+
+		Peaks peaks = scan.getPeaks();
+		if(peaks == null) {
+			return massSpectrum;
+		}
+		/*
+		 * Get the ions.
+		 */
+		double[] values = ByteReader.readValues(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision());
+		readIons(values, scan, massSpectrum, chromatogram);
+
+		return massSpectrum;
+	}
+
+	private void readIons(double[] values, Scan scan, IVendorScan massSpectrum, IChromatogramMSD chromatogram) {
+
+		for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
+			/*
+			 * Get m/z and intensity (m/z-int)
+			 */
+			double mz = values[peakIndex];
+			float intensity = (float)values[peakIndex + 1];
+			if(massSpectrum.getMassSpectrometer() >= 2) {
+				float collisionEnergy = scan.getCollisionEnergy() != null ? scan.getCollisionEnergy().floatValue() : 0f;
+				IIonTransition ionTransition = new IonTransition(massSpectrum.getPrecursorIon(), mz, collisionEnergy, 1, 1, 0);
+				massSpectrum.addIon(new VendorIon(mz, intensity, ionTransition), false);
+				chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
+			} else {
+				massSpectrum.addIon(new VendorIon(mz, intensity), false);
+			}
+		}
+
+	}
+
+	private void setRetentionTime(Scan scan, IVendorScan massSpectrum) {
+
+		int retentionTime = scan.getRetentionTime().multiply(1000).getSeconds(); // milliseconds
+		massSpectrum.setRetentionTime(retentionTime);
+	}
+
+	private void setPolarity(Scan scan, IVendorScan massSpectrum) {
+
+		String polarity = scan.getPolarity();
+		if(polarity != null) {
+			if(polarity.equals("+")) {
+				massSpectrum.setPolarity(Polarity.POSITIVE);
+			} else if(polarity.equals("-")) {
+				massSpectrum.setPolarity(Polarity.NEGATIVE);
+			}
+		}
+	}
+
+	private boolean isTandemMeasurement(MsRun msRun) {
+
+		for(Scan scan : msRun.getScan()) {
 			if(scan.getMsLevel().shortValue() > 1) {
 				return true;
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion22.java
@@ -14,11 +14,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.DoubleBuffer;
-import java.nio.FloatBuffer;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -65,7 +60,7 @@ public class ChromatogramReaderVersion22 extends AbstractChromatogramReaderVersi
 	public IChromatogramMSD read(File file, IProgressMonitor monitor) throws IOException {
 
 		IVendorChromatogram chromatogram = null;
-
+		MsRun msRun = null;
 		try {
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
@@ -74,116 +69,7 @@ public class ChromatogramReaderVersion22 extends AbstractChromatogramReaderVersi
 
 			JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
 			Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
-			MsRun msrun = (MsRun)unmarshaller.unmarshal(nodeList.item(0));
-
-			chromatogram = new VendorChromatogram();
-			boolean isTandemMeasurement = isTandemMeasurement(msrun);
-			int cycleNumber = isTandemMeasurement ? 1 : 0;
-
-			MsInstrument instrument = msrun.getMsInstrument();
-			if(instrument != null) {
-				chromatogram.setInstrument(instrument.getMsManufacturer().getTheValue() + " " + instrument.getMsModel().getTheValue());
-				chromatogram.setIonisation(instrument.getMsIonisation().getTheValue());
-				chromatogram.setMassAnalyzer(instrument.getMsMassAnalyzer().getTheValue());
-				chromatogram.setMassDetector(instrument.getMsDetector().getTheValue());
-				Software software = instrument.getSoftware();
-				if(software != null) {
-					chromatogram.setSoftware(software.getName() + " " + software.getVersion());
-				}
-			}
-			for(DataProcessing processing : msrun.getDataProcessing()) {
-				Software software = processing.getSoftware();
-				chromatogram.getEditHistory().add(new EditInformation(software.getType(), software.getName() + " " + software.getVersion()));
-			}
-			List<Scan> scans = msrun.getScan();
-			monitor.beginTask(ConverterMessages.readScans, scans.size());
-			for(Scan scan : scans) {
-				/*
-				 * Get the mass spectra.
-				 */
-				IVendorScan massSpectrum = new VendorScan();
-				int retentionTime = scan.getRetentionTime().multiply(1000).getSeconds(); // milliseconds
-				massSpectrum.setRetentionTime(retentionTime);
-				/*
-				 * Polarity
-				 */
-				String polarity = scan.getPolarity();
-				if(polarity != null) {
-					if(polarity.equals("+")) {
-						massSpectrum.setPolarity(Polarity.POSITIVE);
-					} else if(polarity.equals("-")) {
-						massSpectrum.setPolarity(Polarity.NEGATIVE);
-					}
-				}
-				// MS, MS/MS
-				short msLevel = scan.getMsLevel().shortValue();
-				massSpectrum.setMassSpectrometer(msLevel);
-
-				if(!scan.getPrecursorMz().isEmpty()) {
-					PrecursorMz precursor = scan.getPrecursorMz().get(0);
-					massSpectrum.setPrecursorIon(precursor.getValue());
-				}
-
-				if(msLevel < 2) {
-					cycleNumber++;
-				}
-				if(cycleNumber >= 1) {
-					massSpectrum.setCycleNumber(cycleNumber);
-				}
-				massSpectrum.setRetentionTime(retentionTime);
-				/*
-				 * Get the ions.
-				 */
-				Peaks peaks = scan.getPeaks();
-				if(peaks == null) {
-					continue;
-				}
-				ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
-				/*
-				 * Byte Order
-				 */
-				String byteOrder = peaks.getByteOrder();
-				if(byteOrder != null && byteOrder.equals("network")) {
-					byteBuffer.order(ByteOrder.BIG_ENDIAN);
-				} else {
-					byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
-				}
-				/*
-				 * Precision
-				 */
-				double[] values;
-				BigInteger precision = peaks.getPrecision();
-				if(precision != null && precision.intValue() == 64) {
-					DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
-					values = new double[doubleBuffer.capacity()];
-					for(int index = 0; index < doubleBuffer.capacity(); index++) {
-						values[index] = doubleBuffer.get(index);
-					}
-				} else {
-					FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
-					values = new double[floatBuffer.capacity()];
-					for(int index = 0; index < floatBuffer.capacity(); index++) {
-						values[index] = floatBuffer.get(index);
-					}
-				}
-				for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
-					/*
-					 * Get m/z and intensity (m/z-int)
-					 */
-					double mz = values[peakIndex];
-					float intensity = (float)values[peakIndex + 1];
-					if(msLevel >= 2) {
-						float collisionEnergy = scan.getCollisionEnergy() != null ? scan.getCollisionEnergy().floatValue() : 0f;
-						IIonTransition ionTransition = new IonTransition(massSpectrum.getPrecursorIon(), mz, collisionEnergy, 1, 1, 0);
-						massSpectrum.addIon(new VendorIon(mz, intensity, ionTransition), false);
-						chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
-					} else {
-						massSpectrum.addIon(new VendorIon(mz, intensity), false);
-					}
-				}
-				chromatogram.addScan(massSpectrum);
-				monitor.worked(1);
-			}
+			msRun = (MsRun)unmarshaller.unmarshal(nodeList.item(0));
 		} catch(SAXException e) {
 			logger.warn(e);
 		} catch(JAXBException e) {
@@ -191,14 +77,123 @@ public class ChromatogramReaderVersion22 extends AbstractChromatogramReaderVersi
 		} catch(ParserConfigurationException e) {
 			logger.warn(e);
 		}
+
+		chromatogram = new VendorChromatogram();
+		boolean isTandemMeasurement = isTandemMeasurement(msRun);
+		int cycleNumber = isTandemMeasurement ? 1 : 0;
+
+		MsInstrument instrument = msRun.getMsInstrument();
+		if(instrument != null) {
+			chromatogram.setInstrument(instrument.getMsManufacturer().getTheValue() + " " + instrument.getMsModel().getTheValue());
+			chromatogram.setIonisation(instrument.getMsIonisation().getTheValue());
+			chromatogram.setMassAnalyzer(instrument.getMsMassAnalyzer().getTheValue());
+			chromatogram.setMassDetector(instrument.getMsDetector().getTheValue());
+			Software software = instrument.getSoftware();
+			if(software != null) {
+				chromatogram.setSoftware(software.getName() + " " + software.getVersion());
+			}
+		}
+
+		for(DataProcessing processing : msRun.getDataProcessing()) {
+			Software software = processing.getSoftware();
+			chromatogram.getEditHistory().add(new EditInformation(software.getType(), software.getName() + " " + software.getVersion()));
+		}
+
+		readScans(msRun, cycleNumber, chromatogram, monitor);
+
 		chromatogram.setConverterId("");
 		chromatogram.setFile(file);
+
 		return chromatogram;
 	}
 
-	private boolean isTandemMeasurement(MsRun msrun) {
+	private void readScans(MsRun msRun, int cycleNumber, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
 
-		for(Scan scan : msrun.getScan()) {
+		List<Scan> scans = msRun.getScan();
+		monitor.beginTask(ConverterMessages.readScans, scans.size());
+		for(Scan scan : scans) {
+			IVendorScan massSpectrum = readScan(scan, chromatogram);
+			massSpectrum.setCycleNumber(cycleNumber);
+			chromatogram.addScan(massSpectrum);
+			for(Scan embeddedScan : scan.getScan()) {
+				IVendorScan embeddedMassSpectrum = readScan(embeddedScan, chromatogram);
+				embeddedMassSpectrum.setCycleNumber(cycleNumber);
+				chromatogram.addScan(embeddedMassSpectrum);
+			}
+			cycleNumber++;
+			monitor.worked(1);
+		}
+	}
+
+	private IVendorScan readScan(Scan scan, IChromatogramMSD chromatogram) {
+
+		IVendorScan massSpectrum = new VendorScan();
+
+		setRetentionTime(scan, massSpectrum);
+		setPolarity(scan, massSpectrum);
+
+		// MS, MS/MS
+		massSpectrum.setMassSpectrometer(scan.getMsLevel().shortValue());
+
+		if(!scan.getPrecursorMz().isEmpty()) {
+			PrecursorMz precursor = scan.getPrecursorMz().get(0);
+			massSpectrum.setPrecursorIon(precursor.getValue());
+		}
+
+		Peaks peaks = scan.getPeaks();
+		if(peaks == null) {
+			return massSpectrum;
+		}
+		/*
+		 * Get the ions.
+		 */
+		double[] values = ByteReader.readValues(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision());
+		readIons(values, scan, massSpectrum, chromatogram);
+
+		return massSpectrum;
+	}
+
+	private void readIons(double[] values, Scan scan, IVendorScan massSpectrum, IChromatogramMSD chromatogram) {
+
+		for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
+			/*
+			 * Get m/z and intensity (m/z-int)
+			 */
+			double mz = values[peakIndex];
+			float intensity = (float)values[peakIndex + 1];
+			if(massSpectrum.getMassSpectrometer() >= 2) {
+				float collisionEnergy = scan.getCollisionEnergy() != null ? scan.getCollisionEnergy().floatValue() : 0f;
+				IIonTransition ionTransition = new IonTransition(massSpectrum.getPrecursorIon(), mz, collisionEnergy, 1, 1, 0);
+				massSpectrum.addIon(new VendorIon(mz, intensity, ionTransition), false);
+				chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
+			} else {
+				massSpectrum.addIon(new VendorIon(mz, intensity), false);
+			}
+		}
+
+	}
+
+	private void setRetentionTime(Scan scan, IVendorScan massSpectrum) {
+
+		int retentionTime = scan.getRetentionTime().multiply(1000).getSeconds(); // milliseconds
+		massSpectrum.setRetentionTime(retentionTime);
+	}
+
+	private void setPolarity(Scan scan, IVendorScan massSpectrum) {
+
+		String polarity = scan.getPolarity();
+		if(polarity != null) {
+			if(polarity.equals("+")) {
+				massSpectrum.setPolarity(Polarity.POSITIVE);
+			} else if(polarity.equals("-")) {
+				massSpectrum.setPolarity(Polarity.NEGATIVE);
+			}
+		}
+	}
+
+	private boolean isTandemMeasurement(MsRun msRun) {
+
+		for(Scan scan : msRun.getScan()) {
 			if(scan.getMsLevel().shortValue() > 1) {
 				return true;
 			}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramImportConverterTinyMzXML20_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramImportConverterTinyMzXML20_ITest.java
@@ -21,6 +21,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorChromato
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorChromatogram;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -32,7 +33,7 @@ public class ChromatogramImportConverterTinyMzXML20_ITest {
 	private static IVendorChromatogram chromatogram;
 
 	@BeforeClass
-	public static void setUp() throws Exception {
+	public static void setUp() {
 
 		File importFile = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_TINY1_MZXML20));
 		ChromatogramImportConverter converter = new ChromatogramImportConverter();
@@ -60,19 +61,19 @@ public class ChromatogramImportConverterTinyMzXML20_ITest {
 	@Test
 	public void testNumberOfScans() {
 
-		assertEquals("NumberOfScans", 1, chromatogram.getNumberOfScans());
+		assertEquals("NumberOfScans", 2, chromatogram.getNumberOfScans());
 	}
 
 	@Test
 	public void testTotalSignal() {
 
-		assertEquals("Total Signal", 1.66755259E7f, chromatogram.getTotalSignal(), 0);
+		assertEquals("Total Signal", 1.7440164E7, chromatogram.getTotalSignal(), 0);
 	}
 
 	@Test
 	public void testMaxIonAbundance() {
 
-		assertEquals("Max Signal", 120053.0f, chromatogram.getMaxIonAbundance(), 0);
+		assertEquals("Max Signal", 301045.0f, chromatogram.getMaxIonAbundance(), 0);
 	}
 
 	@Test
@@ -81,5 +82,22 @@ public class ChromatogramImportConverterTinyMzXML20_ITest {
 		IVendorScan massSpectrum = (IVendorScan)chromatogram.getScan(1);
 		assertEquals("Ions", 1313, massSpectrum.getNumberOfIons());
 		assertEquals("Polarity", Polarity.POSITIVE, massSpectrum.getPolarity());
+		assertEquals("RT", 353430, massSpectrum.getRetentionTime());
+	}
+
+	@Test
+	public void testSecondScan() {
+
+		IVendorScan massSpectrum = (IVendorScan)chromatogram.getScan(2);
+		assertEquals("Ions", 43, massSpectrum.getNumberOfIons());
+		assertEquals("RT", 356680, massSpectrum.getRetentionTime());
+		assertEquals("Polarity", Polarity.POSITIVE, massSpectrum.getPolarity());
+		assertEquals("MS", 2, massSpectrum.getMassSpectrometer());
+		assertEquals("Precursor", 445.3500061035156, massSpectrum.getPrecursorIon(), 0);
+
+		IIonTransition ionTransition = massSpectrum.getHighestIon().getIonTransition();
+		assertEquals("CE", 35, ionTransition.getCollisionEnergy(), 0);
+		assertEquals("Q1", 445, ionTransition.getQ1Ion(), 0);
+		assertEquals("Q2", 531.1, ionTransition.getQ3Ion(), 0);
 	}
 }


### PR DESCRIPTION
https://web.archive.org/web/20061117023900/http://sashimi.sourceforge.net/repository.html has example files which when you load them you might notice missing scans so I fixed it and refactored the code. The crucial part is `Scan embeddedScan : scan.getScan()` which is the missing scans from the same scan group on tandem MS.