### PR TITLE
Remove deprecated `IAnalysisSegment.getSegmentWidth()`

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/IAnalysisSegment.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/IAnalysisSegment.java
@@ -21,18 +21,6 @@ import java.util.List;
 public interface IAnalysisSegment extends IScanRange, IRetentionTimeRange {
 
 	/**
-	 * Returns the width of the analysis segment in scan units.
-	 * 
-	 * @deprecated use {@link #getWidth()} instead
-	 * @return int
-	 */
-	@Deprecated
-	default int getSegmentWidth() {
-
-		return getWidth();
-	}
-
-	/**
 	 * An {@link IAnalysisSegment} might be further be separated, this method allows access to its child segments
 	 * 
 	 * @return the child segments for this segment


### PR DESCRIPTION
It has been marked as deprecated over 6 years ago in https://github.com/eclipse-chemclipse/chemclipse/commit/8d79ae03448a673b8d1a06753448cbc6416c8845 and shipped in 0.8.0 and currently has no callers left, so I propose to remove it entirely.