### PR TITLE
Use a darker gray for MS grid lines in dark mode

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
@@ -43,6 +43,7 @@ import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 import org.eclipse.chemclipse.processing.system.ProcessSettingsSupport;
 import org.eclipse.chemclipse.processing.ui.support.ProcessingInfoPartSupport;
 import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
+import org.eclipse.chemclipse.swt.ui.support.Colors;
 import org.eclipse.chemclipse.ux.extension.msd.ui.handlers.DynamicHandler;
 import org.eclipse.chemclipse.ux.extension.msd.ui.internal.provider.UpdateMenuEntry;
 import org.eclipse.chemclipse.ux.extension.ui.editors.ProcessorSupplierMenuEntry;
@@ -54,9 +55,9 @@ import org.eclipse.core.commands.Command;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtchart.IAxis.Position;
@@ -356,9 +357,9 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 	private void setGridColor(IAxisSettings axisSettings) {
 
 		if(PreferencesSupport.isDarkTheme()) {
-			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_GRAY));
+			axisSettings.setGridColor(Colors.getColor(new RGB(64, 64, 64)));
 		} else {
-			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
+			axisSettings.setGridColor(Colors.GRAY);
 		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
@@ -49,6 +49,7 @@ import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 import org.eclipse.chemclipse.processing.system.ProcessSettingsSupport;
 import org.eclipse.chemclipse.processing.ui.support.ProcessingInfoPartSupport;
 import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
+import org.eclipse.chemclipse.swt.ui.support.Colors;
 import org.eclipse.chemclipse.ux.extension.msd.ui.handlers.DynamicHandler;
 import org.eclipse.chemclipse.ux.extension.msd.ui.internal.provider.UpdateMenuEntry;
 import org.eclipse.chemclipse.ux.extension.ui.editors.ProcessorSupplierMenuEntry;
@@ -66,9 +67,9 @@ import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtchart.IAxis.Position;
@@ -462,9 +463,9 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 	private void setGridColor(IAxisSettings axisSettings) {
 
 		if(PreferencesSupport.isDarkTheme()) {
-			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_GRAY));
+			axisSettings.setGridColor(Colors.getColor(new RGB(64, 64, 64)));
 		} else {
-			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
+			axisSettings.setGridColor(Colors.GRAY);
 		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakChartUI.java
@@ -26,10 +26,9 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferenceSupplier
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.PeakChartSupport;
 import org.eclipse.chemclipse.wsd.model.core.IPeakWSD;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swtchart.ILineSeries;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.core.ChartType;
@@ -260,9 +259,9 @@ public class PeakChartUI extends ScrollableChart {
 	private void setGridColor(IAxisSettings axisSettings) {
 
 		if(PreferencesSupport.isDarkTheme()) {
-			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_GRAY));
+			axisSettings.setGridColor(Colors.getColor(new RGB(64, 64, 64)));
 		} else {
-			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
+			axisSettings.setGridColor(Colors.GRAY);
 		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakTracesUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakTracesUI.java
@@ -49,9 +49,8 @@ import org.eclipse.chemclipse.wsd.model.core.IPeakModelWSD;
 import org.eclipse.chemclipse.wsd.model.core.IScanSignalWSD;
 import org.eclipse.chemclipse.wsd.model.core.IScanWSD;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swtchart.ILineSeries;
 import org.eclipse.swtchart.IPlotArea;
 import org.eclipse.swtchart.extensions.core.BaseChart;
@@ -351,9 +350,9 @@ public class PeakTracesUI extends ScrollableChart {
 	private void setGridColor(IAxisSettings axisSettings) {
 
 		if(PreferencesSupport.isDarkTheme()) {
-			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_GRAY));
+			axisSettings.setGridColor(Colors.getColor(new RGB(64, 64, 64)));
 		} else {
-			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
+			axisSettings.setGridColor(Colors.GRAY);
 		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
@@ -48,8 +48,8 @@ import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swtchart.IAxis;
 import org.eclipse.swtchart.IBarSeries;
 import org.eclipse.swtchart.IBarSeries.BarWidthStyle;
@@ -833,9 +833,9 @@ public class ScanChartUI extends ScrollableChart {
 	private void setGridColor(IAxisSettings axisSettings) {
 
 		if(PreferencesSupport.isDarkTheme()) {
-			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_GRAY));
+			axisSettings.setGridColor(Colors.getColor(new RGB(64, 64, 64)));
 		} else {
-			axisSettings.setGridColor(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
+			axisSettings.setGridColor(Colors.GRAY);
 		}
 	}
 }


### PR DESCRIPTION
A small follow-up to https://github.com/eclipse-chemclipse/chemclipse/pull/2448 to align chromatogram chart and mass spectra chart in dark mode. The more subtle, darker gray works much better; otherwise, the grid is too noisy. For comparison:

| Name           | R   | G   | B   |
|----------------|-----|-----|-----|
| Gray           | 192 | 192 | 192 |
| Dark Gray      | 128 | 128 | 128 |
| "Darker Gray"  |  64 |  64 |  64 |