### PR TITLE
Remove deprecated `setSystemSettings`

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/settings/FilterSettingsRemover.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/settings/FilterSettingsRemover.java
@@ -26,12 +26,6 @@ public class FilterSettingsRemover extends AbstractChromatogramFilterSettings {
 	@StringSettingsProperty(regExp = PreferenceSupplier.CHECK_REMOVER_PATTERN, allowEmpty = false)
 	private String scanRemoverPattern = PreferenceSupplier.DEF_REMOVER_PATTERN;
 
-	@Override
-	public void setSystemSettings() {
-
-		scanRemoverPattern = PreferenceSupplier.getScanRemoverPattern();
-	}
-
 	public String getScanRemoverPattern() {
 
 		return scanRemoverPattern;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/settings/FilterSettingsScanClipper.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/settings/FilterSettingsScanClipper.java
@@ -26,12 +26,6 @@ public class FilterSettingsScanClipper extends AbstractChromatogramFilterSetting
 	@StringSettingsProperty(allowEmpty = false)
 	private String scanNumberPattern = PreferenceSupplier.DEF_CLIP_SCAN_NUMBER_PATTERN;
 
-	@Override
-	public void setSystemSettings() {
-
-		scanNumberPattern = PreferenceSupplier.getScanNumberPattern();
-	}
-
 	public String getScanNumberPattern() {
 
 		return scanNumberPattern;

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/settings/AbstractProcessSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/settings/AbstractProcessSettings.java
@@ -23,12 +23,6 @@ public abstract class AbstractProcessSettings implements IProcessSettings {
 
 	private final List<LiteratureReference> literatureReference = new ArrayList<>();
 
-	@Override
-	@Deprecated
-	public void setSystemSettings() {
-
-	}
-
 	/**
 	 * Replaces the pattern and extension.
 	 * For example {chromatogram_name}{extension} is validated to TestChromatogram.csv

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/settings/IProcessSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/settings/IProcessSettings.java
@@ -31,16 +31,5 @@ public interface IProcessSettings {
 	 */
 	public static final String VARIABLE_CURRENT_DIRECTORY = "{current_directory}";
 
-	/**
-	 * Use this method to set specific system settings.
-	 * 
-	 * @deprecated this method will be removed soon
-	 */
-	@Deprecated
-	default void setSystemSettings() {
-
-		throw new UnsupportedOperationException();
-	}
-
 	List<LiteratureReference> getLiteratureReferences();
 }


### PR DESCRIPTION
It has been marked as deprecated over 6 years ago https://github.com/eclipse-chemclipse/chemclipse/commit/c6d0946ba611b0b6a9213836e0b4ef5ace39d189 and shipped in 0.8.0 and currently has no callers left, so I propose to remove it entirely.