### PR TITLE
Add a chromatogram splitter by polarity

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter/plugin.xml
@@ -37,6 +37,13 @@
             filterName="Splitter (Nominal MS)"
             filterSettings="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.settings.FilterSettingsNominalMS"
             id="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.nominalms">
-      </ChromatogramFilterSupplier>                    
+      </ChromatogramFilterSupplier>
+      <ChromatogramFilterSupplier
+            description="This filter splits a chromatogram per polarity."
+            filter="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.core.ChromatogramFilterPolarity"
+            filterName="Splitter (Polarity)"
+            filterSettings="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.settings.FilterSettingsPolarity"
+            id="org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.polarity">
+      </ChromatogramFilterSupplier>
    </extension>
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/splitter/core/ChromatogramFilterPolarity.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/splitter/core/ChromatogramFilterPolarity.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.core;
+
+import org.eclipse.chemclipse.chromatogram.filter.result.ChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
+import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
+import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
+import org.eclipse.chemclipse.chromatogram.msd.filter.core.chromatogram.AbstractChromatogramFilterMSD;
+import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.preferences.PreferenceSupplier;
+import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.settings.FilterSettingsPolarity;
+import org.eclipse.chemclipse.model.core.IChromatogram;
+import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.Polarity;
+import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
+import org.eclipse.chemclipse.msd.model.implementation.ChromatogramMSD;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.processing.core.ProcessingInfo;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+public class ChromatogramFilterPolarity extends AbstractChromatogramFilterMSD {
+
+	@Override
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
+
+		IProcessingInfo<IChromatogramFilterResult> validation = validate(chromatogramSelection, chromatogramFilterSettings);
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = new ProcessingInfo<>();
+		processingInfo.addMessages(validation);
+
+		if(!processingInfo.hasErrorMessages()) {
+			IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+			if(chromatogram instanceof IChromatogramMSD chromatogramMSD) {
+				splitByPolarity(chromatogramMSD);
+			}
+			chromatogramSelection.getChromatogram().setDirty(true);
+			processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, "The chromatogram was splitted into polarity reference chromatograms."));
+		}
+		return processingInfo;
+	}
+
+	@Override
+	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IProgressMonitor monitor) {
+
+		FilterSettingsPolarity splitterSettings = PreferenceSupplier.getFilterSettingsPolarity();
+		return applyFilter(chromatogramSelection, splitterSettings, monitor);
+	}
+
+	private void splitByPolarity(IChromatogramMSD chromatogramMSD) {
+
+		IChromatogramMSD chromatogramReferenceMSD = new ChromatogramMSD();
+		chromatogramReferenceMSD.setConverterId(chromatogramMSD.getConverterId());
+
+		chromatogramMSD.getScans().removeIf(scan -> {
+			if(scan instanceof IRegularMassSpectrum massSpectrum && massSpectrum.getPolarity() == Polarity.NEGATIVE) {
+				chromatogramReferenceMSD.addScan(massSpectrum);
+				return true; // remove from chromatogramMSD
+			}
+			return false;
+		});
+
+		chromatogramMSD.addReferencedChromatogram(chromatogramReferenceMSD);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/splitter/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/splitter/preferences/PreferenceSupplier.java
@@ -15,6 +15,7 @@ package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.prefere
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.settings.FilterSettingsHighResMS;
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.settings.FilterSettingsMSx;
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.settings.FilterSettingsNominalMS;
+import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.settings.FilterSettingsPolarity;
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.settings.FilterSettingsSIM;
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.settings.FilterSettingsTandemMS;
 import org.eclipse.chemclipse.support.preferences.AbstractPreferenceSupplier;
@@ -72,5 +73,10 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static FilterSettingsNominalMS getFilterSettingsNominalMS() {
 
 		return new FilterSettingsNominalMS();
+	}
+
+	public static FilterSettingsPolarity getFilterSettingsPolarity() {
+
+		return new FilterSettingsPolarity();
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/splitter/settings/FilterSettingsPolarity.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/splitter/settings/FilterSettingsPolarity.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.settings;
+
+import org.eclipse.chemclipse.chromatogram.filter.settings.AbstractChromatogramFilterSettings;
+
+public class FilterSettingsPolarity extends AbstractChromatogramFilterSettings {
+}


### PR DESCRIPTION
For LC-MS, which can record +/- and cycle between each scan. Those create hedgehog chromatograms. With this splitter, you get two proper ones again. In the future, maybe this can get automatically detected and the splitter suggested to the user.