### PR TITLE
Do not use e3 api to reset perspective

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/handlers/ResetPerspectiveHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/handlers/ResetPerspectiveHandler.java
@@ -15,17 +15,42 @@ package org.eclipse.chemclipse.rcp.app.ui.handlers;
 import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.core.services.events.IEventBroker;
+import org.eclipse.e4.ui.model.application.ui.MUIElement;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPlaceholder;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
-import org.eclipse.ui.IWorkbenchPage;
-import org.eclipse.ui.PlatformUI;
+import org.eclipse.e4.ui.workbench.modeling.EModelService;
+import org.eclipse.e4.ui.workbench.modeling.EPartService;
+import org.eclipse.e4.ui.workbench.modeling.EPartService.PartState;
+
+import jakarta.inject.Inject;
 
 public class ResetPerspectiveHandler {
 
-	@Execute
-	public void execute(MWindow window, IEventBroker eventBroker) {
+	@Inject
+	private EModelService modelService;
 
-		IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
-		page.resetPerspective();
-		eventBroker.post(IChemClipseEvents.TOPIC_APPLICATION_RESET_PERSPECTIVE, page.getPerspective().getLabel());
+	@Inject
+	private IEventBroker eventBroker;
+	
+    @Inject
+    private EPartService partService;
+
+	@Execute
+	public void execute(MWindow window) {
+
+		MUIElement activePerspective = modelService.getActivePerspective(window);
+
+		if(activePerspective instanceof MPerspective currentPerspective) {
+			eventBroker.post(IChemClipseEvents.TOPIC_APPLICATION_RESET_PERSPECTIVE, currentPerspective.getLabel());
+			modelService.resetPerspectiveModel(currentPerspective, window);
+			for(MPlaceholder placeholder : modelService.findElements(currentPerspective, null, MPlaceholder.class, null)) {
+				if(placeholder.getRef() != null) {
+					String partId = placeholder.getRef().getElementId();
+					partService.showPart(partId, PartState.CREATE);
+				}
+			}
+			
+		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/workbench/PartSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/workbench/PartSupport.java
@@ -81,6 +81,8 @@ public class PartSupport {
 		MPartStack partStack = (MPartStack)eModelService.find(IPerspectiveAndViewIds.EDITOR_PART_STACK_ID, mApplication);
 		part.setToBeRendered(false);
 		part.setVisible(false);
-		DisplayUtils.getDisplay().asyncExec(() -> partStack.getChildren().remove(part));
+		if (partStack != null) {
+			DisplayUtils.getDisplay().asyncExec(() -> partStack.getChildren().remove(part));
+		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/support/DataUpdateSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/support/DataUpdateSupport.java
@@ -164,14 +164,7 @@ public class DataUpdateSupport {
 			/*
 			 * Handler
 			 */
-			EventHandler eventHandler = new EventHandler() {
-
-				@Override
-				public void handleEvent(Event event) {
-
-					update(event, properties);
-				}
-			};
+			EventHandler eventHandler = event -> update(event, properties);
 			/*
 			 * Subscribe the new handler.
 			 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/fragment.e4xmi
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/fragment.e4xmi
@@ -7,6 +7,7 @@
     <elements xsi:type="basic:Part" xmi:id="_E8UhsDmqEei-wI9hy1kIxA" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.part.targetsPart" contributionURI="bundleclass://org.eclipse.chemclipse.ux.extension.xxd.ui/org.eclipse.chemclipse.ux.extension.xxd.ui.parts.TargetsPart" label="%Targets" iconURI="platform:/plugin/org.eclipse.chemclipse.rcp.ui.icons/icons/16x16/target.png"/>
     <elements xsi:type="basic:Part" xmi:id="_NC1V0DmqEei-wI9hy1kIxA" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.part.comparisonScan" contributionURI="bundleclass://org.eclipse.chemclipse.ux.extension.xxd.ui/org.eclipse.chemclipse.ux.extension.xxd.ui.parts.ComparisonScanChartPart" label="%ComparisonScan" iconURI="platform:/plugin/org.eclipse.chemclipse.rcp.ui.icons/icons/16x16/comparisonScanDefault.gif"/>
     <elements xsi:type="basic:Part" xmi:id="_51oP0EMaEeik0tjTEoFbUg" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.part.scanChartPart" contributionURI="bundleclass://org.eclipse.chemclipse.ux.extension.xxd.ui/org.eclipse.chemclipse.ux.extension.xxd.ui.parts.ScanChartPart" label="%ScanChart" iconURI="platform:/plugin/org.eclipse.chemclipse.rcp.ui.icons/icons/16x16/selectedScansDefault.gif"/>
+    <elements xsi:type="basic:Part" xmi:id="_zINEIMrtEfCt6tI6IJCymA" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.part.scanTablePartDescriptor" contributionURI="bundleclass://org.eclipse.chemclipse.ux.extension.xxd.ui/org.eclipse.chemclipse.ux.extension.xxd.ui.parts.ScanTablePart" label="%ScanTable" iconURI="platform:/plugin/org.eclipse.chemclipse.rcp.ui.icons/icons/16x16/ion.gif"/>
     <elements xsi:type="basic:Part" xmi:id="_pWhTQI8wEeiO3oL5WUkZBQ" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.part.sequenceexplorer" contributionURI="bundleclass://org.eclipse.chemclipse.ux.extension.xxd.ui/org.eclipse.chemclipse.ux.extension.xxd.ui.parts.SequenceExplorerPart" label="%SequenceExplorer" iconURI="platform:/plugin/org.eclipse.chemclipse.rcp.ui.icons/icons/16x16/sequenceListDefault.gif"/>
     <elements xsi:type="basic:Part" xmi:id="_7SwRMNngEeiyx5W2f1mKlA" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.part.chromatogramOverlay" contributionURI="bundleclass://org.eclipse.chemclipse.ux.extension.xxd.ui/org.eclipse.chemclipse.ux.extension.xxd.ui.parts.ChromatogramOverlayPart" label="%ChromatogramOverlay" iconURI="platform:/plugin/org.eclipse.chemclipse.rcp.ui.icons/icons/16x16/chromatogramOverlayDefault.gif"/>
     <elements xsi:type="basic:Part" xmi:id="_-4WmgM_TEem5S_IrSHwKAQ" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.part.peakDetector" contributionURI="bundleclass://org.eclipse.chemclipse.ux.extension.xxd.ui/org.eclipse.chemclipse.ux.extension.xxd.ui.parts.PeakDetectorPart" label="%PeakDetector" iconURI="platform:/plugin/org.eclipse.chemclipse.rcp.ui.icons/icons/16x16/detectionTypeScanBB.gif"/>
@@ -35,14 +36,17 @@
           </children>
         </children>
         <children xsi:type="basic:PartSashContainer" xmi:id="_rvP3ECyHEeakko_bfjza1A" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.partsashcontainer.4" containerData="4180" selectedElement="_v9YrcCyHEeakko_bfjza1A" horizontal="true">
-          <children xsi:type="basic:PartStack" xmi:id="_v9YrcCyHEeakko_bfjza1A" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.partstack.bottom.left">
+          <children xsi:type="basic:PartStack" xmi:id="_v9YrcCyHEeakko_bfjza1A" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.partstack.bottom.left" selectedElement="_GYiJgMrnEfCGHeE4LnO-1w">
             <children xsi:type="advanced:Placeholder" xmi:id="_6Zv8oCyHEeakko_bfjza1A" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.part.edithistory" ref="_XKgwsDU0EeuREPdzMrDpOQ"/>
+            <children xsi:type="advanced:Placeholder" xmi:id="_GYiJgMrnEfCGHeE4LnO-1w" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.placeholder.targets" ref="_E8UhsDmqEei-wI9hy1kIxA" closeable="true"/>
           </children>
-          <children xsi:type="basic:PartStack" xmi:id="_wRFDgCyHEeakko_bfjza1A" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.partstack.bottom.center">
+          <children xsi:type="basic:PartStack" xmi:id="_wRFDgCyHEeakko_bfjza1A" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.partstack.bottom.center" selectedElement="_qRr-IMrnEfCGHeE4LnO-1w">
             <children xsi:type="basic:Part" xmi:id="_8g1GMLC4EeyD2cMwBNhxCA" elementId="org.eclipse.ui.console.ConsoleView" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" label="Console" iconURI="platform:/plugin/org.eclipse.ui.console/icons/full/cview16/console_view.png"/>
+            <children xsi:type="advanced:Placeholder" xmi:id="_qRr-IMrnEfCGHeE4LnO-1w" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.placeholder.scanchart" ref="_51oP0EMaEeik0tjTEoFbUg" closeable="true"/>
           </children>
-          <children xsi:type="basic:PartStack" xmi:id="_wjm98CyHEeakko_bfjza1A" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.partstack.bottom.right">
+          <children xsi:type="basic:PartStack" xmi:id="_wjm98CyHEeakko_bfjza1A" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.partstack.bottom.right" selectedElement="_XjWaQMroEfCGHeE4LnO-1w">
             <children xsi:type="advanced:Placeholder" xmi:id="_9p3CgCyHEeakko_bfjza1A" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.part.processinginfo" ref="_aHkWoK2kEeuuJ_UXBFJQCQ"/>
+            <children xsi:type="advanced:Placeholder" xmi:id="_XjWaQMroEfCGHeE4LnO-1w" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.placeholder.scantable" ref="_zINEIMrtEfCt6tI6IJCymA" closeable="true"/>
           </children>
         </children>
       </children>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/addons/PerspectiveSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/addons/PerspectiveSupport.java
@@ -35,7 +35,6 @@ public class PerspectiveSupport {
 	 */
 	private static final String DATA_ANALYSIS_PERSPECTIVE_LABEL = "<Data Analysis (Main)>";
 	private static final String TOOLBAR_ID = "org.eclipse.chemclipse.ux.extension.xxd.ui.toolbar.dataanalysis";
-	private static boolean activatePartsInitially = true;
 
 	@PostConstruct
 	public void postConstruct() {
@@ -56,10 +55,6 @@ public class PerspectiveSupport {
 						 * Show parts initially.
 						 */
 						enableToolBar(true);
-						if(activatePartsInitially) {
-							GroupHandler.activateReferencedParts();
-							activatePartsInitially = false;
-						}
 					} else {
 						enableToolBar(false);
 					}
@@ -70,7 +65,6 @@ public class PerspectiveSupport {
 				if(object instanceof String label) {
 					if(DATA_ANALYSIS_PERSPECTIVE_LABEL.equals(label)) {
 						enableToolBar(true);
-						GroupHandler.activateReferencedParts();
 					} else {
 						enableToolBar(false);
 					}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/toolbar/GroupHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/toolbar/GroupHandler.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.toolbar;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -47,19 +46,6 @@ public class GroupHandler {
 	 */
 	private GroupHandler() {
 
-	}
-
-	/**
-	 * Show mandatory parts by default for these groups.
-	 */
-	public static void activateReferencedParts() {
-
-		for(String handlerName : Arrays.asList(GroupHandlerScans.NAME, GroupHandlerTargets.NAME)) {
-			IGroupHandler groupHandler = getGroupHandler(handlerName);
-			if(groupHandler != null) {
-				groupHandler.setPartStatus(true);
-			}
-		}
 	}
 
 	public static void actionParts(String elementId) {


### PR DESCRIPTION
It doesn't know about e4 parts and thus closes the editors. Change the Main perspective views to be fully defined in e4 xmi rather than partially through code.
Fixes https://github.com/eclipse-chemclipse/chemclipse/issues/901 with the limitation that if a view has been moved it stays in the new position. If the view has been closed it's restored in its proper place.