### PR TITLE
Add optional prefixes when searching MS databases

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/LibraryInformationSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/LibraryInformationSupport.java
@@ -13,6 +13,7 @@
 package org.eclipse.chemclipse.model.support;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
@@ -35,131 +36,127 @@ public class LibraryInformationSupport {
 		}
 	}
 
-	public boolean containsSearchText(ILibraryInformation libraryInformation, String searchText, boolean caseSensitive) {
+	/**
+	 * 
+	 * @param searchText
+	 *            supports "prefix:query" syntax
+	 */
+	public static boolean containsSearchText(ILibraryInformation libraryInformation, String searchText, boolean caseSensitive) {
 
 		if(libraryInformation == null || searchText == null) {
 			return false;
-		} else {
-			/*
-			 * Searh Text
-			 */
-			searchText = caseSensitive ? searchText : searchText.toLowerCase();
-			/*
-			 * Name
-			 */
-			String name = libraryInformation.getName();
-			name = caseSensitive ? name : name.toLowerCase();
-			if(name.contains(searchText)) {
-				return true;
-			}
-			/*
-			 * Reference Identifier
-			 */
-			String referenceIdentifier = libraryInformation.getReferenceIdentifier();
-			referenceIdentifier = caseSensitive ? referenceIdentifier : referenceIdentifier.toLowerCase();
-			if(referenceIdentifier.contains(searchText)) {
-				return true;
-			}
-			/*
-			 * Formula
-			 */
-			String formula = libraryInformation.getFormula();
-			formula = caseSensitive ? formula : formula.toLowerCase();
-			if(formula.contains(searchText)) {
-				return true;
-			}
-			/*
-			 * SMILES
-			 */
-			String smiles = libraryInformation.getSmiles();
-			smiles = caseSensitive ? smiles : smiles.toLowerCase();
-			if(smiles.contains(searchText)) {
-				return true;
-			}
-			/*
-			 * InChI
-			 */
-			String inchi = libraryInformation.getInChI();
-			inchi = caseSensitive ? inchi : inchi.toLowerCase();
-			if(inchi.contains(searchText)) {
-				return true;
-			}
-			/*
-			 * InChI Key
-			 */
-			String inchiKey = libraryInformation.getInChIKey();
-			inchiKey = caseSensitive ? inchiKey : inchiKey.toLowerCase();
-			if(inchiKey.contains(searchText)) {
-				return true;
-			}
-			/*
-			 * CAS Numbers
-			 */
-			List<String> casNumbers = libraryInformation.getCasNumbers();
-			for(String casNumber : casNumbers) {
-				casNumber = caseSensitive ? casNumber : casNumber.toLowerCase();
-				if(casNumber.contains(searchText)) {
-					return true;
-				}
-			}
-			/*
-			 * Comments
-			 */
-			String comments = libraryInformation.getComments();
-			comments = caseSensitive ? comments : comments.toLowerCase();
-			if(comments.contains(searchText)) {
-				return true;
-			}
-			/*
-			 * Synonyms
-			 */
-			Set<String> synonyms = libraryInformation.getSynonyms();
-			for(String synonym : synonyms) {
-				synonym = caseSensitive ? synonym : synonym.toLowerCase();
-				if(synonym.contains(searchText)) {
-					return true;
-				}
-			}
-			/*
-			 * Database
-			 */
-			String database = libraryInformation.getDatabase();
-			database = caseSensitive ? database : database.toLowerCase();
-			if(database.contains(searchText)) {
-				return true;
-			}
-			/*
-			 * Flavor Marker
-			 */
-			for(IFlavorMarker flavorMarker : libraryInformation.getFlavorMarkers()) {
-				/*
-				 * Odor
-				 */
-				String odor = flavorMarker.getOdor();
-				odor = caseSensitive ? odor : odor.toLowerCase();
-				if(odor.contains(searchText)) {
-					return true;
-				}
-				/*
-				 * Matrix
-				 */
-				String matrix = flavorMarker.getMatrix();
-				matrix = caseSensitive ? matrix : matrix.toLowerCase();
-				if(matrix.contains(searchText)) {
-					return true;
-				}
-				/*
-				 * Solvent
-				 */
-				String solvent = flavorMarker.getOdor();
-				solvent = caseSensitive ? solvent : solvent.toLowerCase();
-				if(solvent.contains(searchText)) {
-					return true;
-				}
-			}
+		}
 
+		int colon = searchText.indexOf(':');
+		if(colon > 0) {
+			String possiblePrefix = searchText.substring(0, colon).trim().toLowerCase();
+			String remainder = searchText.substring(colon + 1);
+			SearchField mapped = mapPrefixToField(possiblePrefix);
+			if(mapped != null) {
+				return containsSearchText(libraryInformation, remainder, caseSensitive, EnumSet.of(mapped));
+			}
+		}
+
+		return containsSearchText(libraryInformation, searchText, caseSensitive, EnumSet.of(SearchField.ALL));
+	}
+
+	public static boolean containsSearchText(ILibraryInformation libraryInformation, String searchText, boolean caseSensitive, Set<SearchField> fieldsToSearch) {
+
+		if(libraryInformation == null || searchText == null || fieldsToSearch == null) {
 			return false;
 		}
+
+		String query = caseSensitive ? searchText : searchText.toLowerCase();
+		boolean searchAll = fieldsToSearch.contains(SearchField.ALL);
+
+		if(searchAll || fieldsToSearch.contains(SearchField.NAME)) {
+			if(matches(libraryInformation.getName(), query, caseSensitive)) {
+				return true;
+			}
+		}
+
+		if(searchAll || fieldsToSearch.contains(SearchField.REFERENCE_IDENTIFIER)) {
+			if(matches(libraryInformation.getReferenceIdentifier(), query, caseSensitive)) {
+				return true;
+			}
+		}
+
+		if(searchAll || fieldsToSearch.contains(SearchField.FORMULA)) {
+			if(matches(libraryInformation.getFormula(), query, caseSensitive)) {
+				return true;
+			}
+		}
+
+		if(searchAll || fieldsToSearch.contains(SearchField.SMILES)) {
+			if(matches(libraryInformation.getSmiles(), query, caseSensitive)) {
+				return true;
+			}
+		}
+
+		if(searchAll || fieldsToSearch.contains(SearchField.INCHI)) {
+			if(matches(libraryInformation.getInChI(), query, caseSensitive)) {
+				return true;
+			}
+		}
+
+		if(searchAll || fieldsToSearch.contains(SearchField.INCHI_KEY)) {
+			if(matches(libraryInformation.getInChIKey(), query, caseSensitive)) {
+				return true;
+			}
+		}
+
+		if(searchAll || fieldsToSearch.contains(SearchField.CAS)) {
+			List<String> casNumbers = libraryInformation.getCasNumbers();
+			if(casNumbers != null) {
+				for(String cas : casNumbers) {
+					if(matches(cas, query, caseSensitive)) {
+						return true;
+					}
+				}
+			}
+		}
+
+		if(searchAll || fieldsToSearch.contains(SearchField.COMMENTS)) {
+			if(matches(libraryInformation.getComments(), query, caseSensitive)) {
+				return true;
+			}
+		}
+
+		if(searchAll || fieldsToSearch.contains(SearchField.SYNONYMS)) {
+			Set<String> synonyms = libraryInformation.getSynonyms();
+			if(synonyms != null) {
+				for(String synonym : synonyms) {
+					if(matches(synonym, query, caseSensitive)) {
+						return true;
+					}
+				}
+			}
+		}
+
+		if(searchAll || fieldsToSearch.contains(SearchField.DATABASE)) {
+			if(matches(libraryInformation.getDatabase(), query, caseSensitive)) {
+				return true;
+			}
+		}
+
+		if(searchAll || fieldsToSearch.contains(SearchField.FLAVOR_ODOR) || fieldsToSearch.contains(SearchField.FLAVOR_MATRIX) || fieldsToSearch.contains(SearchField.FLAVOR_SOLVENT)) {
+			for(IFlavorMarker flavorMarker : libraryInformation.getFlavorMarkers()) {
+				if(flavorMarker == null) {
+					continue;
+				}
+				if((searchAll || fieldsToSearch.contains(SearchField.FLAVOR_ODOR)) && matches(flavorMarker.getOdor(), query, caseSensitive)) {
+					return true;
+				}
+				if((searchAll || fieldsToSearch.contains(SearchField.FLAVOR_MATRIX)) && matches(flavorMarker.getMatrix(), query, caseSensitive)) {
+					return true;
+				}
+				if((searchAll || fieldsToSearch.contains(SearchField.FLAVOR_SOLVENT)) && matches(flavorMarker.getSolvent(), query, caseSensitive)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	public void extractNameAndReferenceIdentifier(String name, ILibraryInformation libraryInformation, String referenceIdentifierMarker, String referenceIdentifierPrefix) {
@@ -196,5 +193,33 @@ public class LibraryInformationSupport {
 				libraryInformation.setName(name);
 			}
 		}
+	}
+
+	private static SearchField mapPrefixToField(String prefix) {
+
+		if(prefix == null || prefix.isEmpty()) {
+			return SearchField.ALL;
+		}
+
+		for(SearchField field : SearchField.values()) {
+			for(String keyword : field.keywords()) {
+				if(keyword.equalsIgnoreCase(prefix)) {
+					return field;
+				}
+			}
+		}
+
+		return SearchField.ALL;
+	}
+
+	private static boolean matches(String candidate, String query, boolean caseSensitive) {
+
+		if(candidate == null || query == null) {
+			return false;
+		}
+		if(!caseSensitive) {
+			candidate = candidate.toLowerCase();
+		}
+		return candidate.contains(query);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/SearchField.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/SearchField.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.model.support;
+
+import java.util.Arrays;
+import java.util.List;
+
+public enum SearchField {
+
+	ALL(Arrays.asList("all")), //
+	NAME(Arrays.asList("name")), //
+	REFERENCE_IDENTIFIER(Arrays.asList("ref", "id")), //
+	FORMULA(Arrays.asList("formula")), //
+	SMILES(Arrays.asList("smiles")), //
+	INCHI(Arrays.asList("inchi")), //
+	INCHI_KEY(Arrays.asList("inchikey")), //
+	CAS(Arrays.asList("cas")), //
+	COMMENTS(Arrays.asList("comment", "comments")), //
+	SYNONYMS(Arrays.asList("synonym", "synonyms")), //
+	DATABASE(Arrays.asList("database", "db")), //
+	FLAVOR_ODOR(Arrays.asList("odor")), //
+	FLAVOR_MATRIX(Arrays.asList("matrix")), //
+	FLAVOR_SOLVENT(Arrays.asList("solvent"));
+
+	private List<String> keywords;
+
+	private SearchField(List<String> keywords) {
+
+		this.keywords = keywords;
+	}
+
+	public List<String> keywords() {
+
+		return keywords;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/provider/MassSpectrumListFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/provider/MassSpectrumListFilter.java
@@ -24,12 +24,6 @@ public class MassSpectrumListFilter extends ViewerFilter {
 
 	private String searchText;
 	private boolean caseSensitive;
-	private LibraryInformationSupport libraryInformationSupport;
-
-	public MassSpectrumListFilter() {
-
-		libraryInformationSupport = new LibraryInformationSupport();
-	}
 
 	public void setSearchText(String searchText, boolean caseSensitive) {
 
@@ -51,21 +45,17 @@ public class MassSpectrumListFilter extends ViewerFilter {
 		if(searchText == null || searchText.equals("")) {
 			return true;
 		}
-		/*
-		 * ILibraryMassSpectrum
-		 */
-		if(element instanceof ILibraryMassSpectrum libraryMassSpectrum) {
 
+		if(element instanceof ILibraryMassSpectrum libraryMassSpectrum) {
 			ILibraryInformation libraryInformation = libraryMassSpectrum.getLibraryInformation();
-			if(libraryInformationSupport.containsSearchText(libraryInformation, searchText, caseSensitive)) {
+			if(LibraryInformationSupport.containsSearchText(libraryInformation, searchText, caseSensitive)) {
 				return true;
 			}
 		} else if(element instanceof IScanMSD massSpectrum) {
-
 			for(IIdentificationTarget massSpectrumTarget : massSpectrum.getTargets()) {
-				IIdentificationTarget identificationEntry = (IIdentificationTarget)massSpectrumTarget;
+				IIdentificationTarget identificationEntry = massSpectrumTarget;
 				ILibraryInformation libraryInformation = identificationEntry.getLibraryInformation();
-				if(libraryInformationSupport.containsSearchText(libraryInformation, searchText, caseSensitive)) {
+				if(LibraryInformationSupport.containsSearchText(libraryInformation, searchText, caseSensitive)) {
 					return true;
 				}
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/contexts.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/contexts.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?NLS TYPE="org.eclipse.help.contexts"?>
+<contexts>
+   <context id="mass_spectrum_search" title="Mass Spectrum Search">
+      <description>Search through a mass spectrum database.</description>
+      <topic label="Prefixes" href="html/ms_search_prefixes.html"/>
+   </context>
+</contexts>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/html/ms_search_prefixes.html
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/html/ms_search_prefixes.html
@@ -1,0 +1,61 @@
+<h2>Prefixes</h2>
+
+<h3>Mass Spectrum Search</h3>
+<table border="1" cellpadding="10" cellspacing="0" summary="Mass Spectrum Search Prefixes">
+  <tr>
+    <td><code>name:</code></td>
+    <td>Searches for the compound name.</td>
+  </tr>
+  <tr>
+  	<td><code>ref:</code><br/><code>id:</code></td>
+  	<td>Searches the reference or internal identifier for the record as in the database ID or the accession number.</td>
+  </tr>
+  <tr>
+  	<td><code>formula:</code></td>
+  	<td>Searches the molecular formula field.</td>
+  </tr>
+  <tr>
+  	<td><code>smiles:</code></td>
+  	<td>Searches the SMILES structure code.</td>
+  </tr>
+  <tr>
+  	<td><code>inchi:</code></td>
+  	<td>Searches the InChI structure code.</td>
+  </tr>
+  <tr>
+  	<td><code>inchikey:</code></td>
+  	<td>Searches the InChIKey (hashed InChI) field.</td>
+  </tr>
+  <tr>
+  	<td><code>cas:</code></td>
+  	<td>Searches the CAS registry number for the compound.</td>
+  </tr>
+  <tr>
+  	<td><code>comment:</code><br/><code>comments:</code></td>
+  	<td>Searches notes attached to the record by the curator.</td>
+  </tr>
+  <tr>
+    <td><code>synonym:</code><br/><code>synonyms:</code></td>
+    <td>Searches synonyms and alternate names for the compound.</td>
+  </tr>
+  <tr>
+    <td><code>database:</code></td>
+    <td>Searches the source database name.</td>
+  </tr>
+  <tr>
+    <td><code>odor:</code></td>
+    <td>Searches odor descriptor fields.</td>
+  </tr>
+  <tr>
+    <td><code>matrix:</code></td>
+    <td>Searches the food matrix context in terms of flavor.</td>
+  </tr>
+  <tr>
+    <td><code>solvent:</code></td>
+    <td>Searches solvent information attached to sensory/flavor records.</td>
+  </tr>
+  <tr>
+    <td><code>all:</code></td>
+    <td>Searches across all searchable fields which is also the default when no key is used.</td>
+  </tr>
+</table>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/plugin.xml
@@ -8,4 +8,11 @@
             uri="fragment.e4xmi">
       </fragment>
    </extension>
+   <extension
+         point="org.eclipse.help.contexts">
+      <contexts
+            file="contexts.xml"
+            plugin="org.eclipse.chemclipse.ux.extension.msd.ui">
+      </contexts>
+   </extension>   
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/help/HelpContext.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/help/HelpContext.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.ux.extension.msd.ui.help;
+
+public class HelpContext {
+
+	private HelpContext() {
+
+		// static only
+	}
+
+	public static final String PREFIX = "org.eclipse.chemclipse.ux.extension.msd.ui."; //$NON-NLS-1$
+
+	public static final String MASS_SPECTRUM_SEARCH = PREFIX + "mass_spectrum_search"; //$NON-NLS-1$
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumLibraryUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumLibraryUI.java
@@ -35,7 +35,9 @@ import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
 import org.eclipse.chemclipse.swt.ui.components.SearchSupportUI;
 import org.eclipse.chemclipse.swt.ui.notifier.UpdateNotifierUI;
 import org.eclipse.chemclipse.swt.ui.preferences.PreferencePageSystem;
+import org.eclipse.chemclipse.ux.extension.msd.ui.help.HelpContext;
 import org.eclipse.chemclipse.ux.extension.ui.support.PartSupport;
+import org.eclipse.chemclipse.ux.extension.ui.swt.IExtendedPartUI;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.IPreferencePage;
 import org.eclipse.jface.preference.PreferenceDialog;
@@ -51,8 +53,9 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.ui.PlatformUI;
 
-public class MassSpectrumLibraryUI extends Composite {
+public class MassSpectrumLibraryUI extends Composite implements IExtendedPartUI {
 
 	private static final Logger logger = Logger.getLogger(MassSpectrumLibraryUI.class);
 
@@ -117,10 +120,11 @@ public class MassSpectrumLibraryUI extends Composite {
 		GridData gridDataStatus = new GridData(GridData.FILL_HORIZONTAL);
 		gridDataStatus.horizontalAlignment = SWT.END;
 		composite.setLayoutData(gridDataStatus);
-		composite.setLayout(new GridLayout(7, false));
+		composite.setLayout(new GridLayout(8, false));
 
 		createButtonToggleToolbarInfo(composite);
 		createButtonToggleToolbarSearch(composite);
+		createButtonHelp(composite, HelpContext.MASS_SPECTRUM_SEARCH);
 		createButtonToggleToolbarModify(composite);
 		createButtonToggleToolbarEdit(composite);
 		createButtonAddLibraryToSearch(composite);
@@ -307,6 +311,8 @@ public class MassSpectrumLibraryUI extends Composite {
 			massSpectrumListUI.setSearchText(searchText, caseSensitive);
 			updateLabel();
 		});
+
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(searchSupportUI, HelpContext.MASS_SPECTRUM_SEARCH);
 
 		return searchSupportUI;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/TargetListFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/TargetListFilter.java
@@ -21,12 +21,6 @@ public class TargetListFilter extends ViewerFilter {
 
 	private String searchText;
 	private boolean caseSensitive;
-	private LibraryInformationSupport libraryInformationSupport;
-
-	public TargetListFilter() {
-
-		libraryInformationSupport = new LibraryInformationSupport();
-	}
 
 	public void setSearchText(String searchText, boolean caseSensitive) {
 
@@ -45,7 +39,7 @@ public class TargetListFilter extends ViewerFilter {
 		}
 
 		if(element instanceof IIdentificationTarget target) {
-			return libraryInformationSupport.containsSearchText(target.getLibraryInformation(), searchText, caseSensitive);
+			return LibraryInformationSupport.containsSearchText(target.getLibraryInformation(), searchText, caseSensitive);
 		}
 
 		return false;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/PeakScanListFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/PeakScanListFilter.java
@@ -27,7 +27,6 @@ public class PeakScanListFilter extends ViewerFilter {
 
 	private String searchText;
 	private boolean caseSensitive;
-	private final LibraryInformationSupport libraryInformationSupport = new LibraryInformationSupport();
 
 	public void setSearchText(String searchText, boolean caseSensitive) {
 
@@ -61,7 +60,7 @@ public class PeakScanListFilter extends ViewerFilter {
 		}
 		for(ITarget target : peak.getTargets()) {
 			if(target instanceof IIdentificationTarget identificationTarget) {
-				if(libraryInformationSupport.containsSearchText(identificationTarget.getLibraryInformation(), searchText, caseSensitive)) {
+				if(LibraryInformationSupport.containsSearchText(identificationTarget.getLibraryInformation(), searchText, caseSensitive)) {
 					return true;
 				}
 			}
@@ -72,7 +71,7 @@ public class PeakScanListFilter extends ViewerFilter {
 	private boolean matchScan(IScan scan) {
 
 		for(IIdentificationTarget target : scan.getTargets()) {
-			if(libraryInformationSupport.containsSearchText(target.getLibraryInformation(), searchText, caseSensitive)) {
+			if(LibraryInformationSupport.containsSearchText(target.getLibraryInformation(), searchText, caseSensitive)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Also fixes a bug where you couldn't search for solvent:

https://github.com/eclipse-chemclipse/chemclipse/blob/b6342e73b070ed2b0f26361b1a0ed40e173279d2/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/LibraryInformationSupport.java#L151-L158