### PR TITLE
Remove the check for Windows network drives

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/preferences/PreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/preferences/PreferencePage.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.ui.preferences;
 
-import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.LabelFieldEditor;
-import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpacerFieldEditor;
 import org.eclipse.chemclipse.ux.extension.ui.Activator;
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
@@ -35,10 +33,6 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 		addField(new BooleanFieldEditor(PreferenceSupplierDataExplorer.P_OPEN_FIRST_DATA_MATCH_ONLY, "Open First Data Match Only", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplierDataExplorer.P_OPEN_EDITOR_MULTIPLE_TIMES, "Open Editor Multiple Times", getFieldEditorParent()));
-
-		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		addField(new LabelFieldEditor("Microsoft Windows", getFieldEditorParent()));
-		addField(new BooleanFieldEditor(PreferenceSupplierDataExplorer.P_SHOW_NETWORK_SHARES, "Show Network Shares (requires restart)", getFieldEditorParent()));
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/preferences/PreferenceSupplierDataExplorer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/preferences/PreferenceSupplierDataExplorer.java
@@ -30,8 +30,6 @@ public class PreferenceSupplierDataExplorer extends AbstractPreferenceSupplier i
 
 	public static final String P_USER_LOCATION_PATH = "userLocation";
 	public static final String DEF_USER_LOCATION_PATH = UserManagement.getUserHome();
-	public static final String P_SHOW_NETWORK_SHARES = "showWindowsNetworkDrive";
-	public static final boolean DEF_SHOW_NETWORK_SHARES = true;
 
 	public static final String P_OPEN_FIRST_DATA_MATCH_ONLY = "openFirstDataMatchOnly";
 	public static final boolean DEF_OPEN_FIRST_DATA_MATCH_ONLY = true;
@@ -62,7 +60,6 @@ public class PreferenceSupplierDataExplorer extends AbstractPreferenceSupplier i
 		putDefault(P_SELECTED_WORKSPACE_PATH, DEF_SELECTED_WORKSPACE_PATH);
 		putDefault(P_SELECTED_USER_LOCATION_PATH, DEF_SELECTED_USER_LOCATION_PATH);
 		putDefault(P_USER_LOCATION_PATH, DEF_USER_LOCATION_PATH);
-		putDefault(P_SHOW_NETWORK_SHARES, DEF_SHOW_NETWORK_SHARES);
 		putDefault(P_OPEN_FIRST_DATA_MATCH_ONLY, DEF_OPEN_FIRST_DATA_MATCH_ONLY);
 		putDefault(P_OPEN_EDITOR_MULTIPLE_TIMES, DEF_OPEN_EDITOR_MULTIPLE_TIMES);
 		putDefault(P_USER_LOCATIONS, DEF_USER_LOCATIONS);
@@ -138,11 +135,6 @@ public class PreferenceSupplierDataExplorer extends AbstractPreferenceSupplier i
 	public static void setUserLocations(String userLocations) {
 
 		INSTANCE().set(P_USER_LOCATIONS, userLocations);
-	}
-
-	public static boolean showNetworkShares() {
-
-		return INSTANCE().getBoolean(P_SHOW_NETWORK_SHARES);
 	}
 
 	public static String getUserLocationsTemplateFolder() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/DataExplorerTreeRoot.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/DataExplorerTreeRoot.java
@@ -14,14 +14,8 @@
 package org.eclipse.chemclipse.ux.extension.ui.swt;
 
 import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
-import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.support.settings.ApplicationSettings;
-import org.eclipse.chemclipse.support.settings.OperatingSystemUtils;
 import org.eclipse.chemclipse.support.settings.UserManagement;
 import org.eclipse.chemclipse.ux.extension.ui.l10n.ExtensionMessages;
 import org.eclipse.chemclipse.ux.extension.ui.preferences.PreferenceSupplierDataExplorer;
@@ -37,8 +31,6 @@ public enum DataExplorerTreeRoot {
 	HOME(ExtensionMessages.home), //
 	WORKSPACE(ExtensionMessages.workspace), //
 	USER_LOCATION(ExtensionMessages.userLocation);
-
-	private static final Logger logger = Logger.getLogger(DataExplorerTreeRoot.class);
 
 	private String label;
 
@@ -75,7 +67,7 @@ public enum DataExplorerTreeRoot {
 		File[] roots;
 		switch(this) {
 			case DRIVES:
-				roots = filterRoots(File.listRoots());
+				roots = File.listRoots();
 				break;
 			case HOME:
 				roots = new File[]{new File(UserManagement.getUserHome())};
@@ -116,42 +108,5 @@ public enum DataExplorerTreeRoot {
 			userLocation = new File(UserManagement.getUserHome());
 		}
 		return userLocation;
-	}
-
-	private static File[] filterRoots(File[] roots) {
-
-		List<File> rootFiles = new ArrayList<>();
-		for(File root : roots) {
-			if((!PreferenceSupplierDataExplorer.showNetworkShares()) && isWindowsNetworkDriveRoot(root)) {
-				continue;
-			}
-			rootFiles.add(root);
-		}
-		return rootFiles.toArray(new File[rootFiles.size()]);
-	}
-
-	private static boolean isWindowsNetworkDriveRoot(File file) {
-
-		if(!OperatingSystemUtils.isWindows()) {
-			return false;
-		}
-		String path = file.getPath();
-		if(path.length() > 3) {
-			return false;
-		}
-		String driveLetter = path.substring(0, 2);
-		List<String> cmd = Arrays.asList("cmd", "/c", "net", "use", driveLetter); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		try {
-			Process process = new ProcessBuilder(cmd).redirectErrorStream(true).start();
-			process.getOutputStream().close();
-			int exitCode = process.waitFor();
-			return exitCode == 0;
-		} catch(IOException e) {
-			logger.error("Failed to detect network drive status for " + driveLetter, e); //$NON-NLS-1$
-		} catch(InterruptedException e) {
-			logger.error(e);
-			Thread.currentThread().interrupt();
-		}
-		return false;
 	}
 }


### PR DESCRIPTION
It uses an external process and then waits for it, which can lead to application stalling when antivirus gets suspicious. I searched for alternatives, and there really is no available API to check if a drive is a network drive. Also, slow networking or local drives is not a Windows thing. It can happen on every OS in UNC paths, which this code does not even check for. Hiding network drives also does not solve the underlying problem of the UI freezing, for which I submitted https://github.com/eclipse-chemclipse/chemclipse/pull/2570.