### PR TITLE
Add support for mzXML MALDI-TOF MS version 3.0+

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/AbstractMassSpectrumReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/AbstractMassSpectrumReader.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Philip Wenig - initial API and implementation
+ * Matthias Mailänder - adapted for MALDI
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+
+import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
+import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
+
+public abstract class AbstractMassSpectrumReader extends AbstractMassSpectraReader implements IMassSpectraReader {
+
+	public double[] readPeaks(byte[] bytes, String byteOrder, BigInteger precision) {
+
+		ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+		/*
+		 * Byte Order
+		 */
+		if(byteOrder != null && byteOrder.equals("network")) {
+			byteBuffer.order(ByteOrder.BIG_ENDIAN);
+		} else {
+			byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+		}
+		/*
+		 * Precision
+		 */
+		double[] values;
+		if(precision != null && precision.intValue() == 64) {
+			DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
+			values = new double[doubleBuffer.capacity()];
+			for(int index = 0; index < doubleBuffer.capacity(); index++) {
+				values[index] = doubleBuffer.get(index);
+			}
+		} else {
+			FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
+			values = new double[floatBuffer.capacity()];
+			for(int index = 0; index < floatBuffer.capacity(); index++) {
+				values[index] = floatBuffer.get(index);
+			}
+		}
+		return values;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/AbstractMassSpectrumReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/AbstractMassSpectrumReader.java
@@ -18,13 +18,17 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
+import java.util.zip.DataFormatException;
+import java.util.zip.Inflater;
 
 import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
 
 public abstract class AbstractMassSpectrumReader extends AbstractMassSpectraReader implements IMassSpectraReader {
 
-	public double[] readPeaks(byte[] bytes, String byteOrder, BigInteger precision) {
+	private Inflater inflater = new Inflater();
+
+	public double[] readPeaks(byte[] bytes, String byteOrder, BigInteger precision, String compressionType) throws DataFormatException {
 
 		ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
 		/*
@@ -34,6 +38,15 @@ public abstract class AbstractMassSpectrumReader extends AbstractMassSpectraRead
 			byteBuffer.order(ByteOrder.BIG_ENDIAN);
 		} else {
 			byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+		}
+		/*
+		 * Compression
+		 */
+		if(compressionType != null && compressionType.equalsIgnoreCase("zlib")) {
+			inflater.reset();
+			inflater.setInput(byteBuffer.array());
+			byte[] byteArray = new byte[byteBuffer.capacity() * 10];
+			byteBuffer = ByteBuffer.wrap(byteArray, 0, inflater.inflate(byteArray));
 		}
 		/*
 		 * Precision

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion20.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion20.java
@@ -15,11 +15,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.DoubleBuffer;
-import java.nio.FloatBuffer;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -28,8 +23,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
-import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v20.model.DataProcessing;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v20.model.Maldi;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v20.model.MsRun;
@@ -53,7 +46,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 
-public class MassSpectrumReaderVersion20 extends AbstractMassSpectraReader implements IMassSpectraReader {
+public class MassSpectrumReaderVersion20 extends AbstractMassSpectrumReader {
 
 	public static final String VERSION = "mzXML_2.0";
 
@@ -110,34 +103,7 @@ public class MassSpectrumReaderVersion20 extends AbstractMassSpectraReader imple
 				 * Get the ions.
 				 */
 				Peaks peaks = scan.getPeaks();
-				ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
-				/*
-				 * Byte Order
-				 */
-				String byteOrder = peaks.getByteOrder();
-				if(byteOrder != null && byteOrder.equals("network")) {
-					byteBuffer.order(ByteOrder.BIG_ENDIAN);
-				} else {
-					byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
-				}
-				/*
-				 * Precision
-				 */
-				double[] values;
-				BigInteger precision = peaks.getPrecision();
-				if(precision != null && precision.intValue() == 64) {
-					DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
-					values = new double[doubleBuffer.capacity()];
-					for(int index = 0; index < doubleBuffer.capacity(); index++) {
-						values[index] = doubleBuffer.get(index);
-					}
-				} else {
-					FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
-					values = new double[floatBuffer.capacity()];
-					for(int index = 0; index < floatBuffer.capacity(); index++) {
-						values[index] = floatBuffer.get(index);
-					}
-				}
+				double[] values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision());
 				for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
 					/*
 					 * Get m/z and intensity (m/z-int)

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion20.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion20.java
@@ -16,6 +16,7 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.zip.DataFormatException;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -103,7 +104,7 @@ public class MassSpectrumReaderVersion20 extends AbstractMassSpectrumReader {
 				 * Get the ions.
 				 */
 				Peaks peaks = scan.getPeaks();
-				double[] values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision());
+				double[] values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision(), null);
 				for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
 					/*
 					 * Get m/z and intensity (m/z-int)
@@ -117,6 +118,8 @@ public class MassSpectrumReaderVersion20 extends AbstractMassSpectrumReader {
 		} catch(JAXBException e) {
 			logger.warn(e);
 		} catch(ParserConfigurationException e) {
+			logger.warn(e);
+		} catch(DataFormatException e) {
 			logger.warn(e);
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion21.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion21.java
@@ -16,6 +16,7 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.zip.DataFormatException;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -103,7 +104,7 @@ public class MassSpectrumReaderVersion21 extends AbstractMassSpectrumReader {
 				 * Get the ions.
 				 */
 				Peaks peaks = scan.getPeaks();
-				double[] values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision());
+				double[] values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision(), null);
 				for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
 					/*
 					 * Get m/z and intensity (m/z-int)
@@ -117,6 +118,8 @@ public class MassSpectrumReaderVersion21 extends AbstractMassSpectrumReader {
 		} catch(JAXBException e) {
 			logger.warn(e);
 		} catch(ParserConfigurationException e) {
+			logger.warn(e);
+		} catch(DataFormatException e) {
 			logger.warn(e);
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion21.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion21.java
@@ -15,11 +15,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.DoubleBuffer;
-import java.nio.FloatBuffer;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -28,8 +23,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
-import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.DataProcessing;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.Maldi;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.MsRun;
@@ -53,7 +46,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 
-public class MassSpectrumReaderVersion21 extends AbstractMassSpectraReader implements IMassSpectraReader {
+public class MassSpectrumReaderVersion21 extends AbstractMassSpectrumReader {
 
 	public static final String VERSION = "mzXML_2.1";
 
@@ -110,35 +103,7 @@ public class MassSpectrumReaderVersion21 extends AbstractMassSpectraReader imple
 				 * Get the ions.
 				 */
 				Peaks peaks = scan.getPeaks();
-				ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
-				/*
-				 * Byte Order
-				 */
-				String byteOrder = peaks.getByteOrder();
-				if(byteOrder != null && byteOrder.equals("network")) {
-					byteBuffer.order(ByteOrder.BIG_ENDIAN);
-				} else {
-					byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
-				}
-				/*
-				 * Precision
-				 */
-				double[] values;
-				BigInteger precision = peaks.getPrecision();
-				if(precision != null && precision.intValue() == 64) {
-					DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
-					values = new double[doubleBuffer.capacity()];
-					for(int index = 0; index < doubleBuffer.capacity(); index++) {
-						values[index] = doubleBuffer.get(index);
-					}
-				} else {
-					FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
-					values = new double[floatBuffer.capacity()];
-					for(int index = 0; index < floatBuffer.capacity(); index++) {
-						values[index] = floatBuffer.get(index);
-					}
-				}
-
+				double[] values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision());
 				for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
 					/*
 					 * Get m/z and intensity (m/z-int)

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion22.java
@@ -15,11 +15,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.DoubleBuffer;
-import java.nio.FloatBuffer;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -28,8 +23,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
-import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.DataProcessing;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.Maldi;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.MsRun;
@@ -54,7 +47,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 
-public class MassSpectrumReaderVersion22 extends AbstractMassSpectraReader implements IMassSpectraReader {
+public class MassSpectrumReaderVersion22 extends AbstractMassSpectrumReader {
 
 	public static final String VERSION = "mzXML_2.2";
 
@@ -112,34 +105,7 @@ public class MassSpectrumReaderVersion22 extends AbstractMassSpectraReader imple
 				 * Get the ions.
 				 */
 				Peaks peaks = scan.getPeaks();
-				ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
-				/*
-				 * Byte Order
-				 */
-				String byteOrder = peaks.getByteOrder();
-				if(byteOrder != null && byteOrder.equals("network")) {
-					byteBuffer.order(ByteOrder.BIG_ENDIAN);
-				} else {
-					byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
-				}
-				/*
-				 * Precision
-				 */
-				double[] values;
-				BigInteger precision = peaks.getPrecision();
-				if(precision != null && precision.intValue() == 64) {
-					DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
-					values = new double[doubleBuffer.capacity()];
-					for(int index = 0; index < doubleBuffer.capacity(); index++) {
-						values[index] = doubleBuffer.get(index);
-					}
-				} else {
-					FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
-					values = new double[floatBuffer.capacity()];
-					for(int index = 0; index < floatBuffer.capacity(); index++) {
-						values[index] = floatBuffer.get(index);
-					}
-				}
+				double[] values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision());
 
 				for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
 					/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion22.java
@@ -16,6 +16,7 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.zip.DataFormatException;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -105,7 +106,7 @@ public class MassSpectrumReaderVersion22 extends AbstractMassSpectrumReader {
 				 * Get the ions.
 				 */
 				Peaks peaks = scan.getPeaks();
-				double[] values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision());
+				double[] values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision(), null);
 
 				for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
 					/*
@@ -120,6 +121,8 @@ public class MassSpectrumReaderVersion22 extends AbstractMassSpectrumReader {
 		} catch(JAXBException e) {
 			logger.warn(e);
 		} catch(ParserConfigurationException e) {
+			logger.warn(e);
+		} catch(DataFormatException e) {
 			logger.warn(e);
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion30.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion30.java
@@ -16,6 +16,7 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.zip.DataFormatException;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -117,7 +118,15 @@ public class MassSpectrumReaderVersion30 extends AbstractMassSpectrumReader {
 
 	private void readIons(Peaks peaks, IStandaloneMassSpectrum massSpectrum) {
 
-		double[] values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision());
+		double[] values = null;
+		try {
+			values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision(), peaks.getCompressionType());
+		} catch(DataFormatException e) {
+			logger.error(e);
+		}
+		if(values == null) {
+			return;
+		}
 		for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
 			/*
 			 * Get m/z and intensity (m/z-int)

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion30.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion30.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Philip Wenig - initial API and implementation
+ * Matthias Mailänder - adapted for MALDI
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
+import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v30.model.Maldi;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v30.model.MsInstrument;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v30.model.MsRun;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v30.model.ObjectFactory;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v30.model.Peaks;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v30.model.Scan;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorMassSpectra;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.Polarity;
+import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+
+public class MassSpectrumReaderVersion30 extends AbstractMassSpectraReader implements IMassSpectraReader {
+
+	public static final String VERSION = "mzXML_3.0";
+
+	private static final Logger logger = Logger.getLogger(MassSpectrumReaderVersion30.class);
+
+	@Override
+	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
+
+		MsRun msRun = null;
+		try {
+			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+			Document document = documentBuilder.parse(file);
+			NodeList nodeList = document.getElementsByTagName(AbstractChromatogramReaderVersion.NODE_MS_RUN);
+
+			JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
+			Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+			msRun = (MsRun)unmarshaller.unmarshal(nodeList.item(0));
+		} catch(SAXException e) {
+			logger.warn(e);
+		} catch(JAXBException e) {
+			logger.warn(e);
+		} catch(ParserConfigurationException e) {
+			logger.warn(e);
+		}
+		IVendorMassSpectra massSpectra = createMassSpectra(file, msRun, monitor);
+		massSpectra.setName(file.getName());
+		return massSpectra;
+	}
+
+	private IVendorMassSpectra createMassSpectra(File file, MsRun msRun, IProgressMonitor monitor) {
+
+		IVendorMassSpectra massSpectra = new VendorMassSpectra();
+
+		List<Scan> scans = msRun.getScan();
+		monitor.beginTask(ConverterMessages.readScans, scans.size());
+		for(Scan scan : scans) {
+			IStandaloneMassSpectrum massSpectrum = new StandaloneMassSpectrum();
+			for(MsInstrument instrument : msRun.getMsInstrument()) {
+				massSpectrum.setInstrument(instrument.getMsManufacturer().getTheValue() + " " + instrument.getMsModel().getTheValue());
+			}
+			massSpectrum.setFile(file);
+			massSpectrum.setIdentifier(file.getName());
+			/*
+			 * Polarity
+			 */
+			if(scan.getPolarity() != null) {
+				if(scan.getPolarity().equals("+")) {
+					massSpectrum.setPolarity(Polarity.POSITIVE);
+				} else if(scan.getPolarity().equals("-")) {
+					massSpectrum.setPolarity(Polarity.NEGATIVE);
+				}
+			}
+			/*
+			 * Plate
+			 */
+			Maldi maldi = scan.getMaldi();
+			if(maldi != null) {
+				massSpectrum.setPlate(maldi.getPlateID());
+				massSpectrum.setPosition(maldi.getSpotID());
+			}
+			for(Peaks peaks : scan.getPeaks()) {
+				readIons(peaks, massSpectrum);
+			}
+			massSpectra.addMassSpectrum(massSpectrum);
+		}
+		return massSpectra;
+	}
+
+	private void readIons(Peaks peaks, IStandaloneMassSpectrum massSpectrum) {
+
+		ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
+		/*
+		 * Byte Order
+		 */
+		String byteOrder = peaks.getByteOrder();
+		if(byteOrder != null && byteOrder.equals("network")) {
+			byteBuffer.order(ByteOrder.BIG_ENDIAN);
+		} else {
+			byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+		}
+		/*
+		 * Precision
+		 */
+		double[] values;
+		BigInteger precision = peaks.getPrecision();
+		if(precision != null && precision.intValue() == 64) {
+			DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
+			values = new double[doubleBuffer.capacity()];
+			for(int index = 0; index < doubleBuffer.capacity(); index++) {
+				values[index] = doubleBuffer.get(index);
+			}
+		} else {
+			FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
+			values = new double[floatBuffer.capacity()];
+			for(int index = 0; index < floatBuffer.capacity(); index++) {
+				values[index] = floatBuffer.get(index);
+			}
+		}
+
+		for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
+			/*
+			 * Get m/z and intensity (m/z-int)
+			 */
+			massSpectrum.addIon(new VendorIon(values[peakIndex], (float)values[peakIndex + 1]), false);
+		}
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion30.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion30.java
@@ -15,11 +15,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.DoubleBuffer;
-import java.nio.FloatBuffer;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -28,8 +23,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
-import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v30.model.Maldi;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v30.model.MsInstrument;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v30.model.MsRun;
@@ -52,7 +45,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 
-public class MassSpectrumReaderVersion30 extends AbstractMassSpectraReader implements IMassSpectraReader {
+public class MassSpectrumReaderVersion30 extends AbstractMassSpectrumReader {
 
 	public static final String VERSION = "mzXML_3.0";
 
@@ -124,35 +117,7 @@ public class MassSpectrumReaderVersion30 extends AbstractMassSpectraReader imple
 
 	private void readIons(Peaks peaks, IStandaloneMassSpectrum massSpectrum) {
 
-		ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
-		/*
-		 * Byte Order
-		 */
-		String byteOrder = peaks.getByteOrder();
-		if(byteOrder != null && byteOrder.equals("network")) {
-			byteBuffer.order(ByteOrder.BIG_ENDIAN);
-		} else {
-			byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
-		}
-		/*
-		 * Precision
-		 */
-		double[] values;
-		BigInteger precision = peaks.getPrecision();
-		if(precision != null && precision.intValue() == 64) {
-			DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
-			values = new double[doubleBuffer.capacity()];
-			for(int index = 0; index < doubleBuffer.capacity(); index++) {
-				values[index] = doubleBuffer.get(index);
-			}
-		} else {
-			FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
-			values = new double[floatBuffer.capacity()];
-			for(int index = 0; index < floatBuffer.capacity(); index++) {
-				values[index] = floatBuffer.get(index);
-			}
-		}
-
+		double[] values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision());
 		for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
 			/*
 			 * Get m/z and intensity (m/z-int)

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion31.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion31.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Philip Wenig - initial API and implementation
+ * Matthias Mailänder - adapted for MALDI
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
+import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v31.model.Maldi;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v31.model.MsInstrument;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v31.model.MsRun;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v31.model.ObjectFactory;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v31.model.Peaks;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v31.model.Scan;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorMassSpectra;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.Polarity;
+import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+
+public class MassSpectrumReaderVersion31 extends AbstractMassSpectraReader implements IMassSpectraReader {
+
+	public static final String VERSION = "mzXML_3.1";
+
+	private static final Logger logger = Logger.getLogger(MassSpectrumReaderVersion31.class);
+
+	@Override
+	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
+
+		MsRun msRun = null;
+		try {
+			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+			Document document = documentBuilder.parse(file);
+			NodeList nodeList = document.getElementsByTagName(AbstractChromatogramReaderVersion.NODE_MS_RUN);
+
+			JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
+			Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+			msRun = (MsRun)unmarshaller.unmarshal(nodeList.item(0));
+		} catch(SAXException e) {
+			logger.warn(e);
+		} catch(JAXBException e) {
+			logger.warn(e);
+		} catch(ParserConfigurationException e) {
+			logger.warn(e);
+		}
+		IVendorMassSpectra massSpectra = createMassSpectra(file, msRun, monitor);
+		massSpectra.setName(file.getName());
+		return massSpectra;
+	}
+
+	private IVendorMassSpectra createMassSpectra(File file, MsRun msRun, IProgressMonitor monitor) {
+
+		IVendorMassSpectra massSpectra = new VendorMassSpectra();
+
+		List<Scan> scans = msRun.getScan();
+		monitor.beginTask(ConverterMessages.readScans, scans.size());
+		for(Scan scan : scans) {
+			IStandaloneMassSpectrum massSpectrum = new StandaloneMassSpectrum();
+			for(MsInstrument instrument : msRun.getMsInstrument()) {
+				massSpectrum.setInstrument(instrument.getMsManufacturer().getTheValue() + " " + instrument.getMsModel().getTheValue());
+			}
+			massSpectrum.setFile(file);
+			massSpectrum.setIdentifier(file.getName());
+			/*
+			 * Polarity
+			 */
+			if(scan.getPolarity() != null) {
+				if(scan.getPolarity().equals("+")) {
+					massSpectrum.setPolarity(Polarity.POSITIVE);
+				} else if(scan.getPolarity().equals("-")) {
+					massSpectrum.setPolarity(Polarity.NEGATIVE);
+				}
+			}
+			/*
+			 * Plate
+			 */
+			Maldi maldi = scan.getMaldi();
+			if(maldi != null) {
+				massSpectrum.setPlate(maldi.getPlateID());
+				massSpectrum.setPosition(maldi.getSpotID());
+			}
+			for(Peaks peaks : scan.getPeaks()) {
+				readIons(peaks, massSpectrum);
+			}
+			massSpectra.addMassSpectrum(massSpectrum);
+		}
+		return massSpectra;
+	}
+
+	private void readIons(Peaks peaks, IStandaloneMassSpectrum massSpectrum) {
+
+		ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
+		/*
+		 * Byte Order
+		 */
+		String byteOrder = peaks.getByteOrder();
+		if(byteOrder != null && byteOrder.equals("network")) {
+			byteBuffer.order(ByteOrder.BIG_ENDIAN);
+		} else {
+			byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+		}
+		/*
+		 * Precision
+		 */
+		double[] values;
+		BigInteger precision = peaks.getPrecision();
+		if(precision != null && precision.intValue() == 64) {
+			DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
+			values = new double[doubleBuffer.capacity()];
+			for(int index = 0; index < doubleBuffer.capacity(); index++) {
+				values[index] = doubleBuffer.get(index);
+			}
+		} else {
+			FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
+			values = new double[floatBuffer.capacity()];
+			for(int index = 0; index < floatBuffer.capacity(); index++) {
+				values[index] = floatBuffer.get(index);
+			}
+		}
+
+		for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
+			/*
+			 * Get m/z and intensity (m/z-int)
+			 */
+			massSpectrum.addIon(new VendorIon(values[peakIndex], (float)values[peakIndex + 1]), false);
+		}
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion31.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion31.java
@@ -16,6 +16,7 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.zip.DataFormatException;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -117,7 +118,15 @@ public class MassSpectrumReaderVersion31 extends AbstractMassSpectrumReader {
 
 	private void readIons(Peaks peaks, IStandaloneMassSpectrum massSpectrum) {
 
-		double[] values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision());
+		double[] values = null;
+		try {
+			values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision(), peaks.getCompressionType());
+		} catch(DataFormatException e) {
+			logger.error(e);
+		}
+		if(values == null) {
+			return;
+		}
 		for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
 			/*
 			 * Get m/z and intensity (m/z-int)

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion31.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion31.java
@@ -15,11 +15,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.DoubleBuffer;
-import java.nio.FloatBuffer;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -28,8 +23,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
-import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v31.model.Maldi;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v31.model.MsInstrument;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v31.model.MsRun;
@@ -52,7 +45,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 
-public class MassSpectrumReaderVersion31 extends AbstractMassSpectraReader implements IMassSpectraReader {
+public class MassSpectrumReaderVersion31 extends AbstractMassSpectrumReader {
 
 	public static final String VERSION = "mzXML_3.1";
 
@@ -124,35 +117,7 @@ public class MassSpectrumReaderVersion31 extends AbstractMassSpectraReader imple
 
 	private void readIons(Peaks peaks, IStandaloneMassSpectrum massSpectrum) {
 
-		ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
-		/*
-		 * Byte Order
-		 */
-		String byteOrder = peaks.getByteOrder();
-		if(byteOrder != null && byteOrder.equals("network")) {
-			byteBuffer.order(ByteOrder.BIG_ENDIAN);
-		} else {
-			byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
-		}
-		/*
-		 * Precision
-		 */
-		double[] values;
-		BigInteger precision = peaks.getPrecision();
-		if(precision != null && precision.intValue() == 64) {
-			DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
-			values = new double[doubleBuffer.capacity()];
-			for(int index = 0; index < doubleBuffer.capacity(); index++) {
-				values[index] = doubleBuffer.get(index);
-			}
-		} else {
-			FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
-			values = new double[floatBuffer.capacity()];
-			for(int index = 0; index < floatBuffer.capacity(); index++) {
-				values[index] = floatBuffer.get(index);
-			}
-		}
-
+		double[] values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision());
 		for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
 			/*
 			 * Get m/z and intensity (m/z-int)

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion32.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion32.java
@@ -15,11 +15,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.DoubleBuffer;
-import java.nio.FloatBuffer;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -28,8 +23,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
-import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v32.model.Maldi;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v32.model.MsInstrument;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v32.model.MsRun;
@@ -52,7 +45,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 
-public class MassSpectrumReaderVersion32 extends AbstractMassSpectraReader implements IMassSpectraReader {
+public class MassSpectrumReaderVersion32 extends AbstractMassSpectrumReader {
 
 	public static final String VERSION = "mzXML_3.2";
 
@@ -124,35 +117,7 @@ public class MassSpectrumReaderVersion32 extends AbstractMassSpectraReader imple
 
 	private void readIons(Peaks peaks, IStandaloneMassSpectrum massSpectrum) {
 
-		ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
-		/*
-		 * Byte Order
-		 */
-		String byteOrder = peaks.getByteOrder();
-		if(byteOrder != null && byteOrder.equals("network")) {
-			byteBuffer.order(ByteOrder.BIG_ENDIAN);
-		} else {
-			byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
-		}
-		/*
-		 * Precision
-		 */
-		double[] values;
-		BigInteger precision = peaks.getPrecision();
-		if(precision != null && precision.intValue() == 64) {
-			DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
-			values = new double[doubleBuffer.capacity()];
-			for(int index = 0; index < doubleBuffer.capacity(); index++) {
-				values[index] = doubleBuffer.get(index);
-			}
-		} else {
-			FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
-			values = new double[floatBuffer.capacity()];
-			for(int index = 0; index < floatBuffer.capacity(); index++) {
-				values[index] = floatBuffer.get(index);
-			}
-		}
-
+		double[] values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision());
 		for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
 			/*
 			 * Get m/z and intensity (m/z-int)

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion32.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion32.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Philip Wenig - initial API and implementation
+ * Matthias Mailänder - adapted for MALDI
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
+import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v32.model.Maldi;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v32.model.MsInstrument;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v32.model.MsRun;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v32.model.ObjectFactory;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v32.model.Peaks;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v32.model.Scan;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorMassSpectra;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.Polarity;
+import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+
+public class MassSpectrumReaderVersion32 extends AbstractMassSpectraReader implements IMassSpectraReader {
+
+	public static final String VERSION = "mzXML_3.2";
+
+	private static final Logger logger = Logger.getLogger(MassSpectrumReaderVersion32.class);
+
+	@Override
+	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
+
+		MsRun msRun = null;
+		try {
+			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+			Document document = documentBuilder.parse(file);
+			NodeList nodeList = document.getElementsByTagName(AbstractChromatogramReaderVersion.NODE_MS_RUN);
+
+			JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
+			Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+			msRun = (MsRun)unmarshaller.unmarshal(nodeList.item(0));
+		} catch(SAXException e) {
+			logger.warn(e);
+		} catch(JAXBException e) {
+			logger.warn(e);
+		} catch(ParserConfigurationException e) {
+			logger.warn(e);
+		}
+		IVendorMassSpectra massSpectra = createMassSpectra(file, msRun, monitor);
+		massSpectra.setName(file.getName());
+		return massSpectra;
+	}
+
+	private IVendorMassSpectra createMassSpectra(File file, MsRun msRun, IProgressMonitor monitor) {
+
+		IVendorMassSpectra massSpectra = new VendorMassSpectra();
+
+		List<Scan> scans = msRun.getScan();
+		monitor.beginTask(ConverterMessages.readScans, scans.size());
+		for(Scan scan : scans) {
+			IStandaloneMassSpectrum massSpectrum = new StandaloneMassSpectrum();
+			for(MsInstrument instrument : msRun.getMsInstrument()) {
+				massSpectrum.setInstrument(instrument.getMsManufacturer().getTheValue() + " " + instrument.getMsModel().getTheValue());
+			}
+			massSpectrum.setFile(file);
+			massSpectrum.setIdentifier(file.getName());
+			/*
+			 * Polarity
+			 */
+			if(scan.getPolarity() != null) {
+				if(scan.getPolarity().equals("+")) {
+					massSpectrum.setPolarity(Polarity.POSITIVE);
+				} else if(scan.getPolarity().equals("-")) {
+					massSpectrum.setPolarity(Polarity.NEGATIVE);
+				}
+			}
+			/*
+			 * Plate
+			 */
+			Maldi maldi = scan.getMaldi();
+			if(maldi != null) {
+				massSpectrum.setPlate(maldi.getPlateID());
+				massSpectrum.setPosition(maldi.getSpotID());
+			}
+			for(Peaks peaks : scan.getPeaks()) {
+				readIons(peaks, massSpectrum);
+			}
+			massSpectra.addMassSpectrum(massSpectrum);
+		}
+		return massSpectra;
+	}
+
+	private void readIons(Peaks peaks, IStandaloneMassSpectrum massSpectrum) {
+
+		ByteBuffer byteBuffer = ByteBuffer.wrap(peaks.getValue());
+		/*
+		 * Byte Order
+		 */
+		String byteOrder = peaks.getByteOrder();
+		if(byteOrder != null && byteOrder.equals("network")) {
+			byteBuffer.order(ByteOrder.BIG_ENDIAN);
+		} else {
+			byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+		}
+		/*
+		 * Precision
+		 */
+		double[] values;
+		BigInteger precision = peaks.getPrecision();
+		if(precision != null && precision.intValue() == 64) {
+			DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
+			values = new double[doubleBuffer.capacity()];
+			for(int index = 0; index < doubleBuffer.capacity(); index++) {
+				values[index] = doubleBuffer.get(index);
+			}
+		} else {
+			FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
+			values = new double[floatBuffer.capacity()];
+			for(int index = 0; index < floatBuffer.capacity(); index++) {
+				values[index] = floatBuffer.get(index);
+			}
+		}
+
+		for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
+			/*
+			 * Get m/z and intensity (m/z-int)
+			 */
+			massSpectrum.addIon(new VendorIon(values[peakIndex], (float)values[peakIndex + 1]), false);
+		}
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion32.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion32.java
@@ -16,6 +16,7 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.zip.DataFormatException;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -117,7 +118,15 @@ public class MassSpectrumReaderVersion32 extends AbstractMassSpectrumReader {
 
 	private void readIons(Peaks peaks, IStandaloneMassSpectrum massSpectrum) {
 
-		double[] values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision());
+		double[] values = null;
+		try {
+			values = readPeaks(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision(), peaks.getCompressionType());
+		} catch(DataFormatException e) {
+			logger.error(e);
+		}
+		if(values == null) {
+			return;
+		}
 		for(int peakIndex = 0; peakIndex < values.length - 1; peakIndex += 2) {
 			/*
 			 * Get m/z and intensity (m/z-int)

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/io/MassSpectrumReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/io/MassSpectrumReader.java
@@ -23,6 +23,9 @@ import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.MassSpectrumReaderVersion20;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.MassSpectrumReaderVersion21;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.MassSpectrumReaderVersion22;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.MassSpectrumReaderVersion30;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.MassSpectrumReaderVersion31;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.MassSpectrumReaderVersion32;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.core.runtime.IProgressMonitor;
 
@@ -49,6 +52,12 @@ public class MassSpectrumReader extends AbstractMassSpectraReader implements IMa
 			massSpectraReader = new MassSpectrumReaderVersion21();
 		} else if(header.contains(MassSpectrumReaderVersion22.VERSION)) {
 			massSpectraReader = new MassSpectrumReaderVersion22();
+		} else if(header.contains(MassSpectrumReaderVersion30.VERSION)) {
+			massSpectraReader = new MassSpectrumReaderVersion30();
+		} else if(header.contains(MassSpectrumReaderVersion31.VERSION)) {
+			massSpectraReader = new MassSpectrumReaderVersion31();
+		} else if(header.contains(MassSpectrumReaderVersion32.VERSION)) {
+			massSpectraReader = new MassSpectrumReaderVersion32();
 		} else {
 			throw new UnknownVersionException();
 		}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/MassSpectrumImportConverterMaldiAxima_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/MassSpectrumImportConverterMaldiAxima_ITest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 @TestInstance(Lifecycle.PER_CLASS)
-public class ChromatogramImportConverterMaldiAxima_ITest {
+public class MassSpectrumImportConverterMaldiAxima_ITest {
 
 	private IStandaloneMassSpectrum standaloneMassSpectrum;
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/TestPathHelper.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/TestPathHelper.java
@@ -18,5 +18,8 @@ public class TestPathHelper extends PathResolver {
 	 * IMPORT
 	 */
 	public static final String TESTFILE_IMPORT_TINY1_MZXML20 = "testData/files/import/tiny1.mzXML2.0.mzxml";
+	public static final String TESTFILE_IMPORT_TINY1_MZXML30 = "testData/files/import/tiny1.mzXML3.0.mzXML";
+	public static final String TESTFILE_IMPORT_TINY1_CENTROIDED_MZXML30 = "testData/files/import/tiny1-centroided.mzXML3.0.mzXML";
+	public static final String TESTFILE_IMPORT_TINY1_COMPRESSED_MZXML30 = "testData/files/import/tiny1-compressed.mzXML3.0.mzXML";
 	public static final String TESTFILE_IMPORT_TINY_MZXML30 = "testData/files/import/tiny3.0.mzXML";
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumImportConverterTinyCentroidedMzXML30_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumImportConverterTinyCentroidedMzXML30_ITest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzxml.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.TestPathHelper;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorMassSpectra;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
+import org.eclipse.chemclipse.msd.model.core.Polarity;
+import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class MassSpectrumImportConverterTinyCentroidedMzXML30_ITest {
+
+	private IStandaloneMassSpectrum standaloneMassSpectrum;
+
+	@BeforeAll
+	public void setUp() {
+
+		File importFile = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_TINY1_CENTROIDED_MZXML30));
+		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();
+		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(importFile, new NullProgressMonitor());
+		IVendorMassSpectra massSpectra = (VendorMassSpectra)processingInfo.getProcessingResult();
+		standaloneMassSpectrum = (StandaloneMassSpectrum)massSpectra.getMassSpectrum(1);
+	}
+
+	@Test
+	public void testInstrument() {
+
+		assertEquals("FooBar FooBar Model1", standaloneMassSpectrum.getInstrument());
+	}
+
+	@Test
+	public void testMassSpectrum() {
+
+		assertEquals(Polarity.POSITIVE, standaloneMassSpectrum.getPolarity());
+		assertEquals(MassSpectrumType.CENTROID, standaloneMassSpectrum.getMassSpectrumType());
+	}
+
+	@Test
+	public void testIons() {
+
+		assertEquals(5, standaloneMassSpectrum.getNumberOfIons());
+		assertEquals(1, standaloneMassSpectrum.getLowestIon().getIon());
+		assertEquals(6, standaloneMassSpectrum.getLowestIon().getAbundance());
+		assertEquals(5, standaloneMassSpectrum.getHighestIon().getIon());
+		assertEquals(10, standaloneMassSpectrum.getHighestIon().getAbundance());
+	}
+}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumImportConverterTinyCompressedMzXML30_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumImportConverterTinyCompressedMzXML30_ITest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzxml.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.TestPathHelper;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorMassSpectra;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.Polarity;
+import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class MassSpectrumImportConverterTinyCompressedMzXML30_ITest {
+
+	private IStandaloneMassSpectrum standaloneMassSpectrum;
+
+	@BeforeAll
+	public void setUp() {
+
+		File importFile = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_TINY1_COMPRESSED_MZXML30));
+		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();
+		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(importFile, new NullProgressMonitor());
+		IVendorMassSpectra massSpectra = (VendorMassSpectra)processingInfo.getProcessingResult();
+		standaloneMassSpectrum = (StandaloneMassSpectrum)massSpectra.getMassSpectrum(1);
+	}
+
+	@Test
+	public void testInstrument() {
+
+		assertEquals("FooBar FooBar Model1", standaloneMassSpectrum.getInstrument());
+	}
+
+	@Test
+	public void testMassSpectrum() {
+
+		assertEquals(Polarity.POSITIVE, standaloneMassSpectrum.getPolarity());
+	}
+
+	@Test
+	public void testIons() {
+
+		assertEquals(5, standaloneMassSpectrum.getNumberOfIons());
+		assertEquals(1, standaloneMassSpectrum.getLowestIon().getIon());
+		assertEquals(6, standaloneMassSpectrum.getLowestIon().getAbundance());
+		assertEquals(5, standaloneMassSpectrum.getHighestIon().getIon());
+		assertEquals(10, standaloneMassSpectrum.getHighestIon().getAbundance());
+	}
+}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumImportConverterTinyMzXML30_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumImportConverterTinyMzXML30_ITest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzxml.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.TestPathHelper;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorMassSpectra;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.Polarity;
+import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class MassSpectrumImportConverterTinyMzXML30_ITest {
+
+	private IStandaloneMassSpectrum standaloneMassSpectrum;
+
+	@BeforeAll
+	public void setUp() {
+
+		File importFile = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_TINY1_MZXML30));
+		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();
+		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(importFile, new NullProgressMonitor());
+		IVendorMassSpectra massSpectra = (VendorMassSpectra)processingInfo.getProcessingResult();
+		standaloneMassSpectrum = (StandaloneMassSpectrum)massSpectra.getMassSpectrum(1);
+	}
+
+	@Test
+	public void testInstrument() {
+
+		assertEquals("FooBar FooBar Model1", standaloneMassSpectrum.getInstrument());
+	}
+
+	@Test
+	public void testMassSpectrum() {
+
+		assertEquals(Polarity.POSITIVE, standaloneMassSpectrum.getPolarity());
+	}
+
+	@Test
+	public void testIons() {
+
+		assertEquals(5, standaloneMassSpectrum.getNumberOfIons());
+		assertEquals(1, standaloneMassSpectrum.getLowestIon().getIon());
+		assertEquals(6, standaloneMassSpectrum.getLowestIon().getAbundance());
+		assertEquals(5, standaloneMassSpectrum.getHighestIon().getIon());
+		assertEquals(10, standaloneMassSpectrum.getHighestIon().getAbundance());
+	}
+}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/testData/files/import/tiny1-centroided.mzXML3.0.mzXML
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/testData/files/import/tiny1-centroided.mzXML3.0.mzXML
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<mzXML
+ xmlns="http://sashimi.sourceforge.net/schema_revision/mzXML_3.0"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://sashimi.sourceforge.net/schema_revision/mzXML_3.0 http://sashimi.sourceforge.net/schema_revision/mzXML_3.0/mzXML_idx_3.0.xsd">
+  <msRun scanCount="1">
+    <parentFile fileName="file://tiny.RAW"
+                fileType="RAW"
+                fileSha1="0000000000000000000000000000000000000000"/>
+    <msInstrument>
+	    <msManufacturer category="msManufacturer" value="FooBar"/>
+      <msModel category="msModel" value="FooBar Model1"/>
+ 	    <msIonisation category="msIonisation" value="MALDI"/>
+	    <msMassAnalyzer category="msMassAnalyzer" value="TOF"/>
+	    <msDetector category="msDetector" value="msD"/>
+      <software type="acquisition"
+                name="AcquisitionSoftware"
+                version="1.0.0"/>
+    </msInstrument>
+    <scan num="1"
+          msLevel="1"
+          peaksCount="5"
+          centroided="1"
+          polarity="+"
+          scanType="Full"
+          lowMz="1"
+          highMz="5"
+	        totIonCurrent="40">
+      <peaks precision="64"
+             byteOrder="network"
+             contentType="m/z-int"
+             compressionType="none"
+             compressedLen="0">P/AAAAAAAABAGAAAAAAAAEAAAAAAAAAAQBwAAAAAAABACAAAAAAAAEAgAAAAAAAAQBAAAAAAAABAIgAAAAAAAEAUAAAAAAAAQCQAAAAAAAA=</peaks>
+    </scan>
+  </msRun>
+  <index name="scan">
+    <offset id="1">0</offset>
+  </index>
+  <indexOffset>0</indexOffset>
+  <sha1>1cf2b3695447d2dd698b465e27f452a80192dd62</sha1>
+</mzXML>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/testData/files/import/tiny1-compressed.mzXML3.0.mzXML
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/testData/files/import/tiny1-compressed.mzXML3.0.mzXML
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<mzXML
+ xmlns="http://sashimi.sourceforge.net/schema_revision/mzXML_3.0"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://sashimi.sourceforge.net/schema_revision/mzXML_3.0 http://sashimi.sourceforge.net/schema_revision/mzXML_3.0/mzXML_idx_3.0.xsd">
+  <msRun scanCount="1">
+    <parentFile fileName="file://tiny.RAW"
+                fileType="RAW"
+                fileSha1="0000000000000000000000000000000000000000"/>
+    <msInstrument>
+	    <msManufacturer category="msManufacturer" value="FooBar"/>
+      <msModel category="msModel" value="FooBar Model1"/>
+ 	    <msIonisation category="msIonisation" value="MALDI"/>
+	    <msMassAnalyzer category="msMassAnalyzer" value="TOF"/>
+	    <msDetector category="msDetector" value="msD"/>
+      <software type="acquisition"
+                name="AcquisitionSoftware"
+                version="1.0.0"/>
+    </msInstrument>
+    <scan num="1"
+          msLevel="1"
+          peaksCount="5"
+          polarity="+"
+          scanType="Full"
+          lowMz="1"
+          highMz="5"
+	        totIonCurrent="40">
+      <peaks precision="64"
+             byteOrder="network"
+             contentType="m/z-int"
+             compressionType="zlib"
+             compressedLen="0">eJyz/8AABg4SUJoBSstAaQ4orQClBaC0EpQWgdIqEBoA0joENg==</peaks>
+    </scan>
+  </msRun>
+  <index name="scan">
+    <offset id="1">0</offset>
+  </index>
+  <indexOffset>0</indexOffset>
+  <sha1>7e7ef0ea030f6a56d34a4ebd446e22b22844d432</sha1>
+</mzXML>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/testData/files/import/tiny1.mzXML3.0.mzXML
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/testData/files/import/tiny1.mzXML3.0.mzXML
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<mzXML
+ xmlns="http://sashimi.sourceforge.net/schema_revision/mzXML_3.0"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://sashimi.sourceforge.net/schema_revision/mzXML_3.0 http://sashimi.sourceforge.net/schema_revision/mzXML_3.0/mzXML_idx_3.0.xsd">
+  <msRun scanCount="1">
+    <parentFile fileName="file://tiny.RAW"
+                fileType="RAW"
+                fileSha1="0000000000000000000000000000000000000000"/>
+    <msInstrument>
+	    <msManufacturer category="msManufacturer" value="FooBar"/>
+      <msModel category="msModel" value="FooBar Model1"/>
+ 	    <msIonisation category="msIonisation" value="MALDI"/>
+	    <msMassAnalyzer category="msMassAnalyzer" value="TOF"/>
+	    <msDetector category="msDetector" value="msD"/>
+      <software type="acquisition"
+                name="AcquisitionSoftware"
+                version="1.0.0"/>
+    </msInstrument>
+    <scan num="1"
+          msLevel="1"
+          peaksCount="5"
+          polarity="+"
+          scanType="Full"
+          lowMz="1"
+          highMz="5"
+	        totIonCurrent="40">
+      <peaks precision="64"
+             byteOrder="network"
+             contentType="m/z-int"
+             compressionType="none"
+             compressedLen="0">P/AAAAAAAABAGAAAAAAAAEAAAAAAAAAAQBwAAAAAAABACAAAAAAAAEAgAAAAAAAAQBAAAAAAAABAIgAAAAAAAEAUAAAAAAAAQCQAAAAAAAA=</peaks>
+    </scan>
+  </msRun>
+  <index name="scan">
+    <offset id="1">0</offset>
+  </index>
+  <indexOffset>0</indexOffset>
+  <sha1>b87b09a4f34561d5572f9a6d30056106f819bc69</sha1>
+</mzXML>


### PR DESCRIPTION
with integration tests as a followup to https://github.com/eclipse-chemclipse/chemclipse/pull/1845.