### PR TITLE
Exclude Eclipse Babel from update site

### DIFF
--- a/chemclipse/sites/chemclipse/category.xml
+++ b/chemclipse/sites/chemclipse/category.xml
@@ -14,4 +14,5 @@
    <repository-reference location="https://download.eclipse.org/releases/2025-09/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2025-09" enabled="true" />
    <repository-reference location="https://download.eclipse.org/nebula/updates/release/3.1.1/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/technology/babel/update-site/R0.20.0/2022-12/" enabled="true" />
 </site>


### PR DESCRIPTION
It can be fetched from https://download.eclipse.org/technology/babel/update-site/ and mirrors instead.