### PR TITLE
Remove deprecated interface `IMarkedWavelengths`: `void add(int start, int stop)`

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/wavelengths/AbstractMarkedWavelengths.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/wavelengths/AbstractMarkedWavelengths.java
@@ -135,20 +135,6 @@ public abstract class AbstractMarkedWavelengths implements IMarkedWavelengths {
 		return wavelengths;
 	}
 
-	@Deprecated
-	@Override
-	public void add(int ionStart, int ionStop) {
-
-		if(ionStart > ionStop) {
-			int tmp = ionStart;
-			ionStart = ionStop;
-			ionStop = tmp;
-		}
-		for(int i = ionStart; i <= ionStop; i++) {
-			markedWavelengths.add(new MarkedWavelength(i));
-		}
-	}
-
 	@Override
 	public void add(float... wavelenghts) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/wavelengths/IMarkedWavelengths.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/wavelengths/IMarkedWavelengths.java
@@ -34,14 +34,4 @@ public interface IMarkedWavelengths extends IMarkedTraces<IMarkedWavelength> {
 	void add(float... wavelength);
 
 	void add(Collection<? extends Number> wavelengths);
-
-	/**
-	 * Adds the wavelength range with magnification factor = 1.
-	 * Deprecated because wavelength could be double values
-	 * 
-	 * @param wavelengthStart
-	 * @param wavelengthStop
-	 */
-	@Deprecated
-	void add(int wavelengthStart, int wavelengthStop);
 }


### PR DESCRIPTION
It has been marked as deprecated over 7 years ago in https://github.com/eclipse-chemclipse/chemclipse/commit/51fbc0459232246569eb3fec8334e91ec243c177 and shipped in 0.8.0 and currently has no callers left, so I propose to remove it entirely.