### PR TITLE
Improved pseudo gel looks in dark mode

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ChromatogramHeatmapUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ChromatogramHeatmapUI.java
@@ -26,9 +26,7 @@ import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.support.ui.provider.AbstractLabelProvider;
 import org.eclipse.chemclipse.support.ui.swt.EnhancedComboViewer;
-import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
 import org.eclipse.chemclipse.swt.ui.components.InformationUI;
-import org.eclipse.chemclipse.swt.ui.support.Colors;
 import org.eclipse.chemclipse.ux.extension.ui.swt.IExtendedPartUI;
 import org.eclipse.chemclipse.ux.extension.ui.swt.ISettingsHandler;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
@@ -429,22 +427,15 @@ public class ChromatogramHeatmapUI extends Composite implements IExtendedPartUI 
 	private LightweightSystem createLightweightSystem(Canvas canvas) {
 
 		LightweightSystem lightweightSystem = new LightweightSystem(canvas);
-		if(PreferencesSupport.isDarkTheme()) {
-			lightweightSystem.getRootFigure().setBackgroundColor(Colors.BLACK);
-		} else {
-			lightweightSystem.getRootFigure().setBackgroundColor(Colors.WHITE);
-		}
+		lightweightSystem.getRootFigure().setBackgroundColor(getDisplay().getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
+
 		return lightweightSystem;
 	}
 
 	private IntensityGraphFigure createIntensityGraphFigure(boolean zoom) {
 
 		IntensityGraphFigure intensityGraphFigure = new IntensityGraphFigure(zoom);
-		if(PreferencesSupport.isDarkTheme()) {
-			intensityGraphFigure.setForegroundColor(Colors.WHITE);
-		} else {
-			intensityGraphFigure.setForegroundColor(Colors.BLACK);
-		}
+		intensityGraphFigure.setForegroundColor(getDisplay().getSystemColor(SWT.COLOR_WIDGET_FOREGROUND));
 		intensityGraphFigure.getXAxis().setTitle("Retention Time [min]");
 		intensityGraphFigure.getYAxis().setTitle("Trace");
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/MassSpectrumPseudoGelUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/MassSpectrumPseudoGelUI.java
@@ -20,7 +20,6 @@ import java.util.List;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
-import org.eclipse.chemclipse.swt.ui.support.Colors;
 import org.eclipse.chemclipse.ux.extension.ui.swt.IExtendedPartUI;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.part.support.EditorUpdateSupport;
 import org.eclipse.draw2d.LightweightSystem;
@@ -173,22 +172,14 @@ public class MassSpectrumPseudoGelUI extends Composite implements IExtendedPartU
 	private LightweightSystem createLightweightSystem(Canvas canvas) {
 
 		LightweightSystem lightweightSystem = new LightweightSystem(canvas);
-		if(PreferencesSupport.isDarkTheme()) {
-			lightweightSystem.getRootFigure().setBackgroundColor(Colors.BLACK);
-		} else {
-			lightweightSystem.getRootFigure().setBackgroundColor(Colors.WHITE);
-		}
+		lightweightSystem.getRootFigure().setBackgroundColor(getDisplay().getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
 		return lightweightSystem;
 	}
 
 	private IntensityGraphFigure createIntensityGraphFigure(boolean zoom) {
 
 		IntensityGraphFigure intensityGraphFigure = new IntensityGraphFigure(zoom);
-		if(PreferencesSupport.isDarkTheme()) {
-			intensityGraphFigure.setForegroundColor(Colors.WHITE);
-		} else {
-			intensityGraphFigure.setForegroundColor(Colors.BLACK);
-		}
+		intensityGraphFigure.setForegroundColor(getDisplay().getSystemColor(SWT.COLOR_WIDGET_FOREGROUND));
 		intensityGraphFigure.getXAxis().setTitle("Retention Time [min]");
 		intensityGraphFigure.getYAxis().setTitle("Trace");
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/MassSpectrumPseudoGelUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/MassSpectrumPseudoGelUI.java
@@ -124,7 +124,12 @@ public class MassSpectrumPseudoGelUI extends Composite implements IExtendedPartU
 	private LinkedHashMap<Double, RGB> getReversedGrayScaleMap() {
 
 		double[] values = new double[]{0, 1};
-		RGB[] colors = new RGB[]{new RGB(255, 255, 255), new RGB(0, 0, 0)};
+		RGB[] colors = new RGB[]{};
+		if(PreferencesSupport.isDarkTheme()) {
+			colors = new RGB[]{new RGB(0, 0, 0), new RGB(255, 255, 255)};
+		} else {
+			colors = new RGB[]{new RGB(255, 255, 255), new RGB(0, 0, 0)};
+		}
 		LinkedHashMap<Double, RGB> map = new LinkedHashMap<>();
 		for(int i = 0; i < values.length; i++) {
 			map.put(values[i], colors[i]);


### PR DESCRIPTION
also use standard widget colors which are not quite white and not quite black to not look too alien. This also applies to the chromatogram heatmap.