### PR TITLE
Fix a crash when mzData description is missing.

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion104.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion104.java
@@ -30,6 +30,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.v104.model.
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.v104.model.DataProcessingType;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.v104.model.DataProcessingType.Software;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.v104.model.MzData;
+import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.v104.model.MzData.Description;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.v104.model.MzData.SpectrumList.Spectrum;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.v104.model.ObjectFactory;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.v104.model.ParamType;
@@ -217,7 +218,11 @@ public class ChromatogramReaderVersion104 extends AbstractChromatogramReader imp
 
 	private void readEditHistory(MzData mzData, IVendorChromatogram chromatogram) {
 
-		DataProcessingType dataProcessing = mzData.getDescription().getDataProcessing();
+		Description description = mzData.getDescription();
+		if(description == null) {
+			return;
+		}
+		DataProcessingType dataProcessing = description.getDataProcessing();
 		Software software = dataProcessing.getSoftware();
 		ParamType processingMethod = dataProcessing.getProcessingMethod();
 		if(processingMethod != null) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion105.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion105.java
@@ -240,7 +240,11 @@ public class ChromatogramReaderVersion105 extends AbstractChromatogramReader imp
 
 	private void readEditHistory(MzData mzData, IVendorChromatogram chromatogram) {
 
-		DataProcessingType dataProcessing = mzData.getDescription().getDataProcessing();
+		Description description = mzData.getDescription();
+		if(description == null) {
+			return;
+		}
+		DataProcessingType dataProcessing = description.getDataProcessing();
 		if(dataProcessing == null) {
 			return;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/v105/model/MzData.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/v105/model/MzData.java
@@ -28,12 +28,16 @@ import jakarta.xml.bind.annotation.XmlType;
 public class MzData {
 
 	private List<CvLookupType> cvLookup;
+
 	@XmlElement(required = true)
 	private Description description;
+
 	@XmlElement(required = true)
 	private SpectrumList spectrumList;
+
 	@XmlAttribute(name = "version", required = true)
 	private String version;
+
 	@XmlAttribute(name = "accessionNumber", required = true)
 	private String accessionNumber;
 


### PR DESCRIPTION
Description is a required field, but at least this data set didn't care: https://zenodo.org/records/3631074