### PR TITLE
Remove spacings between parts

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/classic.css
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/classic.css
@@ -11,26 +11,8 @@
  *     Christoph Läubrich - swt-tab-height is too low
  *******************************************************************************/
 
-.MTrimmedWindow {
-	margin-top:2px;
-	margin-bottom:2px;
-	margin-left:2px;
-	margin-right:2px;
-}
-
-.MTrimmedWindow.topLevel {
-	margin-top:8px;
-	margin-bottom:2px;
-	margin-left:12px;
-	margin-right:12px;
-}
-
 .MPart {
   background-color: #FFFFFF;
-}
-
-.MPartStack {
-	padding:0px 5px 7px;
 }
 
 .ScrollableChart {

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/dark.css
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/dark.css
@@ -11,24 +11,6 @@
  *     Christoph Läubrich - swt-tab-height is too low
  *******************************************************************************/
 
-.MTrimmedWindow {
-	margin-top:2px;
-	margin-bottom:2px;
-	margin-left:2px;
-	margin-right:2px;
-}
-
-.MTrimmedWindow.topLevel {
-	margin-top:8px;
-	margin-bottom:2px;
-	margin-left:12px;
-	margin-right:12px;
-}
-
-.MPartStack {
-	padding:0px 5px 7px;
-}
-
 .ScrollableChart {
 	background-color: #2f2f2f;
 	grid-color: #404040;

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/default.css
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/css/default.css
@@ -11,26 +11,9 @@
  *     Christoph Läubrich - swt-tab-height is too low
  *******************************************************************************/
 
-.MTrimmedWindow {
-	margin-top:2px;
-	margin-bottom:2px;
-	margin-left:2px;
-	margin-right:2px;
-}
-
-.MTrimmedWindow.topLevel {
-	margin-top:8px;
-	margin-bottom:2px;
-	margin-left:12px;
-	margin-right:12px;
-}
 
 .MPart {
   background-color: #FFFFFF;
-}
-
-.MPartStack {
-	padding:0px 5px 7px;
 }
 
 .ScrollableChart {


### PR DESCRIPTION
This might be controversial or a matter of taste but there is a general design rule that screen space should not be wasted and when compared to the Eclipse IDE our parts have a lot of space between them. Removing that and it looks like this:
<img width="1920" height="1025" alt="grafik" src="https://github.com/user-attachments/assets/a121c2da-8106-4b85-aa00-5b531737b9e7" />
