### PR TITLE
Replace deprecated IConverterSupport API

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractConverterSupport.java
@@ -35,7 +35,6 @@ public abstract class AbstractConverterSupport implements IConverterSupportSette
 		suppliers.add(supplier);
 	}
 
-	@Override
 	public String getConverterId(final int index) throws NoConverterAvailableException {
 
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractConverterSupport.java
@@ -183,7 +183,6 @@ public abstract class AbstractConverterSupport implements IConverterSupportSette
 		return filterNames.toArray(new String[filterNames.size()]);
 	}
 
-	@Override
 	public String[] getExportableFilterNames() throws NoConverterAvailableException {
 
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractConverterSupport.java
@@ -166,7 +166,6 @@ public abstract class AbstractConverterSupport implements IConverterSupportSette
 		return extensions.toArray(new String[extensions.size()]);
 	}
 
-	@Override
 	public String[] getFilterNames() throws NoConverterAvailableException {
 
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractConverterSupport.java
@@ -86,7 +86,6 @@ public abstract class AbstractConverterSupport implements IConverterSupportSette
 		return id;
 	}
 
-	@Override
 	public String[] getFilterExtensions() throws NoConverterAvailableException {
 
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractConverterSupport.java
@@ -114,7 +114,6 @@ public abstract class AbstractConverterSupport implements IConverterSupportSette
 		return extensions.toArray(new String[extensions.size()]);
 	}
 
-	@Override
 	public String[] getExportableFilterExtensions() throws NoConverterAvailableException {
 
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractConverterSupport.java
@@ -225,7 +225,6 @@ public abstract class AbstractConverterSupport implements IConverterSupportSette
 		return instance;
 	}
 
-	@Override
 	public List<ISupplier> getExportSupplier() {
 
 		List<ISupplier> exportSupplier = new ArrayList<>();

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/IConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/IConverterSupport.java
@@ -58,16 +58,6 @@ public interface IConverterSupport {
 		return extensions.toArray(new String[extensions.size()]);
 	}
 
-	@Deprecated
-	default String[] getExportableFilterExtensions() throws NoConverterAvailableException {
-
-		String[] extensions = getFilterExtensions(EXPORT_SUPPLIER);
-		if(extensions.length == 0) {
-			throw new NoConverterAvailableException();
-		}
-		return extensions;
-	}
-
 	/**
 	 * Returns the filter names which are actually registered at the
 	 * chromatogram converter extension point.<br/>

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/IConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/IConverterSupport.java
@@ -97,23 +97,6 @@ public interface IConverterSupport {
 	}
 
 	/**
-	 * Returns the same as getFilterNames() but with filter names (converter)
-	 * that are exportable.
-	 * 
-	 * @return String[]
-	 * @throws NoConverterAvailableException
-	 */
-	@Deprecated
-	default String[] getExportableFilterNames() throws NoConverterAvailableException {
-
-		String[] names = getFilterNames(EXPORT_SUPPLIER);
-		if(names.length == 0) {
-			throw new NoConverterAvailableException();
-		}
-		return names;
-	}
-
-	/**
 	 * Returns the id of the selected filter name.<br/>
 	 * The id of the selected filter is used to determine which converter should
 	 * be used to import or export the chromatogram.<br/>

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/IConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/IConverterSupport.java
@@ -59,16 +59,6 @@ public interface IConverterSupport {
 	}
 
 	@Deprecated
-	default String[] getFilterExtensions() throws NoConverterAvailableException {
-
-		String[] extensions = getFilterExtensions(ALL_SUPPLIER);
-		if(extensions.length == 0) {
-			throw new NoConverterAvailableException();
-		}
-		return extensions;
-	}
-
-	@Deprecated
 	default String[] getExportableFilterExtensions() throws NoConverterAvailableException {
 
 		String[] extensions = getFilterExtensions(EXPORT_SUPPLIER);

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/IConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/IConverterSupport.java
@@ -77,26 +77,6 @@ public interface IConverterSupport {
 	}
 
 	/**
-	 * Returns the id of the selected filter name.<br/>
-	 * The id of the selected filter is used to determine which converter should
-	 * be used to import or export the chromatogram.<br/>
-	 * Be aware of that the first index is 0. It is a 0-based index.
-	 * 
-	 * @param index
-	 * @return String
-	 * @throws NoConverterAvailableException
-	 */
-	@Deprecated
-	default String getConverterId(int index) throws NoConverterAvailableException {
-
-		try {
-			return getSupplier().get(index).getId();
-		} catch(IndexOutOfBoundsException e) {
-			throw new NoConverterAvailableException();
-		}
-	}
-
-	/**
 	 * Returns the converter id "org.eclipse.chemclipse.msd.converter.supplier.agilent" available in the list defined by its name, e.g. "Agilent Chromatogram (*.D/DATA.MS)".
 	 * If more converter with the given name "Agilent Chromatogram (*.D/DATA.MS)" are stored, the first match will be returned. If exportConverterOnly is true, only a converter
 	 * that is able to export the file will be returned.

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/IConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/IConverterSupport.java
@@ -96,12 +96,6 @@ public interface IConverterSupport {
 		return filterNames.toArray(new String[filterNames.size()]);
 	}
 
-	@Deprecated
-	default String[] getFilterNames() throws NoConverterAvailableException {
-
-		return getFilterNames(ALL_SUPPLIER);
-	}
-
 	/**
 	 * Returns the same as getFilterNames() but with filter names (converter)
 	 * that are exportable.

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/IConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/IConverterSupport.java
@@ -88,7 +88,7 @@ public interface IConverterSupport {
 	 */
 	default String getConverterId(String name, boolean exportConverterOnly) throws NoConverterAvailableException {
 
-		Collection<? extends ISupplier> supplier = getSupplier(new Predicate<ISupplier>() {
+		Collection<ISupplier> supplier = getSupplier(new Predicate<ISupplier>() {
 
 			@Override
 			public boolean test(ISupplier supplier) {
@@ -133,9 +133,9 @@ public interface IConverterSupport {
 	/**
 	 * Returns the list of all available suppliers
 	 * 
-	 * @return List<ISupplier>
+	 * @return Collection<ISupplier>
 	 */
-	default Collection<? extends ISupplier> getSupplier(Predicate<? super ISupplier> filter) {
+	default Collection<ISupplier> getSupplier(Predicate<? super ISupplier> filter) {
 
 		List<ISupplier> list = new ArrayList<>();
 		for(ISupplier supplier : getSupplier()) {
@@ -158,7 +158,7 @@ public interface IConverterSupport {
 	 */
 	default ISupplier getSupplier(String id) throws NoConverterAvailableException {
 
-		Collection<? extends ISupplier> collection = getSupplier(supplier -> supplier.getId().equals(id));
+		Collection<ISupplier> collection = getSupplier(supplier -> supplier.getId().equals(id));
 		if(collection.isEmpty()) {
 			throw new NoConverterAvailableException();
 		} else {

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/IConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/IConverterSupport.java
@@ -166,17 +166,6 @@ public interface IConverterSupport {
 		}
 	}
 
-	/**
-	 * Returns the list of all available export suppliers.
-	 * 
-	 * @return List<ISupplier>
-	 */
-	@Deprecated
-	default List<ISupplier> getExportSupplier() {
-
-		return new ArrayList<>(getSupplier(EXPORT_SUPPLIER));
-	}
-
 	DataCategory getDataCategory();
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.fsd.converter.ui/src/org/eclipse/chemclipse/fsd/converter/ui/swt/FluorescenceSpectrumFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.fsd.converter.ui/src/org/eclipse/chemclipse/fsd/converter/ui/swt/FluorescenceSpectrumFileSupport.java
@@ -14,6 +14,8 @@ package org.eclipse.chemclipse.fsd.converter.ui.swt;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.io.FilenameUtils;
@@ -62,7 +64,6 @@ public class FluorescenceSpectrumFileSupport {
 	 * @param spectrum
 	 * @throws NoConverterAvailableException
 	 */
-	@SuppressWarnings("deprecation")
 	public static void saveSpectrum(Shell shell, ISpectrumFSD spectrum, String fileName) throws NoConverterAvailableException {
 
 		if(spectrum == null) {
@@ -77,7 +78,7 @@ public class FluorescenceSpectrumFileSupport {
 		dialog.setOverwrite(true);
 		IScanConverterSupport converterSupport = ScanConverterFSD.getScanConverterSupport();
 		/*
-		 * Set the filters that allow an export of chromatographic data.
+		 * Set the filters that allow an export of fluorescence data.
 		 */
 		String[] filterExtensions = converterSupport.getFilterExtensions(IConverterSupport.EXPORT_SUPPLIER);
 		dialog.setFilterExtensions(filterExtensions);
@@ -85,7 +86,8 @@ public class FluorescenceSpectrumFileSupport {
 		dialog.setFilterNames(filterNames);
 		String filename = dialog.open();
 		if(filename != null) {
-			validateFile(dialog, converterSupport.getExportSupplier(), shell, spectrum);
+			Collection<? extends ISupplier> suppliers = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
+			validateFile(dialog, new ArrayList<>(suppliers), shell, spectrum);
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.fsd.converter.ui/src/org/eclipse/chemclipse/fsd/converter/ui/swt/FluorescenceSpectrumFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.fsd.converter.ui/src/org/eclipse/chemclipse/fsd/converter/ui/swt/FluorescenceSpectrumFileSupport.java
@@ -86,7 +86,7 @@ public class FluorescenceSpectrumFileSupport {
 		dialog.setFilterNames(filterNames);
 		String filename = dialog.open();
 		if(filename != null) {
-			Collection<? extends ISupplier> suppliers = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
+			Collection<ISupplier> suppliers = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
 			validateFile(dialog, new ArrayList<>(suppliers), shell, spectrum);
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.fsd.converter.ui/src/org/eclipse/chemclipse/fsd/converter/ui/swt/FluorescenceSpectrumFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.fsd.converter.ui/src/org/eclipse/chemclipse/fsd/converter/ui/swt/FluorescenceSpectrumFileSupport.java
@@ -17,6 +17,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 import org.apache.commons.io.FilenameUtils;
+import org.eclipse.chemclipse.converter.core.IConverterSupport;
 import org.eclipse.chemclipse.converter.exceptions.NoConverterAvailableException;
 import org.eclipse.chemclipse.converter.scan.IScanConverterSupport;
 import org.eclipse.chemclipse.converter.ui.l10n.ConverterMessagesUI;
@@ -80,7 +81,7 @@ public class FluorescenceSpectrumFileSupport {
 		 */
 		String[] filterExtensions = converterSupport.getExportableFilterExtensions();
 		dialog.setFilterExtensions(filterExtensions);
-		String[] filterNames = converterSupport.getExportableFilterNames();
+		String[] filterNames = converterSupport.getFilterNames(IConverterSupport.EXPORT_SUPPLIER);
 		dialog.setFilterNames(filterNames);
 		String filename = dialog.open();
 		if(filename != null) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.fsd.converter.ui/src/org/eclipse/chemclipse/fsd/converter/ui/swt/FluorescenceSpectrumFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.fsd.converter.ui/src/org/eclipse/chemclipse/fsd/converter/ui/swt/FluorescenceSpectrumFileSupport.java
@@ -79,7 +79,7 @@ public class FluorescenceSpectrumFileSupport {
 		/*
 		 * Set the filters that allow an export of chromatographic data.
 		 */
-		String[] filterExtensions = converterSupport.getExportableFilterExtensions();
+		String[] filterExtensions = converterSupport.getFilterExtensions(IConverterSupport.EXPORT_SUPPLIER);
 		dialog.setFilterExtensions(filterExtensions);
 		String[] filterNames = converterSupport.getFilterNames(IConverterSupport.EXPORT_SUPPLIER);
 		dialog.setFilterNames(filterNames);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/charts/ChartPCR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/charts/ChartPCR.java
@@ -17,9 +17,10 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
-import java.util.List;
+import java.util.Collection;
 import java.util.Locale;
 
+import org.eclipse.chemclipse.converter.core.IConverterSupport;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.pcr.converter.core.PlateConverterPCR;
 import org.eclipse.chemclipse.pcr.converter.support.IPlateConverterSupport;
@@ -107,11 +108,10 @@ public class ChartPCR extends LineChart {
 		primaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.0#E0"), new DecimalFormatSymbols(Locale.ENGLISH))); //$NON-NLS-1$
 	}
 
-	@SuppressWarnings("deprecation")
 	private void setExportMenu(IChartSettings settings) {
 
 		IPlateConverterSupport converterSupport = PlateConverterPCR.getPlateConverterSupport();
-		List<ISupplier> exportSupplier = converterSupport.getExportSupplier();
+		Collection<? extends ISupplier> exportSupplier = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
 		for(ISupplier supplier : exportSupplier) {
 			settings.addMenuEntry(new IChartMenuEntry() {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/charts/ChartPCR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/charts/ChartPCR.java
@@ -111,7 +111,7 @@ public class ChartPCR extends LineChart {
 	private void setExportMenu(IChartSettings settings) {
 
 		IPlateConverterSupport converterSupport = PlateConverterPCR.getPlateConverterSupport();
-		Collection<? extends ISupplier> exportSupplier = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
+		Collection<ISupplier> exportSupplier = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
 		for(ISupplier supplier : exportSupplier) {
 			settings.addMenuEntry(new IChartMenuEntry() {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/support/PCRFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/support/PCRFileSupport.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.io.FilenameUtils;
+import org.eclipse.chemclipse.converter.core.IConverterSupport;
 import org.eclipse.chemclipse.converter.exceptions.NoConverterAvailableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.pcr.converter.core.PlateConverterPCR;
@@ -60,7 +61,7 @@ public class PCRFileSupport {
 		if(converterSupport != null) {
 			String[] filterExtensions = converterSupport.getExportableFilterExtensions();
 			dialog.setFilterExtensions(filterExtensions);
-			String[] filterNames = converterSupport.getExportableFilterNames();
+			String[] filterNames = converterSupport.getFilterNames(IConverterSupport.EXPORT_SUPPLIER);
 			dialog.setFilterNames(filterNames);
 			/*
 			 * Opens the dialog.<br/> Use converterSupport.getExportSupplier()

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/support/PCRFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/support/PCRFileSupport.java
@@ -59,7 +59,7 @@ public class PCRFileSupport {
 
 		IPlateConverterSupport converterSupport = PlateConverterPCR.getPlateConverterSupport();
 		if(converterSupport != null) {
-			String[] filterExtensions = converterSupport.getExportableFilterExtensions();
+			String[] filterExtensions = converterSupport.getFilterExtensions(IConverterSupport.EXPORT_SUPPLIER);
 			dialog.setFilterExtensions(filterExtensions);
 			String[] filterNames = converterSupport.getFilterNames(IConverterSupport.EXPORT_SUPPLIER);
 			dialog.setFilterNames(filterNames);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/support/PCRFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/support/PCRFileSupport.java
@@ -71,7 +71,7 @@ public class PCRFileSupport {
 			 */
 			String filename = dialog.open();
 			if(filename != null) {
-				Collection<? extends ISupplier> exportSupplier = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
+				Collection<ISupplier> exportSupplier = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
 				return validateFile(dialog, new ArrayList<>(exportSupplier), shell, plate, filename);
 			} else {
 				return null;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/support/PCRFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/support/PCRFileSupport.java
@@ -15,6 +15,8 @@ package org.eclipse.chemclipse.ux.extension.pcr.ui.support;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -41,7 +43,6 @@ public class PCRFileSupport {
 
 	}
 
-	@SuppressWarnings("deprecation")
 	public static File savePlate(Shell shell, IPlate plate, String filterPath) throws NoConverterAvailableException {
 
 		if(plate == null || shell == null) {
@@ -70,8 +71,8 @@ public class PCRFileSupport {
 			 */
 			String filename = dialog.open();
 			if(filename != null) {
-				List<ISupplier> exportSupplier = converterSupport.getExportSupplier();
-				return validateFile(dialog, exportSupplier, shell, plate, filename);
+				Collection<? extends ISupplier> exportSupplier = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
+				return validateFile(dialog, new ArrayList<>(exportSupplier), shell, plate, filename);
 			} else {
 				return null;
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartNMR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartNMR.java
@@ -75,7 +75,7 @@ public class ChartNMR extends LineChart {
 		if(measurementSupplier != null) {
 			IChartSettings settings = getChartSettings();
 			IScanConverterSupport converterSupport = ScanConverterNMR.getScanConverterSupport();
-			Collection<? extends ISupplier> exportSupplier = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
+			Collection<ISupplier> exportSupplier = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
 			for(ISupplier supplier : exportSupplier) {
 				settings.addMenuEntry(new IChartMenuEntry() {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartNMR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartNMR.java
@@ -23,6 +23,7 @@ import java.util.Locale;
 import java.util.function.Supplier;
 import java.util.stream.StreamSupport;
 
+import org.eclipse.chemclipse.converter.core.IConverterSupport;
 import org.eclipse.chemclipse.converter.scan.IScanConverterSupport;
 import org.eclipse.chemclipse.model.core.IComplexSignalMeasurement;
 import org.eclipse.chemclipse.model.core.ISignal;
@@ -67,7 +68,6 @@ public class ChartNMR extends LineChart {
 		this(parent, style, null);
 	}
 
-	@SuppressWarnings("deprecation")
 	public ChartNMR(Composite parent, int style, Supplier<IComplexSignalMeasurement<?>> measurementSupplier) {
 
 		super(parent, style);
@@ -75,7 +75,7 @@ public class ChartNMR extends LineChart {
 		if(measurementSupplier != null) {
 			IChartSettings settings = getChartSettings();
 			IScanConverterSupport converterSupport = ScanConverterNMR.getScanConverterSupport();
-			List<ISupplier> exportSupplier = converterSupport.getExportSupplier();
+			Collection<? extends ISupplier> exportSupplier = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
 			for(ISupplier supplier : exportSupplier) {
 				settings.addMenuEntry(new IChartMenuEntry() {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/editors/ChromatogramFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/editors/ChromatogramFileSupport.java
@@ -111,7 +111,7 @@ public class ChromatogramFileSupport {
 		 * Get the names and extensions.
 		 */
 		String[] names = chromatogramConverterSupport.getFilterNames(IConverterSupport.EXPORT_SUPPLIER);
-		String[] extensions = chromatogramConverterSupport.getExportableFilterExtensions();
+		String[] extensions = chromatogramConverterSupport.getFilterExtensions(IConverterSupport.EXPORT_SUPPLIER);
 		List<ISupplier> suppliers = chromatogramConverterSupport.getExportSupplier();
 		if(extensions.length != names.length) {
 			throw new NoConverterAvailableException("The size of extensions and names is unequal.");

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/editors/ChromatogramFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/editors/ChromatogramFileSupport.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 import org.apache.commons.io.FilenameUtils;
 import org.eclipse.chemclipse.converter.chromatogram.IChromatogramConverterSupport;
+import org.eclipse.chemclipse.converter.core.IConverterSupport;
 import org.eclipse.chemclipse.converter.exceptions.NoConverterAvailableException;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.fsd.converter.chromatogram.ChromatogramConverterFSD;
@@ -109,7 +110,7 @@ public class ChromatogramFileSupport {
 		/*
 		 * Get the names and extensions.
 		 */
-		String[] names = chromatogramConverterSupport.getExportableFilterNames();
+		String[] names = chromatogramConverterSupport.getFilterNames(IConverterSupport.EXPORT_SUPPLIER);
 		String[] extensions = chromatogramConverterSupport.getExportableFilterExtensions();
 		List<ISupplier> suppliers = chromatogramConverterSupport.getExportSupplier();
 		if(extensions.length != names.length) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/editors/ChromatogramFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/editors/ChromatogramFileSupport.java
@@ -15,6 +15,7 @@ package org.eclipse.chemclipse.ux.extension.xxd.ui.internal.editors;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -103,7 +104,6 @@ public class ChromatogramFileSupport {
 		return false;
 	}
 
-	@SuppressWarnings("deprecation")
 	private static Map<Integer, ISupplier> setExportConverter(IChromatogramConverterSupport chromatogramConverterSupport, FileDialog fileDialog) throws NoConverterAvailableException {
 
 		Map<Integer, ISupplier> exportSupplierMap = new HashMap<>();
@@ -112,7 +112,7 @@ public class ChromatogramFileSupport {
 		 */
 		String[] names = chromatogramConverterSupport.getFilterNames(IConverterSupport.EXPORT_SUPPLIER);
 		String[] extensions = chromatogramConverterSupport.getFilterExtensions(IConverterSupport.EXPORT_SUPPLIER);
-		List<ISupplier> suppliers = chromatogramConverterSupport.getExportSupplier();
+		Collection<? extends ISupplier> suppliers = chromatogramConverterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
 		if(extensions.length != names.length) {
 			throw new NoConverterAvailableException("The size of extensions and names is unequal.");
 		}
@@ -172,7 +172,7 @@ public class ChromatogramFileSupport {
 		return exportSupplierMap;
 	}
 
-	private static ISupplier getSupplier(String filterName, List<ISupplier> suppliers) {
+	private static ISupplier getSupplier(String filterName, Collection<? extends ISupplier> suppliers) {
 
 		for(ISupplier supplier : suppliers) {
 			if(supplier.isExportable() && supplier.getFilterName().equals(filterName)) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/editors/ChromatogramFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/editors/ChromatogramFileSupport.java
@@ -112,7 +112,7 @@ public class ChromatogramFileSupport {
 		 */
 		String[] names = chromatogramConverterSupport.getFilterNames(IConverterSupport.EXPORT_SUPPLIER);
 		String[] extensions = chromatogramConverterSupport.getFilterExtensions(IConverterSupport.EXPORT_SUPPLIER);
-		Collection<? extends ISupplier> suppliers = chromatogramConverterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
+		Collection<ISupplier> suppliers = chromatogramConverterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
 		if(extensions.length != names.length) {
 			throw new NoConverterAvailableException("The size of extensions and names is unequal.");
 		}
@@ -172,7 +172,7 @@ public class ChromatogramFileSupport {
 		return exportSupplierMap;
 	}
 
-	private static ISupplier getSupplier(String filterName, Collection<? extends ISupplier> suppliers) {
+	private static ISupplier getSupplier(String filterName, Collection<ISupplier> suppliers) {
 
 		for(ISupplier supplier : suppliers) {
 			if(supplier.isExportable() && supplier.getFilterName().equals(filterName)) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.ui/src/org/eclipse/chemclipse/vsd/converter/ui/swt/VibrationalSpectroscopyFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.ui/src/org/eclipse/chemclipse/vsd/converter/ui/swt/VibrationalSpectroscopyFileSupport.java
@@ -14,6 +14,8 @@ package org.eclipse.chemclipse.vsd.converter.ui.swt;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.io.FilenameUtils;
@@ -63,7 +65,6 @@ public class VibrationalSpectroscopyFileSupport {
 	 * @param spectrum
 	 * @throws NoConverterAvailableException
 	 */
-	@SuppressWarnings("deprecation")
 	public static void saveSpectrum(Shell shell, ISpectrumVSD spectrum, String fileName) throws NoConverterAvailableException {
 
 		if(spectrum == null) {
@@ -78,7 +79,7 @@ public class VibrationalSpectroscopyFileSupport {
 		dialog.setOverwrite(true);
 		IScanConverterSupport converterSupport = ScanConverterVSD.getScanConverterSupport();
 		/*
-		 * Set the filters that allow an export of chromatographic data.
+		 * Set the filters that allow an export of IR data.
 		 */
 		String[] filterExtensions = converterSupport.getFilterExtensions(IConverterSupport.EXPORT_SUPPLIER);
 		dialog.setFilterExtensions(filterExtensions);
@@ -86,7 +87,8 @@ public class VibrationalSpectroscopyFileSupport {
 		dialog.setFilterNames(filterNames);
 		String filename = dialog.open();
 		if(filename != null) {
-			validateFile(dialog, converterSupport.getExportSupplier(), shell, spectrum);
+			Collection<? extends ISupplier> suppliers = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
+			validateFile(dialog, new ArrayList<>(suppliers), shell, spectrum);
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.ui/src/org/eclipse/chemclipse/vsd/converter/ui/swt/VibrationalSpectroscopyFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.ui/src/org/eclipse/chemclipse/vsd/converter/ui/swt/VibrationalSpectroscopyFileSupport.java
@@ -17,6 +17,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 import org.apache.commons.io.FilenameUtils;
+import org.eclipse.chemclipse.converter.core.IConverterSupport;
 import org.eclipse.chemclipse.converter.exceptions.NoConverterAvailableException;
 import org.eclipse.chemclipse.converter.scan.IScanConverterSupport;
 import org.eclipse.chemclipse.converter.ui.l10n.ConverterMessagesUI;
@@ -81,7 +82,7 @@ public class VibrationalSpectroscopyFileSupport {
 		 */
 		String[] filterExtensions = converterSupport.getExportableFilterExtensions();
 		dialog.setFilterExtensions(filterExtensions);
-		String[] filterNames = converterSupport.getExportableFilterNames();
+		String[] filterNames = converterSupport.getFilterNames(IConverterSupport.EXPORT_SUPPLIER);
 		dialog.setFilterNames(filterNames);
 		String filename = dialog.open();
 		if(filename != null) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.ui/src/org/eclipse/chemclipse/vsd/converter/ui/swt/VibrationalSpectroscopyFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.ui/src/org/eclipse/chemclipse/vsd/converter/ui/swt/VibrationalSpectroscopyFileSupport.java
@@ -87,7 +87,7 @@ public class VibrationalSpectroscopyFileSupport {
 		dialog.setFilterNames(filterNames);
 		String filename = dialog.open();
 		if(filename != null) {
-			Collection<? extends ISupplier> suppliers = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
+			Collection<ISupplier> suppliers = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
 			validateFile(dialog, new ArrayList<>(suppliers), shell, spectrum);
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.ui/src/org/eclipse/chemclipse/vsd/converter/ui/swt/VibrationalSpectroscopyFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.ui/src/org/eclipse/chemclipse/vsd/converter/ui/swt/VibrationalSpectroscopyFileSupport.java
@@ -80,7 +80,7 @@ public class VibrationalSpectroscopyFileSupport {
 		/*
 		 * Set the filters that allow an export of chromatographic data.
 		 */
-		String[] filterExtensions = converterSupport.getExportableFilterExtensions();
+		String[] filterExtensions = converterSupport.getFilterExtensions(IConverterSupport.EXPORT_SUPPLIER);
 		dialog.setFilterExtensions(filterExtensions);
 		String[] filterNames = converterSupport.getFilterNames(IConverterSupport.EXPORT_SUPPLIER);
 		dialog.setFilterNames(filterNames);

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.ui/src/org/eclipse/chemclipse/wsd/converter/ui/swt/UVVisSpectrumFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.ui/src/org/eclipse/chemclipse/wsd/converter/ui/swt/UVVisSpectrumFileSupport.java
@@ -79,7 +79,7 @@ public class UVVisSpectrumFileSupport {
 		/*
 		 * Set the filters that allow an export of chromatographic data.
 		 */
-		String[] filterExtensions = converterSupport.getExportableFilterExtensions();
+		String[] filterExtensions = converterSupport.getFilterExtensions(IConverterSupport.EXPORT_SUPPLIER);
 		dialog.setFilterExtensions(filterExtensions);
 		String[] filterNames = converterSupport.getFilterNames(IConverterSupport.EXPORT_SUPPLIER);
 		dialog.setFilterNames(filterNames);

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.ui/src/org/eclipse/chemclipse/wsd/converter/ui/swt/UVVisSpectrumFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.ui/src/org/eclipse/chemclipse/wsd/converter/ui/swt/UVVisSpectrumFileSupport.java
@@ -17,6 +17,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 import org.apache.commons.io.FilenameUtils;
+import org.eclipse.chemclipse.converter.core.IConverterSupport;
 import org.eclipse.chemclipse.converter.exceptions.NoConverterAvailableException;
 import org.eclipse.chemclipse.converter.scan.IScanConverterSupport;
 import org.eclipse.chemclipse.converter.ui.l10n.ConverterMessagesUI;
@@ -80,7 +81,7 @@ public class UVVisSpectrumFileSupport {
 		 */
 		String[] filterExtensions = converterSupport.getExportableFilterExtensions();
 		dialog.setFilterExtensions(filterExtensions);
-		String[] filterNames = converterSupport.getExportableFilterNames();
+		String[] filterNames = converterSupport.getFilterNames(IConverterSupport.EXPORT_SUPPLIER);
 		dialog.setFilterNames(filterNames);
 		String filename = dialog.open();
 		if(filename != null) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.ui/src/org/eclipse/chemclipse/wsd/converter/ui/swt/UVVisSpectrumFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.ui/src/org/eclipse/chemclipse/wsd/converter/ui/swt/UVVisSpectrumFileSupport.java
@@ -86,7 +86,7 @@ public class UVVisSpectrumFileSupport {
 		dialog.setFilterNames(filterNames);
 		String filename = dialog.open();
 		if(filename != null) {
-			Collection<? extends ISupplier> suppliers = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
+			Collection<ISupplier> suppliers = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
 			validateFile(dialog, new ArrayList<>(suppliers), shell, spectrum);
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.ui/src/org/eclipse/chemclipse/wsd/converter/ui/swt/UVVisSpectrumFileSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.ui/src/org/eclipse/chemclipse/wsd/converter/ui/swt/UVVisSpectrumFileSupport.java
@@ -14,6 +14,8 @@ package org.eclipse.chemclipse.wsd.converter.ui.swt;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.io.FilenameUtils;
@@ -62,7 +64,6 @@ public class UVVisSpectrumFileSupport {
 	 * @param spectrum
 	 * @throws NoConverterAvailableException
 	 */
-	@SuppressWarnings("deprecation")
 	public static void saveSpectrum(Shell shell, ISpectrumWSD spectrum, String fileName) throws NoConverterAvailableException {
 
 		if(spectrum == null) {
@@ -77,7 +78,7 @@ public class UVVisSpectrumFileSupport {
 		dialog.setOverwrite(true);
 		IScanConverterSupport converterSupport = ScanConverterWSD.getScanConverterSupport();
 		/*
-		 * Set the filters that allow an export of chromatographic data.
+		 * Set the filters that allow an export of UV/Vis data.
 		 */
 		String[] filterExtensions = converterSupport.getFilterExtensions(IConverterSupport.EXPORT_SUPPLIER);
 		dialog.setFilterExtensions(filterExtensions);
@@ -85,7 +86,8 @@ public class UVVisSpectrumFileSupport {
 		dialog.setFilterNames(filterNames);
 		String filename = dialog.open();
 		if(filename != null) {
-			validateFile(dialog, converterSupport.getExportSupplier(), shell, spectrum);
+			Collection<? extends ISupplier> suppliers = converterSupport.getSupplier(IConverterSupport.EXPORT_SUPPLIER);
+			validateFile(dialog, new ArrayList<>(suppliers), shell, spectrum);
 		}
 	}
 


### PR DESCRIPTION
This is another incomplete API refactor that started over 6 years ago https://github.com/eclipse-chemclipse/chemclipse/commit/839cf1f7a6dab7a66aeedea05aaacc00ab45785e and was never finished. It was released in 0.8.0 so it is time to finally end this.