### PR TITLE
Run license vetting only on target file change

### DIFF
--- a/.github/workflows/license-vetting.yml
+++ b/.github/workflows/license-vetting.yml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - 'develop'
+    paths:
+      - '**/*.target'
   pull_request:
     branches:
      - 'develop'
+    paths:
+     - '**/*.target'
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
That will make some changes be found later e.g. Maven dependency defining it's dependency version with a range and new version of this dependency of dependency still within the range be pushed to Maven central.
It is needed due to EF dash tool not being able to survive the load.