### PR TITLE
Fixed wrong chromatogram icon being displayed in Data Explorer

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.ui/src/org/eclipse/chemclipse/msd/converter/ui/adapter/PeakSupplierAdapterFactory.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.ui/src/org/eclipse/chemclipse/msd/converter/ui/adapter/PeakSupplierAdapterFactory.java
@@ -15,6 +15,7 @@ package org.eclipse.chemclipse.msd.converter.ui.adapter;
 import org.eclipse.chemclipse.msd.converter.peak.IPeakSupplier;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
+import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.ux.extension.ui.editors.EditorDescriptor;
 import org.eclipse.chemclipse.ux.extension.ui.editors.SnippetEditorDescriptor;
 import org.eclipse.core.runtime.IAdapterFactory;
@@ -44,7 +45,7 @@ public class PeakSupplierAdapterFactory implements IAdapterFactory, SnippetEdito
 	@Override
 	public ImageDescriptor getImageDescriptor() {
 
-		return ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_PEAKS, IApplicationImage.SIZE_16x16);
+		return ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_PEAKS, IApplicationImageProvider.SIZE_16x16);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/peak/PeakConverterMSDSupplierContext.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/peak/PeakConverterMSDSupplierContext.java
@@ -22,7 +22,7 @@ import org.osgi.service.component.annotations.Component;
 public class PeakConverterMSDSupplierContext implements SupplierContext {
 
 	@Override
-	public Collection<ISupplier> getSupplier() {
+	public Collection<ISupplier> getSuppliers() {
 
 		return PeakConverterMSD.getPeakConverterSupport().getSupplier();
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing.ui/src/org/eclipse/chemclipse/processing/ui/internal/provider/EclipseSupplierFileIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing.ui/src/org/eclipse/chemclipse/processing/ui/internal/provider/EclipseSupplierFileIdentifier.java
@@ -39,7 +39,7 @@ public class EclipseSupplierFileIdentifier implements SupplierContext {
 	private Collection<ISupplier> list;
 
 	@Override
-	public Collection<ISupplier> getSupplier() {
+	public Collection<ISupplier> getSuppliers() {
 
 		if(list == null) {
 			ArrayList<ISupplier> items = new ArrayList<>();

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/converter/AbstractSupplierFileIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/converter/AbstractSupplierFileIdentifier.java
@@ -31,13 +31,13 @@ public abstract class AbstractSupplierFileIdentifier implements ISupplierFileIde
 	public boolean isSupplierFile(File file) {
 
 		if(file.isFile()) {
-			for(ISupplier supplier : getSupplier()) {
+			for(ISupplier supplier : getSuppliers()) {
 				if(isValidFileSupplier(file, supplier)) {
 					return true;
 				}
 			}
 		} else if(file.isDirectory()) {
-			for(ISupplier supplier : getSupplier()) {
+			for(ISupplier supplier : getSuppliers()) {
 				if(isValidDirectorySupplier(file, supplier)) {
 					return true;
 				}
@@ -47,17 +47,17 @@ public abstract class AbstractSupplierFileIdentifier implements ISupplierFileIde
 	}
 
 	@Override
-	public Collection<ISupplier> getSupplier(File file) {
+	public Collection<ISupplier> getSuppliers(File file) {
 
 		List<ISupplier> list = new ArrayList<>();
 		if(file.isFile()) {
-			for(ISupplier supplier : getSupplier()) {
+			for(ISupplier supplier : getSuppliers()) {
 				if(isValidFileSupplier(file, supplier) && isMatchMagicNumber(file)) {
 					list.add(supplier);
 				}
 			}
 		} else if(file.isDirectory()) {
-			for(ISupplier supplier : getSupplier()) {
+			for(ISupplier supplier : getSuppliers()) {
 				if(isValidDirectorySupplier(file, supplier) && isMatchMagicNumber(file)) {
 					list.add(supplier);
 				}
@@ -121,7 +121,7 @@ public abstract class AbstractSupplierFileIdentifier implements ISupplierFileIde
 	}
 
 	@Override
-	public Collection<ISupplier> getSupplier() {
+	public Collection<ISupplier> getSuppliers() {
 
 		return suppliers;
 	}
@@ -153,7 +153,7 @@ public abstract class AbstractSupplierFileIdentifier implements ISupplierFileIde
 	@Override
 	public boolean isMatchMagicNumber(File file) {
 
-		for(ISupplier supplier : getSupplier()) {
+		for(ISupplier supplier : getSuppliers()) {
 			if(supplier.isMatchMagicNumber(file)) {
 				return true;
 			}
@@ -164,7 +164,7 @@ public abstract class AbstractSupplierFileIdentifier implements ISupplierFileIde
 	@Override
 	public boolean isMatchContent(File file) {
 
-		for(ISupplier supplier : getSupplier()) {
+		for(ISupplier supplier : getSuppliers()) {
 			if(supplier.isMatchMagicNumber(file) && supplier.isMatchContent(file)) {
 				return true;
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/converter/ISupplierFileIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/converter/ISupplierFileIdentifier.java
@@ -67,7 +67,7 @@ public interface ISupplierFileIdentifier extends SupplierContext {
 	 */
 	default boolean isSupplierFile(File file) {
 
-		return !getSupplier(file).isEmpty();
+		return !getSuppliers(file).isEmpty();
 	}
 
 	/**
@@ -76,7 +76,7 @@ public interface ISupplierFileIdentifier extends SupplierContext {
 	 * @param file
 	 * @return
 	 */
-	Collection<ISupplier> getSupplier(File file);
+	Collection<ISupplier> getSuppliers(File file);
 
 	/**
 	 * Try to match the magic number of the file format.

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/converter/SupplierContext.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/converter/SupplierContext.java
@@ -17,5 +17,5 @@ import java.util.Collection;
 
 public interface SupplierContext {
 
-	Collection<ISupplier> getSupplier();
+	Collection<ISupplier> getSuppliers();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/internal/OSGiSupplierFileIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/internal/OSGiSupplierFileIdentifier.java
@@ -55,11 +55,11 @@ public class OSGiSupplierFileIdentifier extends AbstractSupplierFileIdentifier i
 	}
 
 	@Override
-	public Collection<ISupplier> getSupplier() {
+	public Collection<ISupplier> getSuppliers() {
 
 		List<ISupplier> list = new ArrayList<>();
 		for(SupplierContext context : supplierContexts) {
-			list.addAll(context.getSupplier());
+			list.addAll(context.getSuppliers());
 		}
 		return list;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/part/support/GenericSupplierEditorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/part/support/GenericSupplierEditorSupport.java
@@ -57,15 +57,15 @@ public class GenericSupplierEditorSupport implements ISupplierFileEditorSupport 
 	}
 
 	@Override
-	public Collection<ISupplier> getSupplier(File file) {
+	public Collection<ISupplier> getSuppliers(File file) {
 
-		return fileIdentifier.getSupplier(file);
+		return fileIdentifier.getSuppliers(file);
 	}
 
 	@Override
-	public Collection<ISupplier> getSupplier() {
+	public Collection<ISupplier> getSuppliers() {
 
-		return fileIdentifier.getSupplier();
+		return fileIdentifier.getSuppliers();
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/src/org/eclipse/chemclipse/xxd/process/files/SupplierFileIdentifierCache.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/src/org/eclipse/chemclipse/xxd/process/files/SupplierFileIdentifierCache.java
@@ -57,6 +57,7 @@ public class SupplierFileIdentifierCache implements Function<File, Map<ISupplier
 			list = new LinkedHashMap<>();
 			for(ISupplierFileIdentifier supplierFileIdentifier : fileIdentifiers) {
 				Collection<ISupplier> suppliers = supplierFileIdentifier.getSuppliers(file);
+				suppliers.removeIf(s -> !s.isMatchMagicNumber(file) || !s.isMatchContent(file));
 				if(!suppliers.isEmpty()) {
 					list.put(supplierFileIdentifier, Collections.unmodifiableCollection(suppliers));
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/src/org/eclipse/chemclipse/xxd/process/files/SupplierFileIdentifierCache.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/src/org/eclipse/chemclipse/xxd/process/files/SupplierFileIdentifierCache.java
@@ -56,9 +56,9 @@ public class SupplierFileIdentifierCache implements Function<File, Map<ISupplier
 		if(list == null) {
 			list = new LinkedHashMap<>();
 			for(ISupplierFileIdentifier supplierFileIdentifier : fileIdentifiers) {
-				Collection<ISupplier> supplier = supplierFileIdentifier.getSupplier(file);
-				if(!supplier.isEmpty()) {
-					list.put(supplierFileIdentifier, Collections.unmodifiableCollection(supplier));
+				Collection<ISupplier> suppliers = supplierFileIdentifier.getSuppliers(file);
+				if(!suppliers.isEmpty()) {
+					list.put(supplierFileIdentifier, Collections.unmodifiableCollection(suppliers));
 				}
 			}
 			list = Collections.unmodifiableMap(list);


### PR DESCRIPTION
This was apparent for `.ocb` GC-FID files, for example. These would always be detected as MS and labeled with the red instead of the green icon because the label provider did not filter and picked the first entry from a list of too many possibilities. I do the magic number check first, so I hope to not regress performance too much with the file content match afterward.