### PR TITLE
Use ILog.error method directly

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/dialogs/PerspectiveChooserDialog.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/dialogs/PerspectiveChooserDialog.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 
 import org.eclipse.chemclipse.rcp.app.ui.Activator;
 import org.eclipse.chemclipse.rcp.app.ui.preferences.PreferenceSupplier;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.preference.IPersistentPreferenceStore;
@@ -56,12 +56,6 @@ public class PerspectiveChooserDialog extends Dialog {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see
-	 * org.eclipse.jface.window.Window#configureShell(org.eclipse.swt.widgets
-	 * .Shell)
-	 */
 	@Override
 	protected void configureShell(Shell shell) {
 
@@ -71,9 +65,6 @@ public class PerspectiveChooserDialog extends Dialog {
 		}
 	}
 
-	/*
-	 * (non-Javadoc) Method declared on Dialog.
-	 */
 	@Override
 	protected void buttonPressed(int buttonId) {
 
@@ -90,7 +81,7 @@ public class PerspectiveChooserDialog extends Dialog {
 					try {
 						store.save();
 					} catch(IOException e) {
-						Activator.getDefault().getLog().log(Status.error("Saving preferences failed", e));
+						ILog.get().error("Saving preferences failed", e);
 					}
 				}
 			}
@@ -98,9 +89,6 @@ public class PerspectiveChooserDialog extends Dialog {
 		super.buttonPressed(buttonId);
 	}
 
-	/*
-	 * (non-Javadoc) Method declared on Dialog.
-	 */
 	@Override
 	protected Control createDialogArea(Composite parent) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/DataExplorerTreeUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/DataExplorerTreeUI.java
@@ -22,12 +22,11 @@ import java.util.function.Function;
 
 import org.eclipse.chemclipse.processing.converter.ISupplier;
 import org.eclipse.chemclipse.processing.converter.ISupplierFileIdentifier;
-import org.eclipse.chemclipse.ux.extension.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.ui.l10n.ExtensionMessages;
 import org.eclipse.chemclipse.ux.extension.ui.listener.DataExplorerDragListener;
 import org.eclipse.chemclipse.ux.extension.ui.provider.DataExplorerContentProvider;
 import org.eclipse.chemclipse.ux.extension.ui.provider.DataExplorerLabelProvider;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.jface.preference.IPersistentPreferenceStore;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.viewers.StructuredSelection;
@@ -139,7 +138,7 @@ public class DataExplorerTreeUI {
 				try {
 					persistentPreferenceStore.save();
 				} catch(IOException e) {
-					Activator.getDefault().getLog().log(Status.error(ExtensionMessages.storingPreferencesFailed, e));
+					ILog.get().error(ExtensionMessages.storingPreferencesFailed, e);
 				}
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/TaskTile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/TaskTile.java
@@ -18,9 +18,8 @@ import java.util.function.Function;
 
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.swt.ui.support.Fonts;
-import org.eclipse.chemclipse.ux.extension.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.ui.definitions.TileDefinition;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
@@ -228,7 +227,7 @@ public class TaskTile extends Composite {
 			try {
 				definitionConsumer.accept(definition);
 			} catch(RuntimeException e) {
-				Activator.getDefault().getLog().log(Status.error("Invoke of consumer failed", e)); //$NON-NLS-1$
+				ILog.get().error("Invoke of consumer failed", e); //$NON-NLS-1$
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/runnables/LibraryServiceRunnable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/runnables/LibraryServiceRunnable.java
@@ -24,12 +24,11 @@ import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.identifier.library.ILibraryService;
 import org.eclipse.chemclipse.msd.identifier.library.LibraryService;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
-import org.eclipse.chemclipse.msd.model.core.IScanMSD; 
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.core.runtime.Adapters;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 
@@ -89,7 +88,7 @@ public class LibraryServiceRunnable implements IRunnableWithProgress {
 					return;
 				}
 			} catch(Exception e) {
-				Activator.getDefault().getLog().log(Status.error("Fetching mass spectrum failed!", e));
+				ILog.get().error("Fetching mass spectrum failed!", e);
 			}
 		}
 		libraryMassSpectrumConsumer.accept(null);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedComparisonScanUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedComparisonScanUI.java
@@ -62,8 +62,8 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.ScanChartSuppor
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.ScanDataSupport;
 import org.eclipse.chemclipse.vsd.model.core.IScanVSD;
 import org.eclipse.chemclipse.wsd.model.core.IScanWSD;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.e4.ui.di.Focus;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.preference.IPreferencePage;
@@ -283,7 +283,7 @@ public class ExtendedComparisonScanUI extends Composite implements IExtendedPart
 		} catch(InterruptedException e) {
 			Thread.currentThread().interrupt();
 		} catch(ExecutionException e) {
-			Activator.getDefault().getLog().log(Status.error("Updating the reference scan failed.", e));
+			ILog.get().error("Updating the reference scan failed.", e);
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSubtractScanUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSubtractScanUI.java
@@ -33,13 +33,12 @@ import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
 import org.eclipse.chemclipse.swt.ui.notifier.UpdateNotifierUI;
 import org.eclipse.chemclipse.ux.extension.ui.swt.IExtendedPartUI;
-import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.preferences.PreferenceSupplierModelMSD;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageScans;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageSubtract;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.runnables.LibraryServiceRunnable;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.e4.ui.di.Focus;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.swt.SWT;
@@ -276,7 +275,7 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 					} catch(InterruptedException ex) {
 						Thread.currentThread().interrupt();
 					} catch(ExecutionException ex) {
-						Activator.getDefault().getLog().log(Status.error("Fetch comparison scan failed.", ex));
+						ILog.get().error("Fetch comparison scan failed.", ex);
 					}
 				}
 			}


### PR DESCRIPTION
Makes the code easier to read and reduces dependencies on activators.