### PR TITLE
Fix macro recorder process methods not getting displayed in the toolbar

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/support/PreferencesProcessSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/support/PreferencesProcessSupport.java
@@ -44,6 +44,9 @@ public class PreferencesProcessSupport {
 			@Override
 			public boolean test(IProcessSupplier<?> processSupplier) {
 
+				if(processSupplier.getSupportedDataTypes().contains(DataCategory.AUTO_DETECT)) {
+					return true;
+				}
 				return processSupplier.getSupportedDataTypes().contains(getDataCategory());
 			}
 		};

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ProcessorToolbarUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ProcessorToolbarUI.java
@@ -157,6 +157,9 @@ public class ProcessorToolbarUI extends Composite {
 	private boolean isActiveDataCategory(Processor processor) {
 
 		if(dataCategory != null) {
+			if(processor.getProcessSupplier().getSupportedDataTypes().contains(DataCategory.AUTO_DETECT)) {
+				return true;
+			}
 			return processor.getProcessSupplier().getSupportedDataTypes().contains(dataCategory);
 		}
 


### PR DESCRIPTION
When a process method is created using the macro recorder, its data type is set to auto-detect, which the processor toolbar and its setting would ignore because it does not match the current detector type. This now always allows this wild card setting.