### PR TITLE
Reduce manually started bundles

### DIFF
--- a/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
+++ b/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
@@ -77,8 +77,6 @@ Contributors:
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
-      <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
-      <plugin id="org.eclipse.update.configurator" autoStart="true" startLevel="4" />
       <property name="sun.awt.xembedserver" value="true" />
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="osgi.requiredJavaVersion" value="21" />


### PR DESCRIPTION
* Dropins (https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fmisc%2Fp2_dropins_format.html ) are by design unsafe as if any conflict or missing dependency arise they will not be installed. It is strongly recommended to use p2 operation to install directly thus no need to manually start the dropins bundle.
* Update configurator (org.eclipse.update.configurator) is pre p2 thing that is simply not needed nowadays and even marked fro removal in 2025-06 (https://github.com/eclipse-platform/eclipse.platform/pull/1867 )

This should have some (probably minimal) effect on startup time but what's more important is:
* reduces the unexpected installation possibilities of someone using dropins
* prepares for the actual removal of update.configurator