### PR TITLE
Remove mass spectrum type override

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/preferences/PreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/preferences/PreferencePage.java
@@ -52,7 +52,6 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 
-		addField(new BooleanFieldEditor(PreferenceSupplier.P_USE_PROFILE_MASS_SPECTRUM_VIEW, "Use profile mass spectrum view.", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_MASS_SPECTRUM_SHOW_METHODS_TOOLBAR, "Show Methods Toolbar", getFieldEditorParent()));
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/preferences/PreferenceSupplier.java
@@ -36,9 +36,6 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final int MIN_LIBRARY_MSD_LIMIT_SORTING = 500;
 	public static final int MAX_LIBRARY_MSD_LIMIT_SORTING = 30000;
 
-	public static final String P_USE_PROFILE_MASS_SPECTRUM_VIEW = "useProfileMassSpectrumView";
-	public static final boolean DEF_USE_PROFILE_MASS_SPECTRUM_VIEW = false;
-
 	public static final String P_SHOW_MASS_SPECTRUM_SELECTION_COMBO = "showMassSpectrumSelectionCombo";
 	public static final boolean DEF_SHOW_MASS_SPECTRUM_SELECTION_COMBO = false;
 
@@ -63,7 +60,6 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 		putDefault(P_FILTER_LIMIT_IONS, Integer.toString(DEF_FILTER_LIMIT_IONS));
 		putDefault(P_PATH_MASS_SPECTRUM_LIBRARIES, DEF_PATH_MASS_SPECTRUM_LIBRARIES);
 		putDefault(P_LIBRARY_MSD_LIMIT_SORTING, Integer.toString(DEF_LIBRARY_MSD_LIMIT_SORTING));
-		putDefault(PreferenceSupplier.P_USE_PROFILE_MASS_SPECTRUM_VIEW, PreferenceSupplier.DEF_USE_PROFILE_MASS_SPECTRUM_VIEW);
 		putDefault(PreferenceSupplier.P_SHOW_MASS_SPECTRUM_SELECTION_COMBO, PreferenceSupplier.DEF_SHOW_MASS_SPECTRUM_SELECTION_COMBO);
 		putDefault(PreferenceSupplier.P_MASS_SPECTRUM_SHOW_METHODS_TOOLBAR, PreferenceSupplier.DEF_MASS_SPECTRUM_SHOW_METHODS_TOOLBAR);
 	}
@@ -81,11 +77,6 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static int getLibraryMSDLimitSorting() {
 
 		return INSTANCE().getInteger(P_LIBRARY_MSD_LIMIT_SORTING, DEF_LIBRARY_MSD_LIMIT_SORTING);
-	}
-
-	public static boolean useProfileMassSpectrumView() {
-
-		return INSTANCE().getBoolean(P_USE_PROFILE_MASS_SPECTRUM_VIEW);
 	}
 
 	public static boolean isSelectionComboVisible() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/ExtendedMassSpectrumUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/ExtendedMassSpectrumUI.java
@@ -137,20 +137,22 @@ public class ExtendedMassSpectrumUI extends Composite implements IExtendedPartUI
 
 	private void createMassSpectrumChart(Composite composite) {
 
-		if(isProfile()) {
+		if(getMassSpectrumType() == MassSpectrumType.PROFILE) {
 			massSpectrumChart = new MassSpectrumChartProfile(composite, SWT.BORDER);
-		} else {
+		} else if(getMassSpectrumType() == MassSpectrumType.CENTROID) {
 			massSpectrumChart = new MassSpectrumChartCentroid(composite, SWT.BORDER);
+		} else {
+			logger.error("Unknown mass spectrum type.");
 		}
 		massSpectrumChart.update(massSpectrum);
 	}
 
-	private boolean isProfile() {
+	private MassSpectrumType getMassSpectrumType() {
 
 		if(massSpectrum instanceof IRegularMassSpectrum regularMassSpectrum) {
-			return regularMassSpectrum.getMassSpectrumType() == MassSpectrumType.PROFILE;
+			return regularMassSpectrum.getMassSpectrumType();
 		} else {
-			return PreferenceSupplier.useProfileMassSpectrumView();
+			return null;
 		}
 	}
 


### PR DESCRIPTION
This causes problems if the mass spectrum type is set to centroid but overridden to profile in the editor viewer. It then looks correct, but in fact is using the wrong type internally and will show the wrong filter actions, which causes hard to spot bugs that are very irritating.