### PR TITLE
Keep the current selection after running a process method

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/ProcessMethodToolbar.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/ProcessMethodToolbar.java
@@ -302,7 +302,7 @@ public class ProcessMethodToolbar extends ToolBar {
 
 		final ToolItem item = new ToolItem(toolBar, SWT.DROP_DOWN);
 		item.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_ADD, IApplicationImageProvider.SIZE_16x16));
-		item.setToolTipText("Add a process method.");
+		item.setToolTipText("Add a processor.");
 		final Menu menu = new Menu(toolBar.getShell(), SWT.POP_UP);
 
 		toolBar.addDisposeListener(e -> menu.dispose());
@@ -336,7 +336,7 @@ public class ProcessMethodToolbar extends ToolBar {
 				}
 
 				MenuItem loadItem = new MenuItem(menu, SWT.NONE);
-				loadItem.setText("Load from file...");
+				loadItem.setText("Load process method from file...");
 				loadItem.addSelectionListener(new SelectionAdapter() {
 
 					@Override
@@ -406,7 +406,7 @@ public class ProcessMethodToolbar extends ToolBar {
 
 		final ToolItem item = new ToolItem(toolBar, SWT.PUSH);
 		item.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_DELETE, IApplicationImageProvider.SIZE_16x16));
-		item.setToolTipText("Remove the selected process methods.");
+		item.setToolTipText("Remove the selected processors.");
 		item.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -423,7 +423,7 @@ public class ProcessMethodToolbar extends ToolBar {
 
 		final ToolItem item = new ToolItem(toolBar, SWT.PUSH);
 		item.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_DELETE_ALL, IApplicationImageProvider.SIZE_16x16));
-		item.setToolTipText("Remove all process methods.");
+		item.setToolTipText("Remove all processors.");
 		item.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -439,7 +439,7 @@ public class ProcessMethodToolbar extends ToolBar {
 
 		final ToolItem item = new ToolItem(toolBar, SWT.PUSH);
 		item.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_COPY, IApplicationImageProvider.SIZE_16x16));
-		item.setToolTipText("Copy a process method.");
+		item.setToolTipText("Copy a processor.");
 		item.addSelectionListener(new SelectionAdapter() {
 
 			@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -770,11 +770,6 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 		}
 	}
 
-	private void forceReset(boolean resetRange) {
-
-		getDisplay().asyncExec(() -> reset(resetRange));
-	}
-
 	public void updateResult(IMessageProvider processingInfo) {
 
 		getDisplay().asyncExec(() -> ProcessingInfoPartSupport.getInstance().update(processingInfo, true));
@@ -1211,7 +1206,6 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 			updateResult(processingInfo);
 			AuditTrailSupport.updateAuditTrail(chromatogram, processingInfo, processMethod, processTypeSupport);
 			NoiseFactorSupport.updateNoiseFactor(chromatogram, processMethod, processTypeSupport);
-			forceReset(true);
 			UpdateNotifierUI.update(getDisplay(), chromatogramSelection.getSelectedScan());
 		}));
 


### PR DESCRIPTION
As the process method is applied to the chromatogram selection, it is unexpected behavior for it to always zoom out after being run. You then lose track of the range where you applied the method, like when you only use a few filters at once when working half-manually. To retain the previous behavior, you can simply add a `Chromatogram Selection (1:1)` processor to the end of your process method.