### PR TITLE
Add missing Targets list update after Peak/Scan hotkeys fired

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
@@ -669,6 +669,12 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 			}
 		}
 
+		/*
+		 * Send update.
+		 */
+		tableViewer.get().refresh();
+		UpdateNotifierUI.update(display, chromatogramSelection);
+
 		chromatogramSelection.getChromatogram().setDirty(true);
 		UpdateNotifierUI.update(display, IChemClipseEvents.TOPIC_EDITOR_CHROMATOGRAM_UPDATE, "Peaks/Scans unknown targets have been set.");
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
@@ -473,6 +473,8 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 						addTargetsUnknown(e.display); // CTRL + u
 					} else if(e.keyCode == IKeyboardSupport.KEY_CODE_LC_Q) {
 						scanIdentifierControl.get().runIdentification(e.display); // CTRL + q
+						tableViewer.get().refresh();
+						UpdateNotifierUI.update(display, chromatogramSelection);
 					} else if(e.keyCode == IKeyboardSupport.KEY_CODE_LC_A) {
 						if(showPeakProfilesSelectionAll) {
 							propagateSelection(display);


### PR DESCRIPTION
Specifically, <kbd>CTRL</kbd> + <kbd>U</kbd> sets an unknown, and when triggered via the `Peak/Scan` list, it does not update the `Targets` part until it is focused again. The same bug occurs on <kbd>CTRL</kbd> + <kbd>Q</kbd> after a library search. This is unsatisfying and inconsistent with <kbd>CTRL</kbd> + <kbd>D</kbd> which deletes a target and immediately shows the results.