### PR TITLE
Remove ChromatogramSelection bad boys

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/selection/ChromatogramSelectionCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/selection/ChromatogramSelectionCSD.java
@@ -26,8 +26,6 @@ import org.eclipse.chemclipse.model.selection.AbstractChromatogramSelection;
 
 public class ChromatogramSelectionCSD extends AbstractChromatogramSelection implements IChromatogramSelectionCSD {
 
-	private IScanCSD selectedScan;
-
 	public ChromatogramSelectionCSD(IChromatogramCSD chromatogram) throws ChromatogramIsNullException {
 
 		this(chromatogram, true);
@@ -44,13 +42,6 @@ public class ChromatogramSelectionCSD extends AbstractChromatogramSelection impl
 	}
 
 	@Override
-	public void dispose() {
-
-		super.dispose();
-		selectedScan = null;
-	}
-
-	@Override
 	public IChromatogramCSD getChromatogram() {
 
 		IChromatogram chromatogram = super.getChromatogram();
@@ -63,7 +54,11 @@ public class ChromatogramSelectionCSD extends AbstractChromatogramSelection impl
 	@Override
 	public IScanCSD getSelectedScan() {
 
-		return selectedScan;
+		if(super.getSelectedScan() instanceof IScanCSD scanCSD) {
+			return scanCSD;
+		}
+
+		return null;
 	}
 
 	@Override
@@ -85,10 +80,10 @@ public class ChromatogramSelectionCSD extends AbstractChromatogramSelection impl
 			 * Chromatogram CSD
 			 */
 			if(chromatogram instanceof IChromatogramCSD chromatogramCSD) {
-				selectedScan = chromatogramCSD.getScan(1);
+				setSelectedScan(chromatogramCSD.getScan(1));
 			}
 		} else {
-			selectedScan = null;
+			setSelectedScan(null);
 		}
 		/*
 		 * Peak
@@ -138,7 +133,7 @@ public class ChromatogramSelectionCSD extends AbstractChromatogramSelection impl
 	public void setSelectedScan(IScanCSD selectedScan, boolean update) {
 
 		if(selectedScan != null) {
-			this.selectedScan = selectedScan;
+			setSelectedScan(selectedScan);
 			/*
 			 * Fire update change if necessary.
 			 */
@@ -158,8 +153,6 @@ public class ChromatogramSelectionCSD extends AbstractChromatogramSelection impl
 	public void update(boolean forceReload) {
 
 		super.update(forceReload);
-
-		setSelectedScan(selectedScan, false);
 
 		fireUpdateChange(forceReload);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/selection/AbstractChromatogramSelection.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/selection/AbstractChromatogramSelection.java
@@ -17,13 +17,17 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.exceptions.ChromatogramIsNullException;
+import org.eclipse.chemclipse.model.notifier.UpdateNotifier;
 import org.eclipse.chemclipse.numeric.core.Point;
 
 public abstract class AbstractChromatogramSelection implements IChromatogramSelection {
+
+	private static final Logger logger = Logger.getLogger(ChromatogramSelection.class);
 
 	private IChromatogram chromatogram;
 	private int startRetentionTime;
@@ -33,6 +37,9 @@ public abstract class AbstractChromatogramSelection implements IChromatogramSele
 
 	private List<IPeak> selectedPeaks = new ArrayList<>();
 	private List<IScan> selectedIdentifiedScans = new ArrayList<>();
+
+	private IScan selectedScan;
+
 	/*
 	 * UI fields
 	 */
@@ -238,6 +245,43 @@ public abstract class AbstractChromatogramSelection implements IChromatogramSele
 		setStartAbundance(startAbundance, false);
 		setStartAbundance(startAbundance, false);
 		setStopAbundance(stopAbundance, false);
+		setSelectedScan(selectedScan, false);
+	}
+
+	@Override
+	public void fireUpdateChange(boolean forceReload) {
+
+		try {
+			UpdateNotifier.update(this);
+		} catch(Exception e) {
+			logger.error(e);
+		}
+	}
+
+	@Override
+	public IScan getSelectedScan() {
+
+		return selectedScan;
+	}
+
+	@Override
+	public void setSelectedScan(IScan selectedScan) {
+
+		setSelectedScan(selectedScan, true);
+	}
+
+	@Override
+	public void setSelectedScan(IScan selectedScan, boolean update) {
+
+		if(selectedScan != null) {
+			this.selectedScan = selectedScan;
+			/*
+			 * Fire update change if neccessary.
+			 */
+			if(update) {
+				fireUpdateChange(false);
+			}
+		}
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/selection/ChromatogramSelection.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/selection/ChromatogramSelection.java
@@ -13,10 +13,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.model.selection;
 
-import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IPeak;
-import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.exceptions.ChromatogramIsNullException;
 
 /**
@@ -29,8 +26,6 @@ import org.eclipse.chemclipse.model.exceptions.ChromatogramIsNullException;
  *
  */
 public class ChromatogramSelection extends AbstractChromatogramSelection implements IChromatogramSelection {
-
-	private static final Logger logger = Logger.getLogger(ChromatogramSelection.class);
 
 	public ChromatogramSelection(IChromatogram chromatogram, boolean fireUpdate) throws ChromatogramIsNullException {
 
@@ -51,56 +46,5 @@ public class ChromatogramSelection extends AbstractChromatogramSelection impleme
 	public void reset() {
 
 		super.reset(false);
-	}
-
-	@Override
-	public void fireUpdateChange(boolean forceReload) {
-
-		logger.warn("Bad boy - fireUpdateChange(boolean forceReload): don't use the ChromatogramSelection implementation");
-	}
-
-	@Override
-	public IScan getSelectedScan() {
-
-		logger.warn("Bad boy - getSelectedScan(): don't use the ChromatogramSelection implementation");
-		return null;
-	}
-
-	@Override
-	public void setSelectedScan(IScan selectedScan) {
-
-		logger.warn("Bad boy - setSelectedScan(IScan selectedScan): don't use the ChromatogramSelection implementation");
-	}
-
-	@Override
-	public void setSelectedScan(IScan selectedScan, boolean update) {
-
-		logger.warn("Bad boy - setSelectedScan(IScan selectedScan, boolean update): don't use the ChromatogramSelection implementation");
-	}
-
-	@Override
-	public IPeak getSelectedPeak() {
-
-		logger.warn("Bad boy - getSelectedPeak(): don't use the ChromatogramSelection implementation");
-		return null;
-	}
-
-	@Override
-	public void setSelectedPeak(IPeak selectedPeak) {
-
-		logger.warn("Bad boy - setSelectedPeak(IPeak selectedPeak): don't use the ChromatogramSelection implementation");
-	}
-
-	@Override
-	public IScan getSelectedIdentifiedScan() {
-
-		logger.warn("Bad boy - getSelectedIdentifiedScan(): don't use the ChromatogramSelection implementation");
-		return null;
-	}
-
-	@Override
-	public void setSelectedIdentifiedScan(IScan identifiedScan) {
-
-		logger.warn("Bad boy - setSelectedIdentifiedScan: don't use the ChromatogramSelection implementation");
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelectionMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelectionMSD.java
@@ -44,7 +44,6 @@ import org.eclipse.chemclipse.msd.model.core.support.MarkedIons;
  */
 public class ChromatogramSelectionMSD extends AbstractChromatogramSelection implements IChromatogramSelectionMSD {
 
-	private IScanMSD selectedScan;
 	private IMarkedIons selectedIons;
 	private IMarkedIons excludedIons;
 	private IMarkedIonTransitions markedIonTransitions;
@@ -88,7 +87,6 @@ public class ChromatogramSelectionMSD extends AbstractChromatogramSelection impl
 	public void dispose() {
 
 		super.dispose();
-		selectedScan = null;
 		selectedIons = null;
 		excludedIons = null;
 	}
@@ -106,7 +104,11 @@ public class ChromatogramSelectionMSD extends AbstractChromatogramSelection impl
 	@Override
 	public IScanMSD getSelectedScan() {
 
-		return selectedScan;
+		if(super.getSelectedScan() instanceof IScanMSD scanMSD) {
+			return scanMSD;
+		}
+
+		return null;
 	}
 
 	@Override
@@ -146,10 +148,10 @@ public class ChromatogramSelectionMSD extends AbstractChromatogramSelection impl
 			 * Chromatogram MSD
 			 */
 			if(chromatogram instanceof IChromatogramMSD chromatogramMSD) {
-				selectedScan = chromatogramMSD.getScan(1);
+				setSelectedScan(chromatogramMSD.getScan(1));
 			}
 		} else {
-			selectedScan = null;
+			setSelectedScan(null);
 		}
 		/*
 		 * Selected Identified Scan
@@ -183,14 +185,6 @@ public class ChromatogramSelectionMSD extends AbstractChromatogramSelection impl
 	}
 
 	@Override
-	public void setSelectedScan(IScan selectedScan, boolean update) {
-
-		if(selectedScan instanceof IRegularMassSpectrum vendorMassSpectrum) {
-			setSelectedScan(vendorMassSpectrum, update);
-		}
-	}
-
-	@Override
 	public void setSelectedScan(IScanMSD selectedScan) {
 
 		/*
@@ -203,7 +197,7 @@ public class ChromatogramSelectionMSD extends AbstractChromatogramSelection impl
 	public void setSelectedScan(IRegularMassSpectrum selectedScan, boolean update) {
 
 		if(selectedScan != null) {
-			this.selectedScan = selectedScan;
+			setSelectedScan(selectedScan);
 			/*
 			 * Fire update change if neccessary.
 			 */
@@ -227,8 +221,6 @@ public class ChromatogramSelectionMSD extends AbstractChromatogramSelection impl
 	public void update(boolean forceReload) {
 
 		super.update(forceReload);
-
-		setSelectedScan(selectedScan, false);
 
 		fireUpdateChange(forceReload);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelectionMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/selection/ChromatogramSelectionMSD.java
@@ -16,12 +16,14 @@ package org.eclipse.chemclipse.msd.model.core.selection;
 
 import java.util.List;
 
+import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.core.MarkedTraceModus;
 import org.eclipse.chemclipse.model.exceptions.ChromatogramIsNullException;
 import org.eclipse.chemclipse.model.notifier.UpdateNotifier;
 import org.eclipse.chemclipse.model.selection.AbstractChromatogramSelection;
+import org.eclipse.chemclipse.model.selection.ChromatogramSelection;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -46,6 +48,8 @@ public class ChromatogramSelectionMSD extends AbstractChromatogramSelection impl
 	private IMarkedIons selectedIons;
 	private IMarkedIons excludedIons;
 	private IMarkedIonTransitions markedIonTransitions;
+
+	private static final Logger logger = Logger.getLogger(ChromatogramSelection.class);
 
 	public ChromatogramSelectionMSD(IChromatogramMSD chromatogram) throws ChromatogramIsNullException {
 
@@ -215,7 +219,7 @@ public class ChromatogramSelectionMSD extends AbstractChromatogramSelection impl
 		try {
 			UpdateNotifier.update(this);
 		} catch(Exception e) {
-			e.printStackTrace();
+			logger.error(e);
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/selection/ChromatogramSelectionWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/selection/ChromatogramSelectionWSD.java
@@ -29,7 +29,6 @@ import org.eclipse.chemclipse.wsd.model.core.IScanWSD;
 
 public class ChromatogramSelectionWSD extends AbstractChromatogramSelection implements IChromatogramSelectionWSD {
 
-	private IScanWSD selectedScan;
 	private IMarkedWavelengths selectedWavelengths;
 
 	public ChromatogramSelectionWSD(IChromatogramWSD chromatogram) throws ChromatogramIsNullException {
@@ -62,13 +61,6 @@ public class ChromatogramSelectionWSD extends AbstractChromatogramSelection impl
 	}
 
 	@Override
-	public void dispose() {
-
-		selectedScan = null;
-		super.dispose();
-	}
-
-	@Override
 	public IChromatogramWSD getChromatogram() {
 
 		IChromatogram chromatogram = super.getChromatogram();
@@ -81,7 +73,11 @@ public class ChromatogramSelectionWSD extends AbstractChromatogramSelection impl
 	@Override
 	public IScanWSD getSelectedScan() {
 
-		return selectedScan;
+		if(super.getSelectedScan() instanceof IScanWSD scanWSD) {
+			return scanWSD;
+		}
+
+		return null;
 	}
 
 	@Override
@@ -103,10 +99,10 @@ public class ChromatogramSelectionWSD extends AbstractChromatogramSelection impl
 			 * Chromatogram WSD
 			 */
 			if(chromatogram instanceof IChromatogramWSD chromatogramWSD) {
-				selectedScan = chromatogramWSD.getScan(1);
+				setSelectedScan(chromatogramWSD.getScan(1));
 			}
 		} else {
-			selectedScan = null;
+			setSelectedScan(null);
 		}
 		/*
 		 * Fire an update.
@@ -145,7 +141,7 @@ public class ChromatogramSelectionWSD extends AbstractChromatogramSelection impl
 	public void setSelectedScan(IScanWSD selectedScan, boolean update) {
 
 		if(selectedScan != null) {
-			this.selectedScan = selectedScan;
+			setSelectedScan(selectedScan);
 			/*
 			 * Fire update change if necessary.
 			 */
@@ -165,8 +161,6 @@ public class ChromatogramSelectionWSD extends AbstractChromatogramSelection impl
 	public void update(boolean forceReload) {
 
 		super.update(forceReload);
-
-		setSelectedScan(selectedScan, false);
 
 		fireUpdateChange(forceReload);
 	}


### PR DESCRIPTION
These "Bad boy" functions that do nothing or just return `null` get called pretty often from within ChemClipse itself. I also don't know how to reasonably replace them when everything is at generic `IChromatogramSelection` level. Therefore I decided to implement the missing bits. They will get overridden by `IChromatogramSelectionXXD` variants similar to https://github.com/eclipse-chemclipse/chemclipse/pull/2068.