### PR TITLE
Remove display from color constructors

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/provider/PeakListLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/provider/PeakListLabelProvider.java
@@ -32,7 +32,6 @@ import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.support.ui.provider.AbstractChemClipseLabelProvider;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.widgets.Display;
 
 public class PeakListLabelProvider extends AbstractChemClipseLabelProvider {
 
@@ -45,7 +44,7 @@ public class PeakListLabelProvider extends AbstractChemClipseLabelProvider {
 				IComparisonResult cp = target.getComparisonResult();
 				if(cp instanceof IPeakComparisonResult pcp) {
 					if(pcp.isMarkerPeak()) {
-						return new Color(Display.getDefault(), 255, 140, 0);
+						return new Color(255, 140, 0);
 					}
 				}
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/src/org/eclipse/chemclipse/swt/ui/support/Colors.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/src/org/eclipse/chemclipse/swt/ui/support/Colors.java
@@ -287,8 +287,7 @@ public class Colors {
 		 */
 		Color color = alphaColors.get(rgb);
 		if(color == null) {
-			Display display = DisplayUtils.getDisplay();
-			color = new Color(display, rgb, alpha);
+			color = new Color(rgb, alpha);
 			alphaColors.put(rgb, color);
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/PeakScanListLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/PeakScanListLabelProvider.java
@@ -33,7 +33,6 @@ import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.support.text.ValueFormat;
 import org.eclipse.chemclipse.support.ui.provider.AbstractChemClipseLabelProvider;
-import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.preferences.PreferenceSupplierModel;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramPeakWSD;
@@ -140,7 +139,7 @@ public class PeakScanListLabelProvider extends AbstractChemClipseLabelProvider {
 				IComparisonResult comparisonResult = peakTarget.getComparisonResult();
 				if(comparisonResult instanceof IPeakComparisonResult peakComparisonResult) {
 					if(peakComparisonResult.isMarkerPeak()) {
-						return new Color(DisplayUtils.getDisplay(), 255, 140, 0);
+						return new Color(255, 140, 0);
 					}
 				}
 			}


### PR DESCRIPTION
Apparently you can create colors without a display because they no longer need to be disposed.