### PR TITLE
Fix search case sensitivity confusion

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/preferences/PreferenceSupplier.java
@@ -39,7 +39,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final String P_SORT_CASE_SENSITIVE = "sortCaseSensitive";
 	public static final boolean DEF_SORT_CASE_SENSITIVE = true;
 	public static final String P_SEARCH_CASE_SENSITIVE = "searchCaseSensitive";
-	public static final boolean DEF_SEARCH_CASE_SENSITIVE = true;
+	public static final boolean DEF_SEARCH_CASE_SENSITIVE = false;
 	public static final String P_BEST_TARGET_LIBRARY_FIELD = "bestTargetLibraryField";
 	public static final String DEF_BEST_TARGET_LIBRARY_FIELD = LibraryField.NAME.name();
 	public static final String P_ION_ROUND_METHOD = "ionRoundMethod"; // When changing this value, call clearCacheActiveIonRoundMethod.

--- a/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/src/org/eclipse/chemclipse/swt/ui/components/SearchSupportUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/src/org/eclipse/chemclipse/swt/ui/components/SearchSupportUI.java
@@ -179,6 +179,7 @@ public class SearchSupportUI extends Composite {
 		Button button = new Button(parent, SWT.TOGGLE);
 		button.setText("");
 		button.setToolTipText("");
+		button.setSelection(caseSensitive);
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_CASE_SENSITIVE, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
 


### PR DESCRIPTION
where the initial state of the button was wrong, which was misleading. Also, most modern applications let you search case-insensitively by default to be more forgiving. An example for this is searching MS databases where UPPERCASE, lowercase or Capital Case may be mixed as there is no global convention across distributors.