### PR TITLE
Port chromatogram chart preferences to color/font definition

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/dark.css
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/dark.css
@@ -49,3 +49,107 @@ Table {
 ToolItem {
 	color: #FFFFFF;
 }
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-ChromatogramChart-AxisMilliseconds-LineColor {
+  color: #fcfcf7;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-ChromatogramChart-AxisMilliseconds-GridColor {
+  color: #404040;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-ChromatogramChart-AxisIntensity-LineColor {
+  color: #fcfcf7;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-ChromatogramChart-AxisIntensity-GridColor {
+  color: #404040;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-ChromatogramChart-AxisRelativeIntensity-LineColor {
+  color: #fcfcf7;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-ChromatogramChart-AxisRelativeIntensity-GridColor {
+  color: #404040;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-ChromatogramChart-AxisSeconds-LineColor {
+  color: #fcfcf7;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-ChromatogramChart-AxisSeconds-GridColor {
+  color: #404040;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-ChromatogramChart-AxisMinutes-LineColor {
+  color: #fcfcf7;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-ChromatogramChart-AxisMinutes-GridColor {
+  color: #404040;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-swt-editors-ExtendedChromatogramUI-ScanAxis-LineColor {
+  color: #fcfcf7;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-swt-editors-ExtendedChromatogramUI-ScanAxis-GridColor {
+  color: #404040;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-PeaksChart-YAxisRelativeResponse-LineColor {
+  color: #fcfcf7;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-PeaksChart-YAxisRelativeResponse-GridColor {
+  color: #404040;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-PeaksChart-XAxisMinutes-LineColor {
+  color: #fcfcf7;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-PeaksChart-XAxisMinutes-GridColor {
+  color: #404040;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-PeaksChart-YAxisResponse-LineColor {
+  color: #fcfcf7;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-PeaksChart-YAxisResponse-GridColor {
+  color: #404040;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-PeaksChart-XAxisMilliseconds-LineColor {
+  color: #fcfcf7;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-PeaksChart-XAxisMilliseconds-GridColor {
+  color: #404040;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-CalibrationChart-YAxisRelativeResponse-LineColor {
+  color: #fcfcf7;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-CalibrationChart-YAxisRelativeResponse-GridColor {
+  color: #404040;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-CalibrationChart-YAxisResponse-LineColor {
+  color: #fcfcf7;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-CalibrationChart-YAxisResponse-GridColor {
+  color: #404040;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-CalibrationChart-XAxisConcentration-LineColor {
+  color: #fcfcf7;
+}
+
+ColorDefinition#org-eclipse-chemclipse-ux-extension-xxd-ui-charts-CalibrationChart-XAxisConcentration-GridColor {
+  color: #404040;
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
@@ -294,4 +294,378 @@
          </adapter>
       </factory>
    </extension>
+
+   <extension point="org.eclipse.ui.themes">
+   	<themeElementCategory
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        label="Charts">
+        <description>
+            Theming of charts.
+        </description>
+    </themeElementCategory>
+
+   <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart.AxisMilliseconds.GridColor"
+        label="Chromatogram Chart Axis Milliseconds Grid Color"
+        value="0,0,0">
+        <description>
+            The color of the chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart.AxisMilliseconds.LineColor"
+        label="Chromatogram Chart Axis Milliseconds Line Color"
+        value="192,192,192">
+        <description>
+            The color of the chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart.AxisMilliseconds.Font"
+        label="Chromatogram Chart Axis Milliseconds Intensity Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font.
+        </description>
+    </fontDefinition>
+
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart.AxisIntensity.GridColor"
+        label="Chromatogram Chart Axis Intensity Grid Color"
+        value="0,0,0">
+        <description>
+            The color of the chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart.AxisIntensity.LineColor"
+        label="Chromatogram Chart Axis Intensity Line Color"
+        value="192,192,192">
+        <description>
+            The color of the chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart.AxisIntensity.Font"
+        label="Chromatogram Chart Axis Intensity Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font
+        </description>
+    </fontDefinition>
+
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart.AxisRelativeIntensity.GridColor"
+        label="Chromatogram Chart Axis Relative Intensity Grid Color"
+        value="0,0,0">
+        <description>
+            The color of the chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart.AxisRelativeIntensity.LineColor"
+        label="Chromatogram Chart Axis Relative Intensity Line Color"
+        value="192,192,192">
+        <description>
+            The color of the chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart.AxisRelativeIntensity.Font"
+        label="Chromatogram Chart Axis Relative Intensity Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font.
+        </description>
+    </fontDefinition>
+
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart.AxisSeconds.GridColor"
+        label="Chromatogram Chart Axis Seconds Grid Color"
+        value="0,0,0">
+        <description>
+            The color of the chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart.AxisSeconds.LineColor"
+        label="Chromatogram Chart Axis Seconds Line Color"
+        value="192,192,192">
+        <description>
+            The color of the chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart.AxisSeconds.Font"
+        label="Chromatogram Chart Axis Seconds Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font.
+        </description>
+    </fontDefinition>
+
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart.AxisMinutes.GridColor"
+        label="Chromatogram Chart Axis Minutes Grid Color"
+        value="192,192,192">
+        <description>
+            The color of the chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart.AxisMinutes.LineColor"
+        label="Chromatogram Chart Axis Minutes Line Color"
+        value="0,0,0">
+        <description>
+            The color of the chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart.AxisMinutes.Font"
+        label="Chromatogram Chart Axis Minutes Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font.
+        </description>
+    </fontDefinition>
+
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.CalibrationChart.XAxisConcentration.GridColor"
+        label="Calibration Chart X Axis Concentration Grid Color"
+        value="0,0,0">
+        <description>
+            The color of the chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.CalibrationChart.XAxisConcentration.LineColor"
+        label="Calibration Chart X Axis Concentration Line Color"
+        value="192,192,192">
+        <description>
+            The color of the chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.CalibrationChart.XAxisConcentration.Font"
+        label="Calibration Chart X Axis Concentration Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font.
+        </description>
+    </fontDefinition>
+
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.CalibrationChart.YAxisResponse.GridColor"
+        label="Peaks Chart Y Axis Response Grid Color"
+        value="0,0,0">
+        <description>
+            The color of the chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.CalibrationChart.YAxisResponse.LineColor"
+        label="Peaks Chart Y Axis Response Line Color"
+        value="192,192,192">
+        <description>
+            The color of the chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.CalibrationChart.YAxisResponse.Font"
+        label="Peaks Chart Y Axis Response Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font.
+        </description>
+    </fontDefinition>
+
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.CalibrationChart.YAxisRelativeResponse.GridColor"
+        label="Peaks Chart Y Axis Relative Response Color"
+        value="0,0,0">
+        <description>
+            The color of the chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.CalibrationChart.YAxisRelativeResponse.LineColor"
+        label="Peaks Chart Y Axis Relative Response Color"
+        value="192,192,192">
+        <description>
+            The color of the chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.CalibrationChart.YAxisRelativeResponse.Font"
+        label="Peaks Chart Y Axis Relative Response Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font.
+        </description>
+    </fontDefinition>
+    
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.PeaksChart.XAxisMilliseconds.GridColor"
+        label="Peaks Chart X Axis Milliseconds Grid Color"
+        value="0,0,0">
+        <description>
+            The color of the chromatogram chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.PeaksChart.XAxisMilliseconds.LineColor"
+        label="Peaks Chart X Axis Milliseconds Line Color"
+        value="192,192,192">
+        <description>
+            The color of the chromatogram chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.PeaksChart.XAxisMilliseconds.Font"
+        label="Peaks Chart X Axis Milliseconds Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font.
+        </description>
+    </fontDefinition>
+    
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.PeaksChart.YAxisResponse.GridColor"
+        label="Peaks Chart Y Axis Grid Color"
+        value="0,0,0">
+        <description>
+            The color of the chromatogram chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.PeaksChart.YAxisResponse.LineColor"
+        label="Peaks Chart Y Axis Line Color"
+        value="192,192,192">
+        <description>
+            The color of the chromatogram chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.PeaksChart.YAxisResponse.Font"
+        label="Peaks Chart Y Axis Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font.
+        </description>
+    </fontDefinition>
+
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.PeaksChart.XAxisMinutes.GridColor"
+        label="Peaks Chart X Axis Grid Color"
+        value="0,0,0">
+        <description>
+            The color of the chromatogram chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.PeaksChart.XAxisMinutes.LineColor"
+        label="Peaks Chart X Axis Line Color"
+        value="192,192,192">
+        <description>
+            The color of the chromatogram chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.PeaksChart.XAxisMinutes.Font"
+        label="Peaks Chart X Axis Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font.
+        </description>
+    </fontDefinition>
+    
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.PeaksChart.YAxisRelativeResponse.GridColor"
+        label="Peaks Chart Y Axis Relative Response Color"
+        value="0,0,0">
+        <description>
+            The color of the chromatogram chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.PeaksChart.YAxisRelativeResponse.LineColor"
+        label="Peaks Chart Y Axis Relative Response Color"
+        value="192,192,192">
+        <description>
+            The color of the chromatogram chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.charts.PeaksChart.YAxisRelativeResponse.Font"
+        label="Peaks Chart Y Axis Relative Response Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font.
+        </description>
+    </fontDefinition>
+    
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.editors.ExtendedChromatogramUI.ScanAxis.GridColor"
+        label="Chromatogram Chart Scan Axis Grid Color"
+        value="0,0,0">
+        <description>
+            The color of the chromatogram chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.editors.ExtendedChromatogramUI.ScanAxis.LineColor"
+        label="Chromatogram Chart Scan Axis Line Color"
+        value="192,192,192">
+        <description>
+            The color of the chromatogram chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.editors.ExtendedChromatogramUI.ScanAxis.Font"
+        label="Chromatogram Chart Scan Axis Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font.
+        </description>
+    </fontDefinition>
+</extension>
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/CalibrationChart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/CalibrationChart.java
@@ -86,13 +86,14 @@ public class CalibrationChart extends LineChart {
 
 		String positionNode = PreferenceSupplier.P_POSITION_X_AXIS_CONCENTRATION_CALIBRATION;
 		String pattern = "0.0##";
-		String colorNode = PreferenceSupplier.P_COLOR_X_AXIS_CONCENTRATION_CALIBRATION;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_CONCENTRATION_CALIBRATION;
-		String gridColorNode = PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_CONCENTRATION_CALIBRATION;
-		boolean isShowAxis = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_CONCENTRATION_CALIBRATION);
 
-		ChartSupport.setAxisSettings(primaryAxisSettingsX, positionNode, pattern, colorNode, gridLineStyleNode, gridColorNode);
+		ChartSupport.setAxisSettings(primaryAxisSettingsX, positionNode, pattern, gridLineStyleNode);
+
+		boolean isShowAxis = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_CONCENTRATION_CALIBRATION);
 		primaryAxisSettingsX.setVisible(isShowAxis);
+
+		ChartSupport.themeAxis(primaryAxisSettingsX, "XAxisConcentration");
 	}
 
 	private void modifyYAxisResponse() {
@@ -103,13 +104,13 @@ public class CalibrationChart extends LineChart {
 
 		String positionNode = PreferenceSupplier.P_POSITION_Y_AXIS_RESPONSE_CALIBRATION;
 		String pattern = "0.0#E0";
-		String colorNode = PreferenceSupplier.P_COLOR_Y_AXIS_RESPONSE_CALIBRATION;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_Y_AXIS_RESPONSE_CALIBRATION;
-		String gridColorNode = PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_RESPONSE_CALIBRATION;
-		boolean isShowAxis = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_Y_AXIS_RESPONSE_CALIBRATION);
+		ChartSupport.setAxisSettings(primaryAxisSettingsY, positionNode, pattern, gridLineStyleNode);
 
-		ChartSupport.setAxisSettings(primaryAxisSettingsY, positionNode, pattern, colorNode, gridLineStyleNode, gridColorNode);
+		boolean isShowAxis = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_Y_AXIS_RESPONSE_CALIBRATION);
 		primaryAxisSettingsY.setVisible(isShowAxis);
+
+		ChartSupport.themeAxis(primaryAxisSettingsY, "YAxisResponse");
 	}
 
 	private void modifyYAxisRelativeResponse() {
@@ -119,18 +120,18 @@ public class CalibrationChart extends LineChart {
 
 		String positionNode = PreferenceSupplier.P_POSITION_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION;
 		String pattern = "0.00";
-		String colorNode = PreferenceSupplier.P_COLOR_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION;
-		String gridColorNode = PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION;
 		boolean isShowAxis = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION);
+
+		ChartSupport.themeAxis(axisSettings, "YAxisRelativeResponse");
 
 		if(isShowAxis) {
 			if(axisSettings == null) {
 				ISecondaryAxisSettings secondaryAxisSettingsY = new SecondaryAxisSettings(TITLE_Y_AXIS_RELATIVE_RESPONSE, new PercentageConverter(SWT.VERTICAL, true));
-				ChartSupport.setAxisSettings(secondaryAxisSettingsY, positionNode, pattern, colorNode, gridLineStyleNode, gridColorNode);
+				ChartSupport.setAxisSettings(secondaryAxisSettingsY, positionNode, pattern, gridLineStyleNode);
 				chartSettings.getSecondaryAxisSettingsListY().add(secondaryAxisSettingsY);
 			} else {
-				ChartSupport.setAxisSettings(axisSettings, positionNode, pattern, colorNode, gridLineStyleNode, gridColorNode);
+				ChartSupport.setAxisSettings(axisSettings, positionNode, pattern, gridLineStyleNode);
 				axisSettings.setVisible(true);
 			}
 		} else {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartSupport.java
@@ -18,11 +18,13 @@ import java.util.List;
 import java.util.Locale;
 
 import org.eclipse.chemclipse.support.text.ValueFormat;
-import org.eclipse.chemclipse.swt.ui.support.Colors;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.resource.ColorRegistry;
+import org.eclipse.jface.resource.FontRegistry;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Font;
 import org.eclipse.swtchart.IAxis;
 import org.eclipse.swtchart.IAxis.Position;
 import org.eclipse.swtchart.LineStyle;
@@ -34,6 +36,9 @@ import org.eclipse.swtchart.extensions.core.IChartSettings;
 import org.eclipse.swtchart.extensions.core.IPrimaryAxisSettings;
 import org.eclipse.swtchart.extensions.core.ISecondaryAxisSettings;
 import org.eclipse.swtchart.extensions.core.SecondaryAxisSettings;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.themes.ITheme;
+import org.eclipse.ui.themes.IThemeManager;
 
 public class ChartSupport {
 
@@ -80,28 +85,24 @@ public class ChartSupport {
 		chartSettings.getSecondaryAxisSettingsListY().add(secondaryAxisSettingsY);
 	}
 
-	public static void setAxisSettingsExtended(IAxisSettings axisSettings, String positionNode, String patternNode, String colorNode, String gridLineStyleNode, String gridColorNode) {
+	public static void setAxisSettingsExtended(IAxisSettings axisSettings, String positionNode, String patternNode, String gridLineStyleNode) {
 
 		String pattern = preferenceStore.getString(patternNode);
-		setAxisSettings(axisSettings, positionNode, pattern, colorNode, gridLineStyleNode, gridColorNode);
+		setAxisSettings(axisSettings, positionNode, pattern, gridLineStyleNode);
 	}
 
-	public static void setAxisSettings(IAxisSettings axisSettings, String positionNode, String pattern, String colorNode, String gridLineStyleNode, String gridColorNode) {
+	public static void setAxisSettings(IAxisSettings axisSettings, String positionNode, String pattern, String gridLineStyleNode) {
 
 		Position position = Position.valueOf(preferenceStore.getString(positionNode));
-		Color color = Colors.getColor(preferenceStore.getString(colorNode));
 		LineStyle gridLineStyle = LineStyle.valueOf(preferenceStore.getString(gridLineStyleNode));
-		Color gridColor = Colors.getColor(preferenceStore.getString(gridColorNode));
-		setAxisSettings(axisSettings, position, pattern, color, gridLineStyle, gridColor);
+		setAxisSettings(axisSettings, position, pattern, gridLineStyle);
 	}
 
-	public static void setAxisSettings(IAxisSettings axisSettings, Position position, String decimalPattern, Color color, LineStyle gridLineStyle, Color gridColor) {
+	public static void setAxisSettings(IAxisSettings axisSettings, Position position, String decimalPattern, LineStyle gridLineStyle) {
 
 		if(axisSettings != null) {
 			axisSettings.setPosition(position);
 			axisSettings.setDecimalFormat(ValueFormat.getDecimalFormatEnglish(decimalPattern));
-			axisSettings.setColor(color);
-			axisSettings.setGridColor(gridColor);
 			axisSettings.setGridLineStyle(gridLineStyle);
 		}
 	}
@@ -168,5 +169,22 @@ public class ChartSupport {
 		}
 
 		return null;
+	}
+
+	public static void themeAxis(IAxisSettings axisSettings, String part) {
+
+		IThemeManager themeManager = PlatformUI.getWorkbench().getThemeManager();
+		ITheme currentTheme = themeManager.getCurrentTheme();
+
+		ColorRegistry colorRegistry = currentTheme.getColorRegistry();
+		Color color = colorRegistry.get(ChromatogramChart.class.getName() + "." + part + ".LineColor");
+		axisSettings.setColor(color);
+
+		Color gridColor = colorRegistry.get(ChromatogramChart.class.getName() + "." + part + ".GridColor");
+		axisSettings.setGridColor(gridColor);
+
+		FontRegistry fontRegistry = currentTheme.getFontRegistry();
+		Font font = fontRegistry.get(ChromatogramChart.class.getName() + "." + part + ".Font");
+		axisSettings.setTitleFont(font);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChromatogramChart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChromatogramChart.java
@@ -13,14 +13,11 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.charts;
 
-import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
-import org.eclipse.chemclipse.swt.ui.support.Fonts;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.custom.IRangeSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferenceSupplier;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swtchart.IAxis;
 import org.eclipse.swtchart.IAxisSet;
@@ -196,18 +193,12 @@ public class ChromatogramChart extends LineChart implements IRangeSupport {
 
 		String positionNode = PreferenceSupplier.P_POSITION_X_AXIS_MILLISECONDS;
 		String patternNode = PreferenceSupplier.P_FORMAT_X_AXIS_MILLISECONDS;
-		String colorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_COLOR_X_AXIS_MILLISECONDS_DARKTHEME : PreferenceSupplier.P_COLOR_X_AXIS_MILLISECONDS;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_MILLISECONDS;
-		String gridColorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_DARKTHEME : PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS;
 
-		ChartSupport.setAxisSettingsExtended(primaryAxisSettingsX, positionNode, patternNode, colorNode, gridLineStyleNode, gridColorNode);
+		ChartSupport.setAxisSettingsExtended(primaryAxisSettingsX, positionNode, patternNode, gridLineStyleNode);
+		ChartSupport.themeAxis(primaryAxisSettingsX, "AxisMilliseconds");
 		primaryAxisSettingsX.setVisible(ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_MILLISECONDS));
 		primaryAxisSettingsX.setTitleVisible(ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_TITLE_MILLISECONDS));
-
-		String name = preferenceStore.getString(PreferenceSupplier.P_FONT_NAME_X_AXIS_MILLISECONDS);
-		int height = preferenceStore.getInt(PreferenceSupplier.P_FONT_SIZE_X_AXIS_MILLISECONDS);
-		int style = preferenceStore.getInt(PreferenceSupplier.P_FONT_STYLE_X_AXIS_MILLISECONDS);
-		primaryAxisSettingsX.setTitleFont(Fonts.getCachedFont(getBaseChart().getDisplay(), name, height, style));
 	}
 
 	private void adjustAxisIntensity() {
@@ -218,18 +209,12 @@ public class ChromatogramChart extends LineChart implements IRangeSupport {
 
 		String positionNode = PreferenceSupplier.P_POSITION_Y_AXIS_INTENSITY;
 		String patternNode = PreferenceSupplier.P_FORMAT_Y_AXIS_INTENSITY;
-		String colorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_COLOR_Y_AXIS_INTENSITY_DARKTHEME : PreferenceSupplier.P_COLOR_Y_AXIS_INTENSITY;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_Y_AXIS_INTENSITY;
-		String gridColorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_INTENSITY_DARKTHEME : PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_INTENSITY;
 
-		ChartSupport.setAxisSettingsExtended(primaryAxisSettingsY, positionNode, patternNode, colorNode, gridLineStyleNode, gridColorNode);
+		ChartSupport.setAxisSettingsExtended(primaryAxisSettingsY, positionNode, patternNode, gridLineStyleNode);
+		ChartSupport.themeAxis(primaryAxisSettingsY, "AxisIntensity");
 		primaryAxisSettingsY.setVisible(ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_Y_AXIS_INTENSITY));
 		primaryAxisSettingsY.setTitleVisible(ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_Y_AXIS_TITLE_INTENSITY));
-
-		String name = preferenceStore.getString(PreferenceSupplier.P_FONT_NAME_Y_AXIS_INTENSITY);
-		int height = preferenceStore.getInt(PreferenceSupplier.P_FONT_SIZE_Y_AXIS_INTENSITY);
-		int style = preferenceStore.getInt(PreferenceSupplier.P_FONT_STYLE_Y_AXIS_INTENSITY);
-		primaryAxisSettingsY.setTitleFont(Fonts.getCachedFont(getBaseChart().getDisplay(), name, height, style));
 	}
 
 	private void adjustAxisRelativeIntensity() {
@@ -239,37 +224,30 @@ public class ChromatogramChart extends LineChart implements IRangeSupport {
 
 		String positionNode = PreferenceSupplier.P_POSITION_Y_AXIS_RELATIVE_INTENSITY;
 		String patternNode = PreferenceSupplier.P_FORMAT_Y_AXIS_RELATIVE_INTENSITY;
-		String colorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME : PreferenceSupplier.P_COLOR_Y_AXIS_RELATIVE_INTENSITY;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY;
-		String gridColorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME : PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY;
 
 		boolean isShowAxis = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_Y_AXIS_RELATIVE_INTENSITY);
 		boolean isShowAxisTitle = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY);
 
 		String title = preferenceStore.getString(PreferenceSupplier.P_TITLE_Y_AXIS_RELATIVE_INTENSITY);
-		String name = preferenceStore.getString(PreferenceSupplier.P_FONT_NAME_Y_AXIS_RELATIVE_INTENSITY);
-		int height = preferenceStore.getInt(PreferenceSupplier.P_FONT_SIZE_Y_AXIS_RELATIVE_INTENSITY);
-		int style = preferenceStore.getInt(PreferenceSupplier.P_FONT_STYLE_Y_AXIS_RELATIVE_INTENSITY);
-		Font titleFont = Fonts.getCachedFont(getBaseChart().getDisplay(), name, height, style);
 
 		if(isShowAxis) {
 			if(axisSettings == null) {
 				ISecondaryAxisSettings secondaryAxisSettingsY = new SecondaryAxisSettings(title, new PercentageConverter(SWT.VERTICAL, true));
-				ChartSupport.setAxisSettingsExtended(secondaryAxisSettingsY, positionNode, patternNode, colorNode, gridLineStyleNode, gridColorNode);
+				ChartSupport.setAxisSettingsExtended(secondaryAxisSettingsY, positionNode, patternNode, gridLineStyleNode);
+				ChartSupport.themeAxis(secondaryAxisSettingsY, "AxisRelativeIntensity");
 				secondaryAxisSettingsY.setTitleVisible(isShowAxisTitle);
-				secondaryAxisSettingsY.setTitleFont(titleFont);
 				chartSettings.getSecondaryAxisSettingsListY().add(secondaryAxisSettingsY);
 			} else {
-				ChartSupport.setAxisSettingsExtended(axisSettings, positionNode, patternNode, colorNode, gridLineStyleNode, gridColorNode);
+				ChartSupport.setAxisSettingsExtended(axisSettings, positionNode, patternNode, gridLineStyleNode);
+				ChartSupport.themeAxis(axisSettings, "AxisRelativeIntensity");
 				axisSettings.setTitle(title);
-				axisSettings.setTitleFont(titleFont);
 				axisSettings.setVisible(true);
 				axisSettings.setTitleVisible(isShowAxisTitle);
 			}
 		} else {
 			if(axisSettings != null) {
 				axisSettings.setTitle(title);
-				axisSettings.setTitleFont(titleFont);
 				axisSettings.setVisible(false);
 				axisSettings.setTitleVisible(isShowAxisTitle);
 			}
@@ -287,36 +265,29 @@ public class ChromatogramChart extends LineChart implements IRangeSupport {
 
 		String positionNode = PreferenceSupplier.P_POSITION_X_AXIS_SECONDS;
 		String patternNode = PreferenceSupplier.P_FORMAT_X_AXIS_SECONDS;
-		String colorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_COLOR_X_AXIS_SECONDS_DARKTHEME : PreferenceSupplier.P_COLOR_X_AXIS_SECONDS;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_SECONDS;
-		String gridColorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_SECONDS_DARKTHEME : PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_SECONDS;
 		boolean isShowAxis = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_SECONDS);
 		boolean isShowAxisTitle = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_TITLE_SECONDS);
 
 		String title = preferenceStore.getString(PreferenceSupplier.P_TITLE_X_AXIS_SECONDS);
-		String name = preferenceStore.getString(PreferenceSupplier.P_FONT_NAME_X_AXIS_SECONDS);
-		int height = preferenceStore.getInt(PreferenceSupplier.P_FONT_SIZE_X_AXIS_SECONDS);
-		int style = preferenceStore.getInt(PreferenceSupplier.P_FONT_STYLE_X_AXIS_SECONDS);
-		Font titleFont = Fonts.getCachedFont(getBaseChart().getDisplay(), name, height, style);
 
 		if(isShowAxis) {
 			if(axisSettings == null) {
 				ISecondaryAxisSettings secondaryAxisSettingsX = new SecondaryAxisSettings(title, new MillisecondsToSecondsConverter());
-				ChartSupport.setAxisSettingsExtended(secondaryAxisSettingsX, positionNode, patternNode, colorNode, gridLineStyleNode, gridColorNode);
-				secondaryAxisSettingsX.setTitleFont(titleFont);
+				ChartSupport.setAxisSettingsExtended(secondaryAxisSettingsX, positionNode, patternNode, gridLineStyleNode);
+				ChartSupport.themeAxis(secondaryAxisSettingsX, "AxisSeconds");
 				secondaryAxisSettingsX.setTitleVisible(isShowAxisTitle);
 				chartSettings.getSecondaryAxisSettingsListX().add(secondaryAxisSettingsX);
 			} else {
-				ChartSupport.setAxisSettingsExtended(axisSettings, positionNode, patternNode, colorNode, gridLineStyleNode, gridColorNode);
+				ChartSupport.setAxisSettingsExtended(axisSettings, positionNode, patternNode, gridLineStyleNode);
+				ChartSupport.themeAxis(axisSettings, "AxisSeconds");
 				axisSettings.setTitle(title);
-				axisSettings.setTitleFont(titleFont);
 				axisSettings.setVisible(true);
 				axisSettings.setTitleVisible(isShowAxisTitle);
 			}
 		} else {
 			if(axisSettings != null) {
 				axisSettings.setTitle(title);
-				axisSettings.setTitleFont(titleFont);
 				axisSettings.setVisible(false);
 				axisSettings.setTitleVisible(isShowAxisTitle);
 			}
@@ -334,33 +305,27 @@ public class ChromatogramChart extends LineChart implements IRangeSupport {
 
 		String positionNode = PreferenceSupplier.P_POSITION_X_AXIS_MINUTES;
 		String patternNode = PreferenceSupplier.P_FORMAT_X_AXIS_MINUTES;
-		String colorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_COLOR_X_AXIS_MINUTES_DARKTHEME : PreferenceSupplier.P_COLOR_X_AXIS_MINUTES;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_MINUTES;
-		String gridColorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MINUTES_DARKTHEME : PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MINUTES;
 		boolean isShowAxis = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_MINUTES);
 		boolean isShowAxisTitle = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_TITLE_MINUTES);
 
 		String title = preferenceStore.getString(PreferenceSupplier.P_TITLE_X_AXIS_MINUTES);
-		String name = preferenceStore.getString(PreferenceSupplier.P_FONT_NAME_X_AXIS_MINUTES);
-		int height = preferenceStore.getInt(PreferenceSupplier.P_FONT_SIZE_X_AXIS_MINUTES);
-		int style = preferenceStore.getInt(PreferenceSupplier.P_FONT_STYLE_X_AXIS_MINUTES);
-		Font titleFont = Fonts.getCachedFont(getBaseChart().getDisplay(), name, height, style);
 		boolean drawAxisLine = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_LINE_MINUTES);
 		boolean drawPositionMarker = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_POSITION_MARKER_MINUTES);
 
 		if(isShowAxis) {
 			if(axisSettings == null) {
 				ISecondaryAxisSettings secondaryAxisSettingsX = new SecondaryAxisSettings(title, new MillisecondsToMinuteConverter());
-				ChartSupport.setAxisSettingsExtended(secondaryAxisSettingsX, positionNode, patternNode, colorNode, gridLineStyleNode, gridColorNode);
-				secondaryAxisSettingsX.setTitleFont(titleFont);
+				ChartSupport.setAxisSettingsExtended(secondaryAxisSettingsX, positionNode, patternNode, gridLineStyleNode);
+				ChartSupport.themeAxis(secondaryAxisSettingsX, "AxisMinutes");
 				secondaryAxisSettingsX.setTitleVisible(isShowAxisTitle);
 				secondaryAxisSettingsX.setDrawAxisLine(drawAxisLine);
 				secondaryAxisSettingsX.setDrawPositionMarker(drawPositionMarker);
 				chartSettings.getSecondaryAxisSettingsListX().add(secondaryAxisSettingsX);
 			} else {
-				ChartSupport.setAxisSettingsExtended(axisSettings, positionNode, patternNode, colorNode, gridLineStyleNode, gridColorNode);
+				ChartSupport.setAxisSettingsExtended(axisSettings, positionNode, patternNode, gridLineStyleNode);
+				ChartSupport.themeAxis(axisSettings, "AxisMinutes");
 				axisSettings.setTitle(title);
-				axisSettings.setTitleFont(titleFont);
 				axisSettings.setVisible(true);
 				axisSettings.setTitleVisible(isShowAxisTitle);
 				axisSettings.setDrawAxisLine(drawAxisLine);
@@ -369,7 +334,6 @@ public class ChromatogramChart extends LineChart implements IRangeSupport {
 		} else {
 			if(axisSettings != null) {
 				axisSettings.setTitle(title);
-				axisSettings.setTitleFont(titleFont);
 				axisSettings.setVisible(false);
 				axisSettings.setTitleVisible(isShowAxisTitle);
 				axisSettings.setDrawAxisLine(drawAxisLine);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/PeaksChart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/PeaksChart.java
@@ -12,12 +12,10 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.charts;
 
-import org.eclipse.chemclipse.swt.ui.support.Fonts;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferenceSupplier;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swtchart.extensions.axisconverter.MillisecondsToMinuteConverter;
 import org.eclipse.swtchart.extensions.axisconverter.PercentageConverter;
@@ -92,13 +90,12 @@ public class PeaksChart extends LineChart {
 
 		String positionNode = PreferenceSupplier.P_POSITION_X_AXIS_MILLISECONDS_PEAKS;
 		String pattern = "0.0##";
-		String colorNode = PreferenceSupplier.P_COLOR_X_AXIS_MILLISECONDS_PEAKS;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_MILLISECONDS_PEAKS;
-		String gridColorNode = PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_PEAKS;
 		boolean isShowAxis = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_MILLISECONDS_PEAKS);
 
-		ChartSupport.setAxisSettings(primaryAxisSettingsX, positionNode, pattern, colorNode, gridLineStyleNode, gridColorNode);
+		ChartSupport.setAxisSettings(primaryAxisSettingsX, positionNode, pattern, gridLineStyleNode);
 		primaryAxisSettingsX.setVisible(isShowAxis);
+		ChartSupport.themeAxis(primaryAxisSettingsX, "XAxisMilliseconds");
 	}
 
 	private void modifyYAxisResponse() {
@@ -109,13 +106,13 @@ public class PeaksChart extends LineChart {
 
 		String positionNode = PreferenceSupplier.P_POSITION_Y_AXIS_INTENSITY_PEAKS;
 		String pattern = "0.0#E0";
-		String colorNode = PreferenceSupplier.P_COLOR_Y_AXIS_INTENSITY_PEAKS;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_Y_AXIS_INTENSITY_PEAKS;
-		String gridColorNode = PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_INTENSITY_PEAKS;
 		boolean isShowAxis = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_Y_AXIS_INTENSITY_PEAKS);
 
-		ChartSupport.setAxisSettings(primaryAxisSettingsY, positionNode, pattern, colorNode, gridLineStyleNode, gridColorNode);
+		ChartSupport.setAxisSettings(primaryAxisSettingsY, positionNode, pattern, gridLineStyleNode);
 		primaryAxisSettingsY.setVisible(isShowAxis);
+
+		ChartSupport.themeAxis(primaryAxisSettingsY, "YAxisResponse");
 	}
 
 	private void modifyXAxisMinutes() {
@@ -125,36 +122,29 @@ public class PeaksChart extends LineChart {
 
 		String positionNode = PreferenceSupplier.P_POSITION_X_AXIS_MINUTES_PEAKS;
 		String pattern = "0.00";
-		String colorNode = PreferenceSupplier.P_COLOR_X_AXIS_MINUTES_PEAKS;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_MINUTES_PEAKS;
-		String gridColorNode = PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MINUTES_PEAKS;
 		boolean isShowAxis = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_MINUTES_PEAKS);
 		boolean isShowAxisTitle = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_TITLE_MINUTES);
 
 		String title = preferenceStore.getString(PreferenceSupplier.P_TITLE_X_AXIS_MINUTES);
-		String name = preferenceStore.getString(PreferenceSupplier.P_FONT_NAME_X_AXIS_MINUTES);
-		int height = preferenceStore.getInt(PreferenceSupplier.P_FONT_SIZE_X_AXIS_MINUTES);
-		int style = preferenceStore.getInt(PreferenceSupplier.P_FONT_STYLE_X_AXIS_MINUTES);
-		Font titleFont = Fonts.getCachedFont(getBaseChart().getDisplay(), name, height, style);
 
 		if(isShowAxis) {
 			if(axisSettings == null) {
 				ISecondaryAxisSettings secondaryAxisSettingsX = new SecondaryAxisSettings(title, new MillisecondsToMinuteConverter());
-				ChartSupport.setAxisSettings(secondaryAxisSettingsX, positionNode, pattern, colorNode, gridLineStyleNode, gridColorNode);
-				secondaryAxisSettingsX.setTitleFont(titleFont);
+				ChartSupport.setAxisSettings(secondaryAxisSettingsX, positionNode, pattern, gridLineStyleNode);
+				ChartSupport.themeAxis(axisSettings, "XAxisMinutes");
 				secondaryAxisSettingsX.setTitleVisible(isShowAxisTitle);
 				chartSettings.getSecondaryAxisSettingsListX().add(secondaryAxisSettingsX);
 			} else {
-				ChartSupport.setAxisSettings(axisSettings, positionNode, pattern, colorNode, gridLineStyleNode, gridColorNode);
+				ChartSupport.setAxisSettings(axisSettings, positionNode, pattern, gridLineStyleNode);
+				ChartSupport.themeAxis(axisSettings, "XAxisMinutes");
 				axisSettings.setTitle(title);
-				axisSettings.setTitleFont(titleFont);
 				axisSettings.setVisible(true);
 				axisSettings.setTitleVisible(isShowAxisTitle);
 			}
 		} else {
 			if(axisSettings != null) {
 				axisSettings.setTitle(title);
-				axisSettings.setTitleFont(titleFont);
 				axisSettings.setVisible(false);
 				axisSettings.setTitleVisible(isShowAxisTitle);
 			}
@@ -172,36 +162,30 @@ public class PeaksChart extends LineChart {
 
 		String positionNode = PreferenceSupplier.P_POSITION_Y_AXIS_RELATIVE_INTENSITY_PEAKS;
 		String pattern = "0.00";
-		String colorNode = PreferenceSupplier.P_COLOR_Y_AXIS_RELATIVE_INTENSITY_PEAKS;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY_PEAKS;
-		String gridColorNode = PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_PEAKS;
 		boolean isShowAxis = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_Y_AXIS_RELATIVE_INTENSITY_PEAKS);
 		boolean isShowAxisTitle = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY);
 
 		String title = preferenceStore.getString(PreferenceSupplier.P_TITLE_Y_AXIS_RELATIVE_INTENSITY);
-		String name = preferenceStore.getString(PreferenceSupplier.P_FONT_NAME_Y_AXIS_RELATIVE_INTENSITY);
-		int height = preferenceStore.getInt(PreferenceSupplier.P_FONT_SIZE_Y_AXIS_RELATIVE_INTENSITY);
-		int style = preferenceStore.getInt(PreferenceSupplier.P_FONT_STYLE_Y_AXIS_RELATIVE_INTENSITY);
-		Font titleFont = Fonts.getCachedFont(getBaseChart().getDisplay(), name, height, style);
 
 		if(isShowAxis) {
 			if(axisSettings == null) {
 				ISecondaryAxisSettings secondaryAxisSettingsY = new SecondaryAxisSettings(title, new PercentageConverter(SWT.VERTICAL, true));
-				ChartSupport.setAxisSettings(secondaryAxisSettingsY, positionNode, pattern, colorNode, gridLineStyleNode, gridColorNode);
+				ChartSupport.setAxisSettings(secondaryAxisSettingsY, positionNode, pattern, gridLineStyleNode);
+				ChartSupport.themeAxis(secondaryAxisSettingsY, "YAxisRelativeResponse");
 				secondaryAxisSettingsY.setTitleVisible(isShowAxisTitle);
-				secondaryAxisSettingsY.setTitleFont(titleFont);
 				chartSettings.getSecondaryAxisSettingsListY().add(secondaryAxisSettingsY);
 			} else {
-				ChartSupport.setAxisSettings(axisSettings, positionNode, pattern, colorNode, gridLineStyleNode, gridColorNode);
+				ChartSupport.setAxisSettings(axisSettings, positionNode, pattern, gridLineStyleNode);
+				ChartSupport.themeAxis(axisSettings, "YAxisRelativeResponse");
 				axisSettings.setTitle(title);
-				axisSettings.setTitleFont(titleFont);
 				axisSettings.setVisible(true);
 				axisSettings.setTitleVisible(isShowAxisTitle);
 			}
 		} else {
 			if(axisSettings != null) {
 				axisSettings.setTitle(title);
-				axisSettings.setTitleFont(titleFont);
+				ChartSupport.themeAxis(axisSettings, "YAxisRelativeResponse");
 				axisSettings.setVisible(false);
 				axisSettings.setTitleVisible(isShowAxisTitle);
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisIntensity.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisIntensity.java
@@ -12,12 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.preferences;
 
-import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpinnerFieldEditor;
-import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.jface.preference.BooleanFieldEditor;
-import org.eclipse.jface.preference.ColorFieldEditor;
 import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.StringFieldEditor;
@@ -42,16 +39,7 @@ public class ChromatogramAxisIntensity extends FieldEditorPreferencePage impleme
 		addField(new StringFieldEditor(PreferenceSupplier.P_FORMAT_Y_AXIS_INTENSITY, ExtensionMessages.format + ":", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_Y_AXIS_INTENSITY, ExtensionMessages.show, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_POSITION_Y_AXIS_INTENSITY, ExtensionMessages.position + ":", ChartOptions.POSITIONS, getFieldEditorParent()));
-		if(PreferencesSupport.isDarkTheme()) {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_Y_AXIS_INTENSITY_DARKTHEME, ExtensionMessages.color + ":", getFieldEditorParent()));
-		} else {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_Y_AXIS_INTENSITY, ExtensionMessages.color + ":", getFieldEditorParent()));
-		}
-		addField(new StringFieldEditor(PreferenceSupplier.P_FONT_NAME_Y_AXIS_INTENSITY, ExtensionMessages.fontName + ":", getFieldEditorParent()));
-		addField(new SpinnerFieldEditor(PreferenceSupplier.P_FONT_SIZE_Y_AXIS_INTENSITY, ExtensionMessages.fontSize + ":", PreferenceSupplier.MIN_FONT_SIZE, PreferenceSupplier.MAX_FONT_SIZE, getFieldEditorParent()));
-		addField(new ComboFieldEditor(PreferenceSupplier.P_FONT_STYLE_Y_AXIS_INTENSITY, ExtensionMessages.fontStyle + ":", ChartOptions.FONT_STYLES, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_Y_AXIS_INTENSITY, ExtensionMessages.gridLineStyle + ":", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_INTENSITY, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_Y_AXIS_TITLE_INTENSITY, ExtensionMessages.showAxisTitle, getFieldEditorParent()));
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisMilliseconds.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisMilliseconds.java
@@ -12,15 +12,12 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.preferences;
 
-import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpinnerFieldEditor;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.jface.preference.BooleanFieldEditor;
-import org.eclipse.jface.preference.ColorFieldEditor;
 import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.StringFieldEditor;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swtchart.extensions.charts.ChartOptions;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
@@ -42,20 +39,7 @@ public class ChromatogramAxisMilliseconds extends FieldEditorPreferencePage impl
 		addField(new StringFieldEditor(PreferenceSupplier.P_FORMAT_X_AXIS_MILLISECONDS, ExtensionMessages.format + ":", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_MILLISECONDS, ExtensionMessages.show, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_POSITION_X_AXIS_MILLISECONDS, ExtensionMessages.position + ":", ChartOptions.POSITIONS, getFieldEditorParent()));
-		if(Display.isSystemDarkTheme()) {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_X_AXIS_MILLISECONDS_DARKTHEME, ExtensionMessages.color + ":", getFieldEditorParent()));
-		} else {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_X_AXIS_MILLISECONDS, ExtensionMessages.color + ":", getFieldEditorParent()));
-		}
-		addField(new StringFieldEditor(PreferenceSupplier.P_FONT_NAME_X_AXIS_MILLISECONDS, ExtensionMessages.fontName + ":", getFieldEditorParent()));
-		addField(new SpinnerFieldEditor(PreferenceSupplier.P_FONT_SIZE_X_AXIS_MILLISECONDS, ExtensionMessages.fontSize + ":", PreferenceSupplier.MIN_FONT_SIZE, PreferenceSupplier.MAX_FONT_SIZE, getFieldEditorParent()));
-		addField(new ComboFieldEditor(PreferenceSupplier.P_FONT_STYLE_X_AXIS_MILLISECONDS, ExtensionMessages.fontStyle + ":", ChartOptions.FONT_STYLES, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_MILLISECONDS, ExtensionMessages.gridLineStyle + ":", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		if(Display.isSystemDarkTheme()) {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_DARKTHEME, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
-		} else {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
-		}
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_TITLE_MILLISECONDS, ExtensionMessages.showAxisTitle + ":", getFieldEditorParent()));
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisMinutes.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisMinutes.java
@@ -12,12 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.preferences;
 
-import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpinnerFieldEditor;
-import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.jface.preference.BooleanFieldEditor;
-import org.eclipse.jface.preference.ColorFieldEditor;
 import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.StringFieldEditor;
@@ -42,20 +39,7 @@ public class ChromatogramAxisMinutes extends FieldEditorPreferencePage implement
 		addField(new StringFieldEditor(PreferenceSupplier.P_FORMAT_X_AXIS_MINUTES, ExtensionMessages.format + ":", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_MINUTES, ExtensionMessages.show, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_POSITION_X_AXIS_MINUTES, ExtensionMessages.position + ":", ChartOptions.POSITIONS, getFieldEditorParent()));
-		if(PreferencesSupport.isDarkTheme()) {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_X_AXIS_MINUTES_DARKTHEME, ExtensionMessages.color + ":", getFieldEditorParent()));
-		} else {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_X_AXIS_MINUTES, ExtensionMessages.color + ":", getFieldEditorParent()));
-		}
-		addField(new StringFieldEditor(PreferenceSupplier.P_FONT_NAME_X_AXIS_MINUTES, ExtensionMessages.fontName + ":", getFieldEditorParent()));
-		addField(new SpinnerFieldEditor(PreferenceSupplier.P_FONT_SIZE_X_AXIS_MINUTES, ExtensionMessages.fontSize + ":", PreferenceSupplier.MIN_FONT_SIZE, PreferenceSupplier.MAX_FONT_SIZE, getFieldEditorParent()));
-		addField(new ComboFieldEditor(PreferenceSupplier.P_FONT_STYLE_X_AXIS_MINUTES, ExtensionMessages.fontStyle + ":", ChartOptions.FONT_STYLES, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_MINUTES, ExtensionMessages.gridLineStyle + ":", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		if(PreferencesSupport.isDarkTheme()) {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MINUTES_DARKTHEME, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
-		} else {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MINUTES, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
-		}
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_TITLE_MINUTES, ExtensionMessages.showAxisTitle, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_LINE_MINUTES, ExtensionMessages.showAxisLine, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_POSITION_MARKER_MINUTES, ExtensionMessages.showAxisPositionMarker, getFieldEditorParent()));

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisRelativeIntensity.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisRelativeIntensity.java
@@ -12,12 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.preferences;
 
-import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpinnerFieldEditor;
-import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.jface.preference.BooleanFieldEditor;
-import org.eclipse.jface.preference.ColorFieldEditor;
 import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.StringFieldEditor;
@@ -42,20 +39,7 @@ public class ChromatogramAxisRelativeIntensity extends FieldEditorPreferencePage
 		addField(new StringFieldEditor(PreferenceSupplier.P_FORMAT_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.format + ":", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.show, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_POSITION_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.position + ":", ChartOptions.POSITIONS, getFieldEditorParent()));
-		if(PreferencesSupport.isDarkTheme()) {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME, ExtensionMessages.color + ":", getFieldEditorParent()));
-		} else {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.color + ":", getFieldEditorParent()));
-		}
-		addField(new StringFieldEditor(PreferenceSupplier.P_FONT_NAME_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.fontName + ":", getFieldEditorParent()));
-		addField(new SpinnerFieldEditor(PreferenceSupplier.P_FONT_SIZE_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.fontSize + ":", PreferenceSupplier.MIN_FONT_SIZE, PreferenceSupplier.MAX_FONT_SIZE, getFieldEditorParent()));
-		addField(new ComboFieldEditor(PreferenceSupplier.P_FONT_STYLE_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.fontStyle + ":", ChartOptions.FONT_STYLES, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.gridLineStyle + ":", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		if(PreferencesSupport.isDarkTheme()) {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
-		} else {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
-		}
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY, ExtensionMessages.showAxisTitle, getFieldEditorParent()));
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisRetentionIndex.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisRetentionIndex.java
@@ -12,15 +12,12 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.preferences;
 
-import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpinnerFieldEditor;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.jface.preference.BooleanFieldEditor;
-import org.eclipse.jface.preference.ColorFieldEditor;
 import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.StringFieldEditor;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swtchart.extensions.charts.ChartOptions;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
@@ -42,16 +39,7 @@ public class ChromatogramAxisRetentionIndex extends FieldEditorPreferencePage im
 		addField(new StringFieldEditor(PreferenceSupplier.P_FORMAT_X_AXIS_RETENTION_INDEX, ExtensionMessages.format + ":", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_RETENTION_INDEX, ExtensionMessages.show, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_POSITION_X_AXIS_RETENTION_INDEX, ExtensionMessages.position + ":", ChartOptions.POSITIONS, getFieldEditorParent()));
-		if(Display.isSystemDarkTheme()) {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_X_AXIS_RETENTION_INDEX_DARKTHEME, ExtensionMessages.color + ":", getFieldEditorParent()));
-		} else {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_X_AXIS_RETENTION_INDEX, ExtensionMessages.color + ":", getFieldEditorParent()));
-		}
-		addField(new StringFieldEditor(PreferenceSupplier.P_FONT_NAME_X_AXIS_RETENTION_INDEX, ExtensionMessages.fontName + ":", getFieldEditorParent()));
-		addField(new SpinnerFieldEditor(PreferenceSupplier.P_FONT_SIZE_X_AXIS_RETENTION_INDEX, ExtensionMessages.fontSize + ":", PreferenceSupplier.MIN_FONT_SIZE, PreferenceSupplier.MAX_FONT_SIZE, getFieldEditorParent()));
-		addField(new ComboFieldEditor(PreferenceSupplier.P_FONT_STYLE_X_AXIS_RETENTION_INDEX, ExtensionMessages.fontStyle + ":", ChartOptions.FONT_STYLES, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_RETENTION_INDEX, ExtensionMessages.gridLineStyle + ":", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_RETENTION_INDEX, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_TITLE_RETENTION_INDEX, ExtensionMessages.showAxisTitle + ":", getFieldEditorParent()));
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisScans.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisScans.java
@@ -12,12 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.preferences;
 
-import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpinnerFieldEditor;
-import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.jface.preference.BooleanFieldEditor;
-import org.eclipse.jface.preference.ColorFieldEditor;
 import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.StringFieldEditor;
@@ -42,16 +39,7 @@ public class ChromatogramAxisScans extends FieldEditorPreferencePage implements 
 		addField(new StringFieldEditor(PreferenceSupplier.P_FORMAT_X_AXIS_SCANS, ExtensionMessages.format + ":", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_SCANS, ExtensionMessages.show, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_POSITION_X_AXIS_SCANS, ExtensionMessages.position + ":", ChartOptions.POSITIONS, getFieldEditorParent()));
-		if(PreferencesSupport.isDarkTheme()) {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_X_AXIS_SCANS_DARKTHEME, ExtensionMessages.color + ":", getFieldEditorParent()));
-		} else {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_X_AXIS_SCANS, ExtensionMessages.color + ":", getFieldEditorParent()));
-		}
-		addField(new StringFieldEditor(PreferenceSupplier.P_FONT_NAME_X_AXIS_SCANS, ExtensionMessages.fontName + ":", getFieldEditorParent()));
-		addField(new SpinnerFieldEditor(PreferenceSupplier.P_FONT_SIZE_X_AXIS_SCANS, ExtensionMessages.fontSize + ":", PreferenceSupplier.MIN_FONT_SIZE, PreferenceSupplier.MAX_FONT_SIZE, getFieldEditorParent()));
-		addField(new ComboFieldEditor(PreferenceSupplier.P_FONT_STYLE_X_AXIS_SCANS, ExtensionMessages.fontStyle + ":", ChartOptions.FONT_STYLES, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_SCANS, ExtensionMessages.gridLineStyle + ":", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_SCANS, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_TITLE_SCANS, ExtensionMessages.showAxisTitle, getFieldEditorParent()));
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisSeconds.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ChromatogramAxisSeconds.java
@@ -12,12 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.preferences;
 
-import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpinnerFieldEditor;
-import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.jface.preference.BooleanFieldEditor;
-import org.eclipse.jface.preference.ColorFieldEditor;
 import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.StringFieldEditor;
@@ -42,20 +39,7 @@ public class ChromatogramAxisSeconds extends FieldEditorPreferencePage implement
 		addField(new StringFieldEditor(PreferenceSupplier.P_FORMAT_X_AXIS_SECONDS, ExtensionMessages.format + ":", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_SECONDS, ExtensionMessages.show, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_POSITION_X_AXIS_SECONDS, ExtensionMessages.position + ":", ChartOptions.POSITIONS, getFieldEditorParent()));
-		if(PreferencesSupport.isDarkTheme()) {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_X_AXIS_SECONDS_DARKTHEME, ExtensionMessages.color + ":", getFieldEditorParent()));
-		} else {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_X_AXIS_SECONDS, ExtensionMessages.color + ":", getFieldEditorParent()));
-		}
-		addField(new StringFieldEditor(PreferenceSupplier.P_FONT_NAME_X_AXIS_SECONDS, ExtensionMessages.fontName + ":", getFieldEditorParent()));
-		addField(new SpinnerFieldEditor(PreferenceSupplier.P_FONT_SIZE_X_AXIS_SECONDS, ExtensionMessages.fontSize + ":", PreferenceSupplier.MIN_FONT_SIZE, PreferenceSupplier.MAX_FONT_SIZE, getFieldEditorParent()));
-		addField(new ComboFieldEditor(PreferenceSupplier.P_FONT_STYLE_X_AXIS_SECONDS, ExtensionMessages.fontStyle + ":", ChartOptions.FONT_STYLES, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_SECONDS, ExtensionMessages.gridLineStyle + ":", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		if(PreferencesSupport.isDarkTheme()) {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_SECONDS_DARKTHEME, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
-		} else {
-			addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_SECONDS, ExtensionMessages.gridLineColor + ":", getFieldEditorParent()));
-		}
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_TITLE_SECONDS, ExtensionMessages.showAxisTitle, getFieldEditorParent()));
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferencePagePeaksAxes.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferencePagePeaksAxes.java
@@ -60,17 +60,13 @@ public class PreferencePagePeaksAxes extends FieldEditorPreferencePage implement
 		addField(new LabelFieldEditor("Intensity", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_Y_AXIS_INTENSITY_PEAKS, "Show Y Axis (Intensity)", getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_POSITION_Y_AXIS_INTENSITY_PEAKS, "Position Y Axis (Intensity):", ChartOptions.POSITIONS, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_Y_AXIS_INTENSITY_PEAKS, "Color Y Axis (Intensity):", getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_Y_AXIS_INTENSITY_PEAKS, "GridLine Style Y Axis (Intensity):", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_INTENSITY_PEAKS, "GridLine Color Y Axis (Intensity):", getFieldEditorParent()));
 
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Intensity%", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_Y_AXIS_RELATIVE_INTENSITY_PEAKS, "Show Y Axis (Intensity %)", getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_POSITION_Y_AXIS_RELATIVE_INTENSITY_PEAKS, "Position Y Axis (Intensity %):", ChartOptions.POSITIONS, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_Y_AXIS_RELATIVE_INTENSITY_PEAKS, "Color Y Axis (Intensity %):", getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY_PEAKS, "GridLine Style Y Axis (Intensity %):", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_PEAKS, "GridLine Color Y Axis (Intensity %):", getFieldEditorParent()));
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferencePageQuantitationAxes.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferencePageQuantitationAxes.java
@@ -17,7 +17,6 @@ import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpacerFieldEdi
 import org.eclipse.chemclipse.swt.ui.support.Colors;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.jface.preference.BooleanFieldEditor;
-import org.eclipse.jface.preference.ColorFieldEditor;
 import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.swtchart.extensions.charts.ChartOptions;
@@ -43,25 +42,19 @@ public class PreferencePageQuantitationAxes extends FieldEditorPreferencePage im
 		addField(new LabelFieldEditor("Concentration", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_X_AXIS_CONCENTRATION_CALIBRATION, "Show X Axis (Concentration)", getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_POSITION_X_AXIS_CONCENTRATION_CALIBRATION, "Position X Axis (Concentration):", ChartOptions.POSITIONS, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_X_AXIS_CONCENTRATION_CALIBRATION, "Color X Axis (Concentration):", getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_CONCENTRATION_CALIBRATION, "GridLine Style X Axis (Concentration):", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_CONCENTRATION_CALIBRATION, "GridLine Color X Axis (Concentration):", getFieldEditorParent()));
 
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Response", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_Y_AXIS_RESPONSE_CALIBRATION, "Show Y Axis (Response)", getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_POSITION_Y_AXIS_RESPONSE_CALIBRATION, "Position Y Axis (Response):", ChartOptions.POSITIONS, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_Y_AXIS_RESPONSE_CALIBRATION, "Color Y Axis (Response):", getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_Y_AXIS_RESPONSE_CALIBRATION, "GridLine Style Y Axis (Response):", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_RESPONSE_CALIBRATION, "GridLine Color Y Axis (Response):", getFieldEditorParent()));
 
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Response%", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION, "Show Y Axis (Response %)", getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_POSITION_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION, "Position Y Axis (Response %):", ChartOptions.POSITIONS, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION, "Color Y Axis (Response %):", getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION, "GridLine Style Y Axis (Response %):", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION, "GridLine Color Y Axis (Response %):", getFieldEditorParent()));
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
@@ -398,23 +398,15 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final boolean DEF_SHOW_Y_AXIS_INTENSITY_PEAKS = true;
 	public static final String P_POSITION_Y_AXIS_INTENSITY_PEAKS = "positionYAxisIntensityPeaks";
 	public static final String DEF_POSITION_Y_AXIS_INTENSITY_PEAKS = Position.Primary.toString();
-	public static final String P_COLOR_Y_AXIS_INTENSITY_PEAKS = "colorYAxisIntensityPeaks";
-	public static final String DEF_COLOR_Y_AXIS_INTENSITY_PEAKS = "0,0,0";
 	public static final String P_GRIDLINE_STYLE_Y_AXIS_INTENSITY_PEAKS = "gridlineStyleYAxisIntensityPeaks";
 	public static final String DEF_GRIDLINE_STYLE_Y_AXIS_INTENSITY_PEAKS = LineStyle.NONE.toString();
-	public static final String P_GRIDLINE_COLOR_Y_AXIS_INTENSITY_PEAKS = "gridlineColorYAxisIntensityPeaks";
-	public static final String DEF_GRIDLINE_COLOR_Y_AXIS_INTENSITY_PEAKS = "192,192,192";
 
 	public static final String P_SHOW_Y_AXIS_RELATIVE_INTENSITY_PEAKS = "showYAxisRelativeIntensityPeaks";
 	public static final boolean DEF_SHOW_Y_AXIS_RELATIVE_INTENSITY_PEAKS = true;
 	public static final String P_POSITION_Y_AXIS_RELATIVE_INTENSITY_PEAKS = "positionYAxisRelativeIntensityPeaks";
 	public static final String DEF_POSITION_Y_AXIS_RELATIVE_INTENSITY_PEAKS = Position.Secondary.toString();
-	public static final String P_COLOR_Y_AXIS_RELATIVE_INTENSITY_PEAKS = "colorYAxisRelativeIntensityPeaks";
-	public static final String DEF_COLOR_Y_AXIS_RELATIVE_INTENSITY_PEAKS = "0,0,0";
 	public static final String P_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY_PEAKS = "gridlineStyleYAxisRelativeIntensityPeaks";
 	public static final String DEF_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY_PEAKS = LineStyle.DOT.toString();
-	public static final String P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_PEAKS = "gridlineColorYAxisRelativeIntensityPeaks";
-	public static final String DEF_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_PEAKS = "192,192,192";
 	/*
 	 * Targets
 	 */
@@ -639,21 +631,8 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final boolean DEF_SHOW_X_AXIS_MILLISECONDS = false;
 	public static final String P_POSITION_X_AXIS_MILLISECONDS = "positionXAxisMilliseconds";
 	public static final String DEF_POSITION_X_AXIS_MILLISECONDS = Position.Secondary.toString();
-	public static final String P_COLOR_X_AXIS_MILLISECONDS = "colorXAxisMilliseconds";
-	public static final String DEF_COLOR_X_AXIS_MILLISECONDS = "0,0,0";
-	public static final String P_COLOR_X_AXIS_MILLISECONDS_DARKTHEME = "colorXAxisMillisecondsDarkTheme";
-	public static final String DEF_COLOR_X_AXIS_MILLISECONDS_DARKTHEME = "252,252,247";
-	public static final String P_FONT_NAME_X_AXIS_MILLISECONDS = "fontNameXAxisMilliseconds";
-	public static final String DEF_FONT_NAME_X_AXIS_MILLISECONDS = Resources.DEFAULT_FONT_NAME;
-	public static final String P_FONT_SIZE_X_AXIS_MILLISECONDS = "fontSizeXAxisMilliseconds";
-	public static final String P_FONT_STYLE_X_AXIS_MILLISECONDS = "fontStyleXAxisMilliseconds";
-	public static final int DEF_FONT_STYLE_X_AXIS_MILLISECONDS = SWT.BOLD;
 	public static final String P_GRIDLINE_STYLE_X_AXIS_MILLISECONDS = "gridlineStyleXAxisMilliseconds";
 	public static final String DEF_GRIDLINE_STYLE_X_AXIS_MILLISECONDS = LineStyle.NONE.toString();
-	public static final String P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS = "gridlineColorXAxisMilliseconds";
-	public static final String DEF_GRIDLINE_COLOR_X_AXIS_MILLISECONDS = "192,192,192";
-	public static final String P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_DARKTHEME = "gridlineColorXAxisMillisecondsDarkTheme";
-	public static final String DEF_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_DARKTHEME = "64, 64, 64";
 	public static final String P_SHOW_X_AXIS_TITLE_MILLISECONDS = "showXAxisTitleMilliseconds";
 	public static final boolean DEF_SHOW_X_AXIS_TITLE_MILLISECONDS = true;
 
@@ -665,19 +644,8 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final boolean DEF_SHOW_X_AXIS_RETENTION_INDEX = false;
 	public static final String P_POSITION_X_AXIS_RETENTION_INDEX = "positionXAxisRetentionIndex";
 	public static final String DEF_POSITION_X_AXIS_RETENTION_INDEX = Position.Primary.toString();
-	public static final String P_COLOR_X_AXIS_RETENTION_INDEX = "colorXAxisRetentionIndex";
-	public static final String DEF_COLOR_X_AXIS_RETENTION_INDEX = "0,0,0";
-	public static final String P_COLOR_X_AXIS_RETENTION_INDEX_DARKTHEME = "colorXAxisRetentionIndexDarkTheme";
-	public static final String DEF_COLOR_X_AXIS_RETENTION_INDEX_DARKTHEME = "252,252,247";
-	public static final String P_FONT_NAME_X_AXIS_RETENTION_INDEX = "fontNameXAxisRetentionIndex";
-	public static final String DEF_FONT_NAME_X_AXIS_RETENTION_INDEX = Resources.DEFAULT_FONT_NAME;
-	public static final String P_FONT_SIZE_X_AXIS_RETENTION_INDEX = "fontSizeXAxisRetentionIndex";
-	public static final String P_FONT_STYLE_X_AXIS_RETENTION_INDEX = "fontStyleXAxisRetentionIndex";
-	public static final int DEF_FONT_STYLE_X_AXIS_RETENTION_INDEX = SWT.BOLD;
 	public static final String P_GRIDLINE_STYLE_X_AXIS_RETENTION_INDEX = "gridlineStyleXAxisRetentionIndex";
 	public static final String DEF_GRIDLINE_STYLE_X_AXIS_RETENTION_INDEX = LineStyle.DOT.toString();
-	public static final String P_GRIDLINE_COLOR_X_AXIS_RETENTION_INDEX = "gridlineColorXAxisRetentionIndex";
-	public static final String DEF_GRIDLINE_COLOR_X_AXIS_RETENTION_INDEX = "192,192,192";
 	public static final String P_SHOW_X_AXIS_TITLE_RETENTION_INDEX = "showXAxisTitleRetentionIndex";
 	public static final boolean DEF_SHOW_X_AXIS_TITLE_RETENTION_INDEX = true;
 
@@ -689,21 +657,8 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final boolean DEF_SHOW_X_AXIS_SECONDS = false;
 	public static final String P_POSITION_X_AXIS_SECONDS = "positionXAxisSeconds";
 	public static final String DEF_POSITION_X_AXIS_SECONDS = Position.Primary.toString();
-	public static final String P_COLOR_X_AXIS_SECONDS = "colorXAxisSeconds";
-	public static final String DEF_COLOR_X_AXIS_SECONDS = "0,0,0";
-	public static final String P_COLOR_X_AXIS_SECONDS_DARKTHEME = "colorXAxisSecondsDarkTheme";
-	public static final String DEF_COLOR_X_AXIS_SECONDS_DARKTHEME = "252,252,247";
-	public static final String P_FONT_NAME_X_AXIS_SECONDS = "fontNameXAxisSeconds";
-	public static final String DEF_FONT_NAME_X_AXIS_SECONDS = Resources.DEFAULT_FONT_NAME;
-	public static final String P_FONT_SIZE_X_AXIS_SECONDS = "fontSizeXAxisSeconds";
-	public static final String P_FONT_STYLE_X_AXIS_SECONDS = "fontStyleXAxisSeconds";
-	public static final int DEF_FONT_STYLE_X_AXIS_SECONDS = SWT.BOLD;
 	public static final String P_GRIDLINE_STYLE_X_AXIS_SECONDS = "gridlineStyleXAxisSeconds";
 	public static final String DEF_GRIDLINE_STYLE_X_AXIS_SECONDS = LineStyle.NONE.toString();
-	public static final String P_GRIDLINE_COLOR_X_AXIS_SECONDS = "gridlineColorXAxisSeconds";
-	public static final String DEF_GRIDLINE_COLOR_X_AXIS_SECONDS = "192,192,192";
-	public static final String P_GRIDLINE_COLOR_X_AXIS_SECONDS_DARKTHEME = "gridlineColorXAxisSecondsDarkTheme";
-	public static final String DEF_GRIDLINE_COLOR_X_AXIS_SECONDS_DARKTHEME = "64, 64, 64";
 	public static final String P_SHOW_X_AXIS_TITLE_SECONDS = "showXAxisTitleSeconds";
 	public static final boolean DEF_SHOW_X_AXIS_TITLE_SECONDS = true;
 
@@ -715,21 +670,8 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final boolean DEF_SHOW_X_AXIS_MINUTES = true;
 	public static final String P_POSITION_X_AXIS_MINUTES = "positionXAxisMinutes";
 	public static final String DEF_POSITION_X_AXIS_MINUTES = Position.Primary.toString();
-	public static final String P_COLOR_X_AXIS_MINUTES = "colorXAxisMinutes";
-	public static final String DEF_COLOR_X_AXIS_MINUTES = "0,0,0";
-	public static final String P_COLOR_X_AXIS_MINUTES_DARKTHEME = "colorXAxisMinutesDarkTheme";
-	public static final String DEF_COLOR_X_AXIS_MINUTES_DARKTHEME = "252,252,247";
-	public static final String P_FONT_NAME_X_AXIS_MINUTES = "fontNameXAxisMinutes";
-	public static final String DEF_FONT_NAME_X_AXIS_MINUTES = Resources.DEFAULT_FONT_NAME;
-	public static final String P_FONT_SIZE_X_AXIS_MINUTES = "fontSizeXAxisMinutes";
-	public static final String P_FONT_STYLE_X_AXIS_MINUTES = "fontStyleXAxisMinutes";
-	public static final int DEF_FONT_STYLE_X_AXIS_MINUTES = SWT.BOLD;
 	public static final String P_GRIDLINE_STYLE_X_AXIS_MINUTES = "gridlineStyleXAxisMinutes";
 	public static final String DEF_GRIDLINE_STYLE_X_AXIS_MINUTES = LineStyle.DOT.toString();
-	public static final String P_GRIDLINE_COLOR_X_AXIS_MINUTES = "gridlineColorXAxisMinutes";
-	public static final String DEF_GRIDLINE_COLOR_X_AXIS_MINUTES = "192,192,192";
-	public static final String P_GRIDLINE_COLOR_X_AXIS_MINUTES_DARKTHEME = "gridlineColorXAxisMinutesDarkTheme";
-	public static final String DEF_GRIDLINE_COLOR_X_AXIS_MINUTES_DARKTHEME = "64, 64, 64";
 	public static final String P_SHOW_X_AXIS_TITLE_MINUTES = "showXAxisTitleMinutes";
 	public static final boolean DEF_SHOW_X_AXIS_TITLE_MINUTES = true;
 	public static final String P_SHOW_X_AXIS_LINE_MINUTES = "showXAxisLineMinutes";
@@ -747,17 +689,8 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final String DEF_POSITION_X_AXIS_SCANS = Position.Primary.toString();
 	public static final String P_COLOR_X_AXIS_SCANS = "colorXAxisScans";
 	public static final String DEF_COLOR_X_AXIS_SCANS = "0,0,0";
-	public static final String P_COLOR_X_AXIS_SCANS_DARKTHEME = "colorXAxisScansDarkTheme";
-	public static final String DEF_COLOR_X_AXIS_SCANS_DARKTHEME = "252,252,247";
-	public static final String P_FONT_NAME_X_AXIS_SCANS = "fontNameXAxisScans";
-	public static final String DEF_FONT_NAME_X_AXIS_SCANS = Resources.DEFAULT_FONT_NAME;
-	public static final String P_FONT_SIZE_X_AXIS_SCANS = "fontSizeXAxisScans";
-	public static final String P_FONT_STYLE_X_AXIS_SCANS = "fontStyleXAxisScans";
-	public static final int DEF_FONT_STYLE_X_AXIS_SCANS = SWT.BOLD;
 	public static final String P_GRIDLINE_STYLE_X_AXIS_SCANS = "gridlineStyleXAxisScans";
 	public static final String DEF_GRIDLINE_STYLE_X_AXIS_SCANS = LineStyle.NONE.toString();
-	public static final String P_GRIDLINE_COLOR_X_AXIS_SCANS = "gridlineColorXAxisScans";
-	public static final String DEF_GRIDLINE_COLOR_X_AXIS_SCANS = "192,192,192";
 	public static final String P_SHOW_X_AXIS_TITLE_SCANS = "showXAxisTitleScans";
 	public static final boolean DEF_SHOW_X_AXIS_TITLE_SCANS = true;
 
@@ -769,21 +702,8 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final boolean DEF_SHOW_Y_AXIS_INTENSITY = true;
 	public static final String P_POSITION_Y_AXIS_INTENSITY = "positionYAxisIntensity";
 	public static final String DEF_POSITION_Y_AXIS_INTENSITY = Position.Primary.toString();
-	public static final String P_COLOR_Y_AXIS_INTENSITY = "colorYAxisIntensity";
-	public static final String DEF_COLOR_Y_AXIS_INTENSITY = "0,0,0";
-	public static final String P_COLOR_Y_AXIS_INTENSITY_DARKTHEME = "colorYAxisIntensityDarkTheme";
-	public static final String DEF_COLOR_Y_AXIS_INTENSITY_DARKTHEME = "252,252,247";
-	public static final String P_FONT_NAME_Y_AXIS_INTENSITY = "fontNameYAxisIntensity";
-	public static final String DEF_FONT_NAME_Y_AXIS_INTENSITY = Resources.DEFAULT_FONT_NAME;
-	public static final String P_FONT_SIZE_Y_AXIS_INTENSITY = "fontSizeYAxisIntensity";
-	public static final String P_FONT_STYLE_Y_AXIS_INTENSITY = "fontStyleYAxisIntensity";
-	public static final int DEF_FONT_STYLE_Y_AXIS_INTENSITY = SWT.BOLD;
 	public static final String P_GRIDLINE_STYLE_Y_AXIS_INTENSITY = "gridlineStyleYAxisIntensity";
 	public static final String DEF_GRIDLINE_STYLE_Y_AXIS_INTENSITY = LineStyle.NONE.toString();
-	public static final String P_GRIDLINE_COLOR_Y_AXIS_INTENSITY = "gridlineColorYAxisIntensity";
-	public static final String DEF_GRIDLINE_COLOR_Y_AXIS_INTENSITY = "192,192,192";
-	public static final String P_GRIDLINE_COLOR_Y_AXIS_INTENSITY_DARKTHEME = "gridlineColorYAxisIntensityDarkTheme";
-	public static final String DEF_GRIDLINE_COLOR_Y_AXIS_INTENSITY_DARKTHEME = "64, 64, 64";
 	public static final String P_SHOW_Y_AXIS_TITLE_INTENSITY = "showYAxisTitleIntensity";
 	public static final boolean DEF_SHOW_Y_AXIS_TITLE_INTENSITY = true;
 
@@ -795,21 +715,8 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final boolean DEF_SHOW_Y_AXIS_RELATIVE_INTENSITY = true;
 	public static final String P_POSITION_Y_AXIS_RELATIVE_INTENSITY = "positionYAxisRelativeIntensity";
 	public static final String DEF_POSITION_Y_AXIS_RELATIVE_INTENSITY = Position.Secondary.toString();
-	public static final String P_COLOR_Y_AXIS_RELATIVE_INTENSITY = "colorYAxisRelativeIntensity";
-	public static final String DEF_COLOR_Y_AXIS_RELATIVE_INTENSITY = "0,0,0";
-	public static final String P_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME = "colorYAxisRelativeIntensityDarkTheme";
-	public static final String DEF_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME = "252,252,247";
-	public static final String P_FONT_NAME_Y_AXIS_RELATIVE_INTENSITY = "fontNameYAxisRelativeIntensity";
-	public static final String DEF_FONT_NAME_Y_AXIS_RELATIVE_INTENSITY = Resources.DEFAULT_FONT_NAME;
-	public static final String P_FONT_SIZE_Y_AXIS_RELATIVE_INTENSITY = "fontSizeYAxisRelativeIntensity";
-	public static final String P_FONT_STYLE_Y_AXIS_RELATIVE_INTENSITY = "fontStyleYAxisRelativeIntensity";
-	public static final int DEF_FONT_STYLE_Y_AXIS_RELATIVE_INTENSITY = SWT.BOLD;
 	public static final String P_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY = "gridlineStyleYAxisRelativeIntensity";
 	public static final String DEF_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY = LineStyle.DOT.toString();
-	public static final String P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY = "gridlineColorYAxisRelativeIntensity";
-	public static final String DEF_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY = "192,192,192";
-	public static final String P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME = "gridlineColorYAxisRelativeIntensityDarkTheme";
-	public static final String DEF_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME = "64, 64, 64";
 	public static final String P_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY = "showYAxisTitleRelativeIntensity";
 	public static final boolean DEF_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY = true;
 
@@ -837,34 +744,22 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final boolean DEF_SHOW_X_AXIS_CONCENTRATION_CALIBRATION = true;
 	public static final String P_POSITION_X_AXIS_CONCENTRATION_CALIBRATION = "positionXAxisConcentrationCalibration";
 	public static final String DEF_POSITION_X_AXIS_CONCENTRATION_CALIBRATION = Position.Primary.toString();
-	public static final String P_COLOR_X_AXIS_CONCENTRATION_CALIBRATION = "colorXAxisConcentrationCalibration";
-	public static final String DEF_COLOR_X_AXIS_CONCENTRATION_CALIBRATION = "0,0,0";
 	public static final String P_GRIDLINE_STYLE_X_AXIS_CONCENTRATION_CALIBRATION = "gridlineStyleXAxisConcentrationCalibration";
 	public static final String DEF_GRIDLINE_STYLE_X_AXIS_CONCENTRATION_CALIBRATION = LineStyle.DOT.toString();
-	public static final String P_GRIDLINE_COLOR_X_AXIS_CONCENTRATION_CALIBRATION = "gridlineColorXAxisConcentrationCalibration";
-	public static final String DEF_GRIDLINE_COLOR_X_AXIS_CONCENTRATION_CALIBRATION = "192,192,192";
 
 	public static final String P_SHOW_Y_AXIS_RESPONSE_CALIBRATION = "showYAxisResponseCalibration";
 	public static final boolean DEF_SHOW_Y_AXIS_RESPONSE_CALIBRATION = true;
 	public static final String P_POSITION_Y_AXIS_RESPONSE_CALIBRATION = "positionYAxisResponseCalibration";
 	public static final String DEF_POSITION_Y_AXIS_RESPONSE_CALIBRATION = Position.Primary.toString();
-	public static final String P_COLOR_Y_AXIS_RESPONSE_CALIBRATION = "colorYAxisResponseCalibration";
-	public static final String DEF_COLOR_Y_AXIS_RESPONSE_CALIBRATION = "0,0,0";
 	public static final String P_GRIDLINE_STYLE_Y_AXIS_RESPONSE_CALIBRATION = "gridlineStyleYAxisResponseCalibration";
 	public static final String DEF_GRIDLINE_STYLE_Y_AXIS_RESPONSE_CALIBRATION = LineStyle.NONE.toString();
-	public static final String P_GRIDLINE_COLOR_Y_AXIS_RESPONSE_CALIBRATION = "gridlineColorYAxisResponseCalibration";
-	public static final String DEF_GRIDLINE_COLOR_Y_AXIS_RESPONSE_CALIBRATION = "192,192,192";
 
 	public static final String P_SHOW_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION = "showYAxisRelativeResponseCalibration";
 	public static final boolean DEF_SHOW_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION = true;
 	public static final String P_POSITION_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION = "positionYAxisRelativeResponseCalibration";
 	public static final String DEF_POSITION_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION = Position.Secondary.toString();
-	public static final String P_COLOR_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION = "colorYAxisRelativeResponseCalibration";
-	public static final String DEF_COLOR_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION = "0,0,0";
 	public static final String P_GRIDLINE_STYLE_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION = "gridlineStyleYAxisRelativeResponseCalibration";
 	public static final String DEF_GRIDLINE_STYLE_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION = LineStyle.DOT.toString();
-	public static final String P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION = "gridlineColorYAxisRelativeResponseCalibration";
-	public static final String DEF_GRIDLINE_COLOR_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION = "192,192,192";
 	/*
 	 * File Explorer
 	 */
@@ -1150,15 +1045,11 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 
 		putDefault(P_SHOW_Y_AXIS_INTENSITY_PEAKS, DEF_SHOW_Y_AXIS_INTENSITY_PEAKS);
 		putDefault(P_POSITION_Y_AXIS_INTENSITY_PEAKS, DEF_POSITION_Y_AXIS_INTENSITY_PEAKS);
-		putDefault(P_COLOR_Y_AXIS_INTENSITY_PEAKS, DEF_COLOR_Y_AXIS_INTENSITY_PEAKS);
 		putDefault(P_GRIDLINE_STYLE_Y_AXIS_INTENSITY_PEAKS, DEF_GRIDLINE_STYLE_Y_AXIS_INTENSITY_PEAKS);
-		putDefault(P_GRIDLINE_COLOR_Y_AXIS_INTENSITY_PEAKS, DEF_GRIDLINE_COLOR_Y_AXIS_INTENSITY_PEAKS);
 
 		putDefault(P_SHOW_Y_AXIS_RELATIVE_INTENSITY_PEAKS, DEF_SHOW_Y_AXIS_RELATIVE_INTENSITY_PEAKS);
 		putDefault(P_POSITION_Y_AXIS_RELATIVE_INTENSITY_PEAKS, DEF_POSITION_Y_AXIS_RELATIVE_INTENSITY_PEAKS);
-		putDefault(P_COLOR_Y_AXIS_RELATIVE_INTENSITY_PEAKS, DEF_COLOR_Y_AXIS_RELATIVE_INTENSITY_PEAKS);
 		putDefault(P_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY_PEAKS, DEF_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY_PEAKS);
-		putDefault(P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_PEAKS, DEF_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_PEAKS);
 		/*
 		 * Targets
 		 */
@@ -1197,21 +1088,15 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 
 		putDefault(P_SHOW_X_AXIS_CONCENTRATION_CALIBRATION, DEF_SHOW_X_AXIS_CONCENTRATION_CALIBRATION);
 		putDefault(P_POSITION_X_AXIS_CONCENTRATION_CALIBRATION, DEF_POSITION_X_AXIS_CONCENTRATION_CALIBRATION);
-		putDefault(P_COLOR_X_AXIS_CONCENTRATION_CALIBRATION, DEF_COLOR_X_AXIS_CONCENTRATION_CALIBRATION);
 		putDefault(P_GRIDLINE_STYLE_X_AXIS_CONCENTRATION_CALIBRATION, DEF_GRIDLINE_STYLE_X_AXIS_CONCENTRATION_CALIBRATION);
-		putDefault(P_GRIDLINE_COLOR_X_AXIS_CONCENTRATION_CALIBRATION, DEF_GRIDLINE_COLOR_X_AXIS_CONCENTRATION_CALIBRATION);
 
 		putDefault(P_SHOW_Y_AXIS_RESPONSE_CALIBRATION, DEF_SHOW_Y_AXIS_RESPONSE_CALIBRATION);
 		putDefault(P_POSITION_Y_AXIS_RESPONSE_CALIBRATION, DEF_POSITION_Y_AXIS_RESPONSE_CALIBRATION);
-		putDefault(P_COLOR_Y_AXIS_RESPONSE_CALIBRATION, DEF_COLOR_Y_AXIS_RESPONSE_CALIBRATION);
 		putDefault(P_GRIDLINE_STYLE_Y_AXIS_RESPONSE_CALIBRATION, DEF_GRIDLINE_STYLE_Y_AXIS_RESPONSE_CALIBRATION);
-		putDefault(P_GRIDLINE_COLOR_Y_AXIS_RESPONSE_CALIBRATION, DEF_GRIDLINE_COLOR_Y_AXIS_RESPONSE_CALIBRATION);
 
 		putDefault(P_SHOW_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION, DEF_SHOW_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION);
 		putDefault(P_POSITION_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION, DEF_POSITION_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION);
-		putDefault(P_COLOR_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION, DEF_COLOR_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION);
 		putDefault(P_GRIDLINE_STYLE_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION, DEF_GRIDLINE_STYLE_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION);
-		putDefault(P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION, DEF_GRIDLINE_COLOR_Y_AXIS_RELATIVE_RESPONSE_CALIBRATION);
 		/*
 		 * File Explorer
 		 */
@@ -1359,55 +1244,28 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 		putDefault(P_FORMAT_X_AXIS_MILLISECONDS, DEF_FORMAT_X_AXIS_MILLISECONDS);
 		putDefault(P_SHOW_X_AXIS_MILLISECONDS, DEF_SHOW_X_AXIS_MILLISECONDS);
 		putDefault(P_POSITION_X_AXIS_MILLISECONDS, DEF_POSITION_X_AXIS_MILLISECONDS);
-		putDefault(P_COLOR_X_AXIS_MILLISECONDS, DEF_COLOR_X_AXIS_MILLISECONDS);
-		putDefault(P_COLOR_X_AXIS_MILLISECONDS_DARKTHEME, DEF_COLOR_X_AXIS_MILLISECONDS_DARKTHEME);
-		putDefault(P_FONT_NAME_X_AXIS_MILLISECONDS, DEF_FONT_NAME_X_AXIS_MILLISECONDS);
-		putDefault(P_FONT_SIZE_X_AXIS_MILLISECONDS, DEF_FONT_SIZE);
-		putDefault(P_FONT_STYLE_X_AXIS_MILLISECONDS, DEF_FONT_STYLE_X_AXIS_MILLISECONDS);
 		putDefault(P_GRIDLINE_STYLE_X_AXIS_MILLISECONDS, DEF_GRIDLINE_STYLE_X_AXIS_MILLISECONDS);
-		putDefault(P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS, DEF_GRIDLINE_COLOR_X_AXIS_MILLISECONDS);
-		putDefault(P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_DARKTHEME, DEF_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_DARKTHEME);
 		putDefault(P_SHOW_X_AXIS_TITLE_MILLISECONDS, DEF_SHOW_X_AXIS_TITLE_MILLISECONDS);
 
 		putDefault(P_TITLE_X_AXIS_RETENTION_INDEX, DEF_TITLE_X_AXIS_RETENTION_INDEX);
 		putDefault(P_FORMAT_X_AXIS_RETENTION_INDEX, DEF_FORMAT_X_AXIS_RETENTION_INDEX);
 		putDefault(P_SHOW_X_AXIS_RETENTION_INDEX, DEF_SHOW_X_AXIS_RETENTION_INDEX);
 		putDefault(P_POSITION_X_AXIS_RETENTION_INDEX, DEF_POSITION_X_AXIS_RETENTION_INDEX);
-		putDefault(P_COLOR_X_AXIS_RETENTION_INDEX, DEF_COLOR_X_AXIS_RETENTION_INDEX);
-		putDefault(P_COLOR_X_AXIS_RETENTION_INDEX_DARKTHEME, DEF_COLOR_X_AXIS_RETENTION_INDEX_DARKTHEME);
-		putDefault(P_FONT_NAME_X_AXIS_RETENTION_INDEX, DEF_FONT_NAME_X_AXIS_RETENTION_INDEX);
-		putDefault(P_FONT_SIZE_X_AXIS_RETENTION_INDEX, DEF_FONT_SIZE);
-		putDefault(P_FONT_STYLE_X_AXIS_RETENTION_INDEX, DEF_FONT_STYLE_X_AXIS_RETENTION_INDEX);
 		putDefault(P_GRIDLINE_STYLE_X_AXIS_RETENTION_INDEX, DEF_GRIDLINE_STYLE_X_AXIS_RETENTION_INDEX);
-		putDefault(P_GRIDLINE_COLOR_X_AXIS_RETENTION_INDEX, DEF_GRIDLINE_COLOR_X_AXIS_RETENTION_INDEX);
 		putDefault(P_SHOW_X_AXIS_TITLE_RETENTION_INDEX, DEF_SHOW_X_AXIS_TITLE_RETENTION_INDEX);
 
 		putDefault(P_TITLE_X_AXIS_SECONDS, DEF_TITLE_X_AXIS_SECONDS);
 		putDefault(P_FORMAT_X_AXIS_SECONDS, DEF_FORMAT_X_AXIS_SECONDS);
 		putDefault(P_SHOW_X_AXIS_SECONDS, DEF_SHOW_X_AXIS_SECONDS);
 		putDefault(P_POSITION_X_AXIS_SECONDS, DEF_POSITION_X_AXIS_SECONDS);
-		putDefault(P_COLOR_X_AXIS_SECONDS, DEF_COLOR_X_AXIS_SECONDS);
-		putDefault(P_COLOR_X_AXIS_SECONDS_DARKTHEME, DEF_COLOR_X_AXIS_SECONDS_DARKTHEME);
-		putDefault(P_FONT_NAME_X_AXIS_SECONDS, DEF_FONT_NAME_X_AXIS_SECONDS);
-		putDefault(P_FONT_SIZE_X_AXIS_SECONDS, DEF_FONT_SIZE);
-		putDefault(P_FONT_STYLE_X_AXIS_SECONDS, DEF_FONT_STYLE_X_AXIS_SECONDS);
 		putDefault(P_GRIDLINE_STYLE_X_AXIS_SECONDS, DEF_GRIDLINE_STYLE_X_AXIS_SECONDS);
-		putDefault(P_GRIDLINE_COLOR_X_AXIS_SECONDS, DEF_GRIDLINE_COLOR_X_AXIS_SECONDS);
-		putDefault(P_GRIDLINE_COLOR_X_AXIS_SECONDS_DARKTHEME, DEF_GRIDLINE_COLOR_X_AXIS_SECONDS_DARKTHEME);
 		putDefault(P_SHOW_X_AXIS_TITLE_SECONDS, DEF_SHOW_X_AXIS_TITLE_SECONDS);
 
 		putDefault(P_TITLE_X_AXIS_MINUTES, DEF_TITLE_X_AXIS_MINUTES);
 		putDefault(P_FORMAT_X_AXIS_MINUTES, DEF_FORMAT_X_AXIS_MINUTES);
 		putDefault(P_SHOW_X_AXIS_MINUTES, DEF_SHOW_X_AXIS_MINUTES);
 		putDefault(P_POSITION_X_AXIS_MINUTES, DEF_POSITION_X_AXIS_MINUTES);
-		putDefault(P_COLOR_X_AXIS_MINUTES, DEF_COLOR_X_AXIS_MINUTES);
-		putDefault(P_COLOR_X_AXIS_MINUTES_DARKTHEME, DEF_COLOR_X_AXIS_MINUTES_DARKTHEME);
-		putDefault(P_FONT_NAME_X_AXIS_MINUTES, DEF_FONT_NAME_X_AXIS_MINUTES);
-		putDefault(P_FONT_SIZE_X_AXIS_MINUTES, DEF_FONT_SIZE);
-		putDefault(P_FONT_STYLE_X_AXIS_MINUTES, DEF_FONT_STYLE_X_AXIS_MINUTES);
 		putDefault(P_GRIDLINE_STYLE_X_AXIS_MINUTES, DEF_GRIDLINE_STYLE_X_AXIS_MINUTES);
-		putDefault(P_GRIDLINE_COLOR_X_AXIS_MINUTES, DEF_GRIDLINE_COLOR_X_AXIS_MINUTES);
-		putDefault(P_GRIDLINE_COLOR_X_AXIS_MINUTES_DARKTHEME, DEF_GRIDLINE_COLOR_X_AXIS_MINUTES_DARKTHEME);
 		putDefault(P_SHOW_X_AXIS_TITLE_MINUTES, DEF_SHOW_X_AXIS_TITLE_MINUTES);
 		putDefault(P_SHOW_X_AXIS_LINE_MINUTES, DEF_SHOW_X_AXIS_LINE_MINUTES);
 		putDefault(P_SHOW_X_AXIS_POSITION_MARKER_MINUTES, DEF_SHOW_X_AXIS_POSITION_MARKER_MINUTES);
@@ -1417,40 +1275,21 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 		putDefault(P_SHOW_X_AXIS_SCANS, DEF_SHOW_X_AXIS_SCANS);
 		putDefault(P_POSITION_X_AXIS_SCANS, DEF_POSITION_X_AXIS_SCANS);
 		putDefault(P_COLOR_X_AXIS_SCANS, DEF_COLOR_X_AXIS_SCANS);
-		putDefault(P_COLOR_X_AXIS_SCANS_DARKTHEME, DEF_COLOR_X_AXIS_SCANS_DARKTHEME);
-		putDefault(P_FONT_NAME_X_AXIS_SCANS, DEF_FONT_NAME_X_AXIS_SCANS);
-		putDefault(P_FONT_SIZE_X_AXIS_SCANS, DEF_FONT_SIZE);
-		putDefault(P_FONT_STYLE_X_AXIS_SCANS, DEF_FONT_STYLE_X_AXIS_SCANS);
 		putDefault(P_GRIDLINE_STYLE_X_AXIS_SCANS, DEF_GRIDLINE_STYLE_X_AXIS_SCANS);
-		putDefault(P_GRIDLINE_COLOR_X_AXIS_SCANS, DEF_GRIDLINE_COLOR_X_AXIS_SCANS);
 		putDefault(P_SHOW_X_AXIS_TITLE_SCANS, DEF_SHOW_X_AXIS_TITLE_SCANS);
 
 		putDefault(P_TITLE_Y_AXIS_INTENSITY, DEF_TITLE_Y_AXIS_INTENSITY);
 		putDefault(P_FORMAT_Y_AXIS_INTENSITY, DEF_FORMAT_Y_AXIS_INTENSITY);
 		putDefault(P_SHOW_Y_AXIS_INTENSITY, DEF_SHOW_Y_AXIS_INTENSITY);
 		putDefault(P_POSITION_Y_AXIS_INTENSITY, DEF_POSITION_Y_AXIS_INTENSITY);
-		putDefault(P_COLOR_Y_AXIS_INTENSITY, DEF_COLOR_Y_AXIS_INTENSITY);
-		putDefault(P_COLOR_Y_AXIS_INTENSITY_DARKTHEME, DEF_COLOR_Y_AXIS_INTENSITY_DARKTHEME);
-		putDefault(P_FONT_NAME_Y_AXIS_INTENSITY, DEF_FONT_NAME_Y_AXIS_INTENSITY);
-		putDefault(P_FONT_SIZE_Y_AXIS_INTENSITY, DEF_FONT_SIZE);
-		putDefault(P_FONT_STYLE_Y_AXIS_INTENSITY, DEF_FONT_STYLE_Y_AXIS_INTENSITY);
 		putDefault(P_GRIDLINE_STYLE_Y_AXIS_INTENSITY, DEF_GRIDLINE_STYLE_Y_AXIS_INTENSITY);
-		putDefault(P_GRIDLINE_COLOR_Y_AXIS_INTENSITY, DEF_GRIDLINE_COLOR_Y_AXIS_INTENSITY);
-		putDefault(P_GRIDLINE_COLOR_Y_AXIS_INTENSITY_DARKTHEME, DEF_GRIDLINE_COLOR_Y_AXIS_INTENSITY_DARKTHEME);
 		putDefault(P_SHOW_Y_AXIS_TITLE_INTENSITY, DEF_SHOW_Y_AXIS_TITLE_INTENSITY);
 
 		putDefault(P_TITLE_Y_AXIS_RELATIVE_INTENSITY, DEF_TITLE_Y_AXIS_RELATIVE_INTENSITY);
 		putDefault(P_FORMAT_Y_AXIS_RELATIVE_INTENSITY, DEF_FORMAT_Y_AXIS_RELATIVE_INTENSITY);
 		putDefault(P_SHOW_Y_AXIS_RELATIVE_INTENSITY, DEF_SHOW_Y_AXIS_RELATIVE_INTENSITY);
 		putDefault(P_POSITION_Y_AXIS_RELATIVE_INTENSITY, DEF_POSITION_Y_AXIS_RELATIVE_INTENSITY);
-		putDefault(P_COLOR_Y_AXIS_RELATIVE_INTENSITY, DEF_COLOR_Y_AXIS_RELATIVE_INTENSITY);
-		putDefault(P_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME, DEF_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME);
-		putDefault(P_FONT_NAME_Y_AXIS_RELATIVE_INTENSITY, DEF_FONT_NAME_Y_AXIS_RELATIVE_INTENSITY);
-		putDefault(P_FONT_SIZE_Y_AXIS_RELATIVE_INTENSITY, DEF_FONT_SIZE);
-		putDefault(P_FONT_STYLE_Y_AXIS_RELATIVE_INTENSITY, DEF_FONT_STYLE_Y_AXIS_RELATIVE_INTENSITY);
 		putDefault(P_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY, DEF_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY);
-		putDefault(P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY, DEF_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY);
-		putDefault(P_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME, DEF_GRIDLINE_COLOR_Y_AXIS_RELATIVE_INTENSITY_DARKTHEME);
 		putDefault(P_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY, DEF_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY);
 
 		putDefault(P_CHROMATOGRAM_SELECTED_ACTION_ID, DEF_CHROMATOGRAM_SELECTED_ACTION_ID);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -78,14 +78,12 @@ import org.eclipse.chemclipse.support.comparator.SortOrder;
 import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.chemclipse.support.text.ValueFormat;
 import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
-import org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport;
 import org.eclipse.chemclipse.swt.ui.components.InformationUI;
 import org.eclipse.chemclipse.swt.ui.marker.PositionMarker;
 import org.eclipse.chemclipse.swt.ui.marker.RetentionIndexMarker;
 import org.eclipse.chemclipse.swt.ui.notifier.UpdateNotifierUI;
 import org.eclipse.chemclipse.swt.ui.preferences.PreferencePageSystem;
 import org.eclipse.chemclipse.swt.ui.support.Colors;
-import org.eclipse.chemclipse.swt.ui.support.Fonts;
 import org.eclipse.chemclipse.ux.extension.ui.editors.ProcessorSupplierMenuEntry;
 import org.eclipse.chemclipse.ux.extension.ui.methods.MethodCancelException;
 import org.eclipse.chemclipse.ux.extension.ui.methods.MethodParameters;
@@ -167,7 +165,6 @@ import org.eclipse.swt.events.MenuListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -1750,16 +1747,9 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 
 		String positionNode = PreferenceSupplier.P_POSITION_X_AXIS_SCANS;
 		String patternNode = PreferenceSupplier.P_FORMAT_X_AXIS_SCANS;
-		String colorNode = PreferencesSupport.isDarkTheme() ? PreferenceSupplier.P_COLOR_X_AXIS_SCANS_DARKTHEME : PreferenceSupplier.P_COLOR_X_AXIS_SCANS;
 		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_SCANS;
-		String gridColorNode = PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_SCANS;
-		ChartSupport.setAxisSettingsExtended(axisSettings, positionNode, patternNode, colorNode, gridLineStyleNode, gridColorNode);
-
-		String name = preferenceStore.getString(PreferenceSupplier.P_FONT_NAME_X_AXIS_SCANS);
-		int height = preferenceStore.getInt(PreferenceSupplier.P_FONT_SIZE_X_AXIS_SCANS);
-		int style = preferenceStore.getInt(PreferenceSupplier.P_FONT_STYLE_X_AXIS_SCANS);
-		Font titleFont = Fonts.getCachedFont(chromatogramChartControl.get().getDisplay(), name, height, style);
-		axisSettings.setTitleFont(titleFont);
+		ChartSupport.setAxisSettingsExtended(axisSettings, positionNode, patternNode, gridLineStyleNode);
+		ChartSupport.themeAxis(axisSettings, "ScanAxis");
 	}
 
 	@Override


### PR DESCRIPTION
This is actually a dark mode improvement in disguise. It allows me to CSS-style colors yet keep them user configurable. It also adds a nice preview and font selector as it uses the @eclipse-platform preferences.

<img width="894" height="936" alt="grafik" src="https://github.com/user-attachments/assets/369a6634-c2ba-4cd3-addb-c44fb627578c" />

The downside is that it moves the theming settings away from the rest of the preferences. However now they might be at a location that you would expect, and they are searchable.