### PR TITLE
Fix batch process not displaying profiles from imported process methods

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/core/BatchProcess.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/core/BatchProcess.java
@@ -23,7 +23,7 @@ import org.eclipse.chemclipse.model.types.DataType;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplierContext;
 import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 import org.eclipse.chemclipse.xxd.process.support.ChromatogramTypeSupport;
@@ -60,7 +60,7 @@ public class BatchProcess {
 					if(!inputProcessingInfo.hasErrorMessages()) {
 						IChromatogramSelection chromatogramSelection = inputProcessingInfo.getProcessingResult();
 						ProcessingInfo<?> processorResult = new ProcessingInfo<>();
-						ProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, processorResult, processSupplierContext), IChromatogramSelectionProcessSupplier.createConsumer(chromatogramSelection));
+						IProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, processorResult, processSupplierContext), IChromatogramSelectionProcessSupplier.createConsumer(chromatogramSelection));
 						if(processorResult.hasErrorMessages()) {
 							processingInfo.addErrorMessage(DESCRIPTION, "Processing: " + file + " failed");
 						} else {

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/methods/MetaProcessorProcessSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/methods/MetaProcessorProcessSupplier.java
@@ -14,7 +14,7 @@
 package org.eclipse.chemclipse.converter.methods;
 
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.supplier.AbstractProcessSupplier;
 import org.eclipse.chemclipse.processing.supplier.IProcessExecutionConsumer;
 import org.eclipse.chemclipse.processing.supplier.IProcessExecutor;
@@ -49,7 +49,7 @@ public final class MetaProcessorProcessSupplier extends AbstractProcessSupplier<
 		if(settings instanceof MetaProcessorSettings processorSettings) {
 			IProcessExecutionConsumer<?> callerDelegate = context.getContextObject(IProcessExecutionConsumer.class);
 			if(callerDelegate != null) {
-				ProcessEntryContainer.applyProcessEntries(processMethod, context, (processEntry, processSupplier) -> processorSettings.getProcessorPreferences(processEntry, processEntry.getPreferences(processSupplier)), callerDelegate);
+				IProcessEntryContainer.applyProcessEntries(processMethod, context, (processEntry, processSupplier) -> processorSettings.getProcessorPreferences(processEntry, processEntry.getPreferences(processSupplier)), callerDelegate);
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/methods/MetaProcessorSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/methods/MetaProcessorSettings.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import org.eclipse.chemclipse.processing.methods.IProcessEntry;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
 import org.eclipse.chemclipse.processing.methods.ListProcessEntryContainer;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplier;
 import org.eclipse.chemclipse.processing.supplier.IProcessorPreferences;
 
@@ -127,7 +127,7 @@ public class MetaProcessorSettings {
 	 */
 	private static String getProcessEntryIdentifier(IProcessEntry processEntry) {
 
-		ProcessEntryContainer parent = processEntry.getParent();
+		IProcessEntryContainer parent = processEntry.getParent();
 		String activeProfile = parent.getActiveProfile().replace(" ", "").replaceAll("\\P{InBasic_Latin}", "");
 
 		if(parent instanceof ListProcessEntryContainer listProcessEntryContainer) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/methods/UserMethodProcessSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/methods/UserMethodProcessSupplier.java
@@ -20,14 +20,14 @@ import java.util.Set;
 
 import org.eclipse.chemclipse.processing.methods.IProcessEntry;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.supplier.AbstractProcessSupplier;
 import org.eclipse.chemclipse.processing.supplier.IProcessExecutionConsumer;
 import org.eclipse.chemclipse.processing.supplier.IProcessExecutor;
 import org.eclipse.chemclipse.processing.supplier.IProcessorPreferences;
 import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 
-public final class UserMethodProcessSupplier extends AbstractProcessSupplier<Void> implements ProcessEntryContainer, IProcessExecutor {
+public final class UserMethodProcessSupplier extends AbstractProcessSupplier<Void> implements IProcessEntryContainer, IProcessExecutor {
 
 	private static final String SKIP_MESSAGE = "SKIP CHECK: Is this method used?";
 
@@ -55,7 +55,7 @@ public final class UserMethodProcessSupplier extends AbstractProcessSupplier<Voi
 	public <X> void execute(IProcessorPreferences<X> preferences, ProcessExecutionContext context) throws Exception {
 
 		IProcessExecutionConsumer<?> consumer = context.getContextObject(IProcessExecutionConsumer.class);
-		ProcessEntryContainer.applyProcessEntries(processMethod, context, consumer);
+		IProcessEntryContainer.applyProcessEntries(processMethod, context, consumer);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/AbstractProcessEntryContainer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/AbstractProcessEntryContainer.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.processing.methods;
 
-public abstract class AbstractProcessEntryContainer implements ProcessEntryContainer {
+public abstract class AbstractProcessEntryContainer implements IProcessEntryContainer {
 
 	/*
 	 * The flag supportResume shall be persisted. By default, it is false, due to the following reasons:
@@ -23,7 +23,7 @@ public abstract class AbstractProcessEntryContainer implements ProcessEntryConta
 	 * to select the entry point if needed.
 	 */
 	private boolean supportResume = false;
-	private int resumeIndex = ProcessEntryContainer.DEFAULT_RESUME_INDEX; // transient
+	private int resumeIndex = IProcessEntryContainer.DEFAULT_RESUME_INDEX; // transient
 
 	@Override
 	public boolean isSupportResume() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/IProcessEntry.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/IProcessEntry.java
@@ -21,7 +21,7 @@ import org.eclipse.chemclipse.processing.supplier.IProcessSupplier;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplierContext;
 import org.eclipse.chemclipse.processing.supplier.IProcessorPreferences;
 
-public interface IProcessEntry extends ProcessEntryContainer {
+public interface IProcessEntry extends IProcessEntryContainer {
 
 	/**
 	 * 
@@ -121,7 +121,7 @@ public interface IProcessEntry extends ProcessEntryContainer {
 
 	boolean isReadOnly();
 
-	ProcessEntryContainer getParent();
+	IProcessEntryContainer getParent();
 
 	default <T> IProcessorPreferences<T> getPreferences(IProcessSupplierContext context) {
 
@@ -194,7 +194,7 @@ public interface IProcessEntry extends ProcessEntryContainer {
 
 	public static IProcessSupplierContext getContext(IProcessEntry processEntry, IProcessSupplierContext defaultContext) {
 
-		ProcessEntryContainer processEntryContainer = processEntry.getParent();
+		IProcessEntryContainer processEntryContainer = processEntry.getParent();
 
 		if(processEntryContainer instanceof IProcessEntry processEntryParent) {
 			IProcessSupplier<?> processSupplier = getContext(processEntryParent, defaultContext).getSupplier(processEntryParent.getProcessorId());

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/IProcessEntryContainer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/IProcessEntryContainer.java
@@ -24,10 +24,10 @@ import org.eclipse.chemclipse.processing.supplier.IProcessorPreferences;
 import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 
 /**
- * A {@link ProcessEntryContainer} holds some {@link IProcessEntry}s
+ * A {@link IProcessEntryContainer} holds some {@link IProcessEntry}s
  *
  */
-public interface ProcessEntryContainer extends Iterable<IProcessEntry> {
+public interface IProcessEntryContainer extends Iterable<IProcessEntry> {
 
 	/**
 	 * Empty string "" is used for backward compatibility.
@@ -107,7 +107,7 @@ public interface ProcessEntryContainer extends Iterable<IProcessEntry> {
 	 * @param other
 	 * @return
 	 */
-	default boolean entriesEquals(ProcessEntryContainer other) {
+	default boolean entriesEquals(IProcessEntryContainer other) {
 
 		Iterator<IProcessEntry> thisEntries = iterator();
 		if(other == null) {
@@ -128,12 +128,12 @@ public interface ProcessEntryContainer extends Iterable<IProcessEntry> {
 		return true;
 	}
 
-	static <X, T> T applyProcessEntries(ProcessEntryContainer container, ProcessExecutionContext context, IProcessExecutionConsumer<T> consumer) {
+	static <X, T> T applyProcessEntries(IProcessEntryContainer container, ProcessExecutionContext context, IProcessExecutionConsumer<T> consumer) {
 
 		return applyProcessEntries(container, context, (processEntry, processSupplier) -> processEntry.getPreferences(processSupplier), consumer);
 	}
 
-	static <X, T> T applyProcessEntries(ProcessEntryContainer container, ProcessExecutionContext context, BiFunction<IProcessEntry, IProcessSupplier<X>, IProcessorPreferences<X>> preferenceSupplier, IProcessExecutionConsumer<T> consumer) {
+	static <X, T> T applyProcessEntries(IProcessEntryContainer container, ProcessExecutionContext context, BiFunction<IProcessEntry, IProcessSupplier<X>, IProcessorPreferences<X>> preferenceSupplier, IProcessExecutionConsumer<T> consumer) {
 
 		int resumeIndex = container.isSupportResume() ? container.getResumeIndex() : DEFAULT_RESUME_INDEX;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/IProcessMethod.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/IProcessMethod.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.support.model.SeparationColumnType;
 
-public interface IProcessMethod extends ProcessEntryContainer {
+public interface IProcessMethod extends IProcessEntryContainer {
 
 	/**
 	 * 

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/ListProcessEntryContainer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/ListProcessEntryContainer.java
@@ -44,7 +44,7 @@ public class ListProcessEntryContainer extends AbstractProcessEntryContainer {
 		addDefaultProfile();
 	}
 
-	public ListProcessEntryContainer(ProcessEntryContainer other) {
+	public ListProcessEntryContainer(IProcessEntryContainer other) {
 
 		if(other != null) {
 			profiles.addAll(other.getProfiles());

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/ProcessEntry.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/ProcessEntry.java
@@ -23,7 +23,7 @@ import org.eclipse.chemclipse.processing.DataCategory;
 
 public final class ProcessEntry extends ListProcessEntryContainer implements IProcessEntry {
 
-	private final ProcessEntryContainer parent;
+	private final IProcessEntryContainer parent;
 	private final EnumSet<DataCategory> categories = EnumSet.noneOf(DataCategory.class);
 	private final Map<String, String> jsonSettingsMap = new HashMap<>();
 
@@ -31,12 +31,12 @@ public final class ProcessEntry extends ListProcessEntryContainer implements IPr
 	private String activeProfile = DEFAULT_PROFILE;
 	private boolean skipValidation = false;
 
-	public ProcessEntry(ProcessEntryContainer parent) {
+	public ProcessEntry(IProcessEntryContainer parent) {
 
 		this(null, parent);
 	}
 
-	public ProcessEntry(IProcessEntry other, ProcessEntryContainer newParent) {
+	public ProcessEntry(IProcessEntry other, IProcessEntryContainer newParent) {
 
 		super(other);
 		parent = newParent;
@@ -140,7 +140,7 @@ public final class ProcessEntry extends ListProcessEntryContainer implements IPr
 	}
 
 	@Override
-	public ProcessEntryContainer getParent() {
+	public IProcessEntryContainer getParent() {
 
 		return parent;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/supplier/ExecutionResultTransformer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/supplier/ExecutionResultTransformer.java
@@ -14,11 +14,11 @@ package org.eclipse.chemclipse.processing.supplier;
 
 import java.io.IOException;
 
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 
 /**
  * 
- * A {@link ExecutionResultTransformer} can transform the consumer of a {@link ProcessEntryContainer} child invocation
+ * A {@link ExecutionResultTransformer} can transform the consumer of a {@link IProcessEntryContainer} child invocation
  */
 public interface ExecutionResultTransformer<SettingType> extends IProcessSupplier<SettingType> {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/ExtendedMassSpectrumUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/ExtendedMassSpectrumUI.java
@@ -29,7 +29,7 @@ import org.eclipse.chemclipse.msd.swt.ui.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.processing.core.IMessageProvider;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplierContext;
 import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 import org.eclipse.chemclipse.processing.ui.support.ProcessingInfoPartSupport;
@@ -191,7 +191,7 @@ public class ExtendedMassSpectrumUI extends Composite implements IExtendedPartUI
 		methodSupportUI.setMethodListener((processMethod, monitor) -> executeMethod(massSpectrum, scanMSD -> {
 
 			IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
-			ProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, processingInfo, processTypeSupport), IScanProcessSupplier.createConsumer(scanMSD));
+			IProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, processingInfo, processTypeSupport), IScanProcessSupplier.createConsumer(scanMSD));
 			scanMSD.setDirty(true);
 			UpdateNotifier.update(scanMSD);
 			if(scanMSD instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/editors/ExtendedMethodUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/editors/ExtendedMethodUI.java
@@ -308,6 +308,7 @@ public class ExtendedMethodUI extends Composite implements IExtendedPartUI {
 			@Override
 			public void update() {
 
+				toolbarProfile.get().setInput(processMethodToolbar.getProcessMethod());
 				updateProcessMethod();
 				setMethodDirty(true);
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/editors/ExtendedMethodUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/editors/ExtendedMethodUI.java
@@ -25,7 +25,7 @@ import org.eclipse.chemclipse.model.handler.IModificationHandler;
 import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.methods.IProcessEntry;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplierContext;
 import org.eclipse.chemclipse.processing.supplier.IProcessorPreferences;
@@ -75,7 +75,7 @@ public class ExtendedMethodUI extends Composite implements IExtendedPartUI {
 
 	private ProcessMethod processMethod;
 	private IModificationHandler modificationHandler;
-	private Collection<ProcessEntryContainer> postActions;
+	private Collection<IProcessEntryContainer> postActions;
 
 	private boolean readOnly = false;
 
@@ -101,7 +101,7 @@ public class ExtendedMethodUI extends Composite implements IExtendedPartUI {
 		setInputs(processMethod, Collections.emptyList());
 	}
 
-	public void setInputs(IProcessMethod processMethod, Collection<ProcessEntryContainer> postActions) {
+	public void setInputs(IProcessMethod processMethod, Collection<IProcessEntryContainer> postActions) {
 
 		this.postActions = postActions;
 		this.processMethod = new ProcessMethod(processMethod);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/editors/ExtendedMethodUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/editors/ExtendedMethodUI.java
@@ -17,15 +17,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 import org.eclipse.chemclipse.model.handler.IModificationHandler;
 import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.methods.IProcessEntry;
-import org.eclipse.chemclipse.processing.methods.IProcessMethod;
 import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessMethod;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplierContext;
 import org.eclipse.chemclipse.processing.supplier.IProcessorPreferences;
@@ -40,7 +39,6 @@ import org.eclipse.chemclipse.ux.extension.ui.swt.ProcessMethodProfiles;
 import org.eclipse.chemclipse.ux.extension.ui.swt.ProcessMethodToolbar;
 import org.eclipse.chemclipse.xxd.process.ui.preferences.PreferencePageChromatogramExport;
 import org.eclipse.chemclipse.xxd.process.ui.preferences.PreferencePageReportExport;
-import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.SWT;
@@ -316,30 +314,6 @@ public class ExtendedMethodUI extends Composite implements IExtendedPartUI {
 		});
 
 		toolbarButtons.set(processMethodToolbar);
-	}
-
-	public void loadMethodFile(IProcessMethod method) {
-
-		if(method != null) {
-			List<IProcessEntry> copied = new ArrayList<>();
-			method.forEach(entry -> {
-				copied.add(processMethod.addProcessEntry(entry));
-			});
-			updateProcessMethod();
-			select(copied);
-		}
-	}
-
-	private void select(Iterable<? extends IProcessEntry> entries) {
-
-		ArrayList<IProcessEntry> list = new ArrayList<>();
-		entries.forEach(list::add);
-		StructuredSelection structuredSelection = new StructuredSelection(list);
-		treeViewer.get().setSelection(structuredSelection);
-		Object firstElement = structuredSelection.getFirstElement();
-		if(firstElement != null) {
-			treeViewer.get().reveal(firstElement);
-		}
 	}
 
 	private void updateProcessMethod() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/internal/provider/MethodListLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/internal/provider/MethodListLabelProvider.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 
 import org.eclipse.chemclipse.processing.methods.IProcessEntry;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplier;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplierContext;
 import org.eclipse.chemclipse.processing.supplier.IProcessorPreferences;
@@ -85,7 +85,7 @@ public class MethodListLabelProvider extends AbstractChemClipseLabelProvider {
 				}
 			} else if(element instanceof IProcessMethod) {
 				return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_METHOD, IApplicationImageProvider.SIZE_16x16);
-			} else if(element instanceof ProcessEntryContainer) {
+			} else if(element instanceof IProcessEntryContainer) {
 				return ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_FOLDER_OPENED, IApplicationImageProvider.SIZE_16x16);
 			}
 		}
@@ -150,7 +150,7 @@ public class MethodListLabelProvider extends AbstractChemClipseLabelProvider {
 				default:
 					break;
 			}
-		} else if(element instanceof ProcessEntryContainer method) {
+		} else if(element instanceof IProcessEntryContainer method) {
 			switch(columnIndex) {
 				case 1:
 					return method.getName();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/methods/MethodParameters.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/methods/MethodParameters.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.ui.methods;
 
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 
 public class MethodParameters {
 
-	private String profile = ProcessEntryContainer.DEFAULT_PROFILE;
-	private int resumeIndex = ProcessEntryContainer.DEFAULT_RESUME_INDEX;
+	private String profile = IProcessEntryContainer.DEFAULT_PROFILE;
+	private int resumeIndex = IProcessEntryContainer.DEFAULT_RESUME_INDEX;
 
 	public String getProfile() {
 
@@ -27,7 +27,7 @@ public class MethodParameters {
 	public void setProfile(String profile) {
 
 		if(profile == null || profile.isEmpty()) {
-			this.profile = ProcessEntryContainer.DEFAULT_PROFILE;
+			this.profile = IProcessEntryContainer.DEFAULT_PROFILE;
 		} else {
 			this.profile = profile;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/methods/MethodSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/methods/MethodSupport.java
@@ -19,7 +19,7 @@ import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.chemclipse.processing.methods.IProcessEntry;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
 import org.eclipse.chemclipse.processing.methods.ListProcessEntryContainer;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.ui.support.ProcessingInfoPartSupport;
 import org.eclipse.chemclipse.progress.core.InfoType;
 import org.eclipse.chemclipse.progress.core.StatusLineLogger;
@@ -38,7 +38,7 @@ public class MethodSupport {
 	public static final ListProcessEntryContainer getContainer(Object object) {
 
 		if(object instanceof IProcessEntry processEntry) {
-			ProcessEntryContainer parent = processEntry.getParent();
+			IProcessEntryContainer parent = processEntry.getParent();
 			if(parent instanceof ListProcessEntryContainer container) {
 				if(!container.isReadOnly()) {
 					return container;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/methods/ProcessingWizardPage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/methods/ProcessingWizardPage.java
@@ -27,7 +27,7 @@ import java.util.TreeMap;
 import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.methods.IProcessEntry;
 import org.eclipse.chemclipse.processing.methods.ProcessEntry;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplier;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplierContext;
 import org.eclipse.chemclipse.support.ui.provider.AbstractLabelProvider;
@@ -334,7 +334,7 @@ public class ProcessingWizardPage extends WizardPage {
 		Object object = comboViewerProcessor.getStructuredSelection().getFirstElement();
 		if(object instanceof IProcessSupplier) {
 			IProcessSupplier<?> processorSupplier = (IProcessSupplier<?>)object;
-			processEntry = new ProcessEntry((ProcessEntryContainer)null);
+			processEntry = new ProcessEntry((IProcessEntryContainer)null);
 			processEntry.setProcessorId(processorSupplier.getId());
 			processEntry.setName(processorSupplier.getName());
 			processEntry.setDescription(processorSupplier.getDescription());

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/methods/ResumeMethodDialog.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/methods/ResumeMethodDialog.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.chemclipse.processing.methods.IProcessEntry;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.support.ui.provider.AbstractLabelProvider;
 import org.eclipse.chemclipse.support.ui.provider.ListContentProvider;
 import org.eclipse.chemclipse.support.ui.swt.EnhancedComboViewer;
@@ -47,16 +47,16 @@ public class ResumeMethodDialog extends TitleAreaDialog {
 	private AtomicReference<ComboViewer> comboViewerResumeControl = new AtomicReference<>();
 	private AtomicReference<Label> labelResumeControl = new AtomicReference<>();
 
-	private String profile = ProcessEntryContainer.DEFAULT_PROFILE;
+	private String profile = IProcessEntryContainer.DEFAULT_PROFILE;
 	private int resumeIndex = 0;
-	private ProcessEntryContainer container;
+	private IProcessEntryContainer container;
 
 	public ResumeMethodDialog(Shell shell) {
 
 		super(shell);
 	}
 
-	public void setInput(ProcessEntryContainer container) {
+	public void setInput(IProcessEntryContainer container) {
 
 		this.container = container;
 	}
@@ -122,9 +122,9 @@ public class ResumeMethodDialog extends TitleAreaDialog {
 			profile = container.getActiveProfile();
 			ComboViewer comboViewer = comboViewerProfileControl.get();
 			List<String> profiles = new ArrayList<>(container.getProfiles());
-			profiles.remove(ProcessEntryContainer.DEFAULT_PROFILE);
+			profiles.remove(IProcessEntryContainer.DEFAULT_PROFILE);
 			Collections.sort(profiles);
-			profiles.add(0, ProcessEntryContainer.DEFAULT_PROFILE);
+			profiles.add(0, IProcessEntryContainer.DEFAULT_PROFILE);
 			comboViewer.setInput(profiles);
 			comboViewer.setSelection(new StructuredSelection(profile));
 		}
@@ -231,7 +231,7 @@ public class ResumeMethodDialog extends TitleAreaDialog {
 					resumeIndex = combo.getSelectionIndex() - 1;
 					labelResumeControl.get().setText(processEntry.getDescription());
 				} else {
-					resumeIndex = ProcessEntryContainer.DEFAULT_RESUME_INDEX;
+					resumeIndex = IProcessEntryContainer.DEFAULT_RESUME_INDEX;
 					labelResumeControl.get().setText("");
 				}
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/MethodTreeViewer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/MethodTreeViewer.java
@@ -21,8 +21,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 import org.eclipse.chemclipse.processing.methods.IProcessEntry;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.ProcessEntry;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplier;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplierContext;
 import org.eclipse.chemclipse.processing.supplier.IProcessorPreferences;
@@ -106,12 +106,12 @@ public class MethodTreeViewer extends TreeViewer {
 
 				if(element instanceof IProcessEntry entry) {
 					IProcessSupplier<?> supplier = processingSupport.getSupplier(entry.getProcessorId());
-					if(supplier instanceof ProcessEntryContainer processEntryContainer) {
+					if(supplier instanceof IProcessEntryContainer processEntryContainer) {
 						return processEntryContainer.getNumberOfEntries() > 0;
 					}
 				}
 
-				if(element instanceof ProcessEntryContainer processEntryContainer) {
+				if(element instanceof IProcessEntryContainer processEntryContainer) {
 					return processEntryContainer.getNumberOfEntries() > 0;
 				}
 
@@ -130,7 +130,7 @@ public class MethodTreeViewer extends TreeViewer {
 			@Override
 			public Object[] getElements(Object inputElement) {
 
-				if(inputElement instanceof ProcessEntryContainer container) {
+				if(inputElement instanceof IProcessEntryContainer container) {
 					return entryList(container, false);
 				}
 
@@ -157,12 +157,12 @@ public class MethodTreeViewer extends TreeViewer {
 
 				if(parentElement instanceof IProcessEntry entry) {
 					IProcessSupplier<?> supplier = processingSupport.getSupplier(entry.getProcessorId());
-					if(supplier instanceof ProcessEntryContainer processEntryContainer) {
+					if(supplier instanceof IProcessEntryContainer processEntryContainer) {
 						return entryList(processEntryContainer, true);
 					}
 				}
 
-				if(parentElement instanceof ProcessEntryContainer processEntryContainer) {
+				if(parentElement instanceof IProcessEntryContainer processEntryContainer) {
 					return entryList(processEntryContainer, false);
 				}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/ProcessMethodProfiles.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/ProcessMethodProfiles.java
@@ -65,13 +65,13 @@ public class ProcessMethodProfiles extends Composite {
 	public void setInput(ProcessMethod processMethod) {
 
 		this.processMethod = processMethod;
-		updateProfilesColum();
+		updateProfilesColumn();
 	}
 
 	public void setEnabledEdit(boolean enabledEdit) {
 
 		this.enabledEdit = enabledEdit;
-		updateProfilesColum();
+		updateProfilesColumn();
 	}
 
 	public void setUpdateListener(IUpdateListener updateListener) {
@@ -92,7 +92,7 @@ public class ProcessMethodProfiles extends Composite {
 		createButtonAdd(this);
 		createButtonDelete(this);
 
-		updateProfilesColum();
+		updateProfilesColumn();
 	}
 
 	private void createComboViewerProfiles(Composite composite) {
@@ -127,7 +127,7 @@ public class ProcessMethodProfiles extends Composite {
 					 */
 					String activeProfile = getActiveProfile();
 					processMethod.setActiveProfile(activeProfile);
-					updateProfilesColum();
+					updateProfilesColumn();
 					fireUpdate();
 				}
 			}
@@ -222,7 +222,7 @@ public class ProcessMethodProfiles extends Composite {
 						for(IProcessEntry processEntry : processMethod.getEntries()) {
 							processEntry.copySettings(previousProfile);
 						}
-						updateProfilesColum();
+						updateProfilesColumn();
 						fireUpdate();
 					}
 				}
@@ -254,7 +254,7 @@ public class ProcessMethodProfiles extends Composite {
 						if(SWT.YES == decision) {
 							processMethod.getProfileColumnsMap().remove(activeProfile);
 							processMethod.deleteProfile(activeProfile);
-							updateProfilesColum();
+							updateProfilesColumn();
 							fireUpdate();
 						}
 					}
@@ -296,7 +296,7 @@ public class ProcessMethodProfiles extends Composite {
 		return separationColumnType;
 	}
 
-	private void updateProfilesColum() {
+	private void updateProfilesColumn() {
 
 		updateProfiles();
 		updateColumns();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/ProcessMethodProfiles.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/ProcessMethodProfiles.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.chemclipse.processing.methods.IProcessEntry;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
@@ -201,7 +201,7 @@ public class ProcessMethodProfiles extends Composite {
 								input = input.trim();
 								if(input.isEmpty()) {
 									return "The profile name must be not empty.";
-								} else if(ProcessEntryContainer.DEFAULT_PROFILE.equals(input)) {
+								} else if(IProcessEntryContainer.DEFAULT_PROFILE.equals(input)) {
 									return "The default profile can't be used.";
 								} else if(processMethod.getProfiles().contains(input)) {
 									return "The profile exists already.";
@@ -246,7 +246,7 @@ public class ProcessMethodProfiles extends Composite {
 
 				if(processMethod != null) {
 					String activeProfile = getActiveProfile();
-					if(!ProcessEntryContainer.DEFAULT_PROFILE.equals(activeProfile)) {
+					if(!IProcessEntryContainer.DEFAULT_PROFILE.equals(activeProfile)) {
 						MessageBox messageBox = new MessageBox(e.display.getActiveShell(), SWT.ICON_QUESTION | SWT.YES | SWT.NO);
 						messageBox.setText("Delete Profile");
 						messageBox.setMessage("Do you really want to delete the selected profile?");
@@ -272,7 +272,7 @@ public class ProcessMethodProfiles extends Composite {
 			return text;
 		}
 
-		return ProcessEntryContainer.DEFAULT_PROFILE;
+		return IProcessEntryContainer.DEFAULT_PROFILE;
 	}
 
 	private SeparationColumnType getSeparationColumnType() {
@@ -308,7 +308,7 @@ public class ProcessMethodProfiles extends Composite {
 			/*
 			 * Ensure that the default profile is available.
 			 */
-			String defaultProfile = ProcessEntryContainer.DEFAULT_PROFILE;
+			String defaultProfile = IProcessEntryContainer.DEFAULT_PROFILE;
 			if(!processMethod.getProfiles().contains(defaultProfile)) {
 				processMethod.addProfile(defaultProfile);
 			}
@@ -339,7 +339,7 @@ public class ProcessMethodProfiles extends Composite {
 			 */
 			comboViewerProfiles.get().getCombo().select(index);
 		} else {
-			comboViewerProfiles.get().setInput(new String[]{ProcessEntryContainer.DEFAULT_PROFILE});
+			comboViewerProfiles.get().setInput(new String[]{IProcessEntryContainer.DEFAULT_PROFILE});
 			comboViewerProfiles.get().getCombo().select(0);
 		}
 		/*
@@ -347,7 +347,7 @@ public class ProcessMethodProfiles extends Composite {
 		 */
 		boolean isEditable = enabledEdit && isMethodEditable(processMethod);
 		buttonAdd.get().setEnabled(isEditable);
-		buttonDelete.get().setEnabled(isEditable && !ProcessEntryContainer.DEFAULT_PROFILE.equals(getActiveProfile()));
+		buttonDelete.get().setEnabled(isEditable && !IProcessEntryContainer.DEFAULT_PROFILE.equals(getActiveProfile()));
 	}
 
 	private void updateColumns() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/ProcessMethodToolbar.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/ProcessMethodToolbar.java
@@ -583,9 +583,12 @@ public class ProcessMethodToolbar extends ToolBar {
 		if(method != null) {
 			List<IProcessEntry> copied = new ArrayList<>();
 			method.forEach(entry -> copied.add(processMethod.addProcessEntry(entry)));
+			select(copied);
+
+			method.getProfiles().forEach(profile -> processMethod.addProfile(profile));
+			processMethod.setActiveProfile(method.getActiveProfile());
 
 			fireUpdate();
-			select(copied);
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/ProcessMethodToolbar.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/ProcessMethodToolbar.java
@@ -106,6 +106,11 @@ public class ProcessMethodToolbar extends ToolBar {
 		this.processMethod = processMethod;
 	}
 
+	public ProcessMethod getProcessMethod() {
+
+		return processMethod;
+	}
+
 	public void setStructuredViewer(StructuredViewer structuredViewer) {
 
 		this.structuredViewer = structuredViewer;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
@@ -46,7 +46,7 @@ import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplierContext;
 import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
@@ -333,7 +333,7 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 
 					IProcessMethod processMethod = Adapters.adapt(file, IProcessMethod.class);
 					if(processMethod != null) {
-						ProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, new ProcessingInfo<>(), processSupplierContext), IChromatogramSelectionProcessSupplier.createConsumer(chromatogramSelection));
+						IProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, new ProcessingInfo<>(), processSupplierContext), IChromatogramSelectionProcessSupplier.createConsumer(chromatogramSelection));
 					}
 				});
 			} catch(InvocationTargetException e) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -63,7 +63,7 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
 import org.eclipse.chemclipse.processing.methods.ProcessEntry;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplier;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplier.SupplierType;
@@ -1187,7 +1187,7 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 		methodSupportUI.setMethodListener((processMethod, monitor) -> executeMethod(chromatogramSelection, chromatogramSelection -> {
 
 			IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
-			ProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, processingInfo, processTypeSupport), IChromatogramSelectionProcessSupplier.createConsumer(chromatogramSelection));
+			IProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, processingInfo, processTypeSupport), IChromatogramSelectionProcessSupplier.createConsumer(chromatogramSelection));
 			IChromatogram chromatogram = chromatogramSelection.getChromatogram();
 			updateResult(processingInfo);
 			AuditTrailSupport.updateAuditTrail(chromatogram, processingInfo, processMethod, processTypeSupport);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedSequenceListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedSequenceListUI.java
@@ -28,7 +28,7 @@ import org.eclipse.chemclipse.model.types.DataType;
 import org.eclipse.chemclipse.processing.core.IMessageProvider;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplierContext;
 import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 import org.eclipse.chemclipse.processing.ui.support.ProcessingInfoPartSupport;
@@ -175,7 +175,7 @@ public class ExtendedSequenceListUI extends Composite implements IExtendedPartUI
 						IChromatogramSelection chromatogramSelection = processingInfoChromatogram.getProcessingResult();
 						addSequenceRecordInformation(sequenceRecord, chromatogramSelection.getChromatogram());
 						ProcessingInfo<?> processorInfo = new ProcessingInfo<>();
-						ProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, processorInfo, processSupplierContext), IChromatogramSelectionProcessSupplier.createConsumer(chromatogramSelection));
+						IProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, processorInfo, processSupplierContext), IChromatogramSelectionProcessSupplier.createConsumer(chromatogramSelection));
 						chromatogramSelection.getChromatogram().setDirty(true); // TODO: check each entry
 						if(processorInfo.hasErrorMessages()) {
 							processingInfo.addMessages(processorInfo);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/internal/methods/MethodReaderWriter_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/internal/methods/MethodReaderWriter_1003.java
@@ -24,7 +24,7 @@ import org.eclipse.chemclipse.processing.core.IMessageConsumer;
 import org.eclipse.chemclipse.processing.methods.IProcessEntry;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
 import org.eclipse.chemclipse.processing.methods.ProcessEntry;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.settings.Format;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -75,8 +75,8 @@ public class MethodReaderWriter_1003 extends ObjectStreamMethodFormat {
 		writeString(entry.getSettings(), stream);
 		writeIterable(entry.getDataCategories(), stream, ObjectStreamMethodFormat::writeEnum);
 		// write child entries if there are any...
-		ProcessEntryContainer container;
-		if(entry instanceof ProcessEntryContainer) {
+		IProcessEntryContainer container;
+		if(entry instanceof IProcessEntryContainer) {
 			container = entry;
 		} else {
 			container = null;
@@ -85,7 +85,7 @@ public class MethodReaderWriter_1003 extends ObjectStreamMethodFormat {
 		stream.writeBoolean(entry.isReadOnly());
 	}
 
-	private ObjectInputStreamDeserializer<IProcessEntry> processEntryDeserialization(ProcessEntryContainer parent) {
+	private ObjectInputStreamDeserializer<IProcessEntry> processEntryDeserialization(IProcessEntryContainer parent) {
 
 		return stream -> {
 			ProcessEntry processEntry = new ProcessEntry(parent);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/internal/methods/MethodReaderWriter_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/internal/methods/MethodReaderWriter_1004.java
@@ -25,7 +25,7 @@ import org.eclipse.chemclipse.processing.core.IMessageConsumer;
 import org.eclipse.chemclipse.processing.methods.IProcessEntry;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
 import org.eclipse.chemclipse.processing.methods.ProcessEntry;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.settings.Format;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -79,8 +79,8 @@ public class MethodReaderWriter_1004 extends ObjectStreamMethodFormat {
 		writeProcessSettings(entry, stream);
 		writeIterable(entry.getDataCategories(), stream, ObjectStreamMethodFormat::writeEnum);
 		// write child entries if there are any...
-		ProcessEntryContainer container;
-		if(entry instanceof ProcessEntryContainer) {
+		IProcessEntryContainer container;
+		if(entry instanceof IProcessEntryContainer) {
 			container = entry;
 		} else {
 			container = null;
@@ -89,7 +89,7 @@ public class MethodReaderWriter_1004 extends ObjectStreamMethodFormat {
 		stream.writeBoolean(entry.isReadOnly());
 	}
 
-	private ObjectInputStreamDeserializer<IProcessEntry> processEntryDeserialization(ProcessEntryContainer parent) {
+	private ObjectInputStreamDeserializer<IProcessEntry> processEntryDeserialization(IProcessEntryContainer parent) {
 
 		return stream -> {
 			ProcessEntry processEntry = new ProcessEntry(parent);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/internal/methods/MethodReaderWriter_1401.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/internal/methods/MethodReaderWriter_1401.java
@@ -25,7 +25,7 @@ import org.eclipse.chemclipse.processing.core.IMessageConsumer;
 import org.eclipse.chemclipse.processing.methods.IProcessEntry;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
 import org.eclipse.chemclipse.processing.methods.ProcessEntry;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.settings.Format;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -83,8 +83,8 @@ public class MethodReaderWriter_1401 extends ObjectStreamMethodFormat {
 		writeProcessSettings(entry, stream);
 		writeIterable(entry.getDataCategories(), stream, ObjectStreamMethodFormat::writeEnum);
 		// write child entries if there are any...
-		ProcessEntryContainer container;
-		if(entry instanceof ProcessEntryContainer) {
+		IProcessEntryContainer container;
+		if(entry instanceof IProcessEntryContainer) {
 			container = entry;
 		} else {
 			container = null;
@@ -93,7 +93,7 @@ public class MethodReaderWriter_1401 extends ObjectStreamMethodFormat {
 		stream.writeBoolean(entry.isReadOnly());
 	}
 
-	private ObjectInputStreamDeserializer<IProcessEntry> processEntryDeserialization(ProcessEntryContainer parent) {
+	private ObjectInputStreamDeserializer<IProcessEntry> processEntryDeserialization(IProcessEntryContainer parent) {
 
 		return stream -> {
 			ProcessEntry processEntry = new ProcessEntry(parent);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/internal/methods/MethodReaderWriter_1402.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/internal/methods/MethodReaderWriter_1402.java
@@ -23,9 +23,9 @@ import java.util.Set;
 import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.core.IMessageConsumer;
 import org.eclipse.chemclipse.processing.methods.IProcessEntry;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
 import org.eclipse.chemclipse.processing.methods.ProcessEntry;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.eclipse.chemclipse.support.model.SeparationColumnType;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.settings.Format;
@@ -86,8 +86,8 @@ public class MethodReaderWriter_1402 extends ObjectStreamMethodFormat {
 		writeProcessSettings(entry, stream);
 		writeIterable(entry.getDataCategories(), stream, ObjectStreamMethodFormat::writeEnum);
 		// write child entries if there are any...
-		ProcessEntryContainer container;
-		if(entry instanceof ProcessEntryContainer) {
+		IProcessEntryContainer container;
+		if(entry instanceof IProcessEntryContainer) {
 			container = entry;
 		} else {
 			container = null;
@@ -96,7 +96,7 @@ public class MethodReaderWriter_1402 extends ObjectStreamMethodFormat {
 		stream.writeBoolean(entry.isReadOnly());
 	}
 
-	private ObjectInputStreamDeserializer<IProcessEntry> processEntryDeserialization(ProcessEntryContainer parent) {
+	private ObjectInputStreamDeserializer<IProcessEntry> processEntryDeserialization(IProcessEntryContainer parent) {
 
 		return stream -> {
 			ProcessEntry processEntry = new ProcessEntry(parent);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/src/org/eclipse/chemclipse/xxd/process/support/ProcessTypeSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/src/org/eclipse/chemclipse/xxd/process/support/ProcessTypeSupport.java
@@ -30,7 +30,7 @@ import org.eclipse.chemclipse.processing.core.IMessageConsumer;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplier;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplierContext;
 import org.eclipse.chemclipse.processing.supplier.IProcessTypeSupplier;
@@ -135,7 +135,7 @@ public class ProcessTypeSupport implements IProcessSupplierContext {
 	public <T> IProcessingInfo<T> applyProcessor(IChromatogramSelection chromatogramSelection, IProcessMethod processMethod, IProgressMonitor monitor) {
 
 		ProcessingInfo<T> processingInfo = new ProcessingInfo<>();
-		ProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, processingInfo, this), IChromatogramSelectionProcessSupplier.createConsumer(chromatogramSelection));
+		IProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, processingInfo, this), IChromatogramSelectionProcessSupplier.createConsumer(chromatogramSelection));
 		return processingInfo;
 	}
 
@@ -145,7 +145,7 @@ public class ProcessTypeSupport implements IProcessSupplierContext {
 		ProcessingInfo<T> processingInfo = new ProcessingInfo<>();
 		ProcessExecutionContext executionContext = new ProcessExecutionContext(monitor, processingInfo, this);
 		for(IChromatogramSelection selection : chromatogramSelections) {
-			ProcessEntryContainer.applyProcessEntries(processMethod, executionContext.split(), IChromatogramSelectionProcessSupplier.createConsumer(selection));
+			IProcessEntryContainer.applyProcessEntries(processMethod, executionContext.split(), IChromatogramSelectionProcessSupplier.createConsumer(selection));
 		}
 
 		return processingInfo;
@@ -154,6 +154,6 @@ public class ProcessTypeSupport implements IProcessSupplierContext {
 	@Deprecated
 	public <X> Collection<? extends IMeasurement> applyProcessor(Collection<? extends IMeasurement> measurements, IProcessMethod processMethod, IMessageConsumer messageConsumer, IProgressMonitor monitor) {
 
-		return ProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, messageConsumer, this), IMeasurementProcessSupplier.createConsumer(measurements));
+		return IProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, messageConsumer, this), IMeasurementProcessSupplier.createConsumer(measurements));
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/methods/ProcessEntry_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/methods/ProcessEntry_1_Test.java
@@ -22,7 +22,7 @@ import java.util.Set;
 
 import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.methods.ProcessEntry;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,14 +36,14 @@ public class ProcessEntry_1_Test {
 
 		Set<DataCategory> dataCategories = new HashSet<>();
 		dataCategories.add(DataCategory.MSD);
-		ProcessEntryContainer processEntryContainer = new ProcessMethod(dataCategories);
+		IProcessEntryContainer processEntryContainer = new ProcessMethod(dataCategories);
 		processEntry = new ProcessEntry(processEntryContainer);
 	}
 
 	@Test
 	public void test1() {
 
-		assertEquals(ProcessEntryContainer.DEFAULT_PROFILE, processEntry.getActiveProfile());
+		assertEquals(IProcessEntryContainer.DEFAULT_PROFILE, processEntry.getActiveProfile());
 		Map<String, String> settingsMap = processEntry.getSettingsMap();
 		assertEquals(0, settingsMap.size()); // Settings are created on-the-fly
 	}
@@ -67,13 +67,13 @@ public class ProcessEntry_1_Test {
 		assertEquals(1, settingsMap1.size());
 		assertTrue(settingsMap1.containsKey("Test"));
 
-		processEntry.setActiveProfile(ProcessEntryContainer.DEFAULT_PROFILE);
+		processEntry.setActiveProfile(IProcessEntryContainer.DEFAULT_PROFILE);
 		processEntry.setSettings("");
 		assertEquals("", processEntry.getSettings());
 		Map<String, String> settingsMap2 = processEntry.getSettingsMap();
 		assertEquals(2, settingsMap2.size());
 		assertTrue(settingsMap2.containsKey("Test"));
-		assertTrue(settingsMap2.containsKey(ProcessEntryContainer.DEFAULT_PROFILE));
+		assertTrue(settingsMap2.containsKey(IProcessEntryContainer.DEFAULT_PROFILE));
 	}
 
 	@Test
@@ -86,14 +86,14 @@ public class ProcessEntry_1_Test {
 		assertEquals(1, settingsMap1.size());
 		assertTrue(settingsMap1.containsKey("Test"));
 		processEntry.deleteProfile("Test");
-		assertEquals(ProcessEntryContainer.DEFAULT_PROFILE, processEntry.getActiveProfile());
+		assertEquals(IProcessEntryContainer.DEFAULT_PROFILE, processEntry.getActiveProfile());
 
-		processEntry.setActiveProfile(ProcessEntryContainer.DEFAULT_PROFILE);
+		processEntry.setActiveProfile(IProcessEntryContainer.DEFAULT_PROFILE);
 		processEntry.setSettings("");
 		assertEquals("", processEntry.getSettings());
 		Map<String, String> settingsMap2 = processEntry.getSettingsMap();
 		assertEquals(1, settingsMap2.size());
 		assertFalse(settingsMap2.containsKey("Test"));
-		assertTrue(settingsMap2.containsKey(ProcessEntryContainer.DEFAULT_PROFILE));
+		assertTrue(settingsMap2.containsKey(IProcessEntryContainer.DEFAULT_PROFILE));
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/methods/ProcessEntry_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/methods/ProcessEntry_2_Test.java
@@ -22,7 +22,7 @@ import java.util.Set;
 
 import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.methods.ProcessEntry;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,14 +36,14 @@ public class ProcessEntry_2_Test {
 
 		Set<DataCategory> dataCategories = new HashSet<>();
 		dataCategories.add(DataCategory.MSD);
-		ProcessEntryContainer processEntryContainer = new ProcessMethod(dataCategories);
+		IProcessEntryContainer processEntryContainer = new ProcessMethod(dataCategories);
 		processEntry = new ProcessEntry(processEntryContainer);
 	}
 
 	@Test
 	public void test1() {
 
-		assertEquals(ProcessEntryContainer.DEFAULT_PROFILE, processEntry.getActiveProfile());
+		assertEquals(IProcessEntryContainer.DEFAULT_PROFILE, processEntry.getActiveProfile());
 		Map<String, String> settingsMap = processEntry.getSettingsMap();
 		assertEquals(0, settingsMap.size()); // Settings are created on-the-fly
 	}
@@ -67,13 +67,13 @@ public class ProcessEntry_2_Test {
 		assertEquals(1, settingsMap1.size());
 		assertTrue(settingsMap1.containsKey("Test"));
 
-		processEntry.setActiveProfile(ProcessEntryContainer.DEFAULT_PROFILE);
+		processEntry.setActiveProfile(IProcessEntryContainer.DEFAULT_PROFILE);
 		processEntry.setSettings("");
 		assertEquals("", processEntry.getSettings());
 		Map<String, String> settingsMap2 = processEntry.getSettingsMap();
 		assertEquals(2, settingsMap2.size());
 		assertTrue(settingsMap2.containsKey("Test"));
-		assertTrue(settingsMap2.containsKey(ProcessEntryContainer.DEFAULT_PROFILE));
+		assertTrue(settingsMap2.containsKey(IProcessEntryContainer.DEFAULT_PROFILE));
 	}
 
 	@Test
@@ -86,15 +86,15 @@ public class ProcessEntry_2_Test {
 		assertEquals(1, settingsMap1.size());
 		assertTrue(settingsMap1.containsKey("Test"));
 		processEntry.deleteProfile("Test");
-		assertEquals(ProcessEntryContainer.DEFAULT_PROFILE, processEntry.getActiveProfile());
+		assertEquals(IProcessEntryContainer.DEFAULT_PROFILE, processEntry.getActiveProfile());
 
-		processEntry.setActiveProfile(ProcessEntryContainer.DEFAULT_PROFILE);
+		processEntry.setActiveProfile(IProcessEntryContainer.DEFAULT_PROFILE);
 		processEntry.setSettings("");
 		assertEquals("", processEntry.getSettings());
 		Map<String, String> settingsMap2 = processEntry.getSettingsMap();
 		assertEquals(1, settingsMap2.size());
 		assertFalse(settingsMap2.containsKey("Test"));
-		assertTrue(settingsMap2.containsKey(ProcessEntryContainer.DEFAULT_PROFILE));
+		assertTrue(settingsMap2.containsKey(IProcessEntryContainer.DEFAULT_PROFILE));
 	}
 
 	@Test
@@ -107,7 +107,7 @@ public class ProcessEntry_2_Test {
 		processEntry.setActiveProfile("Entry");
 		processEntry.setSettings("doing?");
 
-		processEntry.setActiveProfile(ProcessEntryContainer.DEFAULT_PROFILE);
+		processEntry.setActiveProfile(IProcessEntryContainer.DEFAULT_PROFILE);
 		assertEquals("", processEntry.getSettings());
 		assertEquals("Hello World", processEntry.getSettings("Test"));
 		assertEquals("how ya'", processEntry.getSettings("My"));

--- a/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/methods/ProcessEntry_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/methods/ProcessEntry_3_Test.java
@@ -19,7 +19,7 @@ import java.util.Set;
 
 import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.methods.ProcessEntry;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,7 +33,7 @@ public class ProcessEntry_3_Test {
 
 		Set<DataCategory> dataCategories = new HashSet<>();
 		dataCategories.add(DataCategory.MSD);
-		ProcessEntryContainer processEntryContainer = new ProcessMethod(dataCategories);
+		IProcessEntryContainer processEntryContainer = new ProcessMethod(dataCategories);
 		processEntry = new ProcessEntry(processEntryContainer);
 	}
 
@@ -45,7 +45,7 @@ public class ProcessEntry_3_Test {
 		processEntry.setActiveProfile("My");
 		processEntry.setActiveProfile("Entry");
 
-		processEntry.setActiveProfile(ProcessEntryContainer.DEFAULT_PROFILE);
+		processEntry.setActiveProfile(IProcessEntryContainer.DEFAULT_PROFILE);
 		assertEquals("", processEntry.getSettings());
 		assertEquals("Hello World", processEntry.getSettings("Test"));
 		assertEquals("", processEntry.getSettings("My"));
@@ -64,7 +64,7 @@ public class ProcessEntry_3_Test {
 		processEntry.setActiveProfile("Extended");
 		processEntry.copySettings("Testx");
 
-		processEntry.setActiveProfile(ProcessEntryContainer.DEFAULT_PROFILE);
+		processEntry.setActiveProfile(IProcessEntryContainer.DEFAULT_PROFILE);
 		assertEquals("", processEntry.getSettings());
 		assertEquals("Hello World", processEntry.getSettings("Test"));
 		assertEquals("", processEntry.getSettings("My"));
@@ -82,7 +82,7 @@ public class ProcessEntry_3_Test {
 		processEntry.setActiveProfile("Entry");
 		processEntry.copySettings("Test");
 
-		processEntry.setActiveProfile(ProcessEntryContainer.DEFAULT_PROFILE);
+		processEntry.setActiveProfile(IProcessEntryContainer.DEFAULT_PROFILE);
 		assertEquals("", processEntry.getSettings());
 		assertEquals("Hello World", processEntry.getSettings("Test"));
 		assertEquals("Hello World", processEntry.getSettings("My"));

--- a/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/methods/ProcessMethod_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/methods/ProcessMethod_1_Test.java
@@ -20,7 +20,7 @@ import java.util.Set;
 
 import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,21 +40,21 @@ public class ProcessMethod_1_Test {
 	@Test
 	public void test1() {
 
-		assertEquals(ProcessEntryContainer.DEFAULT_PROFILE, processMethod.getActiveProfile());
+		assertEquals(IProcessEntryContainer.DEFAULT_PROFILE, processMethod.getActiveProfile());
 		Set<String> profiles = processMethod.getProfiles();
 		assertEquals(1, profiles.size());
-		assertTrue(profiles.contains(ProcessEntryContainer.DEFAULT_PROFILE));
+		assertTrue(profiles.contains(IProcessEntryContainer.DEFAULT_PROFILE));
 	}
 
 	@Test
 	public void test2() {
 
-		assertEquals(ProcessEntryContainer.DEFAULT_PROFILE, processMethod.getActiveProfile());
+		assertEquals(IProcessEntryContainer.DEFAULT_PROFILE, processMethod.getActiveProfile());
 		processMethod.addProfile("Test");
-		assertEquals(ProcessEntryContainer.DEFAULT_PROFILE, processMethod.getActiveProfile());
+		assertEquals(IProcessEntryContainer.DEFAULT_PROFILE, processMethod.getActiveProfile());
 		Set<String> profiles = processMethod.getProfiles();
 		assertEquals(2, profiles.size());
-		assertTrue(profiles.contains(ProcessEntryContainer.DEFAULT_PROFILE));
+		assertTrue(profiles.contains(IProcessEntryContainer.DEFAULT_PROFILE));
 		assertTrue(profiles.contains("Test"));
 	}
 
@@ -65,7 +65,7 @@ public class ProcessMethod_1_Test {
 		assertEquals("Test", processMethod.getActiveProfile());
 		Set<String> profiles = processMethod.getProfiles();
 		assertEquals(2, profiles.size());
-		assertTrue(profiles.contains(ProcessEntryContainer.DEFAULT_PROFILE));
+		assertTrue(profiles.contains(IProcessEntryContainer.DEFAULT_PROFILE));
 		assertTrue(profiles.contains("Test"));
 	}
 
@@ -73,10 +73,10 @@ public class ProcessMethod_1_Test {
 	public void test4() {
 
 		processMethod.setActiveProfile(null);
-		assertEquals(ProcessEntryContainer.DEFAULT_PROFILE, processMethod.getActiveProfile());
+		assertEquals(IProcessEntryContainer.DEFAULT_PROFILE, processMethod.getActiveProfile());
 		Set<String> profiles = processMethod.getProfiles();
 		assertEquals(1, profiles.size());
-		assertTrue(profiles.contains(ProcessEntryContainer.DEFAULT_PROFILE));
+		assertTrue(profiles.contains(IProcessEntryContainer.DEFAULT_PROFILE));
 	}
 
 	@Test
@@ -86,10 +86,10 @@ public class ProcessMethod_1_Test {
 		assertEquals("Test", processMethod.getActiveProfile());
 		Set<String> profiles = processMethod.getProfiles();
 		assertEquals(2, profiles.size());
-		assertTrue(profiles.contains(ProcessEntryContainer.DEFAULT_PROFILE));
+		assertTrue(profiles.contains(IProcessEntryContainer.DEFAULT_PROFILE));
 		assertTrue(profiles.contains("Test"));
 		processMethod.deleteProfile("Test");
 		assertEquals(1, processMethod.getProfiles().size());
-		assertEquals(ProcessEntryContainer.DEFAULT_PROFILE, processMethod.getActiveProfile());
+		assertEquals(IProcessEntryContainer.DEFAULT_PROFILE, processMethod.getActiveProfile());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/methods/ProcessMethod_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/methods/ProcessMethod_2_Test.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.methods.IProcessEntry;
 import org.eclipse.chemclipse.processing.methods.ProcessEntry;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,8 +60,8 @@ public class ProcessMethod_2_Test {
 		assertEquals(2, processMethod.getProfiles().size());
 
 		processMethod.deleteProfile(profile);
-		assertEquals(ProcessEntryContainer.DEFAULT_PROFILE, processMethod.getActiveProfile());
-		assertEquals(ProcessEntryContainer.DEFAULT_PROFILE, processEntry.getActiveProfile());
+		assertEquals(IProcessEntryContainer.DEFAULT_PROFILE, processMethod.getActiveProfile());
+		assertEquals(IProcessEntryContainer.DEFAULT_PROFILE, processEntry.getActiveProfile());
 		assertEquals(1, processMethod.getProfiles().size());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/methods/ProcessMethod_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/src/org/eclipse/chemclipse/model/methods/ProcessMethod_4_Test.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.methods.IProcessEntry;
 import org.eclipse.chemclipse.processing.methods.ProcessEntry;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,11 +40,11 @@ public class ProcessMethod_4_Test {
 		processMethod.setActiveProfile("Test");
 
 		processEntry = new ProcessEntry(processMethod);
-		processEntry.setActiveProfile(ProcessEntryContainer.DEFAULT_PROFILE);
+		processEntry.setActiveProfile(IProcessEntryContainer.DEFAULT_PROFILE);
 		processEntry.setSettings("Hello World");
 		processEntry.setActiveProfile("Test");
 		processEntry.setSettings("This is another setting");
-		processEntry.setActiveProfile(ProcessEntryContainer.DEFAULT_PROFILE);
+		processEntry.setActiveProfile(IProcessEntryContainer.DEFAULT_PROFILE);
 		processMethod.getEntries().add(processEntry);
 
 		processMethod.setActiveProfile("Test");

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/MethodReaderTest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/MethodReaderTest.java
@@ -28,7 +28,7 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
 import org.eclipse.chemclipse.processing.methods.ProcessEntry;
-import org.eclipse.chemclipse.processing.methods.ProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.methods.MethodExportConverter;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.methods.MethodImportConverter;
@@ -116,7 +116,7 @@ public class MethodReaderTest {
 		checkResult("ChromIdentMethod.ocm", convert, "nested");
 		IProcessMethod result = convert.getProcessingResult();
 		assertEquals(3, result.getNumberOfEntries());
-		ProcessEntryContainer next = result.iterator().next();
+		IProcessEntryContainer next = result.iterator().next();
 		assertEquals(1, next.getNumberOfEntries());
 	}
 
@@ -128,7 +128,7 @@ public class MethodReaderTest {
 		return createEntry;
 	}
 
-	private ProcessEntry createEntry(ProcessEntryContainer method, String id) {
+	private ProcessEntry createEntry(IProcessEntryContainer method, String id) {
 
 		ProcessEntry entry = new ProcessEntry(method);
 		entry.setProcessorId(id);


### PR DESCRIPTION
Only the profile entries were copied, and a default profile was set instead, which causes loss of information.