### PR TITLE
Do not include LTK and Team bundles in the core feature

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
@@ -133,14 +133,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.team.core"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.team.ui"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.text"
          version="0.0.0"/>
 
@@ -242,14 +234,6 @@
 
    <plugin
          id="org.eclipse.ui.themes"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.ltk.core.refactoring"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.ltk.ui.refactoring"
          version="0.0.0"/>
 
    <plugin


### PR DESCRIPTION
These just end up adding extra UI elements (views/preference pages/etc.) that are totally useless in chemclipse.