### PR TITLE
Provide all mass spectra to child widgets

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/IMassSpectrumEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/IMassSpectrumEditor.java
@@ -12,10 +12,10 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.msd.ui.editors;
 
-import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.ux.extension.ui.editors.IChemClipseEditor;
 
 public interface IMassSpectrumEditor extends IChemClipseEditor {
 
-	IScanMSD getScanSelection();
+	IMassSpectra getScanSelection();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/MassSpectrumEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/MassSpectrumEditor.java
@@ -352,8 +352,8 @@ public class MassSpectrumEditor implements IMassSpectrumEditor {
 	}
 
 	@Override
-	public IScanMSD getScanSelection() {
+	public IMassSpectra getScanSelection() {
 
-		return massSpectrum;
+		return massSpectra;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/part/support/EditorUpdateSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/part/support/EditorUpdateSupport.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationDatabase;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.nmr.model.selection.IDataNMRSelection;
 import org.eclipse.chemclipse.ux.extension.msd.ui.editors.IMassSpectrumEditor;
@@ -107,13 +108,13 @@ public class EditorUpdateSupport {
 						/*
 						 * MALDI
 						 */
-						IScanMSD selection = null;
+						IMassSpectra selection = null;
 						if(object instanceof IMassSpectrumEditor editor) {
 							selection = editor.getScanSelection();
 						}
 
 						if(selection != null) {
-							dataSelections.add(selection);
+							dataSelections.addAll(selection.getList());
 						}
 					}
 				}


### PR DESCRIPTION
This is a continuation of https://github.com/eclipse-chemclipse/chemclipse/pull/2053 which added multiple mass spectra per editor. These are now also passed on to the mass spectrum overlay instead of just the first.