### PR TITLE
Add support for TIC in mzXML

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion20.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion20.java
@@ -37,6 +37,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorChromatog
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransition;
@@ -142,6 +143,9 @@ public class ChromatogramReaderVersion20 extends AbstractChromatogramReader impl
 
 		Peaks peaks = scan.getPeaks();
 		if(peaks == null) {
+			if(scan.getTotIonCurrent() != 0) {
+				massSpectrum.addIon(new VendorIon(IIon.TIC_ION, scan.getTotIonCurrent()), false);
+			}
 			return massSpectrum;
 		}
 		/*
@@ -176,7 +180,6 @@ public class ChromatogramReaderVersion20 extends AbstractChromatogramReader impl
 				massSpectrum.addIon(new VendorIon(mz, intensity), false);
 			}
 		}
-
 	}
 
 	private void setRetentionTime(Scan scan, IVendorScan massSpectrum) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion21.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion21.java
@@ -37,6 +37,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorChromatog
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransition;
@@ -142,6 +143,9 @@ public class ChromatogramReaderVersion21 extends AbstractChromatogramReader impl
 
 		Peaks peaks = scan.getPeaks();
 		if(peaks == null) {
+			if(scan.getTotIonCurrent() != 0) {
+				massSpectrum.addIon(new VendorIon(IIon.TIC_ION, scan.getTotIonCurrent()), false);
+			}
 			return massSpectrum;
 		}
 		/*
@@ -176,7 +180,6 @@ public class ChromatogramReaderVersion21 extends AbstractChromatogramReader impl
 				massSpectrum.addIon(new VendorIon(mz, intensity), false);
 			}
 		}
-
 	}
 
 	private void setRetentionTime(Scan scan, IVendorScan massSpectrum) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion22.java
@@ -37,6 +37,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorChromatog
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransition;
@@ -142,6 +143,9 @@ public class ChromatogramReaderVersion22 extends AbstractChromatogramReader impl
 
 		Peaks peaks = scan.getPeaks();
 		if(peaks == null) {
+			if(scan.getTotIonCurrent() != 0) {
+				massSpectrum.addIon(new VendorIon(IIon.TIC_ION, scan.getTotIonCurrent()), false);
+			}
 			return massSpectrum;
 		}
 		/*
@@ -176,7 +180,6 @@ public class ChromatogramReaderVersion22 extends AbstractChromatogramReader impl
 				massSpectrum.addIon(new VendorIon(mz, intensity), false);
 			}
 		}
-
 	}
 
 	private void setRetentionTime(Scan scan, IVendorScan massSpectrum) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion30.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion30.java
@@ -38,6 +38,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorChromatog
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransition;
@@ -131,6 +132,9 @@ public class ChromatogramReaderVersion30 extends AbstractChromatogramReader impl
 				 */
 				for(Peaks peaks : scan.getPeaks()) {
 					if(peaks == null) {
+						if(scan.getTotIonCurrent() != 0) {
+							massSpectrum.addIon(new VendorIon(IIon.TIC_ION, scan.getTotIonCurrent()), false);
+						}
 						continue;
 					}
 					double[] values = ByteReaderVersion3.readValues(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision(), peaks.getCompressionType());

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion31.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion31.java
@@ -38,6 +38,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorChromatog
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransition;
@@ -131,6 +132,9 @@ public class ChromatogramReaderVersion31 extends AbstractChromatogramReader impl
 				 */
 				for(Peaks peaks : scan.getPeaks()) {
 					if(peaks == null) {
+						if(scan.getTotIonCurrent() != 0) {
+							massSpectrum.addIon(new VendorIon(IIon.TIC_ION, scan.getTotIonCurrent()), false);
+						}
 						continue;
 					}
 					double[] values = ByteReaderVersion3.readValues(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision(), peaks.getCompressionType());

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion32.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion32.java
@@ -40,6 +40,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorChromatog
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransition;
@@ -134,6 +135,9 @@ public class ChromatogramReaderVersion32 extends AbstractChromatogramReader impl
 				 */
 				for(Peaks peaks : scan.getPeaks()) {
 					if(peaks == null) {
+						if(scan.getTotIonCurrent() != 0) {
+							massSpectrum.addIon(new VendorIon(IIon.TIC_ION, scan.getTotIonCurrent()), false);
+						}
 						continue;
 					}
 					double[] values = ByteReaderVersion3.readValues(peaks.getValue(), peaks.getByteOrder(), peaks.getPrecision(), peaks.getCompressionType());


### PR DESCRIPTION
Some software doesn't export the full chromatogram as mzXML or, rather, exports what the user currently has selected. In that case, peaks might still exist in the XML but are mostly empty. We can still reconstruct a total ion chromatogram from the data stored in the scan, though.