### PR TITLE
Remove supplier scan

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/AbstractChromatogramSignalFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/core/chromatogram/AbstractChromatogramSignalFilter.java
@@ -101,7 +101,7 @@ public abstract class AbstractChromatogramSignalFilter extends AbstractChromatog
 			Iterator<Integer> itScan = totalSignals.iterator();
 			while(itScan.hasNext()) {
 				Integer scan = itScan.next();
-				IScanCSD scanCSD = chromatogramCSD.getSupplierScan(scan);
+				IScanCSD scanCSD = chromatogramCSD.getScan(scan);
 				ITotalScanSignal totalscanSignal = totalSignals.getTotalScanSignal(scan);
 				scanCSD.adjustTotalSignal(totalscanSignal.getTotalSignal());
 			}
@@ -135,7 +135,7 @@ public abstract class AbstractChromatogramSignalFilter extends AbstractChromatog
 		if(chromatogramFilterResult.getResultStatus().equals(ResultStatus.OK)) {
 			while(itScan.hasNext()) {
 				Integer scan = itScan.next();
-				IScanMSD scanMSD = chromatogramMSD.getSupplierScan(scan);
+				IScanMSD scanMSD = chromatogramMSD.getScan(scan);
 				ITotalScanSignal totalscanSignal = totalSignals.getTotalScanSignal(scan);
 				scanMSD.adjustTotalSignal(totalscanSignal.getTotalSignal());
 			}
@@ -173,7 +173,7 @@ public abstract class AbstractChromatogramSignalFilter extends AbstractChromatog
 			float wavelength = totalSignals.getWavelength();
 			while(itScan.hasNext()) {
 				int scan = itScan.next();
-				Optional<IScanSignalWSD> optionalSignal = chromatogramWSD.getSupplierScan(scan).getScanSignal(wavelength);
+				Optional<IScanSignalWSD> optionalSignal = chromatogramWSD.getScan(scan).getScanSignal(wavelength);
 				if(optionalSignal.isPresent()) {
 					IScanSignalWSD scanSignal = optionalSignal.get();
 					IExtractedSingleWavelengthSignal totalSignal = totalSignals.getTotalScanSignal(scan);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/internal/core/support/Calculator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/internal/core/support/Calculator.java
@@ -53,7 +53,7 @@ public class Calculator {
 		 * Extract the ion abundance values.
 		 */
 		for(int scan = startScan; scan <= stopScan; scan++) {
-			IExtractedIonSignal scanSignals = chromatogram.getSupplierScan(scan).getExtractedIonSignal();
+			IExtractedIonSignal scanSignals = chromatogram.getScan(scan).getExtractedIonSignal();
 			for(Integer ion = scanSignals.getStartIon(); ion <= scanSignals.getStopIon(); ion++) {
 				/*
 				 * If there is still an abundance for the ion in the map, than add the signal.

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/ChromatogramFilterMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/ChromatogramFilterMSD.java
@@ -23,7 +23,6 @@ import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.prefe
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.settings.ChromatogramFilterSettings;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.msd.model.xic.IExtractedIonSignals;
@@ -73,8 +72,6 @@ public class ChromatogramFilterMSD extends AbstractChromatogramFilterMSD {
 		 */
 		BackfoldingShifter backfoldingShifter = new BackfoldingShifter();
 		IExtractedIonSignals extractedIonSignals = backfoldingShifter.shiftIons(chromatogramSelection, filterSettings, monitor);
-		IScanMSD massSpectrum;
-		IRegularMassSpectrum supplierMassSpectrum;
 		/*
 		 * Use the start and stop scan range.
 		 */
@@ -86,8 +83,8 @@ public class ChromatogramFilterMSD extends AbstractChromatogramFilterMSD {
 		 * backfolding algorithm.
 		 */
 		for(int scan = startScan; scan <= stopScan; scan++) {
-			massSpectrum = extractedIonSignals.getScan(scan);
-			supplierMassSpectrum = chromatogram.getSupplierScan(scan);
+			IScanMSD massSpectrum = extractedIonSignals.getScan(scan);
+			IScanMSD supplierMassSpectrum = chromatogram.getScan(scan);
 			supplierMassSpectrum.removeAllIons();
 			for(IIon ion : massSpectrum.getIons()) {
 				supplierMassSpectrum.addIon(ion, false);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/core/ChromatogramFilterMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/core/ChromatogramFilterMSD.java
@@ -24,7 +24,7 @@ import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.exceptions.F
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.settings.FilterSettings;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.msd.model.core.support.IMarkedIons;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -81,7 +81,6 @@ public class ChromatogramFilterMSD extends AbstractChromatogramFilterMSD {
 		/*
 		 * Exclude the calculated ions from each scan.
 		 */
-		IRegularMassSpectrum supplierMassSpectrum;
 		IChromatogramMSD chromatogram = chromatogramSelection.getChromatogram();
 		int startScan = chromatogram.getScanNumber(chromatogramSelection.getStartRetentionTime());
 		int stopScan = chromatogram.getScanNumber(chromatogramSelection.getStopRetentionTime());
@@ -90,8 +89,8 @@ public class ChromatogramFilterMSD extends AbstractChromatogramFilterMSD {
 		 * ions.
 		 */
 		for(int scan = startScan; scan <= stopScan; scan++) {
-			supplierMassSpectrum = chromatogram.getSupplierScan(scan);
-			supplierMassSpectrum.removeIons(excludedIons);
+			IScanMSD massSpectrum = chromatogram.getScan(scan);
+			massSpectrum.removeIons(excludedIons);
 		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/DenoiseOperation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/DenoiseOperation.java
@@ -17,7 +17,7 @@ import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.exceptions.NoExtractedIonSignalStoredException;
 import org.eclipse.chemclipse.msd.model.implementation.Ion;
 import org.eclipse.chemclipse.msd.model.xic.ExtractedIonSignals;
@@ -77,7 +77,7 @@ public class DenoiseOperation extends AbstractOperation {
 		for(int scan = startScan; scan <= stopScan; scan++) {
 			try {
 				IExtractedIonSignal extractedIonSignal = extractedIonSignals.getExtractedIonSignal(scan);
-				IRegularMassSpectrum supplierMassSpectrum = chromatogram.getSupplierScan(scan);
+				IScanMSD supplierMassSpectrum = chromatogram.getScan(scan);
 				previousExtractedIonSignals.add(supplierMassSpectrum.getExtractedIonSignal());
 				replaceIons(extractedIonSignal, supplierMassSpectrum);
 			} catch(NoExtractedIonSignalStoredException e) {
@@ -115,7 +115,7 @@ public class DenoiseOperation extends AbstractOperation {
 		for(int scan = startScan; scan <= stopScan; scan++) {
 			try {
 				IExtractedIonSignal extractedIonSignal = previousExtractedIonSignals.getExtractedIonSignal(scan);
-				IRegularMassSpectrum supplierMassSpectrum = chromatogram.getSupplierScan(scan);
+				IScanMSD supplierMassSpectrum = chromatogram.getScan(scan);
 				replaceIons(extractedIonSignal, supplierMassSpectrum);
 			} catch(NoExtractedIonSignalStoredException e) {
 				logger.warn(e);
@@ -130,9 +130,9 @@ public class DenoiseOperation extends AbstractOperation {
 	 * fragments stored in the extracted ion signal.
 	 * 
 	 * @param extractedIonSignal
-	 * @param supplierMassSpectrum
+	 * @param massSpectrum
 	 */
-	private static void replaceIons(IExtractedIonSignal extractedIonSignal, IRegularMassSpectrum supplierMassSpectrum) {
+	private static void replaceIons(IExtractedIonSignal extractedIonSignal, IScanMSD massSpectrum) {
 
 		int startIon = extractedIonSignal.getStartIon();
 		int stopIon = extractedIonSignal.getStopIon();
@@ -140,7 +140,7 @@ public class DenoiseOperation extends AbstractOperation {
 		/*
 		 * Remove all ions.
 		 */
-		supplierMassSpectrum.removeAllIons();
+		massSpectrum.removeAllIons();
 		IIon defaultIon;
 		/*
 		 * Add the new ion values if abundance > 0.0f.
@@ -149,7 +149,7 @@ public class DenoiseOperation extends AbstractOperation {
 			abundance = extractedIonSignal.getAbundance(ion);
 			if(abundance > 0.0f) {
 				defaultIon = new Ion(ion, abundance);
-				supplierMassSpectrum.addIon(defaultIon);
+				massSpectrum.addIon(defaultIon);
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/ionremover/core/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/ionremover/core/ChromatogramFilter.java
@@ -22,7 +22,7 @@ import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover.prefer
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover.settings.ChromatogramFilterSettings;
 import org.eclipse.chemclipse.model.core.MarkedTraceModus;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.msd.model.core.support.IMarkedIons;
 import org.eclipse.chemclipse.msd.model.core.support.MarkedIons;
@@ -81,7 +81,6 @@ public class ChromatogramFilter extends AbstractChromatogramFilterMSD {
 		if(ionsToRemove.getIonsNominal().isEmpty()) {
 			throw new FilterException("There was no ion stored to be excluded.");
 		}
-		IRegularMassSpectrum supplierMassSpectrum;
 		IChromatogramMSD chromatogram = chromatogramSelection.getChromatogram();
 		int startScan = chromatogram.getScanNumber(chromatogramSelection.getStartRetentionTime());
 		int stopScan = chromatogram.getScanNumber(chromatogramSelection.getStopRetentionTime());
@@ -91,8 +90,8 @@ public class ChromatogramFilter extends AbstractChromatogramFilterMSD {
 		 */
 		for(int scan = startScan; scan <= stopScan; scan++) {
 			monitor.subTask("Remove ions from scan: " + scan);
-			supplierMassSpectrum = chromatogram.getSupplierScan(scan);
-			supplierMassSpectrum.removeIons(ionsToRemove);
+			IScanMSD massSpectrum = chromatogram.getScan(scan);
+			massSpectrum.removeIons(ionsToRemove);
 		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.sumarea/src/org/eclipse/chemclipse/chromatogram/msd/integrator/supplier/sumarea/internal/core/BackgroundIntegrator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.sumarea/src/org/eclipse/chemclipse/chromatogram/msd/integrator/supplier/sumarea/internal/core/BackgroundIntegrator.java
@@ -17,7 +17,7 @@ import org.eclipse.chemclipse.model.baseline.IBaselineModel;
 import org.eclipse.chemclipse.model.exceptions.ChromatogramIsNullException;
 import org.eclipse.chemclipse.msd.model.core.AbstractIon;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.msd.model.xic.ExtractedIonSignalExtractor;
 import org.eclipse.chemclipse.msd.model.xic.IExtractedIonSignal;
@@ -50,8 +50,6 @@ public class BackgroundIntegrator extends AbstractSumareaIntegrator implements I
 			IExtractedIonSignals extractedIonSignals = extractedIonSignalExtractor.getExtractedIonSignals(chromatogramSelection);
 			IExtractedIonSignal startSignal;
 			IExtractedIonSignal stopSignal;
-			IRegularMassSpectrum supplierMassSpectrumStart;
-			IRegularMassSpectrum supplierMassSpectrumStop;
 			int start;
 			int stop;
 			double ionPercentage = 0.0d;
@@ -63,8 +61,8 @@ public class BackgroundIntegrator extends AbstractSumareaIntegrator implements I
 				try {
 					startSignal = extractedIonSignals.getExtractedIonSignal(scan);
 					stopSignal = extractedIonSignals.getExtractedIonSignal(scan + 1);
-					supplierMassSpectrumStart = chromatogram.getSupplierScan(scan);
-					supplierMassSpectrumStop = chromatogram.getSupplierScan(scan + 1);
+					IScanMSD supplierMassSpectrumStart = chromatogram.getScan(scan);
+					IScanMSD supplierMassSpectrumStop = chromatogram.getScan(scan + 1);
 					ionPercentage = calculateIonPercentageOfScans(supplierMassSpectrumStart, supplierMassSpectrumStop, ion);
 					if(startSignal != null && stopSignal != null) {
 						start = startSignal.getRetentionTime();
@@ -84,10 +82,10 @@ public class BackgroundIntegrator extends AbstractSumareaIntegrator implements I
 		return backgroundArea;
 	}
 
-	private double calculateIonPercentageOfScans(IRegularMassSpectrum supplierMassSpectrumStart, IRegularMassSpectrum supplierMassSpectrumStop, int ion) {
+	private double calculateIonPercentageOfScans(IScanMSD massSpectrumStart, IScanMSD massSpectrumStop, int ion) {
 
-		IExtractedIonSignal extractedIonSignalStart = supplierMassSpectrumStart.getExtractedIonSignal();
-		IExtractedIonSignal extractedIonSignalStop = supplierMassSpectrumStop.getExtractedIonSignal();
+		IExtractedIonSignal extractedIonSignalStart = massSpectrumStart.getExtractedIonSignal();
+		IExtractedIonSignal extractedIonSignalStop = massSpectrumStop.getExtractedIonSignal();
 		double percentageStartSignal = 0.0d;
 		float startSignal = extractedIonSignalStart.getTotalSignal();
 		if(startSignal > 0) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/calculator/operations/SavitzkyGolayTotalScanSignalOperation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/calculator/operations/SavitzkyGolayTotalScanSignalOperation.java
@@ -119,7 +119,7 @@ public class SavitzkyGolayTotalScanSignalOperation extends AbstractOperation imp
 		Iterator<Integer> iteratorScan = totalSignals.iterator();
 		while(iteratorScan.hasNext()) {
 			Integer scan = iteratorScan.next();
-			IScanMSD scanMSD = chromatogram.getSupplierScan(scan);
+			IScanMSD scanMSD = chromatogram.getScan(scan);
 			ITotalScanSignal totalscanSignal = totalSignals.getTotalScanSignal(scan);
 			scanMSD.adjustTotalSignal(totalscanSignal.getTotalSignal());
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/core/ChromatogramFilterCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/core/ChromatogramFilterCSD.java
@@ -71,7 +71,7 @@ public class ChromatogramFilterCSD extends AbstractChromatogramFilterCSD {
 		Iterator<Integer> iteratorScans = totalSignals.iterator();
 		while(iteratorScans.hasNext()) {
 			Integer scan = iteratorScans.next();
-			IScanCSD scanCSD = chromatogram.getSupplierScan(scan);
+			IScanCSD scanCSD = chromatogram.getScan(scan);
 			ITotalScanSignal totalscanSignal = totalSignals.getTotalScanSignal(scan);
 			scanCSD.adjustTotalSignal(totalscanSignal.getTotalSignal());
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/core/ChromatogramFilterWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/core/ChromatogramFilterWSD.java
@@ -45,7 +45,7 @@ public class ChromatogramFilterWSD extends AbstractChromatogramFilterWSD {
 			Iterator<Integer> iteratorScan = totalSignals.iterator();
 			while(iteratorScan.hasNext()) {
 				Integer scan = iteratorScan.next();
-				IScanWSD scanWSD = chromatogramWSD.getSupplierScan(scan);
+				IScanWSD scanWSD = chromatogramWSD.getScan(scan);
 				ITotalScanSignal totalscanSignal = totalSignals.getTotalScanSignal(scan);
 				scanWSD.adjustTotalSignal(totalscanSignal.getTotalSignal());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/AbstractChromatogramCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/AbstractChromatogramCSD.java
@@ -31,7 +31,7 @@ public abstract class AbstractChromatogramCSD extends AbstractChromatogram imple
 	private static final long serialVersionUID = -1514838958855146167L;
 
 	@Override
-	public IScanCSD getSupplierScan(int scan) {
+	public IScanCSD getScan(int scan) {
 
 		int position = scan;
 		if(position > 0 && position <= getScans().size()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/IChromatogramCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/IChromatogramCSD.java
@@ -16,5 +16,6 @@ import org.eclipse.chemclipse.model.core.IChromatogram;
 
 public interface IChromatogramCSD extends IChromatogram, IChromatogramPeaksCSD {
 
-	IScanCSD getSupplierScan(int scan);
+	@Override
+	IScanCSD getScan(int scan);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/selection/ChromatogramSelectionCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/selection/ChromatogramSelectionCSD.java
@@ -85,7 +85,7 @@ public class ChromatogramSelectionCSD extends AbstractChromatogramSelection impl
 			 * Chromatogram CSD
 			 */
 			if(chromatogram instanceof IChromatogramCSD chromatogramCSD) {
-				selectedScan = chromatogramCSD.getSupplierScan(1);
+				selectedScan = chromatogramCSD.getScan(1);
 			}
 		} else {
 			selectedScan = null;

--- a/chemclipse/plugins/org.eclipse.chemclipse.fsd.model/src/org/eclipse/chemclipse/fsd/model/core/IChromatogramFSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.fsd.model/src/org/eclipse/chemclipse/fsd/model/core/IChromatogramFSD.java
@@ -25,7 +25,8 @@ public interface IChromatogramFSD extends IChromatogram, IChromatogramBaselineFS
 	 * @param scan
 	 * @return {@link IScanFSD}
 	 */
-	IScanFSD getSupplierScan(int scan);
+	@Override
+	IScanFSD getScan(int scan);
 
 	/**
 	 * 

--- a/chemclipse/plugins/org.eclipse.chemclipse.fsd.model/src/org/eclipse/chemclipse/fsd/model/core/implementation/AbstractChromatogramFSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.fsd.model/src/org/eclipse/chemclipse/fsd/model/core/implementation/AbstractChromatogramFSD.java
@@ -51,13 +51,13 @@ public abstract class AbstractChromatogramFSD extends AbstractChromatogram imple
 
 		Set<Float> wavelengths = new HashSet<>();
 		for(int i = 1; i < getNumberOfScans(); i++) {
-			getSupplierScan(i).getScanSignals().forEach(signal -> wavelengths.add(signal.getWavelength()));
+			getScan(i).getScanSignals().forEach(signal -> wavelengths.add(signal.getWavelength()));
 		}
 		return wavelengths;
 	}
 
 	@Override
-	public IScanFSD getSupplierScan(int scan) {
+	public IScanFSD getScan(int scan) {
 
 		int position = scan;
 		if(position > 0 && position <= getScans().size()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.fsd.model/src/org/eclipse/chemclipse/fsd/model/core/selection/ChromatogramSelectionFSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.fsd.model/src/org/eclipse/chemclipse/fsd/model/core/selection/ChromatogramSelectionFSD.java
@@ -101,7 +101,7 @@ public class ChromatogramSelectionFSD extends AbstractChromatogramSelection impl
 			 * Chromatogram FSD
 			 */
 			if(chromatogram instanceof IChromatogramFSD chromatogramFSD) {
-				selectedScan = chromatogramFSD.getSupplierScan(1);
+				selectedScan = chromatogramFSD.getScan(1);
 			}
 		} else {
 			selectedScan = null;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogramMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogramMSD.java
@@ -124,21 +124,21 @@ public abstract class AbstractChromatogramMSD extends AbstractChromatogram imple
 	@Override
 	public IScanMSD getScan(int scan, IMarkedIons excludedIons) {
 
-		IRegularMassSpectrum supplierMassSpectrum = getSupplierScan(scan);
-		if(supplierMassSpectrum == null) {
+		IScanMSD scanMSD = getScan(scan);
+		if(scanMSD == null) {
 			return null;
 		}
-		return supplierMassSpectrum.getMassSpectrum(excludedIons);
+		return scanMSD.getMassSpectrum(excludedIons);
 	}
 
 	@Override
-	public IRegularMassSpectrum getSupplierScan(int scan) {
+	public IScanMSD getScan(int scan) {
 
 		int position = scan;
 		if(position > 0 && position <= getScans().size()) {
 			IScan storedScan = getScans().get(--position);
-			if(storedScan instanceof IRegularMassSpectrum regularMassSpectrum) {
-				return regularMassSpectrum;
+			if(storedScan instanceof IScanMSD scanMSD) {
+				return scanMSD;
 			}
 		}
 		return null;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogramPeakMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogramPeakMSD.java
@@ -56,7 +56,7 @@ public abstract class AbstractChromatogramPeakMSD extends AbstractPeakMSD implem
 	@Override
 	public IScanMSD getChromatogramMassSpectrum() {
 
-		return chromatogram.getSupplierScan(getScanMax());
+		return chromatogram.getScan(getScanMax());
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IChromatogramMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IChromatogramMSD.java
@@ -45,9 +45,10 @@ public interface IChromatogramMSD extends IChromatogram, IChromatogramPeaksMSD {
 	 * scan mass spectrum is stored.
 	 * 
 	 * @param scan
-	 * @return {@link IRegularMassSpectrum}
+	 * @return {@link IScanMSD}
 	 */
-	IRegularMassSpectrum getSupplierScan(int scan);
+	@Override
+	IScanMSD getScan(int scan);
 
 	/**
 	 * Returns the number of scanned ions.<br/>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelectionMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelectionMSD.java
@@ -26,6 +26,7 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.support.IMarkedIonTransitions;
 import org.eclipse.chemclipse.msd.model.core.support.IMarkedIons;
 import org.eclipse.chemclipse.msd.model.core.support.MarkedIonTransitions;
@@ -41,7 +42,7 @@ import org.eclipse.chemclipse.msd.model.core.support.MarkedIons;
  */
 public class ChromatogramSelectionMSD extends AbstractChromatogramSelection implements IChromatogramSelectionMSD {
 
-	private IRegularMassSpectrum selectedScan;
+	private IScanMSD selectedScan;
 	private IMarkedIons selectedIons;
 	private IMarkedIons excludedIons;
 	private IMarkedIonTransitions markedIonTransitions;
@@ -99,7 +100,7 @@ public class ChromatogramSelectionMSD extends AbstractChromatogramSelection impl
 	}
 
 	@Override
-	public IRegularMassSpectrum getSelectedScan() {
+	public IScanMSD getSelectedScan() {
 
 		return selectedScan;
 	}
@@ -141,7 +142,7 @@ public class ChromatogramSelectionMSD extends AbstractChromatogramSelection impl
 			 * Chromatogram MSD
 			 */
 			if(chromatogram instanceof IChromatogramMSD chromatogramMSD) {
-				selectedScan = chromatogramMSD.getSupplierScan(1);
+				selectedScan = chromatogramMSD.getScan(1);
 			}
 		} else {
 			selectedScan = null;
@@ -186,7 +187,7 @@ public class ChromatogramSelectionMSD extends AbstractChromatogramSelection impl
 	}
 
 	@Override
-	public void setSelectedScan(IRegularMassSpectrum selectedScan) {
+	public void setSelectedScan(IScanMSD selectedScan) {
 
 		/*
 		 * FireUpdateChange will be called in the validate method.

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/selection/IChromatogramSelectionMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/selection/IChromatogramSelectionMSD.java
@@ -16,6 +16,7 @@ package org.eclipse.chemclipse.msd.model.core.selection;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.support.IMarkedIonTransitions;
 import org.eclipse.chemclipse.msd.model.core.support.IMarkedIons;
 
@@ -42,16 +43,16 @@ public interface IChromatogramSelectionMSD extends IChromatogramSelection {
 	 * Returns the selected scan of the current chromatogram or null, if none is
 	 * stored.
 	 *
-	 * @return {@link IRegularMassSpectrum}
+	 * @return {@link IScanMSD}
 	 */
 	@Override
-	IRegularMassSpectrum getSelectedScan();
+	IScanMSD getSelectedScan();
 
 	/**
 	 * Sets the selected scan of the current chromatogram.<br/>
 	 * The scan must not be null.
 	 */
-	void setSelectedScan(IRegularMassSpectrum selectedScan);
+	void setSelectedScan(IScanMSD selectedScan);
 
 	/**
 	 * Use this convenient method, if you don't want to fire and update.

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/support/PeakBuilderMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/support/PeakBuilderMSD.java
@@ -612,7 +612,7 @@ public class PeakBuilderMSD {
 			 * Exclude ions?
 			 */
 			if(excludedIons == null) {
-				massSpectrum = chromatogram.getSupplierScan(scan);
+				massSpectrum = chromatogram.getScan(scan);
 			} else {
 				massSpectrum = chromatogram.getScan(scan, excludedIons);
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/GaussianPeakFactoryMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/GaussianPeakFactoryMSD.java
@@ -25,7 +25,7 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 
 public class GaussianPeakFactoryMSD {
 
@@ -35,6 +35,7 @@ public class GaussianPeakFactoryMSD {
 	private static final String INTEGRATOR_DESCRIPTION = "Gaussian Peak generator";
 
 	private GaussianPeakFactoryMSD() {
+
 	}
 
 	public static IPeakMSD createGaussianPeakMSD(IChromatogramMSD chromatogramMSD, float height, int retentionTime, float startBackgroundAbundance, float stopBackgroundAbundance) throws IllegalArgumentException, PeakException {
@@ -55,8 +56,8 @@ public class GaussianPeakFactoryMSD {
 			peakIntensities.addIntensityValue(rt, (float)gaussian.value(rt));
 		}
 		peakIntensities.normalize();
-		final IRegularMassSpectrum vendorMassSpectrum = chromatogramMSD.getSupplierScan(scanNumber);
-		final IPeakModelMSD peakModelMSD = new PeakModelMSD(new PeakMassSpectrum(vendorMassSpectrum), peakIntensities, startBackgroundAbundance, stopBackgroundAbundance);
+		final IScanMSD massSpectrum = chromatogramMSD.getScan(scanNumber);
+		final IPeakModelMSD peakModelMSD = new PeakModelMSD(new PeakMassSpectrum(massSpectrum), peakIntensities, startBackgroundAbundance, stopBackgroundAbundance);
 		return new PeakMSD(peakModelMSD);
 	}
 
@@ -78,11 +79,11 @@ public class GaussianPeakFactoryMSD {
 			peakIntensities.addIntensityValue(rt, (float)gaussian.value(rt));
 		}
 		peakIntensities.normalize();
-		final IRegularMassSpectrum vendorMassSpectrum = chromatogramMSD.getSupplierScan(scanNumber);
+		final IScanMSD massSpectrum = chromatogramMSD.getScan(scanNumber);
 		/*
 		 * Here we pass the retention times and indexes
 		 */
-		final IPeakMassSpectrum peakMassSpectrum = new PeakMassSpectrum(vendorMassSpectrum);
+		final IPeakMassSpectrum peakMassSpectrum = new PeakMassSpectrum(massSpectrum);
 		peakMassSpectrum.setRetentionIndex(retentionIndex);
 		peakMassSpectrum.setRetentionTimeColumn1(setRetentionTimeColumn1);
 		peakMassSpectrum.setRetentionTimeColumn2(setRetentionTimeColumn2);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/support/FilterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/support/FilterSupport.java
@@ -68,7 +68,7 @@ public class FilterSupport {
 			}
 		} else {
 			for(int scan = startScan; scan <= stopScan; scan++) {
-				massSpectrumCalculator.addIons(chromatogram.getSupplierScan(scan).getIons(), excludedIons);
+				massSpectrumCalculator.addIons(chromatogram.getScan(scan).getIons(), excludedIons);
 			}
 		}
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/ExtractedIonSignalExtractor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/ExtractedIonSignalExtractor.java
@@ -96,7 +96,7 @@ public class ExtractedIonSignalExtractor implements IExtractedIonSignalExtractor
 		 */
 		exitloop:
 		for(int scan = start; scan <= stop; scan++) {
-			if(!chromatogram.getSupplierScan(scan).isEmpty()) {
+			if(!chromatogram.getScan(scan).isEmpty()) {
 				startScan = scan;
 				break exitloop;
 			}
@@ -105,7 +105,7 @@ public class ExtractedIonSignalExtractor implements IExtractedIonSignalExtractor
 		 * Get the stop without empty scans.
 		 */
 		for(int scan = stop; scan > startScan; scan--) {
-			if(chromatogram.getSupplierScan(scan).isEmpty()) {
+			if(chromatogram.getScan(scan).isEmpty()) {
 				stopScan = scan - 1;
 			}
 		}
@@ -114,7 +114,7 @@ public class ExtractedIonSignalExtractor implements IExtractedIonSignalExtractor
 		 */
 		IExtractedIonSignals extractedIonSignals = new ExtractedIonSignals(startScan, stopScan, chromatogram);
 		for(int scan = startScan; scan <= stopScan; scan++) {
-			extractSignals(extractedIonSignals, chromatogram.getSupplierScan(scan), startIon, stopIon);
+			extractSignals(extractedIonSignals, chromatogram.getScan(scan), startIon, stopIon);
 		}
 
 		return extractedIonSignals;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/TotalIonSignalExtractor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/TotalIonSignalExtractor.java
@@ -22,6 +22,7 @@ import org.eclipse.chemclipse.model.signals.TotalScanSignalExtractor;
 import org.eclipse.chemclipse.model.signals.TotalScanSignals;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.msd.model.core.support.IMarkedIons;
 
@@ -129,9 +130,8 @@ public class TotalIonSignalExtractor extends TotalScanSignalExtractor implements
 		/*
 		 * Add the selected scans.
 		 */
-		IRegularMassSpectrum ms;
 		for(int scan = startScan; scan <= stopScan; scan++) {
-			ms = chromatogram.getSupplierScan(scan);
+			IScanMSD ms = chromatogram.getScan(scan);
 			totalIonSignal = new TotalScanSignal(ms.getRetentionTime(), ms.getRetentionIndex(), ms.getTotalSignal(excludedIons));
 			signals.add(totalIonSignal);
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSubtractScanUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSubtractScanUI.java
@@ -22,7 +22,6 @@ import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.support.CalculationType;
 import org.eclipse.chemclipse.model.targets.TargetSupport;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 import org.eclipse.chemclipse.msd.model.support.FilterSupport;
@@ -209,7 +208,7 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 					 */
 					IScanMSD massSpectrum1 = PreferenceSupplierModelMSD.getSessionSubtractMassSpectrum();
 					CalculationType calculationType = PreferenceSupplierModelMSD.getCalculationType();
-					IRegularMassSpectrum massSpectrum2 = chromatogramSelectionMSD.getSelectedScan();
+					IScanMSD massSpectrum2 = chromatogramSelectionMSD.getSelectedScan();
 					boolean useNormalize = PreferenceSupplierModelMSD.isUseNormalizedScan();
 					IScanMSD subtractMassSpectrum = FilterSupport.getCombinedMassSpectrum(massSpectrum1, massSpectrum2, null, useNormalize, calculationType);
 					saveSessionMassSpectrum(e.display, subtractMassSpectrum);

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.mzml/src/org/eclipse/chemclipse/wsd/converter/supplier/mzml/io/ChromatogramReaderVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.mzml/src/org/eclipse/chemclipse/wsd/converter/supplier/mzml/io/ChromatogramReaderVersion110.java
@@ -107,7 +107,7 @@ public class ChromatogramReaderVersion110 extends AbstractChromatogramReader imp
 					intensities = binaryData.getValue();
 				}
 			}
-			IVendorScan scan = (IVendorScan)chromatogram.getSupplierScan(i);
+			IVendorScan scan = (IVendorScan)chromatogram.getScan(i);
 			scan.deleteScanSignals(); // otherwise the total signal is added upon
 			addSpectrum(wavelengths, intensities, scan);
 			i++;

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/AbstractChromatogramPeakWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/AbstractChromatogramPeakWSD.java
@@ -81,7 +81,7 @@ public abstract class AbstractChromatogramPeakWSD extends AbstractPeakWSD implem
 		 */
 		IScan peakScan = getPeakModel().getPeakMaximum();
 		if(peakScan instanceof IScanWSD peakScanWSD) {
-			IScanWSD genuineScanWSD = chromatogram.getSupplierScan(getScanMax());
+			IScanWSD genuineScanWSD = chromatogram.getScan(getScanMax());
 			if(genuineScanWSD != null) {
 				int numberOfSignals = genuineScanWSD.getNumberOfScanSignals();
 				if(numberOfSignals != 0) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/AbstractChromatogramWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/AbstractChromatogramWSD.java
@@ -49,13 +49,13 @@ public abstract class AbstractChromatogramWSD extends AbstractChromatogram imple
 
 		Set<Float> wavelengths = new HashSet<>();
 		for(int i = 1; i < getNumberOfScans(); i++) {
-			getSupplierScan(i).getScanSignals().forEach(signal -> wavelengths.add(signal.getWavelength()));
+			getScan(i).getScanSignals().forEach(signal -> wavelengths.add(signal.getWavelength()));
 		}
 		return wavelengths;
 	}
 
 	@Override
-	public IScanWSD getSupplierScan(int scan) {
+	public IScanWSD getScan(int scan) {
 
 		int position = scan;
 		if(position > 0 && position <= getScans().size()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/IChromatogramWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/IChromatogramWSD.java
@@ -19,13 +19,14 @@ import org.eclipse.chemclipse.model.core.IChromatogram;
 public interface IChromatogramWSD extends IChromatogram, IChromatogramWSDBaseline, IChromatogramPeaksWSD {
 
 	/**
-	 * Returns a supplier scan or null, if no supplier
+	 * Returns a scan or null, if no wave
 	 * spectrum is stored.
 	 * 
 	 * @param scan
 	 * @return {@link IScanWSD}
 	 */
-	IScanWSD getSupplierScan(int scan);
+	@Override
+	IScanWSD getScan(int scan);
 
 	/**
 	 * 

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/selection/ChromatogramSelectionWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/selection/ChromatogramSelectionWSD.java
@@ -103,7 +103,7 @@ public class ChromatogramSelectionWSD extends AbstractChromatogramSelection impl
 			 * Chromatogram WSD
 			 */
 			if(chromatogram instanceof IChromatogramWSD chromatogramWSD) {
-				selectedScan = chromatogramWSD.getSupplierScan(1);
+				selectedScan = chromatogramWSD.getScan(1);
 			}
 		} else {
 			selectedScan = null;

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/support/PeakBuilderWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/support/PeakBuilderWSD.java
@@ -485,7 +485,7 @@ public class PeakBuilderWSD {
 		ITotalScanSignal totalScanSignal = totalScanSignals.getMaxTotalScanSignal();
 		if(totalScanSignal != null) {
 			int scan = chromatogram.getScanNumber(totalScanSignal.getRetentionTime());
-			IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+			IScanWSD scanWSD = chromatogram.getScan(scan);
 			float actualSignal = scanWSD.getTotalSignal();
 			float backgroundSignal = (float)backgroundEquation.calculateY(totalScanSignal.getRetentionTime());
 			float correctedSignal = actualSignal - backgroundSignal;

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/xwc/ExtractedSingleWavelengthSignalExtractor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/xwc/ExtractedSingleWavelengthSignalExtractor.java
@@ -94,7 +94,7 @@ public class ExtractedSingleWavelengthSignalExtractor implements IExtractedSingl
 			int startScanSignal = 0;
 			int stopScanSignal = 0;
 			for(int scan = startScan; scan <= stopScan; scan++) {
-				IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+				IScanWSD scanWSD = chromatogram.getScan(scan);
 				if(!scanWSD.getScanSignals().isEmpty()) {
 					Optional<IExtractedSingleWavelengthSignal> extractedWavelengthSignal = scanWSD.getExtractedSingleWavelengthSignal(wavelength);
 					if(extractedWavelengthSignal.isPresent()) {
@@ -208,7 +208,7 @@ public class ExtractedSingleWavelengthSignalExtractor implements IExtractedSingl
 
 		IMarkedWavelengths markedWavelengths = new MarkedWavelengths();
 		for(int i = startScan; i <= stopScan; i++) {
-			chromatogram.getSupplierScan(i).getScanSignals().forEach(signal -> markedWavelengths.add(signal.getWavelength()));
+			chromatogram.getScan(i).getScanSignals().forEach(signal -> markedWavelengths.add(signal.getWavelength()));
 		}
 		return getExtractedWavelengthSignals(startScan, stopScan, markedWavelengths, joinSignal);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/xwc/ExtractedWavelengthSignalExtractor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/xwc/ExtractedWavelengthSignalExtractor.java
@@ -96,7 +96,7 @@ public class ExtractedWavelengthSignalExtractor implements IExtractedWavelengthS
 		IScanWSD scanWSD;
 		IExtractedWavelengthSignals extractedIonSignals = new ExtractedWavelengthSignals(startScan, stopScan, chromatogram);
 		for(int scan = startScan; scan <= stopScan; scan++) {
-			scanWSD = chromatogram.getSupplierScan(scan);
+			scanWSD = chromatogram.getScan(scan);
 			if(!scanWSD.getScanSignals().isEmpty()) {
 				IExtractedWavelengthSignal extractedWavelengthSignal = scanWSD.getExtractedWavelengthSignal();
 				extractedWavelengthSignal.setRetentionTime(scanWSD.getRetentionTime());

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/xwc/TotalWavelengthSignalExtractor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/xwc/TotalWavelengthSignalExtractor.java
@@ -68,7 +68,7 @@ public class TotalWavelengthSignalExtractor extends TotalScanSignalExtractor imp
 		 * Add the selected scans.
 		 */
 		for(int scan = startScan; scan <= stopScan; scan++) {
-			IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+			IScanWSD scanWSD = chromatogram.getScan(scan);
 			ITotalScanSignal totalWavelengthSignal = new TotalScanSignal(scanWSD.getRetentionTime(), scanWSD.getRetentionIndex(), scanWSD.getTotalSignal(excludedWavelengths));
 			signals.add(totalWavelengthSignal);
 		}
@@ -113,7 +113,7 @@ public class TotalWavelengthSignalExtractor extends TotalScanSignalExtractor imp
 		 * Add the selected scans.
 		 */
 		for(int scan = startScan; scan <= stopScan; scan++) {
-			IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+			IScanWSD scanWSD = chromatogram.getScan(scan);
 			ITotalScanSignal totalWavelengthSignal = new TotalScanSignal(scanWSD.getRetentionTime(), scanWSD.getRetentionIndex(), scanWSD.getTotalSignal(excludedWavelengths));
 			signals.add(totalWavelengthSignal);
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1001.java
@@ -120,7 +120,7 @@ public class ChromatogramWriter_1001 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanCSD scanFID = chromatogram.getSupplierScan(scan);
+			IScanCSD scanFID = chromatogram.getScan(scan);
 
 			dataOutputStream.writeInt(scanFID.getRetentionTime()); // Retention Time
 			dataOutputStream.writeFloat(scanFID.getRetentionIndex()); // Retention Index
@@ -146,7 +146,7 @@ public class ChromatogramWriter_1001 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1002.java
@@ -119,7 +119,7 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 		int scans = chromatogram.getNumberOfScans();
 		dataOutputStream.writeInt(scans); // Number of Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanCSD scanFID = chromatogram.getSupplierScan(scan);
+			IScanCSD scanFID = chromatogram.getScan(scan);
 			dataOutputStream.writeInt(scanFID.getRetentionTime()); // Retention Time
 			dataOutputStream.writeFloat(scanFID.getRetentionIndex()); // Retention Index
 			dataOutputStream.writeFloat(scanFID.getTotalSignal()); // Total Signal
@@ -144,7 +144,7 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1003.java
@@ -120,7 +120,7 @@ public class ChromatogramWriter_1003 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanCSD scanFID = chromatogram.getSupplierScan(scan);
+			IScanCSD scanFID = chromatogram.getScan(scan);
 
 			dataOutputStream.writeInt(scanFID.getRetentionTime()); // Retention Time
 			dataOutputStream.writeFloat(scanFID.getRetentionIndex()); // Retention Index
@@ -147,7 +147,7 @@ public class ChromatogramWriter_1003 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1004.java
@@ -120,7 +120,7 @@ public class ChromatogramWriter_1004 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanCSD scanFID = chromatogram.getSupplierScan(scan);
+			IScanCSD scanFID = chromatogram.getScan(scan);
 
 			dataOutputStream.writeInt(scanFID.getRetentionTime()); // Retention Time
 			dataOutputStream.writeFloat(scanFID.getRetentionIndex()); // Retention Index
@@ -149,7 +149,7 @@ public class ChromatogramWriter_1004 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1005.java
@@ -147,7 +147,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanCSD scanFID = chromatogram.getSupplierScan(scan);
+			IScanCSD scanFID = chromatogram.getScan(scan);
 
 			dataOutputStream.writeInt(scanFID.getRetentionTime()); // Retention Time
 			dataOutputStream.writeFloat(scanFID.getRetentionIndex()); // Retention Index
@@ -176,7 +176,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1006.java
@@ -150,7 +150,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanCSD scanFID = chromatogram.getSupplierScan(scan);
+			IScanCSD scanFID = chromatogram.getScan(scan);
 
 			dataOutputStream.writeInt(scanFID.getRetentionTime()); // Retention Time
 			dataOutputStream.writeFloat(scanFID.getTotalSignal()); // Total Signal
@@ -190,7 +190,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1007.java
@@ -150,7 +150,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanCSD scanFID = chromatogram.getSupplierScan(scan);
+			IScanCSD scanFID = chromatogram.getScan(scan);
 
 			dataOutputStream.writeInt(scanFID.getRetentionTime()); // Retention Time
 			dataOutputStream.writeFloat(scanFID.getTotalSignal()); // Total Signal
@@ -190,7 +190,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1100.java
@@ -162,7 +162,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanCSD scanFID = chromatogram.getSupplierScan(scan);
+			IScanCSD scanFID = chromatogram.getScan(scan);
 
 			dataOutputStream.writeInt(scanFID.getRetentionTime()); // Retention Time
 			dataOutputStream.writeFloat(scanFID.getTotalSignal()); // Total Signal
@@ -202,7 +202,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1300.java
@@ -195,7 +195,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 		SubMonitor subMonitor = SubMonitor.convert(monitor, ConverterMessages.writeScans, scans);
 		try {
 			for(int scan = 1; scan <= scans; scan++) {
-				IScanCSD scanCSD = chromatogram.getSupplierScan(scan);
+				IScanCSD scanCSD = chromatogram.getScan(scan);
 
 				dataOutputStream.writeInt(scanCSD.getRetentionTime()); // Retention Time
 				dataOutputStream.writeInt(scanCSD.getRelativeRetentionTime());
@@ -252,7 +252,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
@@ -195,7 +195,7 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 		SubMonitor subMonitor = SubMonitor.convert(monitor, ConverterMessages.writeScans, scans);
 		try {
 			for(int scan = 1; scan <= scans; scan++) {
-				IScanCSD scanCSD = chromatogram.getSupplierScan(scan);
+				IScanCSD scanCSD = chromatogram.getScan(scan);
 
 				dataOutputStream.writeInt(scanCSD.getRetentionTime()); // Retention Time
 				dataOutputStream.writeInt(scanCSD.getRelativeRetentionTime());
@@ -252,7 +252,7 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackground(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
@@ -198,7 +198,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 		SubMonitor subMonitor = SubMonitor.convert(monitor, ConverterMessages.writeScans, scans);
 		try {
 			for(int scan = 1; scan <= scans; scan++) {
-				IScanCSD scanCSD = chromatogram.getSupplierScan(scan);
+				IScanCSD scanCSD = chromatogram.getScan(scan);
 
 				dataOutputStream.writeInt(scanCSD.getRetentionTime()); // Retention Time
 				dataOutputStream.writeInt(scanCSD.getRelativeRetentionTime());
@@ -259,7 +259,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 			chromatogram.setActiveBaseline(baselineId);
 			IBaselineModel baselineModel = chromatogram.getBaselineModel();
 			for(int scan = 1; scan <= scans; scan++) {
-				int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+				int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 				float backgroundAbundance = baselineModel.getBackground(retentionTime);
 				dataOutputStream.writeInt(retentionTime); // Retention Time
 				dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
@@ -197,7 +197,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 		SubMonitor subMonitor = SubMonitor.convert(monitor, ConverterMessages.writeScans, scans);
 		try {
 			for(int scan = 1; scan <= scans; scan++) {
-				IScanCSD scanCSD = chromatogram.getSupplierScan(scan);
+				IScanCSD scanCSD = chromatogram.getScan(scan);
 
 				dataOutputStream.writeInt(scanCSD.getRetentionTime()); // Retention Time
 				dataOutputStream.writeInt(scanCSD.getRelativeRetentionTime());
@@ -258,7 +258,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 			chromatogram.setActiveBaseline(baselineId);
 			IBaselineModel baselineModel = chromatogram.getBaselineModel();
 			for(int scan = 1; scan <= scans; scan++) {
-				int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+				int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 				float backgroundAbundance = baselineModel.getBackground(retentionTime);
 				dataOutputStream.writeInt(retentionTime); // Retention Time
 				dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
@@ -196,7 +196,7 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 		SubMonitor subMonitor = SubMonitor.convert(monitor, ConverterMessages.writeScans, scans);
 		try {
 			for(int scan = 1; scan <= scans; scan++) {
-				IScanCSD scanCSD = chromatogram.getSupplierScan(scan);
+				IScanCSD scanCSD = chromatogram.getScan(scan);
 
 				dataOutputStream.writeInt(scanCSD.getRetentionTime()); // Retention Time
 				dataOutputStream.writeInt(scanCSD.getRelativeRetentionTime());
@@ -250,7 +250,7 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 			chromatogram.setActiveBaseline(baselineId);
 			IBaselineModel baselineModel = chromatogram.getBaselineModel();
 			for(int scan = 1; scan <= scans; scan++) {
-				int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+				int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 				float backgroundAbundance = baselineModel.getBackground(retentionTime);
 				dataOutputStream.writeInt(retentionTime); // Retention Time
 				dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1502.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1502.java
@@ -196,7 +196,7 @@ public class ChromatogramWriter_1502 extends AbstractChromatogramWriter implemen
 		SubMonitor subMonitor = SubMonitor.convert(monitor, ConverterMessages.writeScans, scans);
 		try {
 			for(int scan = 1; scan <= scans; scan++) {
-				IScanCSD scanCSD = chromatogram.getSupplierScan(scan);
+				IScanCSD scanCSD = chromatogram.getScan(scan);
 
 				dataOutputStream.writeInt(scanCSD.getRetentionTime()); // Retention Time
 				dataOutputStream.writeInt(scanCSD.getRelativeRetentionTime());
@@ -250,7 +250,7 @@ public class ChromatogramWriter_1502 extends AbstractChromatogramWriter implemen
 			chromatogram.setActiveBaseline(baselineId);
 			IBaselineModel baselineModel = chromatogram.getBaselineModel();
 			for(int scan = 1; scan <= scans; scan++) {
-				int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+				int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 				float backgroundAbundance = baselineModel.getBackground(retentionTime);
 				dataOutputStream.writeInt(retentionTime); // Retention Time
 				dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0701.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0701.java
@@ -37,6 +37,7 @@ import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.support.history.IEditHistory;
 import org.eclipse.chemclipse.support.history.IEditInformation;
@@ -160,7 +161,7 @@ public class ChromatogramWriter_0701 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+			IScanMSD massSpectrum = chromatogram.getScan(scan);
 			writeMassSpectrum(dataOutputStream, massSpectrum);
 		}
 
@@ -277,10 +278,12 @@ public class ChromatogramWriter_0701 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		writeString(dataOutputStream, getMassSpectrometer(massSpectrum.getMassSpectrometer()).toString()); // Mass Spectrometer
-		writeString(dataOutputStream, String.valueOf(getMassSpectrumType(massSpectrum.getMassSpectrumType()))); // Mass Spectrum Type
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			writeString(dataOutputStream, getMassSpectrometer(regularMassSpectrum.getMassSpectrometer()).toString()); // Mass Spectrometer
+			writeString(dataOutputStream, String.valueOf(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType()))); // Mass Spectrum Type
+		}
 		dataOutputStream.writeInt(massSpectrum.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(massSpectrum.getRetentionIndex()); // Retention Index
 		List<IIon> ions = massSpectrum.getIons();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0801.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0801.java
@@ -39,6 +39,7 @@ import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.support.history.IEditHistory;
 import org.eclipse.chemclipse.support.history.IEditInformation;
@@ -161,7 +162,7 @@ public class ChromatogramWriter_0801 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+			IScanMSD massSpectrum = chromatogram.getScan(scan);
 			writeMassSpectrum(dataOutputStream, massSpectrum);
 		}
 
@@ -278,11 +279,17 @@ public class ChromatogramWriter_0801 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		dataOutputStream.writeInt(massSpectrum.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(massSpectrum.getRetentionIndex()); // Retention Index
 		List<IIon> ions = massSpectrum.getIons();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0802.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0802.java
@@ -40,6 +40,7 @@ import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.support.history.IEditHistory;
 import org.eclipse.chemclipse.support.history.IEditInformation;
@@ -162,7 +163,7 @@ public class ChromatogramWriter_0802 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+			IScanMSD massSpectrum = chromatogram.getScan(scan);
 			writeMassSpectrum(dataOutputStream, massSpectrum);
 		}
 
@@ -279,11 +280,17 @@ public class ChromatogramWriter_0802 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		dataOutputStream.writeInt(massSpectrum.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(massSpectrum.getRetentionIndex()); // Retention Index
 		List<IIon> ions = massSpectrum.getIons();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0803.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0803.java
@@ -41,6 +41,7 @@ import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.support.history.IEditHistory;
 import org.eclipse.chemclipse.support.history.IEditInformation;
@@ -164,7 +165,7 @@ public class ChromatogramWriter_0803 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+			IScanMSD massSpectrum = chromatogram.getScan(scan);
 			writeMassSpectrum(dataOutputStream, massSpectrum);
 		}
 
@@ -188,7 +189,7 @@ public class ChromatogramWriter_0803 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -307,11 +308,17 @@ public class ChromatogramWriter_0803 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		dataOutputStream.writeInt(massSpectrum.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(massSpectrum.getRetentionIndex()); // Retention Index
 		List<IIon> ions = massSpectrum.getIons();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0901.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0901.java
@@ -41,6 +41,7 @@ import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.support.history.IEditHistory;
 import org.eclipse.chemclipse.support.history.IEditInformation;
@@ -164,7 +165,7 @@ public class ChromatogramWriter_0901 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+			IScanMSD massSpectrum = chromatogram.getScan(scan);
 			writeMassSpectrum(dataOutputStream, massSpectrum);
 		}
 
@@ -188,7 +189,7 @@ public class ChromatogramWriter_0901 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -307,11 +308,17 @@ public class ChromatogramWriter_0901 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		dataOutputStream.writeInt(massSpectrum.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(massSpectrum.getRetentionIndex()); // Retention Index
 		List<IIon> ions = massSpectrum.getIons();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0902.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0902.java
@@ -41,6 +41,7 @@ import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.support.history.IEditHistory;
 import org.eclipse.chemclipse.support.history.IEditInformation;
@@ -164,7 +165,7 @@ public class ChromatogramWriter_0902 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+			IScanMSD massSpectrum = chromatogram.getScan(scan);
 			writeMassSpectrum(dataOutputStream, massSpectrum);
 		}
 
@@ -188,7 +189,7 @@ public class ChromatogramWriter_0902 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -307,11 +308,17 @@ public class ChromatogramWriter_0902 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		dataOutputStream.writeInt(massSpectrum.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(massSpectrum.getRetentionIndex()); // Retention Index
 		List<IIon> ions = massSpectrum.getIons();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0903.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0903.java
@@ -41,6 +41,7 @@ import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.support.history.IEditHistory;
 import org.eclipse.chemclipse.support.history.IEditInformation;
@@ -164,7 +165,7 @@ public class ChromatogramWriter_0903 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+			IScanMSD massSpectrum = chromatogram.getScan(scan);
 			writeMassSpectrum(dataOutputStream, massSpectrum);
 		}
 
@@ -188,7 +189,7 @@ public class ChromatogramWriter_0903 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -307,11 +308,17 @@ public class ChromatogramWriter_0903 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		dataOutputStream.writeInt(massSpectrum.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(massSpectrum.getRetentionIndex()); // Retention Index
 		List<IIon> ions = massSpectrum.getIons();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1001.java
@@ -41,6 +41,7 @@ import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.support.history.IEditHistory;
 import org.eclipse.chemclipse.support.history.IEditInformation;
@@ -164,7 +165,7 @@ public class ChromatogramWriter_1001 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+			IScanMSD massSpectrum = chromatogram.getScan(scan);
 			writeMassSpectrum(dataOutputStream, massSpectrum);
 		}
 
@@ -188,7 +189,7 @@ public class ChromatogramWriter_1001 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -307,11 +308,17 @@ public class ChromatogramWriter_1001 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		dataOutputStream.writeInt(massSpectrum.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(massSpectrum.getRetentionIndex()); // Retention Index
 		List<IIon> ions = massSpectrum.getIons();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1002.java
@@ -42,6 +42,7 @@ import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.support.history.IEditHistory;
 import org.eclipse.chemclipse.support.history.IEditInformation;
@@ -165,7 +166,7 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+			IScanMSD massSpectrum = chromatogram.getScan(scan);
 			writeMassSpectrum(dataOutputStream, massSpectrum);
 		}
 
@@ -189,7 +190,7 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -308,11 +309,17 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		dataOutputStream.writeInt(massSpectrum.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(massSpectrum.getRetentionIndex()); // Retention Index
 		List<IIon> ions = massSpectrum.getIons();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1003.java
@@ -42,6 +42,7 @@ import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.support.history.IEditHistory;
 import org.eclipse.chemclipse.support.history.IEditInformation;
@@ -168,7 +169,7 @@ public class ChromatogramWriter_1003 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 
 		for(int scan = 1; scan <= scans; scan++) {
-			IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+			IScanMSD massSpectrum = chromatogram.getScan(scan);
 			/*
 			 * Write separate scan proxy values.
 			 */
@@ -235,7 +236,7 @@ public class ChromatogramWriter_1003 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -354,11 +355,17 @@ public class ChromatogramWriter_1003 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		dataOutputStream.writeInt(massSpectrum.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(massSpectrum.getRetentionIndex()); // Retention Index
 		List<IIon> ions = massSpectrum.getIons();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1004.java
@@ -170,7 +170,7 @@ public class ChromatogramWriter_1004 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 
 		for(int scan = 1; scan <= scans; scan++) {
-			IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+			IScanMSD massSpectrum = chromatogram.getScan(scan);
 			/*
 			 * Write separate scan proxy values.
 			 */
@@ -251,7 +251,7 @@ public class ChromatogramWriter_1004 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -370,11 +370,17 @@ public class ChromatogramWriter_1004 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		writeNormalMassSpectrum(dataOutputStream, massSpectrum);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1005.java
@@ -186,7 +186,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
-		List<IScanProxy> scanProxies = new ArrayList<IScanProxy>();
+		List<IScanProxy> scanProxies = new ArrayList<>();
 		/*
 		 * Scans
 		 */
@@ -197,7 +197,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 
 		for(int scan = 1; scan <= scans; scan++) {
-			IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+			IScanMSD massSpectrum = chromatogram.getScan(scan);
 			/*
 			 * Write separate scan proxy values.
 			 */
@@ -278,7 +278,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -397,11 +397,17 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		writeNormalMassSpectrum(dataOutputStream, massSpectrum);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1006.java
@@ -200,7 +200,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 
 		for(int scan = 1; scan <= scans; scan++) {
-			IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+			IScanMSD massSpectrum = chromatogram.getScan(scan);
 			/*
 			 * Write separate scan proxy values.
 			 */
@@ -281,7 +281,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -402,11 +402,17 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		writeNormalMassSpectrum(dataOutputStream, massSpectrum);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1007.java
@@ -200,7 +200,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 
 		for(int scan = 1; scan <= scans; scan++) {
-			IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+			IScanMSD massSpectrum = chromatogram.getScan(scan);
 			/*
 			 * Write separate scan proxy values.
 			 */
@@ -281,7 +281,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -402,11 +402,17 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		writeNormalMassSpectrum(dataOutputStream, massSpectrum);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1100.java
@@ -201,7 +201,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
-		List<IScanProxy> scanProxies = new ArrayList<IScanProxy>();
+		List<IScanProxy> scanProxies = new ArrayList<>();
 		/*
 		 * Scans
 		 */
@@ -212,7 +212,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 
 		for(int scan = 1; scan <= scans; scan++) {
-			IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+			IScanMSD massSpectrum = chromatogram.getScan(scan);
 			/*
 			 * Write separate scan proxy values.
 			 */
@@ -293,7 +293,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -414,11 +414,17 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		writeNormalMassSpectrum(dataOutputStream, massSpectrum);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1300.java
@@ -237,7 +237,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 				/*
 				 * Write separate scan proxy values.
 				 */
-				IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+				IScanMSD massSpectrum = chromatogram.getScan(scan);
 				int offset = dataOutputStream.size();
 				int retentionTime = massSpectrum.getRetentionTime();
 				int numberOfIons = massSpectrum.getNumberOfIons();
@@ -320,7 +320,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -441,11 +441,17 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		writeNormalMassSpectrum(dataOutputStream, massSpectrum);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
@@ -237,7 +237,7 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 				/*
 				 * Write separate scan proxy values.
 				 */
-				IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+				IScanMSD massSpectrum = chromatogram.getScan(scan);
 				int offset = dataOutputStream.size();
 				int retentionTime = massSpectrum.getRetentionTime();
 				int numberOfIons = massSpectrum.getNumberOfIons();
@@ -320,7 +320,7 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackground(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -441,11 +441,17 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		writeNormalMassSpectrum(dataOutputStream, massSpectrum);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
@@ -240,7 +240,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 				/*
 				 * Write separate scan proxy values.
 				 */
-				IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+				IScanMSD massSpectrum = chromatogram.getScan(scan);
 				int offset = dataOutputStream.size();
 				int retentionTime = massSpectrum.getRetentionTime();
 				int numberOfIons = massSpectrum.getNumberOfIons();
@@ -326,7 +326,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 			chromatogram.setActiveBaseline(baselineId);
 			IBaselineModel baselineModel = chromatogram.getBaselineModel();
 			for(int scan = 1; scan <= scans; scan++) {
-				int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+				int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 				float backgroundAbundance = baselineModel.getBackground(retentionTime);
 				dataOutputStream.writeInt(retentionTime); // Retention Time
 				dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -532,11 +532,17 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 		}
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		writeNormalMassSpectrum(dataOutputStream, massSpectrum);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
@@ -239,7 +239,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 				/*
 				 * Write separate scan proxy values.
 				 */
-				IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+				IScanMSD massSpectrum = chromatogram.getScan(scan);
 				int offset = dataOutputStream.size();
 				int retentionTime = massSpectrum.getRetentionTime();
 				int numberOfIons = massSpectrum.getNumberOfIons();
@@ -325,7 +325,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 			chromatogram.setActiveBaseline(baselineId);
 			IBaselineModel baselineModel = chromatogram.getBaselineModel();
 			for(int scan = 1; scan <= scans; scan++) {
-				int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+				int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 				float backgroundAbundance = baselineModel.getBackground(retentionTime);
 				dataOutputStream.writeInt(retentionTime); // Retention Time
 				dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -536,11 +536,17 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 		}
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		writeNormalMassSpectrum(dataOutputStream, massSpectrum);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
@@ -237,7 +237,7 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 				/*
 				 * Write separate scan proxy values.
 				 */
-				IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+				IScanMSD massSpectrum = chromatogram.getScan(scan);
 				int offset = dataOutputStream.size();
 				int retentionTime = massSpectrum.getRetentionTime();
 				int numberOfIons = massSpectrum.getNumberOfIons();
@@ -323,7 +323,7 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 			chromatogram.setActiveBaseline(baselineId);
 			IBaselineModel baselineModel = chromatogram.getBaselineModel();
 			for(int scan = 1; scan <= scans; scan++) {
-				int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+				int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 				float backgroundAbundance = baselineModel.getBackground(retentionTime);
 				dataOutputStream.writeInt(retentionTime); // Retention Time
 				dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -513,11 +513,17 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		writeNormalMassSpectrum(dataOutputStream, massSpectrum);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1502.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1502.java
@@ -237,7 +237,7 @@ public class ChromatogramWriter_1502 extends AbstractChromatogramWriter implemen
 				/*
 				 * Write separate scan proxy values.
 				 */
-				IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(scan);
+				IScanMSD massSpectrum = chromatogram.getScan(scan);
 				int offset = dataOutputStream.size();
 				int retentionTime = massSpectrum.getRetentionTime();
 				int numberOfIons = massSpectrum.getNumberOfIons();
@@ -323,7 +323,7 @@ public class ChromatogramWriter_1502 extends AbstractChromatogramWriter implemen
 			chromatogram.setActiveBaseline(baselineId);
 			IBaselineModel baselineModel = chromatogram.getBaselineModel();
 			for(int scan = 1; scan <= scans; scan++) {
-				int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+				int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 				float backgroundAbundance = baselineModel.getBackground(retentionTime);
 				dataOutputStream.writeInt(retentionTime); // Retention Time
 				dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance
@@ -509,11 +509,17 @@ public class ChromatogramWriter_1502 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeMassSpectrum(DataOutputStream dataOutputStream, IRegularMassSpectrum massSpectrum) throws IOException {
+	private void writeMassSpectrum(DataOutputStream dataOutputStream, IScanMSD massSpectrum) throws IOException {
 
-		dataOutputStream.writeShort(massSpectrum.getMassSpectrometer()); // Mass Spectrometer
-		dataOutputStream.writeShort(getMassSpectrumType(massSpectrum.getMassSpectrumType())); // Mass Spectrum Type
-		dataOutputStream.writeDouble(massSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
+			dataOutputStream.writeShort(regularMassSpectrum.getMassSpectrometer()); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(regularMassSpectrum.getMassSpectrumType())); // Mass Spectrum Type
+			dataOutputStream.writeDouble(regularMassSpectrum.getPrecursorIon()); // Precursor Ion (0 if MS1 or none has been selected)
+		} else {
+			dataOutputStream.writeShort(1); // Mass Spectrometer
+			dataOutputStream.writeShort(getMassSpectrumType(MassSpectrumType.CENTROID)); // Mass Spectrum Type
+			dataOutputStream.writeDouble(0); // Precursor Ion
+		}
 		writeNormalMassSpectrum(dataOutputStream, massSpectrum);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1005.java
@@ -104,7 +104,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Retention Times - Total Signals
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanWSD scanWsd = chromatogram.getSupplierScan(scan);
+			IScanWSD scanWsd = chromatogram.getScan(scan);
 			int scanSignalTotal = scanWsd.getScanSignals().size();
 			dataOutputStream.writeInt(scanSignalTotal);
 			for(int signal = 0; signal < scanSignalTotal; signal++) {
@@ -114,12 +114,12 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 				dataOutputStream.writeInt(wavelength);
 				dataOutputStream.writeFloat(abundance);
 			}
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			dataOutputStream.writeInt(retentionTime); // Retention Time
-			dataOutputStream.writeFloat(chromatogram.getSupplierScan(scan).getRetentionIndex()); // Retention Index
-			dataOutputStream.writeFloat(chromatogram.getSupplierScan(scan).getTotalSignal()); // Total Signal
-			dataOutputStream.writeInt(chromatogram.getSupplierScan(scan).getTimeSegmentId()); // Time Segment Id
-			dataOutputStream.writeInt(chromatogram.getSupplierScan(scan).getCycleNumber()); // Cycle Number
+			dataOutputStream.writeFloat(chromatogram.getScan(scan).getRetentionIndex()); // Retention Index
+			dataOutputStream.writeFloat(chromatogram.getScan(scan).getTotalSignal()); // Total Signal
+			dataOutputStream.writeInt(chromatogram.getScan(scan).getTimeSegmentId()); // Time Segment Id
+			dataOutputStream.writeInt(chromatogram.getScan(scan).getCycleNumber()); // Cycle Number
 		}
 
 		dataOutputStream.flush();
@@ -183,7 +183,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		int scans = chromatogram.getNumberOfScans();
 		dataOutputStream.writeInt(scans);
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanWSD scanWsd = chromatogram.getSupplierScan(scan);
+			IScanWSD scanWsd = chromatogram.getScan(scan);
 			int scanSignalTotal = scanWsd.getScanSignals().size();
 			dataOutputStream.writeInt(scanSignalTotal);
 			for(int signal = 0; signal < scanSignalTotal; signal++) {
@@ -193,12 +193,12 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 				dataOutputStream.writeInt(wavelength);
 				dataOutputStream.writeFloat(abundance);
 			}
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			dataOutputStream.writeInt(retentionTime); // Retention Time
-			dataOutputStream.writeFloat(chromatogram.getSupplierScan(scan).getRetentionIndex()); // Retention Index
-			dataOutputStream.writeFloat(chromatogram.getSupplierScan(scan).getTotalSignal()); // Total Signal
-			dataOutputStream.writeInt(chromatogram.getSupplierScan(scan).getTimeSegmentId()); // Time Segment Id
-			dataOutputStream.writeInt(chromatogram.getSupplierScan(scan).getCycleNumber()); // Cycle Number
+			dataOutputStream.writeFloat(chromatogram.getScan(scan).getRetentionIndex()); // Retention Index
+			dataOutputStream.writeFloat(chromatogram.getScan(scan).getTotalSignal()); // Total Signal
+			dataOutputStream.writeInt(chromatogram.getScan(scan).getTimeSegmentId()); // Time Segment Id
+			dataOutputStream.writeInt(chromatogram.getScan(scan).getCycleNumber()); // Cycle Number
 		}
 		// clean up flush the stream and close zip-entry 1
 		dataOutputStream.flush();
@@ -221,7 +221,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1006.java
@@ -107,7 +107,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Retention Times - Total Signals
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+			IScanWSD scanWSD = chromatogram.getScan(scan);
 			int scanSignalTotal = scanWSD.getScanSignals().size();
 			dataOutputStream.writeInt(scanSignalTotal);
 			for(int signal = 0; signal < scanSignalTotal; signal++) {
@@ -186,7 +186,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		int scans = chromatogram.getNumberOfScans();
 		dataOutputStream.writeInt(scans);
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+			IScanWSD scanWSD = chromatogram.getScan(scan);
 			int scanSignalTotal = scanWSD.getScanSignals().size();
 			dataOutputStream.writeInt(scanSignalTotal);
 			for(int signal = 0; signal < scanSignalTotal; signal++) {
@@ -234,7 +234,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1007.java
@@ -107,7 +107,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Retention Times - Total Signals
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+			IScanWSD scanWSD = chromatogram.getScan(scan);
 			int scanSignalTotal = scanWSD.getScanSignals().size();
 			dataOutputStream.writeInt(scanSignalTotal);
 			for(int signal = 0; signal < scanSignalTotal; signal++) {
@@ -186,7 +186,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		int scans = chromatogram.getNumberOfScans();
 		dataOutputStream.writeInt(scans);
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+			IScanWSD scanWSD = chromatogram.getScan(scan);
 			int scanSignalTotal = scanWSD.getScanSignals().size();
 			dataOutputStream.writeInt(scanSignalTotal);
 			for(int signal = 0; signal < scanSignalTotal; signal++) {
@@ -234,7 +234,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1100.java
@@ -109,7 +109,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Retention Times - Total Signals
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+			IScanWSD scanWSD = chromatogram.getScan(scan);
 			int scanSignalTotal = scanWSD.getScanSignals().size();
 			dataOutputStream.writeInt(scanSignalTotal);
 			for(int signal = 0; signal < scanSignalTotal; signal++) {
@@ -194,7 +194,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		int scans = chromatogram.getNumberOfScans();
 		dataOutputStream.writeInt(scans);
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+			IScanWSD scanWSD = chromatogram.getScan(scan);
 			int scanSignalTotal = scanWSD.getScanSignals().size();
 			dataOutputStream.writeInt(scanSignalTotal);
 			for(int signal = 0; signal < scanSignalTotal; signal++) {
@@ -242,7 +242,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1300.java
@@ -140,7 +140,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Retention Times - Total Signals
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+			IScanWSD scanWSD = chromatogram.getScan(scan);
 			dataOutputStream.writeFloat(scanWSD.getTotalSignal());
 			dataOutputStream.writeInt(scanWSD.getRetentionTime());
 		}
@@ -219,7 +219,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 		SubMonitor subMonitor = SubMonitor.convert(monitor, ConverterMessages.writeScans, scans);
 		try {
 			for(int scan = 1; scan <= scans; scan++) {
-				IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+				IScanWSD scanWSD = chromatogram.getScan(scan);
 				int scanSignalTotal = scanWSD.getScanSignals().size();
 				dataOutputStream.writeInt(scanSignalTotal);
 				for(int signal = 0; signal < scanSignalTotal; signal++) {
@@ -284,7 +284,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackgroundAbundance(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
@@ -141,7 +141,7 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Retention Times - Total Signals
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+			IScanWSD scanWSD = chromatogram.getScan(scan);
 			dataOutputStream.writeFloat(scanWSD.getTotalSignal());
 			dataOutputStream.writeInt(scanWSD.getRetentionTime());
 		}
@@ -220,7 +220,7 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 		SubMonitor subMonitor = SubMonitor.convert(monitor, ConverterMessages.writeScans, scans);
 		try {
 			for(int scan = 1; scan <= scans; scan++) {
-				IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+				IScanWSD scanWSD = chromatogram.getScan(scan);
 				int scanSignalTotal = scanWSD.getScanSignals().size();
 				dataOutputStream.writeInt(scanSignalTotal);
 				for(int signal = 0; signal < scanSignalTotal; signal++) {
@@ -285,7 +285,7 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 		IBaselineModel baselineModel = chromatogram.getBaselineModel();
 		// Scans
 		for(int scan = 1; scan <= scans; scan++) {
-			int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+			int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 			float backgroundAbundance = baselineModel.getBackground(retentionTime);
 			dataOutputStream.writeInt(retentionTime); // Retention Time
 			dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
@@ -144,7 +144,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Retention Times - Total Signals
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+			IScanWSD scanWSD = chromatogram.getScan(scan);
 			dataOutputStream.writeFloat(scanWSD.getTotalSignal());
 			dataOutputStream.writeInt(scanWSD.getRetentionTime());
 		}
@@ -223,7 +223,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 		SubMonitor subMonitor = SubMonitor.convert(monitor, ConverterMessages.writeScans, scans);
 		try {
 			for(int scan = 1; scan <= scans; scan++) {
-				IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+				IScanWSD scanWSD = chromatogram.getScan(scan);
 				int scanSignalTotal = scanWSD.getScanSignals().size();
 				dataOutputStream.writeInt(scanSignalTotal);
 				for(int signal = 0; signal < scanSignalTotal; signal++) {
@@ -291,7 +291,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 			chromatogram.setActiveBaseline(baselineId);
 			IBaselineModel baselineModel = chromatogram.getBaselineModel();
 			for(int scan = 1; scan <= scans; scan++) {
-				int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+				int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 				float backgroundAbundance = baselineModel.getBackground(retentionTime);
 				dataOutputStream.writeInt(retentionTime); // Retention Time
 				dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
@@ -143,7 +143,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Retention Times - Total Signals
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+			IScanWSD scanWSD = chromatogram.getScan(scan);
 			dataOutputStream.writeFloat(scanWSD.getTotalSignal());
 			dataOutputStream.writeInt(scanWSD.getRetentionTime());
 		}
@@ -222,7 +222,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 		SubMonitor subMonitor = SubMonitor.convert(monitor, ConverterMessages.writeScans, scans);
 		try {
 			for(int scan = 1; scan <= scans; scan++) {
-				IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+				IScanWSD scanWSD = chromatogram.getScan(scan);
 				int scanSignalTotal = scanWSD.getScanSignals().size();
 				dataOutputStream.writeInt(scanSignalTotal);
 				for(int signal = 0; signal < scanSignalTotal; signal++) {
@@ -290,7 +290,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 			chromatogram.setActiveBaseline(baselineId);
 			IBaselineModel baselineModel = chromatogram.getBaselineModel();
 			for(int scan = 1; scan <= scans; scan++) {
-				int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+				int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 				float backgroundAbundance = baselineModel.getBackground(retentionTime);
 				dataOutputStream.writeInt(retentionTime); // Retention Time
 				dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
@@ -142,7 +142,7 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Retention Times - Total Signals
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+			IScanWSD scanWSD = chromatogram.getScan(scan);
 			dataOutputStream.writeFloat(scanWSD.getTotalSignal());
 			dataOutputStream.writeInt(scanWSD.getRetentionTime());
 		}
@@ -221,7 +221,7 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 		SubMonitor subMonitor = SubMonitor.convert(monitor, ConverterMessages.writeScans, scans);
 		try {
 			for(int scan = 1; scan <= scans; scan++) {
-				IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+				IScanWSD scanWSD = chromatogram.getScan(scan);
 				int scanSignalTotal = scanWSD.getScanSignals().size();
 				dataOutputStream.writeInt(scanSignalTotal);
 				for(int signal = 0; signal < scanSignalTotal; signal++) {
@@ -282,7 +282,7 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 			chromatogram.setActiveBaseline(baselineId);
 			IBaselineModel baselineModel = chromatogram.getBaselineModel();
 			for(int scan = 1; scan <= scans; scan++) {
-				int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+				int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 				float backgroundAbundance = baselineModel.getBackground(retentionTime);
 				dataOutputStream.writeInt(retentionTime); // Retention Time
 				dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1502.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1502.java
@@ -142,7 +142,7 @@ public class ChromatogramWriter_1502 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeInt(scans); // Number of Scans
 		// Retention Times - Total Signals
 		for(int scan = 1; scan <= scans; scan++) {
-			IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+			IScanWSD scanWSD = chromatogram.getScan(scan);
 			dataOutputStream.writeFloat(scanWSD.getTotalSignal());
 			dataOutputStream.writeInt(scanWSD.getRetentionTime());
 		}
@@ -221,7 +221,7 @@ public class ChromatogramWriter_1502 extends AbstractChromatogramWriter implemen
 		SubMonitor subMonitor = SubMonitor.convert(monitor, ConverterMessages.writeScans, scans);
 		try {
 			for(int scan = 1; scan <= scans; scan++) {
-				IScanWSD scanWSD = chromatogram.getSupplierScan(scan);
+				IScanWSD scanWSD = chromatogram.getScan(scan);
 				int scanSignalTotal = scanWSD.getScanSignals().size();
 				dataOutputStream.writeInt(scanSignalTotal);
 				for(int signal = 0; signal < scanSignalTotal; signal++) {
@@ -282,7 +282,7 @@ public class ChromatogramWriter_1502 extends AbstractChromatogramWriter implemen
 			chromatogram.setActiveBaseline(baselineId);
 			IBaselineModel baselineModel = chromatogram.getBaselineModel();
 			for(int scan = 1; scan <= scans; scan++) {
-				int retentionTime = chromatogram.getSupplierScan(scan).getRetentionTime();
+				int retentionTime = chromatogram.getScan(scan).getRetentionTime();
 				float backgroundAbundance = baselineModel.getBackground(retentionTime);
 				dataOutputStream.writeInt(retentionTime); // Retention Time
 				dataOutputStream.writeFloat(backgroundAbundance); // Background Abundance

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogram_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogram_4_Test.java
@@ -23,12 +23,12 @@ import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
 import org.eclipse.chemclipse.model.implementation.IntegrationEntry;
 import org.eclipse.chemclipse.model.implementation.PeakIntensityValues;
-import org.eclipse.chemclipse.model.implementation.Scan;
 import org.eclipse.chemclipse.msd.model.implementation.ChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.implementation.ChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.implementation.Ion;
 import org.eclipse.chemclipse.msd.model.implementation.PeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.implementation.PeakModelMSD;
+import org.eclipse.chemclipse.msd.model.implementation.ScanMSD;
 import org.junit.Test;
 
 public class AbstractChromatogram_4_Test {
@@ -95,9 +95,9 @@ public class AbstractChromatogram_4_Test {
 		assertTrue("Peaks are returned even if no peak rt-max should be in this range", chromatogram.getPeaks(peakStart + numberOfPeaks / 2, Integer.MAX_VALUE).isEmpty());
 	}
 
-	private static Scan createScanAt(int retentionTime) {
+	private static IScanMSD createScanAt(int retentionTime) {
 
-		Scan scan = new Scan(100);
+		IScanMSD scan = new ScanMSD();
 		scan.setRetentionTime(retentionTime);
 		return scan;
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelection_8_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelection_8_Test.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.easymock.EasyMock;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.implementation.Ion;
 import org.eclipse.chemclipse.msd.model.implementation.RegularMassSpectrum;
 import org.junit.Before;
@@ -31,7 +31,7 @@ public class ChromatogramSelection_8_Test {
 
 	private IChromatogramMSD chromatogram;
 	private IChromatogramSelectionMSD selection;
-	private IRegularMassSpectrum regularMassSpectrum;
+	private IScanMSD scanMSD;
 	private IChromatogramPeakMSD peak;
 
 	@Before
@@ -53,9 +53,9 @@ public class ChromatogramSelection_8_Test {
 		EasyMock.replay(peaks);
 		EasyMock.expect(chromatogram.getPeaks()).andStubReturn(peaks);
 
-		regularMassSpectrum = new RegularMassSpectrum();
-		regularMassSpectrum.setRetentionTime(4500);
-		regularMassSpectrum.addIon(new Ion(45.0f, 2883.9f));
+		scanMSD = new RegularMassSpectrum();
+		scanMSD.setRetentionTime(4500);
+		scanMSD.addIon(new Ion(45.0f, 2883.9f));
 		peak = EasyMock.createNiceMock(IChromatogramPeakMSD.class);
 		EasyMock.expect(peak.getIntegratedArea()).andStubReturn(893002.3d);
 		EasyMock.replay(peak);
@@ -76,10 +76,10 @@ public class ChromatogramSelection_8_Test {
 	@Test
 	public void testSetSelectedScan_2() {
 
-		selection.setSelectedScan(regularMassSpectrum);
-		regularMassSpectrum = selection.getSelectedScan();
+		selection.setSelectedScan(scanMSD);
+		scanMSD = selection.getSelectedScan();
 		assertNotNull(selection.getSelectedScan());
-		assertEquals("RetentionTime", 4500, regularMassSpectrum.getRetentionTime());
+		assertEquals("RetentionTime", 4500, scanMSD.getRetentionTime());
 	}
 
 	@Test

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelection_9_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelection_9_Test.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertNotNull;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.implementation.ChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.implementation.Ion;
 import org.eclipse.chemclipse.msd.model.implementation.RegularMassSpectrum;
@@ -50,7 +51,7 @@ public class ChromatogramSelection_9_Test {
 	@Test
 	public void testGetSelectedScan_1() {
 
-		IRegularMassSpectrum selectedScan = selection.getSelectedScan();
+		IScanMSD selectedScan = selection.getSelectedScan();
 		assertNotNull(selectedScan);
 		assertEquals("RetentionTime", 500, selectedScan.getRetentionTime());
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/Chromatogram_8_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/Chromatogram_8_Test.java
@@ -121,16 +121,14 @@ public class Chromatogram_8_Test {
 	@Test
 	public void testGetScan_1() {
 
-		IScanMSD massSpectrum;
-		massSpectrum = chromatogram.getSupplierScan(50);
+		IScanMSD massSpectrum = chromatogram.getScan(50);
 		assertEquals("TotalSignal", 50.0f, massSpectrum.getTotalSignal(), 0);
 	}
 
 	@Test
 	public void testGetScan_2() {
 
-		IScanMSD massSpectrum;
-		massSpectrum = chromatogram.getSupplierScan(51);
+		IScanMSD massSpectrum = chromatogram.getScan(51);
 		assertEquals("TotalSignal", 71.0f, massSpectrum.getTotalSignal(), 0);
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/Chromatogram_9_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/Chromatogram_9_Test.java
@@ -128,16 +128,14 @@ public class Chromatogram_9_Test {
 	@Test
 	public void testGetScan_1() {
 
-		IScanMSD massSpectrum;
-		massSpectrum = chromatogram.getSupplierScan(49);
+		IScanMSD massSpectrum = chromatogram.getScan(49);
 		assertEquals("TotalSignal", 49.0f, massSpectrum.getTotalSignal(), 0);
 	}
 
 	@Test
 	public void testGetScan_2() {
 
-		IScanMSD massSpectrum;
-		massSpectrum = chromatogram.getSupplierScan(50);
+		IScanMSD massSpectrum = chromatogram.getScan(50);
 		assertEquals("TotalSignal", 51.0f, massSpectrum.getTotalSignal(), 0);
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0701_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0701_ITest.java
@@ -111,7 +111,7 @@ public class ChromatogramReader_1_MSD_0701_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(32, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -127,7 +127,7 @@ public class ChromatogramReader_1_MSD_0701_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 
 		assertEquals(35, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -143,7 +143,7 @@ public class ChromatogramReader_1_MSD_0701_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 
 		assertEquals(29, massSpectrum.getNumberOfIons());
 		assertEquals(16.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -159,7 +159,7 @@ public class ChromatogramReader_1_MSD_0701_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 
 		assertEquals(31, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0801_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0801_ITest.java
@@ -111,7 +111,7 @@ public class ChromatogramReader_1_MSD_0801_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(32, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -127,7 +127,7 @@ public class ChromatogramReader_1_MSD_0801_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 
 		assertEquals(35, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -143,7 +143,7 @@ public class ChromatogramReader_1_MSD_0801_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 
 		assertEquals(29, massSpectrum.getNumberOfIons());
 		assertEquals(16.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -159,7 +159,7 @@ public class ChromatogramReader_1_MSD_0801_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 
 		assertEquals(31, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0802_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0802_ITest.java
@@ -111,7 +111,7 @@ public class ChromatogramReader_1_MSD_0802_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(32, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -127,7 +127,7 @@ public class ChromatogramReader_1_MSD_0802_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 
 		assertEquals(35, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -143,7 +143,7 @@ public class ChromatogramReader_1_MSD_0802_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 
 		assertEquals(29, massSpectrum.getNumberOfIons());
 		assertEquals(16.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -159,7 +159,7 @@ public class ChromatogramReader_1_MSD_0802_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 
 		assertEquals(31, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0803_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0803_ITest.java
@@ -111,7 +111,7 @@ public class ChromatogramReader_1_MSD_0803_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(32, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -127,7 +127,7 @@ public class ChromatogramReader_1_MSD_0803_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 
 		assertEquals(35, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -143,7 +143,7 @@ public class ChromatogramReader_1_MSD_0803_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 
 		assertEquals(29, massSpectrum.getNumberOfIons());
 		assertEquals(16.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -159,7 +159,7 @@ public class ChromatogramReader_1_MSD_0803_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 
 		assertEquals(31, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0901_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0901_ITest.java
@@ -111,7 +111,7 @@ public class ChromatogramReader_1_MSD_0901_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(32, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -127,7 +127,7 @@ public class ChromatogramReader_1_MSD_0901_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 
 		assertEquals(35, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -143,7 +143,7 @@ public class ChromatogramReader_1_MSD_0901_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 
 		assertEquals(29, massSpectrum.getNumberOfIons());
 		assertEquals(16.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -159,7 +159,7 @@ public class ChromatogramReader_1_MSD_0901_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 
 		assertEquals(31, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0902_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0902_ITest.java
@@ -111,7 +111,7 @@ public class ChromatogramReader_1_MSD_0902_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(32, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -127,7 +127,7 @@ public class ChromatogramReader_1_MSD_0902_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 
 		assertEquals(35, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -143,7 +143,7 @@ public class ChromatogramReader_1_MSD_0902_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 
 		assertEquals(29, massSpectrum.getNumberOfIons());
 		assertEquals(16.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -159,7 +159,7 @@ public class ChromatogramReader_1_MSD_0902_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 
 		assertEquals(31, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0903_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0903_ITest.java
@@ -111,7 +111,7 @@ public class ChromatogramReader_1_MSD_0903_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(32, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -127,7 +127,7 @@ public class ChromatogramReader_1_MSD_0903_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 
 		assertEquals(35, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -143,7 +143,7 @@ public class ChromatogramReader_1_MSD_0903_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 
 		assertEquals(29, massSpectrum.getNumberOfIons());
 		assertEquals(16.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -159,7 +159,7 @@ public class ChromatogramReader_1_MSD_0903_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 
 		assertEquals(31, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1001_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1001_ITest.java
@@ -111,7 +111,7 @@ public class ChromatogramReader_1_MSD_1001_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(32, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -127,7 +127,7 @@ public class ChromatogramReader_1_MSD_1001_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 
 		assertEquals(35, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -143,7 +143,7 @@ public class ChromatogramReader_1_MSD_1001_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 
 		assertEquals(29, massSpectrum.getNumberOfIons());
 		assertEquals(16.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -159,7 +159,7 @@ public class ChromatogramReader_1_MSD_1001_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 
 		assertEquals(31, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1002_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1002_ITest.java
@@ -19,7 +19,6 @@ import java.io.File;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.TestPathHelper;
@@ -112,7 +111,7 @@ public class ChromatogramReader_1_MSD_1002_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(32, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -128,7 +127,7 @@ public class ChromatogramReader_1_MSD_1002_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 
 		assertEquals(35, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -144,7 +143,7 @@ public class ChromatogramReader_1_MSD_1002_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 
 		assertEquals(29, massSpectrum.getNumberOfIons());
 		assertEquals(16.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -160,7 +159,7 @@ public class ChromatogramReader_1_MSD_1002_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 
 		assertEquals(31, massSpectrum.getNumberOfIons());
 		assertEquals(15.1d, massSpectrum.getLowestIon().getIon(), 0);
@@ -213,14 +212,14 @@ public class ChromatogramReader_1_MSD_1002_ITest {
 	@Test
 	public void testReader_22() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(37);
+		IScanMSD massSpectrum = chromatogram.getScan(37);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testReader_23() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(44);
+		IScanMSD massSpectrum = chromatogram.getScan(44);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1003_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1003_ITest.java
@@ -19,7 +19,6 @@ import java.io.File;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.TestPathHelper;
@@ -126,7 +125,7 @@ public class ChromatogramReader_1_MSD_1003_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -151,7 +150,7 @@ public class ChromatogramReader_1_MSD_1003_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 		/*
 		 * Proxy
 		 */
@@ -176,7 +175,7 @@ public class ChromatogramReader_1_MSD_1003_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 		/*
 		 * Proxy
 		 */
@@ -201,7 +200,7 @@ public class ChromatogramReader_1_MSD_1003_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 		/*
 		 * Proxy
 		 */
@@ -263,14 +262,14 @@ public class ChromatogramReader_1_MSD_1003_ITest {
 	@Test
 	public void testReader_22() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(37);
+		IScanMSD massSpectrum = chromatogram.getScan(37);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testReader_23() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(44);
+		IScanMSD massSpectrum = chromatogram.getScan(44);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1004_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1004_ITest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.TestPathHelper;
@@ -127,7 +126,7 @@ public class ChromatogramReader_1_MSD_1004_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -154,7 +153,7 @@ public class ChromatogramReader_1_MSD_1004_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 		/*
 		 * Proxy
 		 */
@@ -181,7 +180,7 @@ public class ChromatogramReader_1_MSD_1004_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 		/*
 		 * Proxy
 		 */
@@ -208,7 +207,7 @@ public class ChromatogramReader_1_MSD_1004_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 		/*
 		 * Proxy
 		 */
@@ -272,21 +271,21 @@ public class ChromatogramReader_1_MSD_1004_ITest {
 	@Test
 	public void testReader_22() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(37);
+		IScanMSD massSpectrum = chromatogram.getScan(37);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testReader_23() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(44);
+		IScanMSD massSpectrum = chromatogram.getScan(44);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testChromatogramReader_24() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(87);
+		IScanMSD massSpectrum = chromatogram.getScan(87);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(5, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1005_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1005_ITest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.TestPathHelper;
@@ -127,7 +126,7 @@ public class ChromatogramReader_1_MSD_1005_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -154,7 +153,7 @@ public class ChromatogramReader_1_MSD_1005_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 		/*
 		 * Proxy
 		 */
@@ -181,7 +180,7 @@ public class ChromatogramReader_1_MSD_1005_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 		/*
 		 * Proxy
 		 */
@@ -208,7 +207,7 @@ public class ChromatogramReader_1_MSD_1005_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 		/*
 		 * Proxy
 		 */
@@ -272,21 +271,21 @@ public class ChromatogramReader_1_MSD_1005_ITest {
 	@Test
 	public void testReader_22() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(37);
+		IScanMSD massSpectrum = chromatogram.getScan(37);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testReader_23() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(44);
+		IScanMSD massSpectrum = chromatogram.getScan(44);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testChromatogramReader_24() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(87);
+		IScanMSD massSpectrum = chromatogram.getScan(87);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(5, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1006_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1006_ITest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.TestPathHelper;
@@ -127,7 +126,7 @@ public class ChromatogramReader_1_MSD_1006_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -154,7 +153,7 @@ public class ChromatogramReader_1_MSD_1006_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 		/*
 		 * Proxy
 		 */
@@ -181,7 +180,7 @@ public class ChromatogramReader_1_MSD_1006_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 		/*
 		 * Proxy
 		 */
@@ -208,7 +207,7 @@ public class ChromatogramReader_1_MSD_1006_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 		/*
 		 * Proxy
 		 */
@@ -272,21 +271,21 @@ public class ChromatogramReader_1_MSD_1006_ITest {
 	@Test
 	public void testReader_22() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(37);
+		IScanMSD massSpectrum = chromatogram.getScan(37);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testReader_23() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(44);
+		IScanMSD massSpectrum = chromatogram.getScan(44);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testChromatogramReader_24() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(87);
+		IScanMSD massSpectrum = chromatogram.getScan(87);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(5, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1007_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1007_ITest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.TestPathHelper;
@@ -127,7 +126,7 @@ public class ChromatogramReader_1_MSD_1007_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -154,7 +153,7 @@ public class ChromatogramReader_1_MSD_1007_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 		/*
 		 * Proxy
 		 */
@@ -181,7 +180,7 @@ public class ChromatogramReader_1_MSD_1007_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 		/*
 		 * Proxy
 		 */
@@ -208,7 +207,7 @@ public class ChromatogramReader_1_MSD_1007_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 		/*
 		 * Proxy
 		 */
@@ -272,21 +271,21 @@ public class ChromatogramReader_1_MSD_1007_ITest {
 	@Test
 	public void testReader_22() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(37);
+		IScanMSD massSpectrum = chromatogram.getScan(37);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testReader_23() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(44);
+		IScanMSD massSpectrum = chromatogram.getScan(44);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testChromatogramReader_24() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(87);
+		IScanMSD massSpectrum = chromatogram.getScan(87);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(5, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1100_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1100_ITest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.TestPathHelper;
@@ -127,7 +126,7 @@ public class ChromatogramReader_1_MSD_1100_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -154,7 +153,7 @@ public class ChromatogramReader_1_MSD_1100_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 		/*
 		 * Proxy
 		 */
@@ -181,7 +180,7 @@ public class ChromatogramReader_1_MSD_1100_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 		/*
 		 * Proxy
 		 */
@@ -208,7 +207,7 @@ public class ChromatogramReader_1_MSD_1100_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 		/*
 		 * Proxy
 		 */
@@ -272,21 +271,21 @@ public class ChromatogramReader_1_MSD_1100_ITest {
 	@Test
 	public void testReader_22() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(37);
+		IScanMSD massSpectrum = chromatogram.getScan(37);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testReader_23() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(44);
+		IScanMSD massSpectrum = chromatogram.getScan(44);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testChromatogramReader_24() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(87);
+		IScanMSD massSpectrum = chromatogram.getScan(87);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(5, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1300_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1300_ITest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.TestPathHelper;
@@ -127,7 +126,7 @@ public class ChromatogramReader_1_MSD_1300_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -154,7 +153,7 @@ public class ChromatogramReader_1_MSD_1300_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 		/*
 		 * Proxy
 		 */
@@ -181,7 +180,7 @@ public class ChromatogramReader_1_MSD_1300_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 		/*
 		 * Proxy
 		 */
@@ -208,7 +207,7 @@ public class ChromatogramReader_1_MSD_1300_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 		/*
 		 * Proxy
 		 */
@@ -272,21 +271,21 @@ public class ChromatogramReader_1_MSD_1300_ITest {
 	@Test
 	public void testReader_22() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(37);
+		IScanMSD massSpectrum = chromatogram.getScan(37);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testReader_23() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(44);
+		IScanMSD massSpectrum = chromatogram.getScan(44);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testChromatogramReader_24() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(87);
+		IScanMSD massSpectrum = chromatogram.getScan(87);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(5, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1301_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1301_ITest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.TestPathHelper;
@@ -127,7 +126,7 @@ public class ChromatogramReader_1_MSD_1301_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -154,7 +153,7 @@ public class ChromatogramReader_1_MSD_1301_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 		/*
 		 * Proxy
 		 */
@@ -181,7 +180,7 @@ public class ChromatogramReader_1_MSD_1301_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 		/*
 		 * Proxy
 		 */
@@ -208,7 +207,7 @@ public class ChromatogramReader_1_MSD_1301_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 		/*
 		 * Proxy
 		 */
@@ -272,21 +271,21 @@ public class ChromatogramReader_1_MSD_1301_ITest {
 	@Test
 	public void testReader_22() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(37);
+		IScanMSD massSpectrum = chromatogram.getScan(37);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testReader_23() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(44);
+		IScanMSD massSpectrum = chromatogram.getScan(44);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testChromatogramReader_24() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(87);
+		IScanMSD massSpectrum = chromatogram.getScan(87);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(5, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1400_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1400_ITest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.TestPathHelper;
@@ -127,7 +126,7 @@ public class ChromatogramReader_1_MSD_1400_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -154,7 +153,7 @@ public class ChromatogramReader_1_MSD_1400_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 		/*
 		 * Proxy
 		 */
@@ -181,7 +180,7 @@ public class ChromatogramReader_1_MSD_1400_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 		/*
 		 * Proxy
 		 */
@@ -208,7 +207,7 @@ public class ChromatogramReader_1_MSD_1400_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 		/*
 		 * Proxy
 		 */
@@ -272,21 +271,21 @@ public class ChromatogramReader_1_MSD_1400_ITest {
 	@Test
 	public void testReader_22() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(37);
+		IScanMSD massSpectrum = chromatogram.getScan(37);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testReader_23() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(44);
+		IScanMSD massSpectrum = chromatogram.getScan(44);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testChromatogramReader_24() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(87);
+		IScanMSD massSpectrum = chromatogram.getScan(87);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(5, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1500_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1500_ITest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.TestPathHelper;
@@ -128,7 +127,7 @@ public class ChromatogramReader_1_MSD_1500_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -155,7 +154,7 @@ public class ChromatogramReader_1_MSD_1500_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 		/*
 		 * Proxy
 		 */
@@ -182,7 +181,7 @@ public class ChromatogramReader_1_MSD_1500_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 		/*
 		 * Proxy
 		 */
@@ -209,7 +208,7 @@ public class ChromatogramReader_1_MSD_1500_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 		/*
 		 * Proxy
 		 */
@@ -273,21 +272,21 @@ public class ChromatogramReader_1_MSD_1500_ITest {
 	@Test
 	public void testReader_22() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(37);
+		IScanMSD massSpectrum = chromatogram.getScan(37);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testReader_23() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(44);
+		IScanMSD massSpectrum = chromatogram.getScan(44);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testChromatogramReader_24() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(87);
+		IScanMSD massSpectrum = chromatogram.getScan(87);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(5, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1501_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1501_ITest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
-import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.TestPathHelper;
@@ -127,7 +126,7 @@ public class ChromatogramReader_1_MSD_1501_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -154,7 +153,7 @@ public class ChromatogramReader_1_MSD_1501_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(22);
+		IScanMSD massSpectrum = chromatogram.getScan(22);
 		/*
 		 * Proxy
 		 */
@@ -181,7 +180,7 @@ public class ChromatogramReader_1_MSD_1501_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(80);
+		IScanMSD massSpectrum = chromatogram.getScan(80);
 		/*
 		 * Proxy
 		 */
@@ -208,7 +207,7 @@ public class ChromatogramReader_1_MSD_1501_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(110);
+		IScanMSD massSpectrum = chromatogram.getScan(110);
 		/*
 		 * Proxy
 		 */
@@ -272,21 +271,21 @@ public class ChromatogramReader_1_MSD_1501_ITest {
 	@Test
 	public void testReader_22() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(37);
+		IScanMSD massSpectrum = chromatogram.getScan(37);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testReader_23() {
 
-		IRegularMassSpectrum massSpectrum = chromatogram.getSupplierScan(44);
+		IScanMSD massSpectrum = chromatogram.getScan(44);
 		assertEquals(16, massSpectrum.getTargets().size());
 	}
 
 	@Test
 	public void testChromatogramReader_24() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(87);
+		IScanMSD massSpectrum = chromatogram.getScan(87);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(5, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0701_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0701_ITest.java
@@ -111,7 +111,7 @@ public class ChromatogramReader_2_MSD_0701_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(6, massSpectrum.getNumberOfIons());
 		assertEquals(159.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -127,7 +127,7 @@ public class ChromatogramReader_2_MSD_0701_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 
 		assertEquals(11, massSpectrum.getNumberOfIons());
 		assertEquals(135.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -143,7 +143,7 @@ public class ChromatogramReader_2_MSD_0701_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 
 		assertEquals(10, massSpectrum.getNumberOfIons());
 		assertEquals(62.9d, massSpectrum.getLowestIon().getIon(), 0);
@@ -159,7 +159,7 @@ public class ChromatogramReader_2_MSD_0701_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 
 		assertEquals(15, massSpectrum.getNumberOfIons());
 		assertEquals(78.9d, massSpectrum.getLowestIon().getIon(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0801_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0801_ITest.java
@@ -111,7 +111,7 @@ public class ChromatogramReader_2_MSD_0801_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(6, massSpectrum.getNumberOfIons());
 		assertEquals(159.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -127,7 +127,7 @@ public class ChromatogramReader_2_MSD_0801_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 
 		assertEquals(11, massSpectrum.getNumberOfIons());
 		assertEquals(135.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -143,7 +143,7 @@ public class ChromatogramReader_2_MSD_0801_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 
 		assertEquals(10, massSpectrum.getNumberOfIons());
 		assertEquals(62.9d, massSpectrum.getLowestIon().getIon(), 0);
@@ -159,7 +159,7 @@ public class ChromatogramReader_2_MSD_0801_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 
 		assertEquals(15, massSpectrum.getNumberOfIons());
 		assertEquals(78.9d, massSpectrum.getLowestIon().getIon(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0802_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0802_ITest.java
@@ -113,7 +113,7 @@ public class ChromatogramReader_2_MSD_0802_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(6, massSpectrum.getNumberOfIons());
 		assertEquals(159.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -129,7 +129,7 @@ public class ChromatogramReader_2_MSD_0802_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 
 		assertEquals(11, massSpectrum.getNumberOfIons());
 		assertEquals(135.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -145,7 +145,7 @@ public class ChromatogramReader_2_MSD_0802_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 
 		assertEquals(10, massSpectrum.getNumberOfIons());
 		assertEquals(62.9d, massSpectrum.getLowestIon().getIon(), 0);
@@ -161,7 +161,7 @@ public class ChromatogramReader_2_MSD_0802_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 
 		assertEquals(15, massSpectrum.getNumberOfIons());
 		assertEquals(78.9d, massSpectrum.getLowestIon().getIon(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0803_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0803_ITest.java
@@ -113,7 +113,7 @@ public class ChromatogramReader_2_MSD_0803_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(6, massSpectrum.getNumberOfIons());
 		assertEquals(159.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -129,7 +129,7 @@ public class ChromatogramReader_2_MSD_0803_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 
 		assertEquals(11, massSpectrum.getNumberOfIons());
 		assertEquals(135.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -145,7 +145,7 @@ public class ChromatogramReader_2_MSD_0803_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 
 		assertEquals(10, massSpectrum.getNumberOfIons());
 		assertEquals(62.9d, massSpectrum.getLowestIon().getIon(), 0);
@@ -161,7 +161,7 @@ public class ChromatogramReader_2_MSD_0803_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 
 		assertEquals(15, massSpectrum.getNumberOfIons());
 		assertEquals(78.9d, massSpectrum.getLowestIon().getIon(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0901_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0901_ITest.java
@@ -113,7 +113,7 @@ public class ChromatogramReader_2_MSD_0901_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(6, massSpectrum.getNumberOfIons());
 		assertEquals(159.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -129,7 +129,7 @@ public class ChromatogramReader_2_MSD_0901_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 
 		assertEquals(11, massSpectrum.getNumberOfIons());
 		assertEquals(135.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -145,7 +145,7 @@ public class ChromatogramReader_2_MSD_0901_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 
 		assertEquals(10, massSpectrum.getNumberOfIons());
 		assertEquals(62.9d, massSpectrum.getLowestIon().getIon(), 0);
@@ -161,7 +161,7 @@ public class ChromatogramReader_2_MSD_0901_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 
 		assertEquals(15, massSpectrum.getNumberOfIons());
 		assertEquals(78.9d, massSpectrum.getLowestIon().getIon(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0902_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0902_ITest.java
@@ -113,7 +113,7 @@ public class ChromatogramReader_2_MSD_0902_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(6, massSpectrum.getNumberOfIons());
 		assertEquals(159.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -129,7 +129,7 @@ public class ChromatogramReader_2_MSD_0902_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 
 		assertEquals(11, massSpectrum.getNumberOfIons());
 		assertEquals(135.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -145,7 +145,7 @@ public class ChromatogramReader_2_MSD_0902_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 
 		assertEquals(10, massSpectrum.getNumberOfIons());
 		assertEquals(62.9d, massSpectrum.getLowestIon().getIon(), 0);
@@ -161,7 +161,7 @@ public class ChromatogramReader_2_MSD_0902_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 
 		assertEquals(15, massSpectrum.getNumberOfIons());
 		assertEquals(78.9d, massSpectrum.getLowestIon().getIon(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0903_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0903_ITest.java
@@ -122,7 +122,7 @@ public class ChromatogramReader_2_MSD_0903_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(6, massSpectrum.getNumberOfIons());
 		assertEquals(159.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -138,7 +138,7 @@ public class ChromatogramReader_2_MSD_0903_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 
 		assertEquals(12, massSpectrum.getNumberOfIons());
 		assertEquals(135.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -154,7 +154,7 @@ public class ChromatogramReader_2_MSD_0903_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 
 		assertEquals(10, massSpectrum.getNumberOfIons());
 		assertEquals(62.9d, massSpectrum.getLowestIon().getIon(), 0);
@@ -170,7 +170,7 @@ public class ChromatogramReader_2_MSD_0903_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 
 		assertEquals(15, massSpectrum.getNumberOfIons());
 		assertEquals(78.9d, massSpectrum.getLowestIon().getIon(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1001_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1001_ITest.java
@@ -113,7 +113,7 @@ public class ChromatogramReader_2_MSD_1001_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(6, massSpectrum.getNumberOfIons());
 		assertEquals(159.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -129,7 +129,7 @@ public class ChromatogramReader_2_MSD_1001_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 
 		assertEquals(11, massSpectrum.getNumberOfIons());
 		assertEquals(135.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -145,7 +145,7 @@ public class ChromatogramReader_2_MSD_1001_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 
 		assertEquals(10, massSpectrum.getNumberOfIons());
 		assertEquals(62.9d, massSpectrum.getLowestIon().getIon(), 0);
@@ -161,7 +161,7 @@ public class ChromatogramReader_2_MSD_1001_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 
 		assertEquals(15, massSpectrum.getNumberOfIons());
 		assertEquals(78.9d, massSpectrum.getLowestIon().getIon(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1002_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1002_ITest.java
@@ -113,7 +113,7 @@ public class ChromatogramReader_2_MSD_1002_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 
 		assertEquals(6, massSpectrum.getNumberOfIons());
 		assertEquals(159.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -129,7 +129,7 @@ public class ChromatogramReader_2_MSD_1002_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 
 		assertEquals(11, massSpectrum.getNumberOfIons());
 		assertEquals(135.0d, massSpectrum.getLowestIon().getIon(), 0);
@@ -145,7 +145,7 @@ public class ChromatogramReader_2_MSD_1002_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 
 		assertEquals(10, massSpectrum.getNumberOfIons());
 		assertEquals(62.9d, massSpectrum.getLowestIon().getIon(), 0);
@@ -161,7 +161,7 @@ public class ChromatogramReader_2_MSD_1002_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 
 		assertEquals(15, massSpectrum.getNumberOfIons());
 		assertEquals(78.9d, massSpectrum.getLowestIon().getIon(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1003_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1003_ITest.java
@@ -127,7 +127,7 @@ public class ChromatogramReader_2_MSD_1003_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -152,7 +152,7 @@ public class ChromatogramReader_2_MSD_1003_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 		/*
 		 * Proxy
 		 */
@@ -177,7 +177,7 @@ public class ChromatogramReader_2_MSD_1003_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 		/*
 		 * Proxy
 		 */
@@ -202,7 +202,7 @@ public class ChromatogramReader_2_MSD_1003_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 		/*
 		 * Proxy
 		 */

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1004_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1004_ITest.java
@@ -128,7 +128,7 @@ public class ChromatogramReader_2_MSD_1004_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -155,7 +155,7 @@ public class ChromatogramReader_2_MSD_1004_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 		/*
 		 * Proxy
 		 */
@@ -182,7 +182,7 @@ public class ChromatogramReader_2_MSD_1004_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 		/*
 		 * Proxy
 		 */
@@ -209,7 +209,7 @@ public class ChromatogramReader_2_MSD_1004_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 		/*
 		 * Proxy
 		 */
@@ -335,7 +335,7 @@ public class ChromatogramReader_2_MSD_1004_ITest {
 	@Test
 	public void testChromatogramReader_25() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(117);
+		IScanMSD massSpectrum = chromatogram.getScan(117);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(8, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1005_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1005_ITest.java
@@ -128,7 +128,7 @@ public class ChromatogramReader_2_MSD_1005_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -155,7 +155,7 @@ public class ChromatogramReader_2_MSD_1005_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 		/*
 		 * Proxy
 		 */
@@ -182,7 +182,7 @@ public class ChromatogramReader_2_MSD_1005_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 		/*
 		 * Proxy
 		 */
@@ -209,7 +209,7 @@ public class ChromatogramReader_2_MSD_1005_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 		/*
 		 * Proxy
 		 */
@@ -335,7 +335,7 @@ public class ChromatogramReader_2_MSD_1005_ITest {
 	@Test
 	public void testChromatogramReader_25() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(117);
+		IScanMSD massSpectrum = chromatogram.getScan(117);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(8, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1006_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1006_ITest.java
@@ -128,7 +128,7 @@ public class ChromatogramReader_2_MSD_1006_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -155,7 +155,7 @@ public class ChromatogramReader_2_MSD_1006_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 		/*
 		 * Proxy
 		 */
@@ -182,7 +182,7 @@ public class ChromatogramReader_2_MSD_1006_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 		/*
 		 * Proxy
 		 */
@@ -209,7 +209,7 @@ public class ChromatogramReader_2_MSD_1006_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 		/*
 		 * Proxy
 		 */
@@ -335,7 +335,7 @@ public class ChromatogramReader_2_MSD_1006_ITest {
 	@Test
 	public void testChromatogramReader_25() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(117);
+		IScanMSD massSpectrum = chromatogram.getScan(117);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(8, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1007_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1007_ITest.java
@@ -128,7 +128,7 @@ public class ChromatogramReader_2_MSD_1007_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -155,7 +155,7 @@ public class ChromatogramReader_2_MSD_1007_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 		/*
 		 * Proxy
 		 */
@@ -182,7 +182,7 @@ public class ChromatogramReader_2_MSD_1007_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 		/*
 		 * Proxy
 		 */
@@ -209,7 +209,7 @@ public class ChromatogramReader_2_MSD_1007_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 		/*
 		 * Proxy
 		 */
@@ -335,7 +335,7 @@ public class ChromatogramReader_2_MSD_1007_ITest {
 	@Test
 	public void testChromatogramReader_25() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(117);
+		IScanMSD massSpectrum = chromatogram.getScan(117);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(8, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1100_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1100_ITest.java
@@ -128,7 +128,7 @@ public class ChromatogramReader_2_MSD_1100_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -155,7 +155,7 @@ public class ChromatogramReader_2_MSD_1100_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 		/*
 		 * Proxy
 		 */
@@ -182,7 +182,7 @@ public class ChromatogramReader_2_MSD_1100_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 		/*
 		 * Proxy
 		 */
@@ -209,7 +209,7 @@ public class ChromatogramReader_2_MSD_1100_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 		/*
 		 * Proxy
 		 */
@@ -335,7 +335,7 @@ public class ChromatogramReader_2_MSD_1100_ITest {
 	@Test
 	public void testChromatogramReader_25() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(117);
+		IScanMSD massSpectrum = chromatogram.getScan(117);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(8, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1300_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1300_ITest.java
@@ -128,7 +128,7 @@ public class ChromatogramReader_2_MSD_1300_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -155,7 +155,7 @@ public class ChromatogramReader_2_MSD_1300_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 		/*
 		 * Proxy
 		 */
@@ -182,7 +182,7 @@ public class ChromatogramReader_2_MSD_1300_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 		/*
 		 * Proxy
 		 */
@@ -209,7 +209,7 @@ public class ChromatogramReader_2_MSD_1300_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 		/*
 		 * Proxy
 		 */
@@ -335,7 +335,7 @@ public class ChromatogramReader_2_MSD_1300_ITest {
 	@Test
 	public void testChromatogramReader_25() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(117);
+		IScanMSD massSpectrum = chromatogram.getScan(117);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(8, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1301_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1301_ITest.java
@@ -128,7 +128,7 @@ public class ChromatogramReader_2_MSD_1301_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -155,7 +155,7 @@ public class ChromatogramReader_2_MSD_1301_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 		/*
 		 * Proxy
 		 */
@@ -182,7 +182,7 @@ public class ChromatogramReader_2_MSD_1301_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 		/*
 		 * Proxy
 		 */
@@ -209,7 +209,7 @@ public class ChromatogramReader_2_MSD_1301_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 		/*
 		 * Proxy
 		 */
@@ -335,7 +335,7 @@ public class ChromatogramReader_2_MSD_1301_ITest {
 	@Test
 	public void testChromatogramReader_25() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(117);
+		IScanMSD massSpectrum = chromatogram.getScan(117);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(8, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1400_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1400_ITest.java
@@ -128,7 +128,7 @@ public class ChromatogramReader_2_MSD_1400_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -155,7 +155,7 @@ public class ChromatogramReader_2_MSD_1400_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 		/*
 		 * Proxy
 		 */
@@ -182,7 +182,7 @@ public class ChromatogramReader_2_MSD_1400_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 		/*
 		 * Proxy
 		 */
@@ -209,7 +209,7 @@ public class ChromatogramReader_2_MSD_1400_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 		/*
 		 * Proxy
 		 */
@@ -335,7 +335,7 @@ public class ChromatogramReader_2_MSD_1400_ITest {
 	@Test
 	public void testChromatogramReader_25() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(117);
+		IScanMSD massSpectrum = chromatogram.getScan(117);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(8, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1500_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1500_ITest.java
@@ -128,7 +128,7 @@ public class ChromatogramReader_2_MSD_1500_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -155,7 +155,7 @@ public class ChromatogramReader_2_MSD_1500_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 		/*
 		 * Proxy
 		 */
@@ -182,7 +182,7 @@ public class ChromatogramReader_2_MSD_1500_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 		/*
 		 * Proxy
 		 */
@@ -209,7 +209,7 @@ public class ChromatogramReader_2_MSD_1500_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 		/*
 		 * Proxy
 		 */
@@ -335,7 +335,7 @@ public class ChromatogramReader_2_MSD_1500_ITest {
 	@Test
 	public void testChromatogramReader_25() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(117);
+		IScanMSD massSpectrum = chromatogram.getScan(117);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(8, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1501_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1501_ITest.java
@@ -128,7 +128,7 @@ public class ChromatogramReader_2_MSD_1501_ITest {
 	@Test
 	public void testChromatogramReader_12() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(1);
+		IScanMSD massSpectrum = chromatogram.getScan(1);
 		/*
 		 * Proxy
 		 */
@@ -155,7 +155,7 @@ public class ChromatogramReader_2_MSD_1501_ITest {
 	@Test
 	public void testChromatogramReader_13() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(92);
+		IScanMSD massSpectrum = chromatogram.getScan(92);
 		/*
 		 * Proxy
 		 */
@@ -182,7 +182,7 @@ public class ChromatogramReader_2_MSD_1501_ITest {
 	@Test
 	public void testChromatogramReader_14() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(147);
+		IScanMSD massSpectrum = chromatogram.getScan(147);
 		/*
 		 * Proxy
 		 */
@@ -209,7 +209,7 @@ public class ChromatogramReader_2_MSD_1501_ITest {
 	@Test
 	public void testChromatogramReader_15() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(207);
+		IScanMSD massSpectrum = chromatogram.getScan(207);
 		/*
 		 * Proxy
 		 */
@@ -335,7 +335,7 @@ public class ChromatogramReader_2_MSD_1501_ITest {
 	@Test
 	public void testChromatogramReader_25() {
 
-		IScanMSD massSpectrum = chromatogram.getSupplierScan(117);
+		IScanMSD massSpectrum = chromatogram.getScan(117);
 		massSpectrum.enforceLoadScanProxy();
 		assertNotNull(massSpectrum.getOptimizedMassSpectrum());
 		assertEquals(8, massSpectrum.getTargets().size());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_4_DAD_1501_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_4_DAD_1501_ITest.java
@@ -101,7 +101,7 @@ public class ChromatogramReader_4_DAD_1501_ITest {
 	@Test
 	public void testReader_9() {
 
-		IScanWSD scan = chromatogram.getSupplierScan(1);
+		IScanWSD scan = chromatogram.getScan(1);
 
 		assertEquals(226, scan.getScanSignals().size());
 		assertEquals(5.9459736E7f, scan.getTotalSignal(), 0);


### PR DESCRIPTION
and replaced it with `getScan` which always gives you the scan type you expect from the chromatogram thanks to an interface override. MSD had a special case where it returned `RegularMassSpectrum` so it could be null if it wasn't one. What the caller usually wants was, however, `ScanMSD` so that is what you get now. You can still cast that later, which is what I had to do for the file format converters. This maybe calls for a future refactor.

When you just want a `Scan` without a detector type, you now get null. This is now only available from a `Chromatogram` without detector type. This is potentially a breaking change, but in more cases, the caller should get what he expects and fewer surprises with null values that I stumbled upon in https://github.com/eclipse-chemclipse/chemclipse/pull/2445.