### PR TITLE
Fix m/z labels persisting across scans

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
@@ -131,6 +131,7 @@ public class ScanChartUI extends ScrollableChart {
 			/*
 			 * Labels
 			 */
+			customSeries.getTextElements().clear();
 			printHighestLabelsNormal(barSeriesValues, e);
 			printHighestLabelsMirrored(barSeriesValues, e);
 		}
@@ -758,9 +759,7 @@ public class ScanChartUI extends ScrollableChart {
 		textElement.setX(pointLabel.getX() - pointSize.getX() / 32);
 		textElement.setY(pointLabel.getY());
 		textElement.setRotation(0);
-		if(customSeries.getTextElements().stream().noneMatch(t -> t.getLabel().equals(textElement.getLabel()))) {
-			customSeries.getTextElements().add(textElement);
-		}
+		customSeries.getTextElements().add(textElement);
 	}
 
 	private void drawTriangle(BarSeriesValue barSeriesValue, int size, PaintEvent e) {


### PR DESCRIPTION
https://github.com/eclipse-chemclipse/chemclipse/pull/2443 introduced a bug where when you select the next scan, the scalable vector graphics output would also print the labels from the previously selected scan if the m/z differs.