### PR TITLE
Move bundle reader service

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.assets/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.assets/.project
@@ -20,6 +20,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>

--- a/chemclipse/plugins/org.eclipse.chemclipse.assets/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.assets/META-INF/MANIFEST.MF
@@ -6,8 +6,10 @@ Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: ChemClipse
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.logging;bundle-version="0.9.0",
- org.eclipse.chemclipse.support;bundle-version="0.9.0"
+ org.eclipse.chemclipse.support;bundle-version="0.9.0",
+ org.osgi.service.cm;bundle-version="1.6.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.eclipse.chemclipse.assets
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.assets.core
+Service-Component: OSGI-INF/org.eclipse.chemclipse.assets.BundleReader.xml

--- a/chemclipse/plugins/org.eclipse.chemclipse.assets/OSGI-INF/org.eclipse.chemclipse.assets.BundleReader.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.assets/OSGI-INF/org.eclipse.chemclipse.assets.BundleReader.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="start" immediate="true" name="org.eclipse.chemclipse.assets.BundleReader">
+   <property name="action" value="BundleReader"/>
+   <service>
+      <provide interface="java.lang.Runnable"/>
+   </service>
+   <implementation class="org.eclipse.chemclipse.assets.BundleReader"/>
+</scr:component>

--- a/chemclipse/plugins/org.eclipse.chemclipse.assets/src/org/eclipse/chemclipse/assets/BundleReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.assets/src/org/eclipse/chemclipse/assets/BundleReader.java
@@ -10,7 +10,7 @@
  * Contributors:
  * Christoph Läubrich - initial API and implementation
  *******************************************************************************/
-package org.eclipse.chemclipse.support.internal;
+package org.eclipse.chemclipse.assets;
 
 import java.io.File;
 import java.io.FileFilter;

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/.project
@@ -20,11 +20,6 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.pde.ds.core.builder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/META-INF/MANIFEST.MF
@@ -34,6 +34,4 @@ Require-Bundle: org.eclipse.osgi;bundle-version="3.13.0",
  com.fasterxml.jackson.core.jackson-core;bundle-version="2.13.5",
  com.fasterxml.jackson.core.jackson-databind;bundle-version="2.13.5",
  org.eclipse.core.databinding;bundle-version="1.13.200",
- org.eclipse.core.runtime;bundle-version="3.31.0",
- org.osgi.service.cm;bundle-version="1.6.1"
-Service-Component: OSGI-INF/org.eclipse.chemclipse.support.internal.BundleReader.xml
+ org.eclipse.core.runtime;bundle-version="3.31.0"

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/OSGI-INF/org.eclipse.chemclipse.support.internal.BundleReader.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/OSGI-INF/org.eclipse.chemclipse.support.internal.BundleReader.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="start" immediate="true" name="org.eclipse.chemclipse.support.internal.BundleReader">
-   <property name="action" value="BundleReader"/>
-   <service>
-      <provide interface="java.lang.Runnable"/>
-   </service>
-   <implementation class="org.eclipse.chemclipse.support.internal.BundleReader"/>
-</scr:component>


### PR DESCRIPTION
> Reading global plugins from /home/matthias/.chemclipse/0.8.x/plugins

was executed regardless of the assets bundle being installed or not.