### PR TITLE
Replace 🔴 decorator with toggle buttons

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.ui.icons/src/org/eclipse/chemclipse/rcp/ui/icons/core/ApplicationImage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.ui.icons/src/org/eclipse/chemclipse/rcp/ui/icons/core/ApplicationImage.java
@@ -13,16 +13,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.rcp.ui.icons.core;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.eclipse.swt.graphics.Image;
 import org.osgi.framework.Bundle;
 
 public class ApplicationImage extends AbstractApplicationImage implements IApplicationImage {
-
-	private ImageDecorator imageDecorator = new ImageDecorator();
-	private Map<String, Image> decoratedImageCache = new HashMap<>();
 
 	public ApplicationImage(Bundle bundle) {
 
@@ -42,28 +35,5 @@ public class ApplicationImage extends AbstractApplicationImage implements IAppli
 		} else {
 			return fileName;
 		}
-	}
-
-	@Override
-	public Image getImage(String fileName, String size, boolean active) {
-
-		Image image = super.getImage(fileName, size);
-		if(active && image != null) {
-			String path = getPath(fileName, size) + "_decorated";
-			Image decoratedImage = decoratedImageCache.get(path);
-			if(decoratedImage == null) {
-				imageDecorator.setSize(size);
-				imageDecorator.setImage(image);
-				decoratedImage = imageDecorator.createImage();
-				if(decoratedImage != null) {
-					decoratedImageCache.put(path, decoratedImage);
-					image = decoratedImage;
-				}
-			} else {
-				image = decoratedImage;
-			}
-		}
-
-		return image;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.ui.icons/src/org/eclipse/chemclipse/rcp/ui/icons/core/IApplicationImageProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.ui.icons/src/org/eclipse/chemclipse/rcp/ui/icons/core/IApplicationImageProvider.java
@@ -48,16 +48,6 @@ public interface IApplicationImageProvider {
 	Image getImage(String fileName, String size);
 
 	/**
-	 * Returns an image with the given icons size.
-	 * 
-	 * @param fileName
-	 * @param size
-	 * @param active
-	 * @return Image
-	 */
-	Image getImage(String fileName, String size, boolean active);
-
-	/**
 	 * Returns an image descriptor with the given icons size.
 	 * 
 	 * @param fileName

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumLibraryUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumLibraryUI.java
@@ -130,7 +130,7 @@ public class MassSpectrumLibraryUI extends Composite {
 
 	private Button createButtonToggleToolbarInfo(Composite parent) {
 
-		Button button = new Button(parent, SWT.PUSH);
+		Button button = new Button(parent, SWT.TOGGLE);
 		button.setToolTipText("Toggle info toolbar.");
 		button.setText("");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImage.SIZE_16x16));
@@ -140,7 +140,7 @@ public class MassSpectrumLibraryUI extends Composite {
 			public void widgetSelected(SelectionEvent e) {
 
 				boolean visible = PartSupport.toggleCompositeVisibility(toolbarInfo);
-				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImage.SIZE_16x16, visible));
+				button.setSelection(visible);
 			}
 		});
 
@@ -149,7 +149,7 @@ public class MassSpectrumLibraryUI extends Composite {
 
 	private Button createButtonToggleToolbarSearch(Composite parent) {
 
-		Button button = new Button(parent, SWT.PUSH);
+		Button button = new Button(parent, SWT.TOGGLE);
 		button.setToolTipText("Toggle search toolbar.");
 		button.setText("");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SEARCH, IApplicationImage.SIZE_16x16));
@@ -159,7 +159,7 @@ public class MassSpectrumLibraryUI extends Composite {
 			public void widgetSelected(SelectionEvent e) {
 
 				boolean visible = PartSupport.toggleCompositeVisibility(toolbarSearch);
-				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SEARCH, IApplicationImage.SIZE_16x16, visible));
+				button.setSelection(visible);
 			}
 		});
 
@@ -168,7 +168,7 @@ public class MassSpectrumLibraryUI extends Composite {
 
 	private Button createButtonToggleToolbarModify(Composite parent) {
 
-		Button button = new Button(parent, SWT.PUSH);
+		Button button = new Button(parent, SWT.TOGGLE);
 		button.setToolTipText("Toggle modify toolbar.");
 		button.setText("");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_DEFAULT, IApplicationImage.SIZE_16x16));
@@ -191,7 +191,7 @@ public class MassSpectrumLibraryUI extends Composite {
 
 	private Button createButtonToggleToolbarEdit(Composite parent) {
 
-		Button button = new Button(parent, SWT.PUSH);
+		Button button = new Button(parent, SWT.TOGGLE);
 		button.setToolTipText("Enable/disable to edit the table.");
 		button.setText("");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_ENTRY, IApplicationImage.SIZE_16x16));

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/IExtendedPartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/IExtendedPartUI.java
@@ -425,8 +425,6 @@ public interface IExtendedPartUI {
 			if(button.getImage() == null) {
 				button.setImage(ApplicationImageFactory.getInstance().getImage(image, IApplicationImageProvider.SIZE_16x16));
 			}
-		} else {
-			button.setImage(ApplicationImageFactory.getInstance().getImage(image, IApplicationImageProvider.SIZE_16x16, enabled));
 		}
 		/*
 		 * Tooltip

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/calibration/ExtendedRetentionIndexListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/calibration/ExtendedRetentionIndexListUI.java
@@ -166,7 +166,7 @@ public class ExtendedRetentionIndexListUI extends Composite implements IExtended
 
 	private Button createButtonToggleToolbarInfo(Composite parent) {
 
-		Button button = new Button(parent, SWT.PUSH);
+		Button button = new Button(parent, SWT.TOGGLE);
 		button.setToolTipText(ExtensionMessages.toggleInfoToolbar);
 		button.setText("");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImageProvider.SIZE_16x16));
@@ -177,7 +177,7 @@ public class ExtendedRetentionIndexListUI extends Composite implements IExtended
 
 				PartSupport.toggleCompositeVisibility(toolbarInfoTop);
 				boolean visible = PartSupport.toggleCompositeVisibility(toolbarInfoBottom);
-				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImageProvider.SIZE_16x16, visible));
+				button.setSelection(visible);
 			}
 		});
 
@@ -221,7 +221,7 @@ public class ExtendedRetentionIndexListUI extends Composite implements IExtended
 
 	private Button createButtonToggleToolbarSearch(Composite parent) {
 
-		Button button = new Button(parent, SWT.PUSH);
+		Button button = new Button(parent, SWT.TOGGLE);
 		button.setToolTipText(ExtensionMessages.toggleSearchToolbar);
 		button.setText("");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SEARCH, IApplicationImageProvider.SIZE_16x16));
@@ -231,7 +231,7 @@ public class ExtendedRetentionIndexListUI extends Composite implements IExtended
 			public void widgetSelected(SelectionEvent e) {
 
 				boolean visible = retentionIndexUI.toggleSearchVisibility();
-				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SEARCH, IApplicationImageProvider.SIZE_16x16, visible));
+				button.setSelection(visible);
 			}
 		});
 
@@ -240,7 +240,7 @@ public class ExtendedRetentionIndexListUI extends Composite implements IExtended
 
 	private Button createButtonToggleToolbarModify(Composite parent) {
 
-		Button button = new Button(parent, SWT.PUSH);
+		Button button = new Button(parent, SWT.TOGGLE);
 		button.setToolTipText(ExtensionMessages.toggleModifyToolbar);
 		button.setText("");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_DEFAULT, IApplicationImageProvider.SIZE_16x16));
@@ -263,7 +263,7 @@ public class ExtendedRetentionIndexListUI extends Composite implements IExtended
 
 	private Button createButtonToggleToolbarEdit(Composite parent) {
 
-		Button button = new Button(parent, SWT.PUSH);
+		Button button = new Button(parent, SWT.TOGGLE);
 		button.setToolTipText(ExtensionMessages.toggleEditToolbar);
 		button.setText("");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_ENTRY_DEFAULT, IApplicationImageProvider.SIZE_16x16));

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedCombinedScanUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedCombinedScanUI.java
@@ -302,7 +302,7 @@ public class ExtendedCombinedScanUI extends Composite implements IExtendedPartUI
 
 	private Button createButtonLocked(Composite parent) {
 
-		Button button = new Button(parent, SWT.PUSH);
+		Button button = new Button(parent, SWT.TOGGLE);
 		button.setToolTipText("Lock the combined scan.");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
@@ -320,7 +320,8 @@ public class ExtendedCombinedScanUI extends Composite implements IExtendedPartUI
 	private void updateStatus() {
 
 		buttonLocked.setToolTipText(locked ? "Edit modus: on" : "Edit modus: off");
-		buttonLocked.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT, IApplicationImageProvider.SIZE_16x16, locked));
+		buttonLocked.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT, IApplicationImageProvider.SIZE_16x16));
+		buttonLocked.setSelection(locked);
 		updateLabel(labelEdit, locked ? "Edit On" : "");
 		updateButtons();
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedInternalStandardsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedInternalStandardsUI.java
@@ -408,7 +408,7 @@ public class ExtendedInternalStandardsUI extends Composite implements IExtendedP
 
 	private Button createButtonToggleToolbarInfo(Composite parent) {
 
-		Button button = new Button(parent, SWT.PUSH);
+		Button button = new Button(parent, SWT.TOGGLE);
 		button.setToolTipText("Toggle info toolbar.");
 		button.setText("");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImageProvider.SIZE_16x16));
@@ -418,7 +418,7 @@ public class ExtendedInternalStandardsUI extends Composite implements IExtendedP
 			public void widgetSelected(SelectionEvent e) {
 
 				boolean visible = PartSupport.toggleCompositeVisibility(toolbarInfo);
-				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImageProvider.SIZE_16x16, visible));
+				button.setSelection(visible);
 			}
 		});
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakChartUI.java
@@ -249,7 +249,7 @@ public class ExtendedPeakChartUI extends Composite implements IExtendedPartUI {
 
 	private Button createButtonToggleToolbarInfo(Composite parent) {
 
-		Button button = new Button(parent, SWT.PUSH);
+		Button button = new Button(parent, SWT.TOGGLE);
 		button.setToolTipText("Toggle info toolbar.");
 		button.setText("");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImageProvider.SIZE_16x16));
@@ -259,7 +259,7 @@ public class ExtendedPeakChartUI extends Composite implements IExtendedPartUI {
 			public void widgetSelected(SelectionEvent e) {
 
 				boolean visible = PartSupport.toggleCompositeVisibility(toolbarInfo);
-				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImageProvider.SIZE_16x16, visible));
+				button.setSelection(visible);
 			}
 		});
 
@@ -387,7 +387,7 @@ public class ExtendedPeakChartUI extends Composite implements IExtendedPartUI {
 
 	private void createToggleLegendMarkerButton(Composite parent) {
 
-		Button button = new Button(parent, SWT.PUSH);
+		Button button = new Button(parent, SWT.TOGGLE);
 		button.setToolTipText("Toggle the chart legend marker.");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_CHART_LEGEND_MARKER, IApplicationImageProvider.SIZE_16x16));
 		button.addSelectionListener(new SelectionAdapter() {
@@ -398,6 +398,7 @@ public class ExtendedPeakChartUI extends Composite implements IExtendedPartUI {
 				IChartSettings chartSettings = peakChart.getChartSettings();
 				boolean isShowLegendMarker = chartSettings.isShowLegendMarker();
 				chartSettings.setShowLegendMarker(!isShowLegendMarker);
+				button.setSelection(isShowLegendMarker);
 				peakChart.applySettings(chartSettings);
 			}
 		});

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSequenceExplorerUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSequenceExplorerUI.java
@@ -109,7 +109,7 @@ public class ExtendedSequenceExplorerUI extends Composite implements IExtendedPa
 
 	private Button createButtonToggleToolbarSearch(Composite parent) {
 
-		Button button = new Button(parent, SWT.PUSH);
+		Button button = new Button(parent, SWT.TOGGLE);
 		button.setToolTipText("Toggle search toolbar.");
 		button.setText("");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SEARCH, IApplicationImageProvider.SIZE_16x16));
@@ -119,7 +119,7 @@ public class ExtendedSequenceExplorerUI extends Composite implements IExtendedPa
 			public void widgetSelected(SelectionEvent e) {
 
 				boolean visible = PartSupport.toggleCompositeVisibility(toolbarSearch);
-				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SEARCH, IApplicationImageProvider.SIZE_16x16, visible));
+				button.setSelection(visible);
 			}
 		});
 
@@ -137,6 +137,7 @@ public class ExtendedSequenceExplorerUI extends Composite implements IExtendedPa
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 
+				// TODO
 			}
 		});
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedQuantCompoundListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedQuantCompoundListUI.java
@@ -150,7 +150,7 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 
 	private Button createButtonToggleToolbarInfo(Composite parent) {
 
-		Button button = new Button(parent, SWT.PUSH);
+		Button button = new Button(parent, SWT.TOGGLE);
 		button.setToolTipText("Toggle the info toolbar.");
 		button.setText("");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImageProvider.SIZE_16x16));
@@ -160,7 +160,7 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 			public void widgetSelected(SelectionEvent e) {
 
 				boolean visible = PartSupport.toggleCompositeVisibility(toolbarInfo);
-				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_INFO, IApplicationImageProvider.SIZE_16x16, visible));
+				button.setSelection(visible);
 			}
 		});
 
@@ -169,7 +169,7 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 
 	private Button createButtonToggleToolbarHeader(Composite parent) {
 
-		Button button = new Button(parent, SWT.PUSH);
+		Button button = new Button(parent, SWT.TOGGLE);
 		button.setToolTipText("Toggle the header toolbar.");
 		button.setText("");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_HEADER_DATA, IApplicationImageProvider.SIZE_16x16));
@@ -179,11 +179,7 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 			public void widgetSelected(SelectionEvent e) {
 
 				boolean visible = PartSupport.toggleCompositeVisibility(toolbarHeader);
-				if(visible) {
-					button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_HEADER_DATA, IApplicationImageProvider.SIZE_16x16));
-				} else {
-					button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_HEADER_DATA, IApplicationImageProvider.SIZE_16x16));
-				}
+				button.setSelection(visible);
 			}
 		});
 
@@ -192,7 +188,7 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 
 	private Button createButtonToggleToolbarModify(Composite parent) {
 
-		Button button = new Button(parent, SWT.PUSH);
+		Button button = new Button(parent, SWT.TOGGLE);
 		button.setToolTipText("Toggle modify toolbar.");
 		button.setText("");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_EDIT_DEFAULT, IApplicationImageProvider.SIZE_16x16));
@@ -445,7 +441,7 @@ public class ExtendedQuantCompoundListUI extends Composite implements IExtendedP
 			public void widgetSelected(SelectionEvent e) {
 
 				boolean visible = PartSupport.toggleCompositeVisibility(toolbarSearch);
-				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SEARCH, IApplicationImageProvider.SIZE_16x16, visible));
+				button.setSelection(visible);
 			}
 		});
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedSequenceListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedSequenceListUI.java
@@ -282,7 +282,7 @@ public class ExtendedSequenceListUI extends Composite implements IExtendedPartUI
 
 	private Button createButtonToggleToolbarSearch(Composite parent) {
 
-		Button button = new Button(parent, SWT.PUSH);
+		Button button = new Button(parent, SWT.TOGGLE);
 		button.setToolTipText("Toggle search toolbar.");
 		button.setText("");
 		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SEARCH, IApplicationImageProvider.SIZE_16x16));
@@ -292,7 +292,7 @@ public class ExtendedSequenceListUI extends Composite implements IExtendedPartUI
 			public void widgetSelected(SelectionEvent e) {
 
 				boolean visible = PartSupport.toggleCompositeVisibility(toolbarSearch);
-				button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_SEARCH, IApplicationImageProvider.SIZE_16x16, visible));
+				button.setSelection(visible);
 			}
 		});
 


### PR DESCRIPTION
This fixes a glitch where icons with 🔴 are rendered not on full size on Windows. It is also more consistent with the toggle button that we already have. I personally find the native toggle button style more satisfying to click.

I also removed the API completely because JFace already has a [DecorationOverlayIcon](https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fapi%2Forg%2Feclipse%2Fjface%2Fviewers%2FDecorationOverlayIcon.html) that can be used instead.