### PR TITLE
Use more subtle grid chart colors in both dark and bright mode

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
@@ -42,6 +42,7 @@ import org.eclipse.chemclipse.processing.supplier.IProcessorPreferences;
 import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 import org.eclipse.chemclipse.processing.system.ProcessSettingsSupport;
 import org.eclipse.chemclipse.processing.ui.support.ProcessingInfoPartSupport;
+import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
 import org.eclipse.chemclipse.ux.extension.msd.ui.handlers.DynamicHandler;
 import org.eclipse.chemclipse.ux.extension.msd.ui.internal.provider.UpdateMenuEntry;
 import org.eclipse.chemclipse.ux.extension.ui.editors.ProcessorSupplierMenuEntry;
@@ -63,6 +64,7 @@ import org.eclipse.swtchart.extensions.axisconverter.PercentageConverter;
 import org.eclipse.swtchart.extensions.barcharts.BarChart;
 import org.eclipse.swtchart.extensions.barcharts.BarSeriesData;
 import org.eclipse.swtchart.extensions.barcharts.IBarSeriesData;
+import org.eclipse.swtchart.extensions.core.IAxisSettings;
 import org.eclipse.swtchart.extensions.core.IChartSettings;
 import org.eclipse.swtchart.extensions.core.IPrimaryAxisSettings;
 import org.eclipse.swtchart.extensions.core.ISecondaryAxisSettings;
@@ -257,12 +259,12 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 	private void setPrimaryAxisSet(IChartSettings chartSettings) {
 
 		IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
-		primaryAxisSettingsX.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
+		setGridColor(primaryAxisSettingsX);
 		primaryAxisSettingsX.setTitle("m/z");
 		primaryAxisSettingsX.setDecimalFormat(new DecimalFormat(("0.0##"), new DecimalFormatSymbols(Locale.ENGLISH)));
 
 		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
-		primaryAxisSettingsY.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
+		setGridColor(primaryAxisSettingsY);
 		primaryAxisSettingsY.setTitle("Intensity");
 		primaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.0#E0"), new DecimalFormatSymbols(Locale.ENGLISH)));
 	}
@@ -270,7 +272,7 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 	private void addSecondaryAxisSet(IChartSettings chartSettings) {
 
 		ISecondaryAxisSettings secondaryAxisSettingsY = new SecondaryAxisSettings("Relative Intensity [%]", new PercentageConverter(SWT.VERTICAL, true));
-		secondaryAxisSettingsY.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
+		setGridColor(secondaryAxisSettingsY);
 		secondaryAxisSettingsY.setPosition(Position.Secondary);
 		secondaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.00"), new DecimalFormatSymbols(Locale.ENGLISH)));
 		chartSettings.getSecondaryAxisSettingsListY().add(secondaryAxisSettingsY);
@@ -348,6 +350,15 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 					}
 				}
 			});
+		}
+	}
+
+	private void setGridColor(IAxisSettings axisSettings) {
+
+		if(PreferencesSupport.isDarkTheme()) {
+			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_GRAY));
+		} else {
+			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
 		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
@@ -48,6 +48,7 @@ import org.eclipse.chemclipse.processing.supplier.IProcessorPreferences;
 import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 import org.eclipse.chemclipse.processing.system.ProcessSettingsSupport;
 import org.eclipse.chemclipse.processing.ui.support.ProcessingInfoPartSupport;
+import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
 import org.eclipse.chemclipse.ux.extension.msd.ui.handlers.DynamicHandler;
 import org.eclipse.chemclipse.ux.extension.msd.ui.internal.provider.UpdateMenuEntry;
 import org.eclipse.chemclipse.ux.extension.ui.editors.ProcessorSupplierMenuEntry;
@@ -75,6 +76,7 @@ import org.eclipse.swtchart.ILineSeries.PlotSymbolType;
 import org.eclipse.swtchart.IPlotArea;
 import org.eclipse.swtchart.LineStyle;
 import org.eclipse.swtchart.extensions.axisconverter.PercentageConverter;
+import org.eclipse.swtchart.extensions.core.IAxisSettings;
 import org.eclipse.swtchart.extensions.core.IChartSettings;
 import org.eclipse.swtchart.extensions.core.IPrimaryAxisSettings;
 import org.eclipse.swtchart.extensions.core.ISecondaryAxisSettings;
@@ -287,12 +289,12 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 	private void setPrimaryAxisSet(IChartSettings chartSettings) {
 
 		IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
-		primaryAxisSettingsX.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
+		setGridColor(primaryAxisSettingsX);
 		primaryAxisSettingsX.setTitle("m/z");
 		primaryAxisSettingsX.setDecimalFormat(new DecimalFormat(("0.0##"), new DecimalFormatSymbols(Locale.ENGLISH)));
 
 		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
-		primaryAxisSettingsY.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
+		setGridColor(primaryAxisSettingsY);
 		primaryAxisSettingsY.setTitle("Intensity");
 		primaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.0#E0"), new DecimalFormatSymbols(Locale.ENGLISH)));
 	}
@@ -300,7 +302,7 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 	private void addSecondaryAxisSet(IChartSettings chartSettings) {
 
 		ISecondaryAxisSettings secondaryAxisSettingsY = new SecondaryAxisSettings("Relative Intensity [%]", new PercentageConverter(SWT.VERTICAL, true));
-		secondaryAxisSettingsY.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
+		setGridColor(secondaryAxisSettingsY);
 		secondaryAxisSettingsY.setPosition(Position.Secondary);
 		secondaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.00"), new DecimalFormatSymbols(Locale.ENGLISH)));
 		chartSettings.getSecondaryAxisSettingsListY().add(secondaryAxisSettingsY);
@@ -454,6 +456,15 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 					}
 				}
 			});
+		}
+	}
+
+	private void setGridColor(IAxisSettings axisSettings) {
+
+		if(PreferencesSupport.isDarkTheme()) {
+			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_GRAY));
+		} else {
+			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
 		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChromatogramChart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChromatogramChart.java
@@ -198,7 +198,7 @@ public class ChromatogramChart extends LineChart implements IRangeSupport {
 		String patternNode = PreferenceSupplier.P_FORMAT_X_AXIS_MILLISECONDS;
 		String colorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_COLOR_X_AXIS_MILLISECONDS_DARKTHEME : PreferenceSupplier.P_COLOR_X_AXIS_MILLISECONDS;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_MILLISECONDS;
-		String gridColorNode = PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS;
+		String gridColorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_DARKTHEME : PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS;
 
 		ChartSupport.setAxisSettingsExtended(primaryAxisSettingsX, positionNode, patternNode, colorNode, gridLineStyleNode, gridColorNode);
 		primaryAxisSettingsX.setVisible(ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_MILLISECONDS));
@@ -220,7 +220,7 @@ public class ChromatogramChart extends LineChart implements IRangeSupport {
 		String patternNode = PreferenceSupplier.P_FORMAT_Y_AXIS_INTENSITY;
 		String colorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_COLOR_Y_AXIS_INTENSITY_DARKTHEME : PreferenceSupplier.P_COLOR_Y_AXIS_INTENSITY;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_Y_AXIS_INTENSITY;
-		String gridColorNode = PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_INTENSITY;
+		String gridColorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_INTENSITY_DARKTHEME : PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_INTENSITY;
 
 		ChartSupport.setAxisSettingsExtended(primaryAxisSettingsY, positionNode, patternNode, colorNode, gridLineStyleNode, gridColorNode);
 		primaryAxisSettingsY.setVisible(ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_Y_AXIS_INTENSITY));
@@ -241,7 +241,8 @@ public class ChromatogramChart extends LineChart implements IRangeSupport {
 		String patternNode = PreferenceSupplier.P_FORMAT_Y_AXIS_RELATIVE_INTENSITY;
 		String colorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME : PreferenceSupplier.P_COLOR_Y_AXIS_RELATIVE_INTENSITY;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY;
-		String gridColorNode = PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY;
+		String gridColorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME : PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY;
+
 		boolean isShowAxis = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_Y_AXIS_RELATIVE_INTENSITY);
 		boolean isShowAxisTitle = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY);
 
@@ -288,7 +289,7 @@ public class ChromatogramChart extends LineChart implements IRangeSupport {
 		String patternNode = PreferenceSupplier.P_FORMAT_X_AXIS_SECONDS;
 		String colorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_COLOR_X_AXIS_SECONDS_DARKTHEME : PreferenceSupplier.P_COLOR_X_AXIS_SECONDS;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_SECONDS;
-		String gridColorNode = PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_SECONDS;
+		String gridColorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_SECONDS_DARKTHEME : PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_SECONDS;
 		boolean isShowAxis = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_SECONDS);
 		boolean isShowAxisTitle = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_TITLE_SECONDS);
 
@@ -335,7 +336,7 @@ public class ChromatogramChart extends LineChart implements IRangeSupport {
 		String patternNode = PreferenceSupplier.P_FORMAT_X_AXIS_MINUTES;
 		String colorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_COLOR_X_AXIS_MINUTES_DARKTHEME : PreferenceSupplier.P_COLOR_X_AXIS_MINUTES;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_MINUTES;
-		String gridColorNode = PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MINUTES;
+		String gridColorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MINUTES_DARKTHEME : PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MINUTES;
 		boolean isShowAxis = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_MINUTES);
 		boolean isShowAxisTitle = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_TITLE_MINUTES);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisMilliseconds.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisMilliseconds.java
@@ -51,7 +51,11 @@ public class ChromatogramAxisMilliseconds extends FieldEditorPreferencePage impl
 		addField(new SpinnerFieldEditor(PreferenceSupplier.P_FONT_SIZE_X_AXIS_MILLISECONDS, ExtensionMessages.fontSize + ":", PreferenceSupplier.MIN_FONT_SIZE, PreferenceSupplier.MAX_FONT_SIZE, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_FONT_STYLE_X_AXIS_MILLISECONDS, ExtensionMessages.fontStyle + ":", ChartOptions.FONT_STYLES, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_MILLISECONDS, ExtensionMessages.gridLineStyle + ":", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
+		if(Display.isSystemDarkTheme()) {
+			addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_DARKTHEME, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
+		} else {
+			addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
+		}
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_TITLE_MILLISECONDS, ExtensionMessages.showAxisTitle + ":", getFieldEditorParent()));
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisMinutes.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisMinutes.java
@@ -51,7 +51,11 @@ public class ChromatogramAxisMinutes extends FieldEditorPreferencePage implement
 		addField(new SpinnerFieldEditor(PreferenceSupplier.P_FONT_SIZE_X_AXIS_MINUTES, ExtensionMessages.fontSize + ":", PreferenceSupplier.MIN_FONT_SIZE, PreferenceSupplier.MAX_FONT_SIZE, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_FONT_STYLE_X_AXIS_MINUTES, ExtensionMessages.fontStyle + ":", ChartOptions.FONT_STYLES, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_MINUTES, ExtensionMessages.gridLineStyle + ":", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MINUTES, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
+		if(PreferencesSupport.isDarkTheme()) {
+			addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MINUTES_DARKTHEME, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
+		} else {
+			addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MINUTES, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
+		}
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_TITLE_MINUTES, ExtensionMessages.showAxisTitle, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_LINE_MINUTES, ExtensionMessages.showAxisLine, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_POSITION_MARKER_MINUTES, ExtensionMessages.showAxisPositionMarker, getFieldEditorParent()));

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisRelativeIntensity.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisRelativeIntensity.java
@@ -51,7 +51,11 @@ public class ChromatogramAxisRelativeIntensity extends FieldEditorPreferencePage
 		addField(new SpinnerFieldEditor(PreferenceSupplier.P_FONT_SIZE_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.fontSize + ":", PreferenceSupplier.MIN_FONT_SIZE, PreferenceSupplier.MAX_FONT_SIZE, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_FONT_STYLE_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.fontStyle + ":", ChartOptions.FONT_STYLES, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.gridLineStyle + ":", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
+		if(PreferencesSupport.isDarkTheme()) {
+			addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
+		} else {
+			addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
+		}
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY, ExtensionMessages.showAxisTitle, getFieldEditorParent()));
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisSeconds.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisSeconds.java
@@ -51,7 +51,11 @@ public class ChromatogramAxisSeconds extends FieldEditorPreferencePage implement
 		addField(new SpinnerFieldEditor(PreferenceSupplier.P_FONT_SIZE_X_AXIS_SECONDS, ExtensionMessages.fontSize + ":", PreferenceSupplier.MIN_FONT_SIZE, PreferenceSupplier.MAX_FONT_SIZE, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_FONT_STYLE_X_AXIS_SECONDS, ExtensionMessages.fontStyle + ":", ChartOptions.FONT_STYLES, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_SECONDS, ExtensionMessages.gridLineStyle + ":", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_SECONDS, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
+		if(PreferencesSupport.isDarkTheme()) {
+			addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_SECONDS_DARKTHEME, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
+		} else {
+			addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_SECONDS, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
+		}
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_TITLE_SECONDS, ExtensionMessages.showAxisTitle, getFieldEditorParent()));
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
@@ -652,6 +652,8 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final String DEF_GRIDLINE_STYLE_X_AXIS_MILLISECONDS = LineStyle.NONE.toString();
 	public static final String P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS = "gridlineColorXAxisMilliseconds";
 	public static final String DEF_GRIDLINE_COLOR_X_AXIS_MILLISECONDS = "192,192,192";
+	public static final String P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_DARKTHEME = "gridlineColorXAxisMillisecondsDarkTheme";
+	public static final String DEF_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_DARKTHEME = "64, 64, 64";
 	public static final String P_SHOW_X_AXIS_TITLE_MILLISECONDS = "showXAxisTitleMilliseconds";
 	public static final boolean DEF_SHOW_X_AXIS_TITLE_MILLISECONDS = true;
 
@@ -700,6 +702,8 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final String DEF_GRIDLINE_STYLE_X_AXIS_SECONDS = LineStyle.NONE.toString();
 	public static final String P_GRIDLINE_COLOR_X_AXIS_SECONDS = "gridlineColorXAxisSeconds";
 	public static final String DEF_GRIDLINE_COLOR_X_AXIS_SECONDS = "192,192,192";
+	public static final String P_GRIDLINE_COLOR_X_AXIS_SECONDS_DARKTHEME = "gridlineColorXAxisSecondsDarkTheme";
+	public static final String DEF_GRIDLINE_COLOR_X_AXIS_SECONDS_DARKTHEME = "64, 64, 64";
 	public static final String P_SHOW_X_AXIS_TITLE_SECONDS = "showXAxisTitleSeconds";
 	public static final boolean DEF_SHOW_X_AXIS_TITLE_SECONDS = true;
 
@@ -724,6 +728,8 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final String DEF_GRIDLINE_STYLE_X_AXIS_MINUTES = LineStyle.DOT.toString();
 	public static final String P_GRIDLINE_COLOR_X_AXIS_MINUTES = "gridlineColorXAxisMinutes";
 	public static final String DEF_GRIDLINE_COLOR_X_AXIS_MINUTES = "192,192,192";
+	public static final String P_GRIDLINE_COLOR_X_AXIS_MINUTES_DARKTHEME = "gridlineColorXAxisMinutesDarkTheme";
+	public static final String DEF_GRIDLINE_COLOR_X_AXIS_MINUTES_DARKTHEME = "64, 64, 64";
 	public static final String P_SHOW_X_AXIS_TITLE_MINUTES = "showXAxisTitleMinutes";
 	public static final boolean DEF_SHOW_X_AXIS_TITLE_MINUTES = true;
 	public static final String P_SHOW_X_AXIS_LINE_MINUTES = "showXAxisLineMinutes";
@@ -776,6 +782,8 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final String DEF_GRIDLINE_STYLE_Y_AXIS_INTENSITY = LineStyle.NONE.toString();
 	public static final String P_GRIDLINE_COLOR_Y_AXIS_INTENSITY = "gridlineColorYAxisIntensity";
 	public static final String DEF_GRIDLINE_COLOR_Y_AXIS_INTENSITY = "192,192,192";
+	public static final String P_GRIDLINE_COLOR_Y_AXIS_INTENSITY_DARKTHEME = "gridlineColorYAxisIntensityDarkTheme";
+	public static final String DEF_GRIDLINE_COLOR_Y_AXIS_INTENSITY_DARKTHEME = "64, 64, 64";
 	public static final String P_SHOW_Y_AXIS_TITLE_INTENSITY = "showYAxisTitleIntensity";
 	public static final boolean DEF_SHOW_Y_AXIS_TITLE_INTENSITY = true;
 
@@ -800,6 +808,8 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final String DEF_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY = LineStyle.DOT.toString();
 	public static final String P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY = "gridlineColorYAxisRelativeIntensity";
 	public static final String DEF_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY = "192,192,192";
+	public static final String P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME = "gridlineColorYAxisRelativeIntensityDarkTheme";
+	public static final String DEF_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME = "64, 64, 64";
 	public static final String P_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY = "showYAxisTitleRelativeIntensity";
 	public static final boolean DEF_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY = true;
 
@@ -1356,6 +1366,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 		putDefault(P_FONT_STYLE_X_AXIS_MILLISECONDS, DEF_FONT_STYLE_X_AXIS_MILLISECONDS);
 		putDefault(P_GRIDLINE_STYLE_X_AXIS_MILLISECONDS, DEF_GRIDLINE_STYLE_X_AXIS_MILLISECONDS);
 		putDefault(P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS, DEF_GRIDLINE_COLOR_X_AXIS_MILLISECONDS);
+		putDefault(P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_DARKTHEME, DEF_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_DARKTHEME);
 		putDefault(P_SHOW_X_AXIS_TITLE_MILLISECONDS, DEF_SHOW_X_AXIS_TITLE_MILLISECONDS);
 
 		putDefault(P_TITLE_X_AXIS_RETENTION_INDEX, DEF_TITLE_X_AXIS_RETENTION_INDEX);
@@ -1382,6 +1393,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 		putDefault(P_FONT_STYLE_X_AXIS_SECONDS, DEF_FONT_STYLE_X_AXIS_SECONDS);
 		putDefault(P_GRIDLINE_STYLE_X_AXIS_SECONDS, DEF_GRIDLINE_STYLE_X_AXIS_SECONDS);
 		putDefault(P_GRIDLINE_COLOR_X_AXIS_SECONDS, DEF_GRIDLINE_COLOR_X_AXIS_SECONDS);
+		putDefault(P_GRIDLINE_COLOR_X_AXIS_SECONDS_DARKTHEME, DEF_GRIDLINE_COLOR_X_AXIS_SECONDS_DARKTHEME);
 		putDefault(P_SHOW_X_AXIS_TITLE_SECONDS, DEF_SHOW_X_AXIS_TITLE_SECONDS);
 
 		putDefault(P_TITLE_X_AXIS_MINUTES, DEF_TITLE_X_AXIS_MINUTES);
@@ -1395,6 +1407,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 		putDefault(P_FONT_STYLE_X_AXIS_MINUTES, DEF_FONT_STYLE_X_AXIS_MINUTES);
 		putDefault(P_GRIDLINE_STYLE_X_AXIS_MINUTES, DEF_GRIDLINE_STYLE_X_AXIS_MINUTES);
 		putDefault(P_GRIDLINE_COLOR_X_AXIS_MINUTES, DEF_GRIDLINE_COLOR_X_AXIS_MINUTES);
+		putDefault(P_GRIDLINE_COLOR_X_AXIS_MINUTES_DARKTHEME, DEF_GRIDLINE_COLOR_X_AXIS_MINUTES_DARKTHEME);
 		putDefault(P_SHOW_X_AXIS_TITLE_MINUTES, DEF_SHOW_X_AXIS_TITLE_MINUTES);
 		putDefault(P_SHOW_X_AXIS_LINE_MINUTES, DEF_SHOW_X_AXIS_LINE_MINUTES);
 		putDefault(P_SHOW_X_AXIS_POSITION_MARKER_MINUTES, DEF_SHOW_X_AXIS_POSITION_MARKER_MINUTES);
@@ -1423,6 +1436,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 		putDefault(P_FONT_STYLE_Y_AXIS_INTENSITY, DEF_FONT_STYLE_Y_AXIS_INTENSITY);
 		putDefault(P_GRIDLINE_STYLE_Y_AXIS_INTENSITY, DEF_GRIDLINE_STYLE_Y_AXIS_INTENSITY);
 		putDefault(P_GRIDLINE_COLOR_Y_AXIS_INTENSITY, DEF_GRIDLINE_COLOR_Y_AXIS_INTENSITY);
+		putDefault(P_GRIDLINE_COLOR_Y_AXIS_INTENSITY_DARKTHEME, DEF_GRIDLINE_COLOR_Y_AXIS_INTENSITY_DARKTHEME);
 		putDefault(P_SHOW_Y_AXIS_TITLE_INTENSITY, DEF_SHOW_Y_AXIS_TITLE_INTENSITY);
 
 		putDefault(P_TITLE_Y_AXIS_RELATIVE_INTENSITY, DEF_TITLE_Y_AXIS_RELATIVE_INTENSITY);
@@ -1436,6 +1450,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 		putDefault(P_FONT_STYLE_Y_AXIS_RELATIVE_INTENSITY, DEF_FONT_STYLE_Y_AXIS_RELATIVE_INTENSITY);
 		putDefault(P_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY, DEF_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY);
 		putDefault(P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY, DEF_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY);
+		putDefault(P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME, DEF_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME);
 		putDefault(P_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY, DEF_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY);
 
 		putDefault(P_CHROMATOGRAM_SELECTED_ACTION_ID, DEF_CHROMATOGRAM_SELECTED_ACTION_ID);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakChartUI.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.eclipse.chemclipse.csd.model.core.IPeakCSD;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
+import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
 import org.eclipse.chemclipse.swt.ui.support.Colors;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChartSupport;
@@ -25,12 +26,16 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferenceSupplier
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.PeakChartSupport;
 import org.eclipse.chemclipse.wsd.model.core.IPeakWSD;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swtchart.ILineSeries;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.core.ChartType;
+import org.eclipse.swtchart.extensions.core.IAxisSettings;
 import org.eclipse.swtchart.extensions.core.IChartSettings;
+import org.eclipse.swtchart.extensions.core.ISecondaryAxisSettings;
 import org.eclipse.swtchart.extensions.core.ISeriesData;
 import org.eclipse.swtchart.extensions.core.RangeRestriction;
 import org.eclipse.swtchart.extensions.core.ScrollableChart;
@@ -119,6 +124,8 @@ public class PeakChartUI extends ScrollableChart {
 		ChartSupport.clearSecondaryAxes(chartSettings);
 		ChartSupport.addSecondaryAxisX(chartSettings, titleX1);
 		ChartSupport.addSecondaryAxisY(chartSettings, titleY1);
+
+		setGridColor(chartSettings);
 	}
 
 	private void initialize() {
@@ -234,6 +241,28 @@ public class PeakChartUI extends ScrollableChart {
 			baseChart.suspendUpdate(false);
 			adjustRange(true);
 			baseChart.redraw();
+		}
+	}
+
+	private void setGridColor(IChartSettings chartSettings) {
+
+		setGridColor(chartSettings.getPrimaryAxisSettingsX());
+		setGridColor(chartSettings.getPrimaryAxisSettingsY());
+
+		for(ISecondaryAxisSettings secondaryAxisSettingsX : chartSettings.getSecondaryAxisSettingsListX()) {
+			setGridColor(secondaryAxisSettingsX);
+		}
+		for(ISecondaryAxisSettings secondaryAxisSettingsY : chartSettings.getSecondaryAxisSettingsListY()) {
+			setGridColor(secondaryAxisSettingsY);
+		}
+	}
+
+	private void setGridColor(IAxisSettings axisSettings) {
+
+		if(PreferencesSupport.isDarkTheme()) {
+			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_GRAY));
+		} else {
+			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
 		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakTracesUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakTracesUI.java
@@ -32,6 +32,7 @@ import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.support.IMarkedIons;
 import org.eclipse.chemclipse.msd.model.core.support.MarkedIons;
+import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
 import org.eclipse.chemclipse.swt.ui.support.Colors;
 import org.eclipse.chemclipse.swt.ui.support.IColorScheme;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
@@ -48,12 +49,16 @@ import org.eclipse.chemclipse.wsd.model.core.IPeakModelWSD;
 import org.eclipse.chemclipse.wsd.model.core.IScanSignalWSD;
 import org.eclipse.chemclipse.wsd.model.core.IScanWSD;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swtchart.ILineSeries;
 import org.eclipse.swtchart.IPlotArea;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.core.ChartType;
+import org.eclipse.swtchart.extensions.core.IAxisSettings;
 import org.eclipse.swtchart.extensions.core.IChartSettings;
+import org.eclipse.swtchart.extensions.core.ISecondaryAxisSettings;
 import org.eclipse.swtchart.extensions.core.ISeriesData;
 import org.eclipse.swtchart.extensions.core.RangeRestriction;
 import org.eclipse.swtchart.extensions.core.ScrollableChart;
@@ -292,6 +297,8 @@ public class PeakTracesUI extends ScrollableChart {
 		ChartSupport.addSecondaryAxisX(chartSettings, titleX1);
 		ChartSupport.addSecondaryAxisY(chartSettings, titleY1);
 
+		setGridColor(chartSettings);
+
 		BaseChart baseChart = getBaseChart();
 		IPlotArea plotArea = baseChart.getPlotArea();
 		plotArea.addCustomPaintListener(peakTracesOffsetListener);
@@ -325,6 +332,28 @@ public class PeakTracesUI extends ScrollableChart {
 			baseChart.suspendUpdate(false);
 			adjustRange(true);
 			baseChart.redraw();
+		}
+	}
+
+	private void setGridColor(IChartSettings chartSettings) {
+
+		setGridColor(chartSettings.getPrimaryAxisSettingsX());
+		setGridColor(chartSettings.getPrimaryAxisSettingsY());
+
+		for(ISecondaryAxisSettings secondaryAxisSettingsX : chartSettings.getSecondaryAxisSettingsListX()) {
+			setGridColor(secondaryAxisSettingsX);
+		}
+		for(ISecondaryAxisSettings secondaryAxisSettingsY : chartSettings.getSecondaryAxisSettingsListY()) {
+			setGridColor(secondaryAxisSettingsY);
+		}
+	}
+
+	private void setGridColor(IAxisSettings axisSettings) {
+
+		if(PreferencesSupport.isDarkTheme()) {
+			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_GRAY));
+		} else {
+			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
 		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
@@ -30,6 +30,7 @@ import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.support.ScanSupport;
 import org.eclipse.chemclipse.support.text.ValueFormat;
 import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
+import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
 import org.eclipse.chemclipse.swt.ui.support.Colors;
 import org.eclipse.chemclipse.swt.ui.support.Fonts;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
@@ -48,6 +49,7 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swtchart.IAxis;
 import org.eclipse.swtchart.IBarSeries;
 import org.eclipse.swtchart.IBarSeries.BarWidthStyle;
@@ -58,6 +60,7 @@ import org.eclipse.swtchart.extensions.barcharts.IBarSeriesData;
 import org.eclipse.swtchart.extensions.barcharts.IBarSeriesSettings;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.core.ChartType;
+import org.eclipse.swtchart.extensions.core.IAxisSettings;
 import org.eclipse.swtchart.extensions.core.IChartSettings;
 import org.eclipse.swtchart.extensions.core.IPrimaryAxisSettings;
 import org.eclipse.swtchart.extensions.core.ISecondaryAxisSettings;
@@ -571,7 +574,12 @@ public class ScanChartUI extends ScrollableChart {
 		chartSettings.setTitle("");
 		chartSettings.setCreateMenu(true);
 		chartSettings.setEnableCompress(enableCompress);
+
 		IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
+		setGridColor(primaryAxisSettingsX);
+
+		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
+		setGridColor(primaryAxisSettingsY);
 
 		RangeRestriction rangeRestriction = chartSettings.getRangeRestriction();
 		rangeRestriction.setRestrictFrame(true);
@@ -628,8 +636,9 @@ public class ScanChartUI extends ScrollableChart {
 				break;
 		}
 
-		for(ISecondaryAxisSettings secondaryAxisSettings : chartSettings.getSecondaryAxisSettingsListY()) {
-			secondaryAxisSettings.setDecimalFormat(new DecimalFormat());
+		for(ISecondaryAxisSettings secondaryAxisSettingsY : chartSettings.getSecondaryAxisSettingsListY()) {
+			secondaryAxisSettingsY.setDecimalFormat(new DecimalFormat());
+			setGridColor(secondaryAxisSettingsY);
 		}
 
 		applySettings(chartSettings);
@@ -819,5 +828,14 @@ public class ScanChartUI extends ScrollableChart {
 			}
 		}
 		return barSeriesIons;
+	}
+
+	private void setGridColor(IAxisSettings axisSettings) {
+
+		if(PreferencesSupport.isDarkTheme()) {
+			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_GRAY));
+		} else {
+			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
+		}
 	}
 }


### PR DESCRIPTION
The default colors chosen in https://github.com/eclipse-swtchart/swtchart/pull/509 are too intense.