### PR TITLE
Add support for multiple mzML mass spectra

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/MassSpectrumReaderVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/MassSpectrumReaderVersion110.java
@@ -27,7 +27,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.Vendor
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
-import org.eclipse.chemclipse.msd.model.implementation.VendorMassSpectrum;
+import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.BinaryReader110;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.XmlReader110;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.BinaryDataArrayType;
@@ -49,35 +49,31 @@ public class MassSpectrumReaderVersion110 extends AbstractMassSpectraReader impl
 	@Override
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
-		IStandaloneMassSpectrum massSpectrum = null;
+		IVendorMassSpectra massSpectra = new VendorMassSpectra();
+		massSpectra.setName(file.getName());
 
 		try {
-
-			massSpectrum = new VendorMassSpectrum();
-			massSpectrum.setFile(file);
-			massSpectrum.setIdentifier(file.getName());
-
 			MzMLType mzML = XmlReader110.getMzML(file);
+			RunType run = mzML.getRun();
 
-			FileDescriptionType fileDescription = mzML.getFileDescription();
-			if(fileDescription != null) {
-				ParamGroupType fileContent = fileDescription.getFileContent();
-				for(CVParamType cvParam : fileContent.getCvParam()) {
-					if(cvParam.getAccession().equals("MS:1000579")) {
-						if(cvParam.getName().equals("MS1 spectrum")) {
-							massSpectrum.setMassSpectrometer((short)1);
+			for(SpectrumType spectrum : run.getSpectrumList().getSpectrum()) {
+
+				IStandaloneMassSpectrum massSpectrum = new StandaloneMassSpectrum();
+				massSpectrum.setFile(file);
+				massSpectrum.setIdentifier(file.getName());
+				massSpectrum.setPosition(spectrum.getSpotID());
+
+				FileDescriptionType fileDescription = mzML.getFileDescription();
+				if(fileDescription != null) {
+					ParamGroupType fileContent = fileDescription.getFileContent();
+					for(CVParamType cvParam : fileContent.getCvParam()) {
+						if(cvParam.getAccession().equals("MS:1000579")) {
+							if(cvParam.getName().equals("MS1 spectrum")) {
+								massSpectrum.setMassSpectrometer((short)1);
+							}
 						}
 					}
 				}
-			}
-
-			double[] mzs = null;
-			double[] intensities = null;
-
-			RunType run = mzML.getRun();
-			for(SpectrumType spectrum : run.getSpectrumList().getSpectrum()) {
-
-				massSpectrum.setPosition(spectrum.getSpotID());
 
 				for(CVParamType cvParam : spectrum.getCvParam()) {
 					if(cvParam.getAccession().equals("MS:1000127") && cvParam.getName().equals("centroid spectrum")) {
@@ -86,6 +82,10 @@ public class MassSpectrumReaderVersion110 extends AbstractMassSpectraReader impl
 						massSpectrum.setMassSpectrumType(MassSpectrumType.PROFILE);
 					}
 				}
+
+				double[] mzs = null;
+				double[] intensities = null;
+
 				for(BinaryDataArrayType binaryDataArrayType : spectrum.getBinaryDataArrayList().getBinaryDataArray()) {
 					Pair<String, double[]> binaryData = BinaryReader110.parseBinaryData(binaryDataArrayType);
 					if(binaryData.getKey().equals("m/z")) {
@@ -94,8 +94,11 @@ public class MassSpectrumReaderVersion110 extends AbstractMassSpectraReader impl
 						intensities = binaryData.getValue();
 					}
 				}
+				XmlMassSpectrumReader.addIons(intensities, mzs, massSpectrum);
+
+				massSpectra.addMassSpectrum(massSpectrum);
 			}
-			XmlMassSpectrumReader.addIons(intensities, mzs, massSpectrum);
+
 		} catch(SAXException e) {
 			logger.warn(e);
 		} catch(JAXBException e) {
@@ -106,9 +109,6 @@ public class MassSpectrumReaderVersion110 extends AbstractMassSpectraReader impl
 			logger.warn(e);
 		}
 
-		IVendorMassSpectra massSpectra = new VendorMassSpectra();
-		massSpectra.setName(file.getName());
-		massSpectra.addMassSpectrum(massSpectrum);
 		return massSpectra;
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/TestPathHelper.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/TestPathHelper.java
@@ -20,6 +20,10 @@ public class TestPathHelper extends PathResolver {
 	public static final String TESTFILE_IMPORT_TINY_PWIZ_1_0 = "testData/files/import/tiny.pwiz.1.0.mzML";
 	public static final String TESTFILE_IMPORT_TINY_PWIZ_1_1 = "testData/files/import/tiny.pwiz.1.1.mzML";
 	public static final String TESTFILE_IMPORT_CHROMATOGRAM_1 = "testData/files/import/Chromatogram1.ocb";
+
+	public static final String TESTFILE_IMPORT_TINY1_1_1 = "testData/files/import/tiny1.mzML1.1.mzML";
+	public static final String TESTFILE_IMPORT_TINY1_COMPRESSED_1_1 = "testData/files/import/tiny1-compressed.mzML1.1.mzML";
+	public static final String TESTFILE_IMPORT_TINY1_CENTROIDED_1_1 = "testData/files/import/tiny1-centroided.mzML1.1.mzML";
 	/*
 	 * EXPORT
 	 */

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverter110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverter110_ITest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.TestPathHelper;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorMassSpectra;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class MassSpectrumImportConverter110_ITest {
+
+	private IVendorMassSpectra massSpectra;
+
+	@BeforeAll
+	public void setUp() {
+
+		File importFile = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_TINY1_1_1));
+		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();
+		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(importFile, new NullProgressMonitor());
+		massSpectra = (VendorMassSpectra)processingInfo.getProcessingResult();
+	}
+
+	@Test
+	public void testIons() {
+
+		assertEquals(2, massSpectra.getList().size());
+	}
+
+	@Test
+	public void testFirstSpectrum() {
+
+		IStandaloneMassSpectrum standaloneMassSpectrum = (IStandaloneMassSpectrum)massSpectra.getMassSpectrum(1);
+		assertEquals(5, standaloneMassSpectrum.getNumberOfIons());
+		assertEquals(5, standaloneMassSpectrum.getNumberOfIons());
+		assertEquals(1, standaloneMassSpectrum.getLowestIon().getIon());
+		assertEquals(6, standaloneMassSpectrum.getLowestIon().getAbundance());
+		assertEquals(5, standaloneMassSpectrum.getHighestIon().getIon());
+		assertEquals(10, standaloneMassSpectrum.getHighestIon().getAbundance());
+	}
+
+	@Test
+	public void testSecondSpectrum() {
+
+		IStandaloneMassSpectrum standaloneMassSpectrum = (IStandaloneMassSpectrum)massSpectra.getMassSpectrum(2);
+		assertEquals(5, standaloneMassSpectrum.getNumberOfIons());
+		assertEquals(5, standaloneMassSpectrum.getNumberOfIons());
+		assertEquals(1, standaloneMassSpectrum.getLowestIon().getIon());
+		assertEquals(10, standaloneMassSpectrum.getLowestIon().getAbundance());
+		assertEquals(5, standaloneMassSpectrum.getHighestIon().getIon());
+		assertEquals(6, standaloneMassSpectrum.getHighestIon().getAbundance());
+	}
+}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverterCentroided110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverterCentroided110_ITest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.TestPathHelper;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorMassSpectra;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class MassSpectrumImportConverterCentroided110_ITest {
+
+	private IVendorMassSpectra massSpectra;
+
+	@BeforeAll
+	public void setUp() {
+
+		File importFile = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_TINY1_CENTROIDED_1_1));
+		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();
+		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(importFile, new NullProgressMonitor());
+		massSpectra = (VendorMassSpectra)processingInfo.getProcessingResult();
+	}
+
+	@Test
+	public void testIons() {
+
+		assertEquals(2, massSpectra.getList().size());
+	}
+
+	@Test
+	public void testFirstSpectrum() {
+
+		IStandaloneMassSpectrum standaloneMassSpectrum = (IStandaloneMassSpectrum)massSpectra.getMassSpectrum(1);
+		assertEquals(5, standaloneMassSpectrum.getNumberOfIons());
+		assertEquals(5, standaloneMassSpectrum.getNumberOfIons());
+		assertEquals(1, standaloneMassSpectrum.getLowestIon().getIon());
+		assertEquals(6, standaloneMassSpectrum.getLowestIon().getAbundance());
+		assertEquals(5, standaloneMassSpectrum.getHighestIon().getIon());
+		assertEquals(10, standaloneMassSpectrum.getHighestIon().getAbundance());
+	}
+
+	@Test
+	public void testSecondSpectrum() {
+
+		IStandaloneMassSpectrum standaloneMassSpectrum = (IStandaloneMassSpectrum)massSpectra.getMassSpectrum(2);
+		assertEquals(5, standaloneMassSpectrum.getNumberOfIons());
+		assertEquals(5, standaloneMassSpectrum.getNumberOfIons());
+		assertEquals(1, standaloneMassSpectrum.getLowestIon().getIon());
+		assertEquals(10, standaloneMassSpectrum.getLowestIon().getAbundance());
+		assertEquals(5, standaloneMassSpectrum.getHighestIon().getIon());
+		assertEquals(6, standaloneMassSpectrum.getHighestIon().getAbundance());
+	}
+}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverterCompressed110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverterCompressed110_ITest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.TestPathHelper;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorMassSpectra;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class MassSpectrumImportConverterCompressed110_ITest {
+
+	private IVendorMassSpectra massSpectra;
+
+	@BeforeAll
+	public void setUp() {
+
+		File importFile = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_TINY1_COMPRESSED_1_1));
+		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();
+		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(importFile, new NullProgressMonitor());
+		massSpectra = (VendorMassSpectra)processingInfo.getProcessingResult();
+	}
+
+	@Test
+	public void testIons() {
+
+		assertEquals(2, massSpectra.getList().size());
+	}
+
+	@Test
+	public void testFirstSpectrum() {
+
+		IStandaloneMassSpectrum standaloneMassSpectrum = (IStandaloneMassSpectrum)massSpectra.getMassSpectrum(1);
+		assertEquals(5, standaloneMassSpectrum.getNumberOfIons());
+		assertEquals(5, standaloneMassSpectrum.getNumberOfIons());
+		assertEquals(1, standaloneMassSpectrum.getLowestIon().getIon());
+		assertEquals(6, standaloneMassSpectrum.getLowestIon().getAbundance());
+		assertEquals(5, standaloneMassSpectrum.getHighestIon().getIon());
+		assertEquals(10, standaloneMassSpectrum.getHighestIon().getAbundance());
+	}
+
+	@Test
+	public void testSecondSpectrum() {
+
+		IStandaloneMassSpectrum standaloneMassSpectrum = (IStandaloneMassSpectrum)massSpectra.getMassSpectrum(2);
+		assertEquals(5, standaloneMassSpectrum.getNumberOfIons());
+		assertEquals(5, standaloneMassSpectrum.getNumberOfIons());
+		assertEquals(1, standaloneMassSpectrum.getLowestIon().getIon());
+		assertEquals(10, standaloneMassSpectrum.getLowestIon().getAbundance());
+		assertEquals(5, standaloneMassSpectrum.getHighestIon().getIon());
+		assertEquals(6, standaloneMassSpectrum.getHighestIon().getAbundance());
+	}
+}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/testData/files/import/tiny1-centroided.mzML1.1.mzML
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/testData/files/import/tiny1-centroided.mzML1.1.mzML
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="tiny" version="">
+  <cvList count="2">
+    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="1.18.2" URI="http://psidev.cvs.sourceforge.net/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo"/>
+    <cv id="UO" fullName="Unit Ontology" version="04:03:2009" URI="http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/phenotype/unit.obo"/>
+  </cvList>
+  <run id="tiny">
+    <spectrumList count="2">
+      <spectrum index="0" id="S1" defaultArrayLength="5">
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
+        <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="40"/>
+        <binaryDataArrayList count="3">
+          <binaryDataArray>
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            <binary>AAAAAAAA8D8AAAAAAAAAQAAAAAAAAAhAAAAAAAAAEEAAAAAAAAAUQA==</binary>
+          </binaryDataArray>
+          <binaryDataArray>
+            <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of counts"/>
+            <binary>AADAQAAA4EAAAABBAAAQQQAAIEE=</binary>
+          </binaryDataArray>
+          <binaryDataArray>
+            <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000517" name="signal to noise array" value=""/>
+            <binary>AADAQAAA4EAAAABBAAAQQQAAIEE=</binary>
+          </binaryDataArray>
+        </binaryDataArrayList>
+      </spectrum>
+      <spectrum index="1" id="S2" defaultArrayLength="5">
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
+        <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="40"/>
+        <binaryDataArrayList count="2">
+          <binaryDataArray>
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            <binary>AAAAAAAA8D8AAAAAAAAAQAAAAAAAAAhAAAAAAAAAEEAAAAAAAAAUQA==</binary>
+          </binaryDataArray>
+          <binaryDataArray>
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of counts"/>
+            <binary>AAAAAAAAJEAAAAAAAAAiQAAAAAAAACBAAAAAAAAAHEAAAAAAAAAYQA==</binary>
+          </binaryDataArray>
+        </binaryDataArrayList>
+      </spectrum>
+    </spectrumList>
+  </run>
+</mzML>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/testData/files/import/tiny1-compressed.mzML1.1.mzML
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/testData/files/import/tiny1-compressed.mzML1.1.mzML
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="tiny" version="">
+  <cvList count="2">
+    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="1.18.2" URI="http://psidev.cvs.sourceforge.net/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo"/>
+    <cv id="UO" fullName="Unit Ontology" version="04:03:2009" URI="http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/phenotype/unit.obo"/>
+  </cvList>
+  <run id="tiny">
+    <spectrumList count="2">
+      <spectrum index="0" id="S1" defaultArrayLength="5">
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
+        <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="40"/>
+        <binaryDataArrayList count="2">
+          <binaryDataArray>
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            <binary>eJxjYACBD/YMEOAAoTigtACUFnEAADZ/Alw=</binary>
+          </binaryDataArray>
+          <binaryDataArray>
+            <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of counts"/>
+            <binary>eJxjYDjgwMDwAIgZHBkYBIBYwREAJcMDFA==</binary>
+          </binaryDataArray>
+        </binaryDataArrayList>
+      </spectrum>
+      <spectrum index="1" id="S2" defaultArrayLength="5">
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
+        <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="40"/>
+        <binaryDataArrayList count="2">
+          <binaryDataArray>
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            <binary>eJxjYACBD/YMEOAAoTigtACUFnEAADZ/Alw=</binary>
+          </binaryDataArray>
+          <binaryDataArray>
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of counts"/>
+            <binary>eJxjYAABFQcwxaAEpRWgtAyUlnAAACEsAds=</binary>
+          </binaryDataArray>
+        </binaryDataArrayList>
+      </spectrum>
+    </spectrumList>
+  </run>
+</mzML>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/testData/files/import/tiny1.mzML1.1.mzML
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/testData/files/import/tiny1.mzML1.1.mzML
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="tiny" version="">
+  <cvList count="2">
+    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="1.18.2" URI="http://psidev.cvs.sourceforge.net/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo"/>
+    <cv id="UO" fullName="Unit Ontology" version="04:03:2009" URI="http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/phenotype/unit.obo"/>
+  </cvList>
+  <run id="tiny">
+    <spectrumList count="2">
+      <spectrum index="0" id="S1" defaultArrayLength="5">
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
+        <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="40"/>
+        <binaryDataArrayList count="2">
+          <binaryDataArray>
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            <binary>AAAAAAAA8D8AAAAAAAAAQAAAAAAAAAhAAAAAAAAAEEAAAAAAAAAUQA==</binary>
+          </binaryDataArray>
+          <binaryDataArray>
+            <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of counts"/>
+            <binary>AADAQAAA4EAAAABBAAAQQQAAIEE=</binary>
+          </binaryDataArray>
+        </binaryDataArrayList>
+      </spectrum>
+      <spectrum index="1" id="S2" defaultArrayLength="5">
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
+        <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="40"/>
+        <binaryDataArrayList count="2">
+          <binaryDataArray>
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            <binary>AAAAAAAA8D8AAAAAAAAAQAAAAAAAAAhAAAAAAAAAEEAAAAAAAAAUQA==</binary>
+          </binaryDataArray>
+          <binaryDataArray>
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of counts"/>
+            <binary>AAAAAAAAJEAAAAAAAAAiQAAAAAAAACBAAAAAAAAAHEAAAAAAAAAYQA==</binary>
+          </binaryDataArray>
+        </binaryDataArrayList>
+      </spectrum>
+    </spectrumList>
+  </run>
+</mzML>


### PR DESCRIPTION
including integration tests. This is a followup to https://github.com/eclipse-chemclipse/chemclipse/pull/588 and https://github.com/eclipse-chemclipse/chemclipse/pull/2053.