### PR TITLE
Fix a crash when there is no m/z array in mzML

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramReaderVersion10.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramReaderVersion10.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -219,6 +219,10 @@ public class ChromatogramReaderVersion10 extends AbstractChromatogramReader impl
 			} catch(DataFormatException e) {
 				logger.error(e);
 			}
+		}
+		if(mzs == null || intensities == null) {
+			logger.warn("Ignoring spectrum " + spectrum.getIndex() + " " + spectrum.getId());
+			return;
 		}
 		SpectrumDescriptionType spectrumDescription = spectrum.getSpectrumDescription();
 		double selectedIon = getSelectedIon(spectrumDescription);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramReaderVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramReaderVersion110.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -255,6 +255,10 @@ public class ChromatogramReaderVersion110 extends AbstractChromatogramReader imp
 			} catch(DataFormatException e) {
 				logger.error(e);
 			}
+		}
+		if(mzs == null || intensities == null) {
+			logger.warn("Ignoring spectrum " + spectrum.getIndex() + " " + spectrum.getId());
+			return;
 		}
 		double selectedIon = getSelectedIon(spectrum);
 		massSpectrum.setPrecursorIon(selectedIon);


### PR DESCRIPTION
Some applications mix MS and DAD data, which we don't yet support. This resolves the crash and at least shows the MS traces. I currently can't detect the separate DAD chromatogram because the file contents are not labeled as such. https://github.com/Nesvilab/MSFragger/issues/399