### PR TITLE
Remove deprecated process type support methods

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.processing.supplier.base.ui/src/org/eclipse/chemclipse/nmr/processing/supplier/base/ui/NMRBatchJob.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.processing.supplier.base.ui/src/org/eclipse/chemclipse/nmr/processing/supplier/base/ui/NMRBatchJob.java
@@ -21,10 +21,16 @@ import java.util.List;
 
 import org.eclipse.chemclipse.model.core.IComplexSignalMeasurement;
 import org.eclipse.chemclipse.model.core.IMeasurement;
+import org.eclipse.chemclipse.model.supplier.IMeasurementProcessSupplier;
 import org.eclipse.chemclipse.model.types.DataType;
 import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.core.DefaultProcessingResult;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
+import org.eclipse.chemclipse.processing.methods.IProcessMethod;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
+import org.eclipse.chemclipse.processing.supplier.IProcessExecutionConsumer;
+import org.eclipse.chemclipse.processing.supplier.IProcessSupplierContext;
+import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 import org.eclipse.chemclipse.processing.ui.support.ProcessingInfoPartSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.part.support.SupplierEditorSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.swt.BatchJobUI;
@@ -41,7 +47,7 @@ import jakarta.annotation.PostConstruct;
 public class NMRBatchJob implements IRunnableWithProgress {
 
 	private BatchJobUI batchJobUI;
-	private ProcessTypeSupport processTypeSupport;
+	private IProcessSupplierContext processTypeSupport;
 
 	@PostConstruct
 	public void postConstruct(Composite parent) {
@@ -58,14 +64,16 @@ public class NMRBatchJob implements IRunnableWithProgress {
 		batchJobUI.doLoad(Collections.emptyList(), new ProcessMethod(EnumSet.of(DataCategory.NMR)));
 	}
 
-	@SuppressWarnings("deprecation")
 	@Override
 	public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
 
 		NMRDataListUI dataList = (NMRDataListUI)batchJobUI.getDataList();
 		List<IComplexSignalMeasurement<?>> measurements = dataList.getMeasurements();
 		DefaultProcessingResult<Object> processingResult = new DefaultProcessingResult<>();
-		Collection<? extends IMeasurement> results = processTypeSupport.applyProcessor(measurements, batchJobUI.getMethod().getProcessMethod(), processingResult, monitor);
+		IProcessMethod processMethod = batchJobUI.getMethod().getProcessMethod();
+		ProcessExecutionContext processExecutionContext = new ProcessExecutionContext(monitor, processingResult, processTypeSupport);
+		IProcessExecutionConsumer<Collection<? extends IMeasurement>> consumer = IMeasurementProcessSupplier.createConsumer(measurements);
+		Collection<? extends IMeasurement> results = IProcessEntryContainer.applyProcessEntries(processMethod, processExecutionContext, consumer);
 		Display.getDefault().asyncExec(() -> ProcessingInfoPartSupport.getInstance().update(processingResult));
 
 		if(!processingResult.hasErrorMessages()) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/src/org/eclipse/chemclipse/xxd/process/support/ProcessTypeSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/src/org/eclipse/chemclipse/xxd/process/support/ProcessTypeSupport.java
@@ -15,28 +15,13 @@
 package org.eclipse.chemclipse.xxd.process.support;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.function.Consumer;
 
-import org.eclipse.chemclipse.model.core.IMeasurement;
-import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
-import org.eclipse.chemclipse.model.supplier.IChromatogramSelectionProcessSupplier;
-import org.eclipse.chemclipse.model.supplier.IMeasurementProcessSupplier;
-import org.eclipse.chemclipse.processing.DataCategory;
-import org.eclipse.chemclipse.processing.core.IMessageConsumer;
-import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.eclipse.chemclipse.processing.core.ProcessingInfo;
-import org.eclipse.chemclipse.processing.methods.IProcessMethod;
-import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplier;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplierContext;
 import org.eclipse.chemclipse.processing.supplier.IProcessTypeSupplier;
-import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 import org.eclipse.chemclipse.xxd.process.Activator;
-import org.eclipse.core.runtime.IProgressMonitor;
 
 /**
  * You could also use the {@link IProcessSupplierContext} OSGI-Service or the E4ProcessSupplierContext if context injection is desired
@@ -69,23 +54,6 @@ public class ProcessTypeSupport implements IProcessSupplierContext {
 		return null;
 	}
 
-	/**
-	 * Get all suppliers matching a given set of datacategories
-	 * 
-	 * @deprecated use {@link #visitSupplier(Consumer)} instead
-	 * @param dataTypes
-	 * @return the matching {@link IProcessSupplier}
-	 */
-	@Deprecated
-	public Set<IProcessSupplier<?>> getSupplier(Iterable<DataCategory> dataTypes) {
-
-		Set<IProcessSupplier<?>> supplier = new TreeSet<>((o1, o2) -> o1.getId().compareTo(o2.getId()));
-		addMatchingSupplier(dataTypes, supplier, localProcessSupplier.toArray(new IProcessTypeSupplier[0]));
-		addMatchingSupplier(dataTypes, supplier, Activator.getProcessTypeSuppliers());
-
-		return supplier;
-	}
-
 	@Override
 	public void visitSupplier(Consumer<? super IProcessSupplier<?>> consumer) {
 
@@ -98,29 +66,6 @@ public class ProcessTypeSupport implements IProcessSupplierContext {
 		}
 	}
 
-	private void addMatchingSupplier(Iterable<DataCategory> dataTypes, Set<IProcessSupplier<?>> supplier, IProcessTypeSupplier[] processTypeSuppliers) {
-
-		if(dataTypes == null) {
-			for(IProcessTypeSupplier processTypeSupplier : processTypeSuppliers) {
-				for(IProcessSupplier<?> processSupplier : processTypeSupplier.getProcessorSuppliers()) {
-					supplier.add(processSupplier);
-				}
-			}
-			return;
-		}
-
-		for(IProcessTypeSupplier processTypeSupplier : processTypeSuppliers) {
-			for(IProcessSupplier<?> processSupplier : processTypeSupplier.getProcessorSuppliers()) {
-				for(DataCategory category : dataTypes) {
-					if(processSupplier.getSupportedDataTypes().contains(category)) {
-						supplier.add(processSupplier);
-						break;
-					}
-				}
-			}
-		}
-	}
-
 	/**
 	 * Adds the given {@link IProcessTypeSupplier} to this
 	 * 
@@ -129,31 +74,5 @@ public class ProcessTypeSupport implements IProcessSupplierContext {
 	public void addProcessSupplier(IProcessTypeSupplier processTypeSupplier) {
 
 		localProcessSupplier.add(processTypeSupplier);
-	}
-
-	@Deprecated
-	public <T> IProcessingInfo<T> applyProcessor(IChromatogramSelection chromatogramSelection, IProcessMethod processMethod, IProgressMonitor monitor) {
-
-		ProcessingInfo<T> processingInfo = new ProcessingInfo<>();
-		IProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, processingInfo, this), IChromatogramSelectionProcessSupplier.createConsumer(chromatogramSelection));
-		return processingInfo;
-	}
-
-	@Deprecated
-	public <T, X> IProcessingInfo<T> applyProcessor(List<? extends IChromatogramSelection> chromatogramSelections, IProcessMethod processMethod, IProgressMonitor monitor) {
-
-		ProcessingInfo<T> processingInfo = new ProcessingInfo<>();
-		ProcessExecutionContext executionContext = new ProcessExecutionContext(monitor, processingInfo, this);
-		for(IChromatogramSelection selection : chromatogramSelections) {
-			IProcessEntryContainer.applyProcessEntries(processMethod, executionContext.split(), IChromatogramSelectionProcessSupplier.createConsumer(selection));
-		}
-
-		return processingInfo;
-	}
-
-	@Deprecated
-	public <X> Collection<? extends IMeasurement> applyProcessor(Collection<? extends IMeasurement> measurements, IProcessMethod processMethod, IMessageConsumer messageConsumer, IProgressMonitor monitor) {
-
-		return IProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, messageConsumer, this), IMeasurementProcessSupplier.createConsumer(measurements));
 	}
 }


### PR DESCRIPTION
They were marked as deprecated in https://github.com/eclipse-chemclipse/chemclipse/commit/8a26934e5e42a045f5f65425057e2f14db82f10d and https://github.com/eclipse-chemclipse/chemclipse/commit/4dd442c914c7d7174e97b67ebbe45bed9b625e75 with no clear indication why. They were released as part of the 0.8.0 release cycle. I replaced their last usage and removed them.