### PR TITLE
Array related code cleanup

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.assets.ui/src/org/eclipse/chemclipse/assets/ui/wizards/AssetInstallPage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.assets.ui/src/org/eclipse/chemclipse/assets/ui/wizards/AssetInstallPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Christoph Läubrich.
+ * Copyright (c) 2020, 2026 Christoph Läubrich.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -217,8 +217,8 @@ public class AssetInstallPage extends WizardPage {
 				/*
 				 * Display available options.
 				 */
-				fileDialog.setFilterNames(new String[]{"Zipped Assets (*.zip)"});
-				fileDialog.setFilterExtensions(new String[]{"*.zip"});
+				fileDialog.setFilterNames("Zipped Assets (*.zip)");
+				fileDialog.setFilterExtensions("*.zip");
 
 				String open = fileDialog.open();
 				if(open != null) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/AbstractCosineComparator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/AbstractCosineComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -67,8 +67,8 @@ public abstract class AbstractCosineComparator extends AbstractMassSpectrumCompa
 	public double calculateCosinePhi(IExtractedIonSignal unknownSignal, IExtractedIonSignal referenceSignal) {
 
 		int size = unknownSignal.getNumberOfIonValues();
-		double unknown[] = new double[size];
-		double reference[] = new double[size];
+		double[] unknown = new double[size];
+		double[] reference = new double[size];
 		for(int i = unknownSignal.getStartIon(),
 				j = 0; i <= unknownSignal.getStopIon(); i++, j++) {
 			unknown[j] = getVectorValue(unknownSignal, i);
@@ -98,8 +98,8 @@ public abstract class AbstractCosineComparator extends AbstractMassSpectrumCompa
 			}
 		}
 
-		double unknown[] = new double[ionList.size()];
-		double reference[] = new double[ionList.size()];
+		double[] unknown = new double[ionList.size()];
+		double[] reference = new double[ionList.size()];
 		int j = 0;
 		for(int ion : ionList) {
 			unknown[j] = unknownSignal.getAbundance(ion);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.vsd.filter.ui/src/org/eclipse/chemclipse/chromatogram/vsd/filter/ui/swt/WavenumberSignalsEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.vsd.filter.ui/src/org/eclipse/chemclipse/chromatogram/vsd/filter/ui/swt/WavenumberSignalsEditor.java
@@ -309,8 +309,8 @@ public class WavenumberSignalsEditor extends Composite implements IChangeListene
 
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText(IMPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{WavenumberSignals.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{WavenumberSignals.FILTER_NAME});
+				fileDialog.setFilterExtensions(WavenumberSignals.FILTER_EXTENSION);
+				fileDialog.setFilterNames(WavenumberSignals.FILTER_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathImport());
 				String path = fileDialog.open();
 				if(path != null) {
@@ -339,8 +339,8 @@ public class WavenumberSignalsEditor extends Composite implements IChangeListene
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 				fileDialog.setOverwrite(true);
 				fileDialog.setText(EXPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{WavenumberSignals.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{WavenumberSignals.FILTER_NAME});
+				fileDialog.setFilterExtensions(WavenumberSignals.FILTER_EXTENSION);
+				fileDialog.setFilterNames(WavenumberSignals.FILTER_NAME);
 				fileDialog.setFileName(WavenumberSignals.FILE_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathExport());
 				String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.vsd.filter.ui/src/org/eclipse/chemclipse/chromatogram/vsd/filter/ui/swt/WavenumberSignalsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.vsd.filter.ui/src/org/eclipse/chemclipse/chromatogram/vsd/filter/ui/swt/WavenumberSignalsUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Lablicate GmbH.
+ * Copyright (c) 2024, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,7 +18,6 @@ import org.eclipse.chemclipse.chromatogram.vsd.filter.ui.internal.provider.Waven
 import org.eclipse.chemclipse.support.ui.provider.ListContentProvider;
 import org.eclipse.chemclipse.support.ui.swt.ExtendedTableViewer;
 import org.eclipse.chemclipse.support.updates.IUpdateListener;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class WavenumberSignalsUI extends ExtendedTableViewer {
@@ -67,6 +66,6 @@ public class WavenumberSignalsUI extends ExtendedTableViewer {
 		setLabelProvider(labelProvider);
 		setContentProvider(new ListContentProvider());
 		setComparator(tableComparator);
-		setFilters(new ViewerFilter[]{listFilter});
+		setFilters(listFilter);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/editors/EditorCalibration.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/editors/EditorCalibration.java
@@ -66,8 +66,8 @@ public class EditorCalibration extends MultiPageEditorPart {
 
 		FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 		fileDialog.setText("Save the *.cal file.");
-		fileDialog.setFilterExtensions(new String[]{"*.cal"});
-		fileDialog.setFilterNames(new String[]{"AMDIS Calibration *.cal"});
+		fileDialog.setFilterExtensions("*.cal");
+		fileDialog.setFilterNames("AMDIS Calibration *.cal");
 		String pathRetentionIndexFile = fileDialog.open();
 		if(pathRetentionIndexFile != null) {
 			File file = new File(pathRetentionIndexFile);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/processors/CalibrationFileExportProcessSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/processors/CalibrationFileExportProcessSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -90,8 +90,8 @@ public class CalibrationFileExportProcessSupplier implements IProcessTypeSupplie
 							FileDialog fileDialog = new FileDialog(display.getActiveShell(), SWT.SAVE);
 							fileDialog.setOverwrite(true);
 							fileDialog.setText(CalibrationFile.DESCRIPTION);
-							fileDialog.setFilterExtensions(new String[]{CalibrationFile.FILTER_EXTENSION});
-							fileDialog.setFilterNames(new String[]{CalibrationFile.FILTER_NAME});
+							fileDialog.setFilterExtensions(CalibrationFile.FILTER_EXTENSION);
+							fileDialog.setFilterNames(CalibrationFile.FILTER_NAME);
 							fileDialog.setFileName(fileName);
 							fileDialog.setFilterPath(PreferenceSupplier.getListPathExport());
 							String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/swt/IndexAssignerListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/swt/IndexAssignerListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,7 +24,6 @@ import org.eclipse.chemclipse.support.updates.IUpdateListener;
 import org.eclipse.jface.viewers.IContentProvider;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.TableViewerColumn;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class IndexAssignerListUI extends ExtendedTableViewer {
@@ -55,7 +54,7 @@ public class IndexAssignerListUI extends ExtendedTableViewer {
 		setLabelProvider(labelProvider);
 		setContentProvider(contentProvider);
 		setComparator(new IndexAssignerTableComparator());
-		setFilters(new ViewerFilter[]{listFilter});
+		setFilters(listFilter);
 		setEditingSupport();
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/swt/RetentionIndexAssignerEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/swt/RetentionIndexAssignerEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -353,8 +353,8 @@ public class RetentionIndexAssignerEditor extends Composite implements IChangeLi
 
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText(IMPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{RetentionIndexAssigner.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{RetentionIndexAssigner.FILTER_NAME});
+				fileDialog.setFilterExtensions(RetentionIndexAssigner.FILTER_EXTENSION);
+				fileDialog.setFilterNames(RetentionIndexAssigner.FILTER_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathImportTemplate());
 				String path = fileDialog.open();
 				if(path != null) {
@@ -383,8 +383,8 @@ public class RetentionIndexAssignerEditor extends Composite implements IChangeLi
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 				fileDialog.setOverwrite(true);
 				fileDialog.setText(EXPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{RetentionIndexAssigner.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{RetentionIndexAssigner.FILTER_NAME});
+				fileDialog.setFilterExtensions(RetentionIndexAssigner.FILTER_EXTENSION);
+				fileDialog.setFilterNames(RetentionIndexAssigner.FILTER_NAME);
 				fileDialog.setFileName(RetentionIndexAssigner.FILE_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathExportTemplate());
 				String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/swt/RetentionIndexMarkerEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/swt/RetentionIndexMarkerEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 Lablicate GmbH.
+ * Copyright (c) 2022, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -345,8 +345,8 @@ public class RetentionIndexMarkerEditor extends Composite implements IChangeList
 
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText(IMPORT_TITLE_FILE);
-				fileDialog.setFilterExtensions(new String[]{CalibrationFile.FILTER_EXTENSION + ";" + CalibrationFile.FILTER_EXTENSION.toUpperCase()});
-				fileDialog.setFilterNames(new String[]{CalibrationFile.FILTER_NAME});
+				fileDialog.setFilterExtensions(CalibrationFile.FILTER_EXTENSION + ";" + CalibrationFile.FILTER_EXTENSION.toUpperCase());
+				fileDialog.setFilterNames(CalibrationFile.FILTER_NAME);
 				/*
 				 * Import *.cal files from a specified directory.
 				 */
@@ -469,8 +469,8 @@ public class RetentionIndexMarkerEditor extends Composite implements IChangeList
 
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText(IMPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{RetentionIndexMarker.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{RetentionIndexMarker.FILTER_NAME});
+				fileDialog.setFilterExtensions(RetentionIndexMarker.FILTER_EXTENSION);
+				fileDialog.setFilterNames(RetentionIndexMarker.FILTER_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathImportTemplate());
 				String path = fileDialog.open();
 				if(path != null) {
@@ -499,8 +499,8 @@ public class RetentionIndexMarkerEditor extends Composite implements IChangeList
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 				fileDialog.setOverwrite(true);
 				fileDialog.setText(EXPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{RetentionIndexMarker.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{RetentionIndexMarker.FILTER_NAME});
+				fileDialog.setFilterExtensions(RetentionIndexMarker.FILTER_EXTENSION);
+				fileDialog.setFilterNames(RetentionIndexMarker.FILTER_NAME);
 				fileDialog.setFileName(RetentionIndexMarker.FILE_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathExportTemplate());
 				String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/PageCalibrationSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/PageCalibrationSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -141,8 +141,8 @@ public class PageCalibrationSettings extends AbstractExtendedWizardPage {
 
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText("Select an existing *.cal template file.");
-				fileDialog.setFilterExtensions(new String[]{"*.cal;*.CAL"});
-				fileDialog.setFilterNames(new String[]{"AMDIS Calibration (*.cal)"});
+				fileDialog.setFilterExtensions("*.cal;*.CAL");
+				fileDialog.setFilterNames("AMDIS Calibration (*.cal)");
 				fileDialog.setFilterPath(wizardElements.getFilterPathCalibrationFile());
 				String pathRetentionIndexFile = fileDialog.open();
 				if(pathRetentionIndexFile != null) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/preferences/PreferenceSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -176,7 +176,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static void setRetentionIndexFiles(List<String> retentionIndexFiles) {
 
 		FileListUtil fileListUtil = new FileListUtil();
-		String items[] = retentionIndexFiles.toArray(new String[retentionIndexFiles.size()]);
+		String[] items = retentionIndexFiles.toArray(new String[retentionIndexFiles.size()]);
 		INSTANCE().put(P_RETENTION_INDEX_FILES, fileListUtil.createList(items));
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/preferences/PreferenceSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -286,7 +286,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static void setMassSpectraFiles(List<String> massSpectraFiles) {
 
 		FileListUtil fileListUtil = new FileListUtil();
-		String items[] = massSpectraFiles.toArray(new String[massSpectraFiles.size()]);
+		String[] items = massSpectraFiles.toArray(new String[massSpectraFiles.size()]);
 		INSTANCE().put(P_MASS_SPECTRA_FILES, fileListUtil.createList(items));
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model.ui/src/org/eclipse/chemclipse/model/ui/swt/LibraryInformationListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model.ui/src/org/eclipse/chemclipse/model/ui/swt/LibraryInformationListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,7 +26,6 @@ import org.eclipse.chemclipse.support.ui.swt.ExtendedTableViewer;
 import org.eclipse.jface.viewers.IContentProvider;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.ViewerComparator;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 
@@ -136,6 +135,6 @@ public class LibraryInformationListUI extends ExtendedTableViewer {
 		setContentProvider(contentProviderNormal);
 		setComparator(comparator);
 		setUseHashlookup(true);
-		setFilters(new ViewerFilter[]{listFilter});
+		setFilters(listFilter);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis.ui/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/ui/wizards/DatabaseCollectorPage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis.ui/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/ui/wizards/DatabaseCollectorPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -119,8 +119,8 @@ public class DatabaseCollectorPage extends WizardPage {
 				FileDialog fileDialog = new FileDialog(e.display.getActiveShell(), SWT.SAVE);
 				fileDialog.setOverwrite(true);
 				fileDialog.setText(MSL.DESCRIPTION);
-				fileDialog.setFilterExtensions(new String[]{MSL.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{MSL.FILTER_NAME});
+				fileDialog.setFilterExtensions(MSL.FILTER_EXTENSION);
+				fileDialog.setFilterNames(MSL.FILTER_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getPathExport());
 				fileDialog.setFileName("CollectedLibrary" + MSL.FILE_EXTENSION);
 				String pathname = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/identification/SynonymsListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/identification/SynonymsListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,14 +26,16 @@ import org.eclipse.swt.widgets.Composite;
 public class SynonymsListUI extends ExtendedTableViewer {
 
 	private String[] titles = {"Synonym"};
-	private int bounds[] = {300};
+	private int[] bounds = {300};
 
 	public SynonymsListUI(Composite parent) {
+
 		super(parent);
 		createColumns();
 	}
 
 	public SynonymsListUI(Composite parent, int style) {
+
 		super(parent, style);
 		createColumns();
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/MassSpectrumListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/MassSpectrumListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -37,7 +37,6 @@ import org.eclipse.jface.viewers.IStructuredContentProvider;
 import org.eclipse.jface.viewers.ITableLabelProvider;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.jface.viewers.ViewerComparator;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
@@ -222,7 +221,7 @@ public class MassSpectrumListUI extends ExtendedTableViewer {
 
 		setLabelAndContentProviders(isVirtualTable());
 		massSpectrumListFilter = new MassSpectrumListFilter();
-		setFilters(new ViewerFilter[]{massSpectrumListFilter});
+		setFilters(massSpectrumListFilter);
 		setEditingSupport();
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.processing.supplier.base.ui/src/org/eclipse/chemclipse/nmr/processing/supplier/base/ui/MultiSpectrumEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.processing.supplier.base.ui/src/org/eclipse/chemclipse/nmr/processing/supplier/base/ui/MultiSpectrumEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -46,7 +46,7 @@ public class MultiSpectrumEditor {
 		left.setLayout(new FillLayout());
 		Composite right = new Composite(sashForm, SWT.NONE);
 		right.setLayout(new FillLayout());
-		sashForm.setWeights(new int[]{800, 200});
+		sashForm.setWeights(800, 200);
 		extendedNMROverlayUI = new ExtendedNMROverlayUI(left, SWT.NONE);
 		measurementsUI = new NMRSpectrumSelection(right, filterFactory);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/swt/ChannelMappingTable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/swt/ChannelMappingTable.java
@@ -296,8 +296,8 @@ public class ChannelMappingTable extends Composite implements IChangeListener, I
 
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText(IMPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{FILTER_NAME});
+				fileDialog.setFilterExtensions(FILTER_EXTENSION);
+				fileDialog.setFilterNames(FILTER_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathImport());
 				String path = fileDialog.open();
 				if(path != null) {
@@ -326,8 +326,8 @@ public class ChannelMappingTable extends Composite implements IChangeListener, I
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 				fileDialog.setOverwrite(true);
 				fileDialog.setText(EXPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{FILTER_NAME});
+				fileDialog.setFilterExtensions(FILTER_EXTENSION);
+				fileDialog.setFilterNames(FILTER_NAME);
 				fileDialog.setFileName(FILE_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathExport());
 				String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/swt/VirtualChannelTable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/swt/VirtualChannelTable.java
@@ -321,8 +321,8 @@ public class VirtualChannelTable extends Composite implements IChangeListener, I
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 				fileDialog.setOverwrite(true);
 				fileDialog.setText(EXPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{FILTER_NAME});
+				fileDialog.setFilterExtensions(FILTER_EXTENSION);
+				fileDialog.setFilterNames(FILTER_NAME);
 				fileDialog.setFileName(FILE_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathExport());
 				String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/swt/WellMappingTable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/ui/swt/WellMappingTable.java
@@ -298,8 +298,8 @@ public class WellMappingTable extends Composite implements IChangeListener, IExt
 
 				FileDialog fileDialog = new FileDialog(e.widget.getDisplay().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText(IMPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{FILTER_NAME});
+				fileDialog.setFilterExtensions(FILTER_EXTENSION);
+				fileDialog.setFilterNames(FILTER_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathImport());
 				String path = fileDialog.open();
 				if(path != null) {
@@ -328,8 +328,8 @@ public class WellMappingTable extends Composite implements IChangeListener, IExt
 				FileDialog fileDialog = new FileDialog(e.widget.getDisplay().getActiveShell(), SWT.SAVE);
 				fileDialog.setOverwrite(true);
 				fileDialog.setText(EXPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{FILTER_NAME});
+				fileDialog.setFilterExtensions(FILTER_EXTENSION);
+				fileDialog.setFilterNames(FILTER_NAME);
 				fileDialog.setFileName(FILE_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathExport());
 				String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/preferences/editors/IonInputValidator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/preferences/editors/IonInputValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -42,7 +42,7 @@ public class IonInputValidator implements IInputValidator {
 		 * otherwise throw a failure description.
 		 */
 		try {
-			String ionList[] = newText.trim().split("-"); //$NON-NLS-1$
+			String[] ionList = newText.trim().split("-"); //$NON-NLS-1$
 			if(ionList.length == 1) {
 				String ion = String.valueOf(Integer.parseInt(ionList[0].trim()));
 				/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/preferences/editors/WavelengthInputValidator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/preferences/editors/WavelengthInputValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -42,7 +42,7 @@ public class WavelengthInputValidator implements IInputValidator {
 		 * otherwise throw a failure description.
 		 */
 		try {
-			String wavelengthList[] = newText.trim().split("-"); //$NON-NLS-1$
+			String[] wavelengthList = newText.trim().split("-"); //$NON-NLS-1$
 			if(wavelengthList.length == 1) {
 				String wavelength = String.valueOf(Integer.parseInt(wavelengthList[0].trim()));
 				/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/src/org/eclipse/chemclipse/swt/ui/components/peaks/PeakQuantitationListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/src/org/eclipse/chemclipse/swt/ui/components/peaks/PeakQuantitationListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -98,7 +98,7 @@ public class PeakQuantitationListUI extends ExtendedTableViewer {
 		setInput(null);
 	}
 
-	private void setColumns(String[] titles, int bounds[]) {
+	private void setColumns(String[] titles, int[] bounds) {
 
 		createColumns(titles, bounds);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -327,8 +327,8 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 					FileDialog fileDialog = new FileDialog(shell, SWT.SAVE);
 					fileDialog.setText("Mass Spectrum Export");
 					fileDialog.setFileName("Mass Spectrum." + supplier.getFileExtension());
-					fileDialog.setFilterExtensions(new String[]{"*" + supplier.getFileExtension()});
-					fileDialog.setFilterNames(new String[]{supplier.getFilterName()});
+					fileDialog.setFilterExtensions("*" + supplier.getFileExtension());
+					fileDialog.setFilterNames(supplier.getFilterName());
 					String pathname = fileDialog.open();
 					if(pathname != null) {
 						File file = new File(pathname);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -428,8 +428,8 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 						fileName = standaloneMassSpectrum.getName();
 					}
 					fileDialog.setFileName(fileName + "." + supplier.getFileExtension());
-					fileDialog.setFilterExtensions(new String[]{"*" + supplier.getFileExtension()});
-					fileDialog.setFilterNames(new String[]{supplier.getFilterName()});
+					fileDialog.setFilterExtensions("*" + supplier.getFileExtension());
+					fileDialog.setFilterNames(supplier.getFilterName());
 					String pathname = fileDialog.open();
 					if(pathname != null) {
 						File file = new File(pathname);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/wizards/ChromatogramSelectionWizardPage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/wizards/ChromatogramSelectionWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -278,8 +278,8 @@ public class ChromatogramSelectionWizardPage extends WizardPage {
 		List<String> selectedFiles = new ArrayList<>();
 		FileDialog fileDialog = new FileDialog(DisplayUtils.getShell(), SWT.OPEN | SWT.MULTI);
 		fileDialog.setText("Please select the chromatograms used for reporting.");
-		fileDialog.setFilterExtensions(new String[]{"*.ocb"});
-		fileDialog.setFilterNames(new String[]{"Open Chromatography Binary (*.ocb)"});
+		fileDialog.setFilterExtensions("*.ocb");
+		fileDialog.setFilterNames("Open Chromatography Binary (*.ocb)");
 		String value = fileDialog.open();
 		if(value != null) {
 			String directory = fileDialog.getFilterPath();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/charts/ChartPCR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/charts/ChartPCR.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -164,8 +164,8 @@ public class ChartPCR extends LineChart {
 					FileDialog fileDialog = new FileDialog(shell, SWT.SAVE);
 					fileDialog.setText(ExtensionMessages.pcrExport);
 					fileDialog.setFileName(plate.getName() + "." + supplier.getFileExtension()); //$NON-NLS-1$
-					fileDialog.setFilterExtensions(new String[]{"*" + supplier.getFileExtension()}); //$NON-NLS-1$
-					fileDialog.setFilterNames(new String[]{supplier.getFilterName()});
+					fileDialog.setFilterExtensions("*" + supplier.getFileExtension()); //$NON-NLS-1$
+					fileDialog.setFilterNames(supplier.getFilterName());
 					String pathname = fileDialog.open();
 					if(pathname != null) {
 						File file = new File(pathname);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/swt/ExtendedWellChannelsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/swt/ExtendedWellChannelsUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -233,7 +233,7 @@ public class ExtendedWellChannelsUI extends Composite implements IExtendedPartUI
 				}
 			}
 		} else {
-			comboChannels.setItems(new String[]{""});
+			comboChannels.setItems("");
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/handlers/CreateSnapshotHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/handlers/CreateSnapshotHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Lablicate GmbH.
+ * Copyright (c) 2011, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -52,9 +52,9 @@ public class CreateSnapshotHandler {
 				FileDialog fileDialog = new FileDialog(DisplayUtils.getShell(), SWT.SAVE);
 				fileDialog.setText("Save Clipboard To File");
 				fileDialog.setFileName("Clipboard.png");
-				fileDialog.setFilterExtensions(new String[]{"*.png"});
+				fileDialog.setFilterExtensions("*.png");
 				fileDialog.setOverwrite(true);
-				fileDialog.setFilterNames(new String[]{" PNG (*.png)"});
+				fileDialog.setFilterNames(" PNG (*.png)");
 				String file = fileDialog.open();
 				if(file != null && !file.equals("")) {
 					ImageLoader imageLoader = new ImageLoader();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/locations/UserLocationsListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/locations/UserLocationsListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,6 @@ import org.eclipse.chemclipse.ux.extension.ui.internal.provider.UserLocationsFil
 import org.eclipse.chemclipse.ux.extension.ui.internal.provider.UserLocationsLabelProvider;
 import org.eclipse.jface.viewers.ITableLabelProvider;
 import org.eclipse.jface.viewers.ViewerComparator;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class UserLocationsListUI extends ExtendedTableViewer {
@@ -59,6 +58,6 @@ public class UserLocationsListUI extends ExtendedTableViewer {
 		setLabelProvider(labelProvider);
 		setContentProvider(new ListContentProvider());
 		setComparator(tableComparator);
-		setFilters(new ViewerFilter[]{listFilter});
+		setFilters(listFilter);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/locations/UserLocationsSettingsEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/locations/UserLocationsSettingsEditor.java
@@ -334,8 +334,8 @@ public class UserLocationsSettingsEditor implements SettingsUIProvider.SettingsU
 
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText("User Locations");
-				fileDialog.setFilterExtensions(new String[]{UserLocations.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{UserLocations.FILTER_NAME});
+				fileDialog.setFilterExtensions(UserLocations.FILTER_EXTENSION);
+				fileDialog.setFilterNames(UserLocations.FILTER_NAME);
 				fileDialog.setFilterPath(PreferenceSupplierDataExplorer.getUserLocationsTemplateFolder());
 				String pathname = fileDialog.open();
 				if(pathname != null) {
@@ -364,8 +364,8 @@ public class UserLocationsSettingsEditor implements SettingsUIProvider.SettingsU
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 				fileDialog.setOverwrite(true);
 				fileDialog.setText("User Locations");
-				fileDialog.setFilterExtensions(new String[]{UserLocations.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{UserLocations.FILTER_NAME});
+				fileDialog.setFilterExtensions(UserLocations.FILTER_EXTENSION);
+				fileDialog.setFilterNames(UserLocations.FILTER_NAME);
 				fileDialog.setFileName(UserLocations.FILE_NAME);
 				fileDialog.setFilterPath(PreferenceSupplierDataExplorer.getUserLocationsTemplateFolder());
 				String pathname = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/locations/UserLocationsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/locations/UserLocationsUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -269,8 +269,8 @@ public class UserLocationsUI extends Composite {
 				if(userLocations != null) {
 					FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 					fileDialog.setText(IMPORT_TITLE);
-					fileDialog.setFilterExtensions(new String[]{UserLocations.FILTER_EXTENSION});
-					fileDialog.setFilterNames(new String[]{UserLocations.FILTER_NAME});
+					fileDialog.setFilterExtensions(UserLocations.FILTER_EXTENSION);
+					fileDialog.setFilterNames(UserLocations.FILTER_NAME);
 					fileDialog.setFilterPath(PreferenceSupplierDataExplorer.getUserLocationsTemplateFolder());
 					String path = fileDialog.open();
 					if(path != null) {
@@ -302,8 +302,8 @@ public class UserLocationsUI extends Composite {
 					FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 					fileDialog.setOverwrite(true);
 					fileDialog.setText(EXPORT_TITLE);
-					fileDialog.setFilterExtensions(new String[]{UserLocations.FILTER_EXTENSION});
-					fileDialog.setFilterNames(new String[]{UserLocations.FILTER_NAME});
+					fileDialog.setFilterExtensions(UserLocations.FILTER_EXTENSION);
+					fileDialog.setFilterNames(UserLocations.FILTER_NAME);
 					fileDialog.setFileName(UserLocations.FILE_NAME);
 					fileDialog.setFilterPath(PreferenceSupplierDataExplorer.getUserLocationsTemplateFolder());
 					String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/methods/MethodSupportUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/methods/MethodSupportUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -481,8 +481,8 @@ public class MethodSupportUI extends Composite implements IExtendedPartUI {
 		fileDialog.setOverwrite(true);
 		fileDialog.setText(ExtensionMessages.processMethod);
 		fileDialog.setFileName(MethodConverter.FILE_NAME);
-		fileDialog.setFilterExtensions(new String[]{MethodConverter.FILTER_EXTENSION});
-		fileDialog.setFilterNames(new String[]{MethodConverter.FILTER_NAME});
+		fileDialog.setFilterExtensions(MethodConverter.FILTER_EXTENSION);
+		fileDialog.setFilterNames(MethodConverter.FILTER_NAME);
 		fileDialog.setFilterPath(MethodConverter.getUserMethodDirectory().getAbsolutePath());
 
 		File file = null;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/ProcessMethodToolbar.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/ProcessMethodToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -350,8 +350,8 @@ public class ProcessMethodToolbar extends ToolBar {
 						FileDialog fileDialog = new FileDialog(toolBar.getShell(), SWT.OPEN);
 						fileDialog.setText("Select Process Method File");
 						fileDialog.setFileName(MethodConverter.FILE_NAME);
-						fileDialog.setFilterExtensions(new String[]{MethodConverter.FILTER_EXTENSION});
-						fileDialog.setFilterNames(new String[]{MethodConverter.FILTER_NAME});
+						fileDialog.setFilterExtensions(MethodConverter.FILTER_EXTENSION);
+						fileDialog.setFilterNames(MethodConverter.FILTER_NAME);
 
 						String filePath = fileDialog.open();
 						if(filePath != null) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/calibration/RetentionIndexTableViewerUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/calibration/RetentionIndexTableViewerUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,7 +24,6 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.RetentionInd
 import org.eclipse.jface.viewers.IContentProvider;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.TableViewerColumn;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class RetentionIndexTableViewerUI extends ExtendedTableViewer {
@@ -55,7 +54,7 @@ public class RetentionIndexTableViewerUI extends ExtendedTableViewer {
 		setLabelProvider(labelProvider);
 		setContentProvider(contentProvider);
 		setComparator(new RetentionIndexTableComparator());
-		setFilters(new ViewerFilter[]{retentionIndexListFilter});
+		setFilters(retentionIndexListFilter);
 		setEditingSupport();
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartNMR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/charts/ChartNMR.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -102,8 +102,8 @@ public class ChartNMR extends LineChart {
 
 						FileDialog fileDialog = new FileDialog(shell, SWT.SAVE);
 						fileDialog.setText("NMR Export");
-						fileDialog.setFilterExtensions(new String[]{"*" + supplier.getFileExtension()});
-						fileDialog.setFilterNames(new String[]{supplier.getFilterName()});
+						fileDialog.setFilterExtensions("*" + supplier.getFileExtension());
+						fileDialog.setFilterNames(supplier.getFilterName());
 						String pathname = fileDialog.open();
 						if(pathname != null) {
 							File file = new File(pathname);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/handlers/CreateProcessMethodHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/handlers/CreateProcessMethodHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -47,8 +47,8 @@ public class CreateProcessMethodHandler {
 			FileDialog fileDialog = new FileDialog(shell, SWT.SAVE);
 			fileDialog.setOverwrite(true);
 			fileDialog.setText(ExtensionMessages.processMethod);
-			fileDialog.setFilterExtensions(new String[]{MethodConverter.FILTER_EXTENSION});
-			fileDialog.setFilterNames(new String[]{MethodConverter.FILTER_NAME});
+			fileDialog.setFilterExtensions(MethodConverter.FILTER_EXTENSION);
+			fileDialog.setFilterNames(MethodConverter.FILTER_NAME);
 			fileDialog.setFileName(MethodConverter.FILE_NAME);
 			fileDialog.setFilterPath(MethodConverter.getUserMethodDirectory().getAbsolutePath());
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/instruments/InstrumentsSettingsEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/instruments/InstrumentsSettingsEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -328,8 +328,8 @@ public class InstrumentsSettingsEditor implements SettingsUIProvider.SettingsUIC
 
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText(ExtensionMessages.instrumentList);
-				fileDialog.setFilterExtensions(new String[]{FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{FILTER_NAME});
+				fileDialog.setFilterExtensions(FILTER_EXTENSION);
+				fileDialog.setFilterNames(FILTER_NAME);
 				fileDialog.setFilterPath(preferenceStore.getString(PreferenceSupplier.P_INSTRUMENTS_TEMPLATE_FOLDER));
 				String pathname = fileDialog.open();
 				if(pathname != null) {
@@ -359,8 +359,8 @@ public class InstrumentsSettingsEditor implements SettingsUIProvider.SettingsUIC
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 				fileDialog.setOverwrite(true);
 				fileDialog.setText(ExtensionMessages.instrumentList);
-				fileDialog.setFilterExtensions(new String[]{FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{FILTER_NAME});
+				fileDialog.setFilterExtensions(FILTER_EXTENSION);
+				fileDialog.setFilterNames(FILTER_NAME);
 				fileDialog.setFileName(FILE_NAME);
 				fileDialog.setFilterPath(preferenceStore.getString(PreferenceSupplier.P_INSTRUMENTS_TEMPLATE_FOLDER));
 				String pathname = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/InternalStandardsLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/InternalStandardsLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -40,7 +40,7 @@ public class InternalStandardsLabelProvider extends AbstractChemClipseLabelProvi
 			CHEMICAL_CLASS //
 	};
 
-	public static final int BOUNDS[] = {//
+	public static final int[] BOUNDS = {//
 			170, //
 			170, //
 			150, //

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/NoiseSegmentLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/NoiseSegmentLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Lablicate GmbH.
+ * Copyright (c) 2024, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -48,7 +48,7 @@ public class NoiseSegmentLabelProvider extends AbstractChemClipseLabelProvider {
 			NOISE_FACTOR //
 	};
 
-	public static final int BOUNDS[] = { //
+	public static final int[] BOUNDS = { //
 			100, //
 			100, //
 			30, //

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/QuantCompoundLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/QuantCompoundLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -55,7 +55,7 @@ public class QuantCompoundLabelProvider extends AbstractChemClipseLabelProvider 
 			RETENTION_INDEX_UPPER //
 	};
 
-	public static final int BOUNDS[] = { //
+	public static final int[] BOUNDS = { //
 			200, //
 			100, //
 			100, //

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangesEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangesEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -129,8 +129,8 @@ public class TimeRangesEditor extends Composite {
 				if(timeRanges != null) {
 					FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 					fileDialog.setText(TimeRanges.DESCRIPTION);
-					fileDialog.setFilterExtensions(new String[]{TimeRanges.FILTER_EXTENSION});
-					fileDialog.setFilterNames(new String[]{TimeRanges.FILTER_NAME});
+					fileDialog.setFilterExtensions(TimeRanges.FILTER_EXTENSION);
+					fileDialog.setFilterNames(TimeRanges.FILTER_NAME);
 					fileDialog.setFilterPath(preferenceStore.getString(PreferenceSupplier.P_TIME_RANGE_TEMPLATE_FOLDER));
 					String pathname = fileDialog.open();
 					if(pathname != null) {
@@ -160,7 +160,7 @@ public class TimeRangesEditor extends Composite {
 				if(timeRanges != null) {
 					FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 					fileDialog.setText("Chromatogram (*.ocb)");
-					fileDialog.setFilterExtensions(new String[]{"*.ocb"});
+					fileDialog.setFilterExtensions("*.ocb");
 					fileDialog.setFilterPath(preferenceStore.getString(PreferenceSupplier.P_TIME_RANGE_TEMPLATE_FOLDER));
 
 					String pathname = fileDialog.open();
@@ -194,8 +194,8 @@ public class TimeRangesEditor extends Composite {
 					FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 					fileDialog.setOverwrite(true);
 					fileDialog.setText(TimeRanges.DESCRIPTION);
-					fileDialog.setFilterExtensions(new String[]{TimeRanges.FILTER_EXTENSION});
-					fileDialog.setFilterNames(new String[]{TimeRanges.FILTER_NAME});
+					fileDialog.setFilterExtensions(TimeRanges.FILTER_EXTENSION);
+					fileDialog.setFilterNames(TimeRanges.FILTER_NAME);
 					fileDialog.setFileName(TimeRanges.FILE_NAME);
 					fileDialog.setFilterPath(preferenceStore.getString(PreferenceSupplier.P_TIME_RANGE_TEMPLATE_FOLDER));
 					String pathname = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangesEditorUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangesEditorUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Lablicate GmbH.
+ * Copyright (c) 2024, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -311,8 +311,8 @@ public class TimeRangesEditorUI extends Composite implements IChangeListener, IE
 
 				FileDialog fileDialog = new FileDialog(e.widget.getDisplay().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText(IMPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{TimeRanges.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{TimeRanges.FILTER_NAME});
+				fileDialog.setFilterExtensions(TimeRanges.FILTER_EXTENSION);
+				fileDialog.setFilterNames(TimeRanges.FILTER_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathImport());
 				String path = fileDialog.open();
 				if(path != null) {
@@ -341,8 +341,8 @@ public class TimeRangesEditorUI extends Composite implements IChangeListener, IE
 				FileDialog fileDialog = new FileDialog(e.widget.getDisplay().getActiveShell(), SWT.SAVE);
 				fileDialog.setOverwrite(true);
 				fileDialog.setText(EXPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{TimeRanges.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{TimeRanges.FILTER_NAME});
+				fileDialog.setFilterExtensions(TimeRanges.FILTER_EXTENSION);
+				fileDialog.setFilterNames(TimeRanges.FILTER_NAME);
 				fileDialog.setFileName(TimeRanges.FILE_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathExport());
 				String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangesListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangesListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,7 +22,6 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.TimeRangesEd
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.TimeRangesFilter;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.TimeRangesLabelProvider;
 import org.eclipse.jface.viewers.TableViewerColumn;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class TimeRangesListUI extends ExtendedTableViewer {
@@ -76,7 +75,7 @@ public class TimeRangesListUI extends ExtendedTableViewer {
 		setLabelProvider(labelProvider);
 		setContentProvider(new ListContentProvider());
 		setComparator(tableComparator);
-		setFilters(new ViewerFilter[]{listFilter});
+		setFilters(listFilter);
 		setEditingSupport();
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangesSettingsEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangesSettingsEditor.java
@@ -370,8 +370,8 @@ public class TimeRangesSettingsEditor implements SettingsUIProvider.SettingsUICo
 
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText(timeRangeLabels.getTitle());
-				fileDialog.setFilterExtensions(new String[]{TimeRanges.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{TimeRanges.FILTER_NAME});
+				fileDialog.setFilterExtensions(TimeRanges.FILTER_EXTENSION);
+				fileDialog.setFilterNames(TimeRanges.FILTER_NAME);
 				fileDialog.setFilterPath(preferenceStore.getString(PreferenceSupplier.P_TIME_RANGE_TEMPLATE_FOLDER));
 				String pathname = fileDialog.open();
 				if(pathname != null) {
@@ -401,8 +401,8 @@ public class TimeRangesSettingsEditor implements SettingsUIProvider.SettingsUICo
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 				fileDialog.setOverwrite(true);
 				fileDialog.setText(timeRangeLabels.getTitle());
-				fileDialog.setFilterExtensions(new String[]{TimeRanges.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{TimeRanges.FILTER_NAME});
+				fileDialog.setFilterExtensions(TimeRanges.FILTER_EXTENSION);
+				fileDialog.setFilterNames(TimeRanges.FILTER_NAME);
 				fileDialog.setFileName(TimeRanges.FILE_NAME);
 				fileDialog.setFilterPath(preferenceStore.getString(PreferenceSupplier.P_TIME_RANGE_TEMPLATE_FOLDER));
 				String pathname = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/CasNumbersListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/CasNumbersListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 Lablicate GmbH.
+ * Copyright (c) 2022, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,7 +17,6 @@ import org.eclipse.chemclipse.support.ui.swt.ExtendedTableViewer;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.CasNumbersComparator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.CasNumbersLabelProvider;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.CasNumbersListFilter;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class CasNumbersListUI extends ExtendedTableViewer {
@@ -52,6 +51,6 @@ public class CasNumbersListUI extends ExtendedTableViewer {
 		setLabelProvider(labelProvider);
 		setContentProvider(new ListContentProvider());
 		setComparator(comparator);
-		setFilters(new ViewerFilter[]{listFilter});
+		setFilters(listFilter);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ColumnIndicesListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ColumnIndicesListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 Lablicate GmbH.
+ * Copyright (c) 2022, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,7 +17,6 @@ import org.eclipse.chemclipse.support.ui.swt.ExtendedTableViewer;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.ColumnIndicesComparator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.ColumnIndicesLabelProvider;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.ColumnIndicesListFilter;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class ColumnIndicesListUI extends ExtendedTableViewer {
@@ -52,6 +51,6 @@ public class ColumnIndicesListUI extends ExtendedTableViewer {
 		setLabelProvider(labelProvider);
 		setContentProvider(new ListContentProvider());
 		setComparator(comparator);
-		setFilters(new ViewerFilter[]{listFilter});
+		setFilters(listFilter);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ColumnMappingListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ColumnMappingListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,6 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.ColumMapping
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.ColumMappingFilter;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.ColumMappingLabelProvider;
 import org.eclipse.jface.viewers.TableViewerColumn;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class ColumnMappingListUI extends ExtendedTableViewer {
@@ -51,7 +50,7 @@ public class ColumnMappingListUI extends ExtendedTableViewer {
 		setLabelProvider(labelProvider);
 		setContentProvider(new ListContentProvider());
 		setComparator(tableComparator);
-		setFilters(new ViewerFilter[]{listFilter});
+		setFilters(listFilter);
 		setEditingSupport();
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/EditHistoryListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/EditHistoryListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,6 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.EditHistoryL
 import org.eclipse.jface.viewers.IContentProvider;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.ViewerComparator;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class EditHistoryListUI extends ExtendedTableViewer {
@@ -49,6 +48,6 @@ public class EditHistoryListUI extends ExtendedTableViewer {
 		setLabelProvider(labelProvider);
 		setContentProvider(contentProvider);
 		setComparator(comparator);
-		setFilters(new ViewerFilter[]{listFilter});
+		setFilters(listFilter);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramIndicesUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramIndicesUI.java
@@ -148,8 +148,8 @@ public class ExtendedChromatogramIndicesUI extends Composite implements IExtende
 					FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 					fileDialog.setOverwrite(true);
 					fileDialog.setText("Save Calibation Data");
-					fileDialog.setFilterExtensions(new String[]{CalibrationFile.FILTER_EXTENSION});
-					fileDialog.setFilterNames(new String[]{CalibrationFile.FILTER_NAME});
+					fileDialog.setFilterExtensions(CalibrationFile.FILTER_EXTENSION);
+					fileDialog.setFilterNames(CalibrationFile.FILTER_NAME);
 					fileDialog.setFileName(CalibrationFile.FILE_NAME);
 					fileDialog.setFilterPath(PreferenceSupplier.getFilterPathRetentionIndices());
 					String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedEditHistoryUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedEditHistoryUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -139,8 +139,8 @@ public class ExtendedEditHistoryUI extends Composite implements IExtendedPartUI 
 					FileDialog fileDialog = new FileDialog(e.display.getActiveShell(), SWT.SAVE);
 					fileDialog.setOverwrite(true);
 					fileDialog.setText(ExtensionMessages.processMethod);
-					fileDialog.setFilterExtensions(new String[]{MethodConverter.FILTER_EXTENSION});
-					fileDialog.setFilterNames(new String[]{MethodConverter.FILTER_NAME});
+					fileDialog.setFilterExtensions(MethodConverter.FILTER_EXTENSION);
+					fileDialog.setFilterNames(MethodConverter.FILTER_NAME);
 					fileDialog.setFileName(MethodConverter.FILE_NAME);
 					fileDialog.setFilterPath(MethodConverter.getUserMethodDirectory().getAbsolutePath());
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedMoleculeUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedMoleculeUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -367,8 +367,8 @@ public class ExtendedMoleculeUI extends Composite implements IExtendedPartUI {
 					FileDialog fileDialog = new FileDialog(e.display.getActiveShell(), SWT.SAVE);
 					fileDialog.setOverwrite(true);
 					fileDialog.setText("Save Molecule");
-					fileDialog.setFilterExtensions(new String[]{"*.png"});
-					fileDialog.setFilterNames(new String[]{"Portable Network Graphics  (*.png)"});
+					fileDialog.setFilterExtensions("*.png");
+					fileDialog.setFilterNames("Portable Network Graphics  (*.png)");
 					fileDialog.setFileName(getExportName());
 					fileDialog.setFilterPath(preferenceStore.getString(PreferenceSupplier.P_MOLECULE_PATH_EXPORT));
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/FlavorMarkerListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/FlavorMarkerListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 Lablicate GmbH.
+ * Copyright (c) 2022, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,6 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.FlavorMarker
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.FlavorMarkerLabelProvider;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.FlavorMarkerListFilter;
 import org.eclipse.jface.viewers.TableViewerColumn;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class FlavorMarkerListUI extends ExtendedTableViewer {
@@ -56,7 +55,7 @@ public class FlavorMarkerListUI extends ExtendedTableViewer {
 		setLabelProvider(labelProvider);
 		setContentProvider(new ListContentProvider());
 		setComparator(comparator);
-		setFilters(new ViewerFilter[]{listFilter});
+		setFilters(listFilter);
 		setEditingSupport();
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/InstrumentListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/InstrumentListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,7 +23,6 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.InstrumentLa
 import org.eclipse.jface.viewers.ITableLabelProvider;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.jface.viewers.ViewerComparator;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class InstrumentListUI extends ExtendedTableViewer {
@@ -63,7 +62,7 @@ public class InstrumentListUI extends ExtendedTableViewer {
 		setLabelProvider(labelProvider);
 		setContentProvider(new ListContentProvider());
 		setComparator(tableComparator);
-		setFilters(new ViewerFilter[]{listFilter});
+		setFilters(listFilter);
 		setEditingSupport();
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakTargetsViewerUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakTargetsViewerUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,14 +21,16 @@ import org.eclipse.swt.widgets.Composite;
 public class PeakTargetsViewerUI extends ExtendedTableViewer {
 
 	private String[] titles = {"Name", "Match Factor", "Reverse Factor", "Match Factor Direct", "Reverse Factor Direct"};
-	private int bounds[] = {150, 100, 100, 100, 100};
+	private int[] bounds = {150, 100, 100, 100, 100};
 
 	public PeakTargetsViewerUI(Composite parent) {
+
 		super(parent);
 		createColumns();
 	}
 
 	public PeakTargetsViewerUI(Composite parent, int style) {
+
 		super(parent, style);
 		createColumns();
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/QuantCompoundListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/QuantCompoundListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,7 +24,6 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.QuantCompoun
 import org.eclipse.jface.viewers.IBaseLabelProvider;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.jface.viewers.ViewerComparator;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class QuantCompoundListUI extends ExtendedTableViewer {
@@ -38,6 +37,7 @@ public class QuantCompoundListUI extends ExtendedTableViewer {
 	private IQuantitationDatabase quantitationDatabase;
 
 	public QuantCompoundListUI(Composite parent, int style) {
+
 		super(parent, style);
 		createColumns();
 	}
@@ -72,7 +72,7 @@ public class QuantCompoundListUI extends ExtendedTableViewer {
 		setLabelProvider(labelProvider);
 		setContentProvider(new ListContentProvider());
 		setComparator(tableComparator);
-		setFilters(new ViewerFilter[]{viewerFilter});
+		setFilters(viewerFilter);
 		setEditingSupport();
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/QuantReferencesListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/QuantReferencesListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,6 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.QuantReferen
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.QuantReferencesFilter;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.QuantReferencesLabelProvider;
 import org.eclipse.jface.viewers.TableViewerColumn;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class QuantReferencesListUI extends ExtendedTableViewer {
@@ -52,7 +51,7 @@ public class QuantReferencesListUI extends ExtendedTableViewer {
 		setLabelProvider(new QuantReferencesLabelProvider());
 		setContentProvider(new ListContentProvider());
 		setComparator(comparator);
-		setFilters(new ViewerFilter[]{filter});
+		setFilters(filter);
 		setEditingSupport();
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/SequenceFilesUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/SequenceFilesUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,7 +18,6 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.SequenceFile
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.SequenceFilesLabelProvider;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.SequenceFilesTableComparator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.TargetsComparator;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class SequenceFilesUI extends ExtendedTableViewer {
@@ -27,6 +26,7 @@ public class SequenceFilesUI extends ExtendedTableViewer {
 	private SequenceFilesFilter sequenceListFilter;
 
 	public SequenceFilesUI(Composite parent, int style) {
+
 		super(parent, style);
 		sequenceListTableComparator = new SequenceFilesTableComparator();
 		createColumns();
@@ -62,6 +62,6 @@ public class SequenceFilesUI extends ExtendedTableViewer {
 		setContentProvider(new ListContentProvider());
 		setComparator(sequenceListTableComparator);
 		sequenceListFilter = new SequenceFilesFilter();
-		setFilters(new ViewerFilter[]{sequenceListFilter});
+		setFilters(sequenceListFilter);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/SequenceListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/SequenceListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,6 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.SequenceList
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.SequenceListTableComparator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferenceSupplier;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class SequenceListUI extends ExtendedTableViewer {
@@ -66,6 +65,6 @@ public class SequenceListUI extends ExtendedTableViewer {
 		setLabelProvider(labelProvider);
 		setContentProvider(contentProvider);
 		setComparator();
-		setFilters(new ViewerFilter[]{listFilter});
+		setFilters(listFilter);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/SynonymsListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/SynonymsListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 Lablicate GmbH.
+ * Copyright (c) 2022, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,7 +17,6 @@ import org.eclipse.chemclipse.support.ui.swt.ExtendedTableViewer;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.SynonymsComparator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.SynonymsLabelProvider;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.SynonymsListFilter;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class SynonymsListUI extends ExtendedTableViewer {
@@ -52,6 +51,6 @@ public class SynonymsListUI extends ExtendedTableViewer {
 		setLabelProvider(labelProvider);
 		setContentProvider(new ListContentProvider());
 		setComparator(comparator);
-		setFilters(new ViewerFilter[]{listFilter});
+		setFilters(listFilter);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ColumnMappingEditorUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ColumnMappingEditorUI.java
@@ -304,8 +304,8 @@ public class ColumnMappingEditorUI extends Composite implements IChangeListener,
 
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText(IMPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{SeparationColumnMapping.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{SeparationColumnMapping.FILTER_NAME});
+				fileDialog.setFilterExtensions(SeparationColumnMapping.FILTER_EXTENSION);
+				fileDialog.setFilterNames(SeparationColumnMapping.FILTER_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathImport());
 				String path = fileDialog.open();
 				if(path != null) {
@@ -335,8 +335,8 @@ public class ColumnMappingEditorUI extends Composite implements IChangeListener,
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 				fileDialog.setOverwrite(true);
 				fileDialog.setText(EXPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{SeparationColumnMapping.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{SeparationColumnMapping.FILTER_NAME});
+				fileDialog.setFilterExtensions(SeparationColumnMapping.FILTER_EXTENSION);
+				fileDialog.setFilterNames(SeparationColumnMapping.FILTER_NAME);
 				fileDialog.setFileName(SeparationColumnMapping.FILE_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathExport());
 				String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/TraceRangesEditor1D.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/TraceRangesEditor1D.java
@@ -347,8 +347,8 @@ public class TraceRangesEditor1D extends Composite implements IChangeListener, I
 
 				FileDialog fileDialog = new FileDialog(e.widget.getDisplay().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText(IMPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{TraceRanges1D.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{TraceRanges1D.FILTER_NAME});
+				fileDialog.setFilterExtensions(TraceRanges1D.FILTER_EXTENSION);
+				fileDialog.setFilterNames(TraceRanges1D.FILTER_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathImport());
 				String path = fileDialog.open();
 				if(path != null) {
@@ -377,8 +377,8 @@ public class TraceRangesEditor1D extends Composite implements IChangeListener, I
 				FileDialog fileDialog = new FileDialog(e.widget.getDisplay().getActiveShell(), SWT.SAVE);
 				fileDialog.setOverwrite(true);
 				fileDialog.setText(EXPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{TraceRanges1D.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{TraceRanges1D.FILTER_NAME});
+				fileDialog.setFilterExtensions(TraceRanges1D.FILTER_EXTENSION);
+				fileDialog.setFilterNames(TraceRanges1D.FILTER_NAME);
 				fileDialog.setFileName(TraceRanges1D.FILE_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathExport());
 				String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/TraceRangesEditor2D.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/TraceRangesEditor2D.java
@@ -339,8 +339,8 @@ public class TraceRangesEditor2D extends Composite implements IChangeListener, I
 
 				FileDialog fileDialog = new FileDialog(e.widget.getDisplay().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText(IMPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{TraceRanges2D.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{TraceRanges2D.FILTER_NAME});
+				fileDialog.setFilterExtensions(TraceRanges2D.FILTER_EXTENSION);
+				fileDialog.setFilterNames(TraceRanges2D.FILTER_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathImport());
 				String path = fileDialog.open();
 				if(path != null) {
@@ -369,8 +369,8 @@ public class TraceRangesEditor2D extends Composite implements IChangeListener, I
 				FileDialog fileDialog = new FileDialog(e.widget.getDisplay().getActiveShell(), SWT.SAVE);
 				fileDialog.setOverwrite(true);
 				fileDialog.setText(EXPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{TraceRanges2D.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{TraceRanges2D.FILTER_NAME});
+				fileDialog.setFilterExtensions(TraceRanges2D.FILTER_EXTENSION);
+				fileDialog.setFilterNames(TraceRanges2D.FILTER_NAME);
 				fileDialog.setFileName(TraceRanges2D.FILE_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathExport());
 				String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/targets/TargetTemplateListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/targets/TargetTemplateListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,6 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.TargetTempla
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.TargetTemplateFilter;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.TargetTemplateLabelProvider;
 import org.eclipse.jface.viewers.TableViewerColumn;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class TargetTemplateListUI extends ExtendedTableViewer {
@@ -56,7 +55,7 @@ public class TargetTemplateListUI extends ExtendedTableViewer {
 		setLabelProvider(labelProvider);
 		setContentProvider(new ListContentProvider());
 		setComparator(tableComparator);
-		setFilters(new ViewerFilter[]{listFilter});
+		setFilters(listFilter);
 		setEditingSupport();
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/targets/TargetTemplatesUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/targets/TargetTemplatesUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -287,8 +287,8 @@ public class TargetTemplatesUI extends Composite {
 				if(targetTemplates != null) {
 					FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 					fileDialog.setText(IMPORT_TITLE);
-					fileDialog.setFilterExtensions(new String[]{TargetTemplates.FILTER_EXTENSION});
-					fileDialog.setFilterNames(new String[]{TargetTemplates.FILTER_NAME});
+					fileDialog.setFilterExtensions(TargetTemplates.FILTER_EXTENSION);
+					fileDialog.setFilterNames(TargetTemplates.FILTER_NAME);
 					fileDialog.setFilterPath(preferenceStore.getString(PreferenceSupplier.P_TARGET_TEMPLATES_FOLDER));
 					String path = fileDialog.open();
 					if(path != null) {
@@ -320,8 +320,8 @@ public class TargetTemplatesUI extends Composite {
 					FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 					fileDialog.setOverwrite(true);
 					fileDialog.setText(EXPORT_TITLE);
-					fileDialog.setFilterExtensions(new String[]{TargetTemplates.FILTER_EXTENSION});
-					fileDialog.setFilterNames(new String[]{TargetTemplates.FILTER_NAME});
+					fileDialog.setFilterExtensions(TargetTemplates.FILTER_EXTENSION);
+					fileDialog.setFilterNames(TargetTemplates.FILTER_NAME);
 					fileDialog.setFileName(TargetTemplates.FILE_NAME);
 					fileDialog.setFilterPath(preferenceStore.getString(PreferenceSupplier.P_TARGET_TEMPLATES_FOLDER));
 					String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/targets/TargetsSettingsEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/targets/TargetsSettingsEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -398,8 +398,8 @@ public class TargetsSettingsEditor extends Composite implements SettingsUIProvid
 
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText("Target List");
-				fileDialog.setFilterExtensions(new String[]{FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{FILTER_NAME});
+				fileDialog.setFilterExtensions(FILTER_EXTENSION);
+				fileDialog.setFilterNames(FILTER_NAME);
 				fileDialog.setFilterPath(preferenceStore.getString(PreferenceSupplier.P_TARGET_TEMPLATE_LIBRARY_IMPORT_FOLDER));
 				String pathname = fileDialog.open();
 				if(pathname != null) {
@@ -429,8 +429,8 @@ public class TargetsSettingsEditor extends Composite implements SettingsUIProvid
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 				fileDialog.setOverwrite(true);
 				fileDialog.setText("Target List");
-				fileDialog.setFilterExtensions(new String[]{FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{FILTER_NAME});
+				fileDialog.setFilterExtensions(FILTER_EXTENSION);
+				fileDialog.setFilterNames(FILTER_NAME);
 				fileDialog.setFileName(FILE_NAME);
 				fileDialog.setFilterPath(preferenceStore.getString(PreferenceSupplier.P_TARGET_TEMPLATE_LIBRARY_IMPORT_FOLDER));
 				String pathname = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/traces/NamedTracesListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/traces/NamedTracesListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,7 +23,6 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.NamedTracesL
 import org.eclipse.jface.viewers.ITableLabelProvider;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.jface.viewers.ViewerComparator;
-import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Composite;
 
 public class NamedTracesListUI extends ExtendedTableViewer {
@@ -36,6 +35,7 @@ public class NamedTracesListUI extends ExtendedTableViewer {
 	private NamedTracesFilter listFilter = new NamedTracesFilter();
 
 	public NamedTracesListUI(Composite parent, int style) {
+
 		super(parent, style);
 		createColumns();
 	}
@@ -62,7 +62,7 @@ public class NamedTracesListUI extends ExtendedTableViewer {
 		setLabelProvider(labelProvider);
 		setContentProvider(new ListContentProvider());
 		setComparator(tableComparator);
-		setFilters(new ViewerFilter[]{listFilter});
+		setFilters(listFilter);
 		setEditingSupport();
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/traces/NamedTracesSettingsEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/traces/NamedTracesSettingsEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -334,8 +334,8 @@ public class NamedTracesSettingsEditor implements SettingsUIProvider.SettingsUIC
 
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText("Named Trace List");
-				fileDialog.setFilterExtensions(new String[]{NamedTraces.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{NamedTraces.FILTER_NAME});
+				fileDialog.setFilterExtensions(NamedTraces.FILTER_EXTENSION);
+				fileDialog.setFilterNames(NamedTraces.FILTER_NAME);
 				fileDialog.setFilterPath(preferenceStore.getString(PreferenceSupplier.P_NAMED_TRACES_TEMPLATE_FOLDER));
 				String pathname = fileDialog.open();
 				if(pathname != null) {
@@ -365,8 +365,8 @@ public class NamedTracesSettingsEditor implements SettingsUIProvider.SettingsUIC
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 				fileDialog.setOverwrite(true);
 				fileDialog.setText("Named Trace List");
-				fileDialog.setFilterExtensions(new String[]{NamedTraces.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{NamedTraces.FILTER_NAME});
+				fileDialog.setFilterExtensions(NamedTraces.FILTER_EXTENSION);
+				fileDialog.setFilterNames(NamedTraces.FILTER_NAME);
 				fileDialog.setFileName(NamedTraces.FILE_NAME);
 				fileDialog.setFilterPath(preferenceStore.getString(PreferenceSupplier.P_NAMED_TRACES_TEMPLATE_FOLDER));
 				String pathname = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/traces/NamedTracesUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/traces/NamedTracesUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -302,8 +302,8 @@ public class NamedTracesUI extends Composite {
 					IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
 					FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 					fileDialog.setText(IMPORT_TITLE);
-					fileDialog.setFilterExtensions(new String[]{NamedTraces.FILTER_EXTENSION});
-					fileDialog.setFilterNames(new String[]{NamedTraces.FILTER_NAME});
+					fileDialog.setFilterExtensions(NamedTraces.FILTER_EXTENSION);
+					fileDialog.setFilterNames(NamedTraces.FILTER_NAME);
 					fileDialog.setFilterPath(preferenceStore.getString(PreferenceSupplier.P_NAMED_TRACES_TEMPLATE_FOLDER));
 					String path = fileDialog.open();
 					if(path != null) {
@@ -337,8 +337,8 @@ public class NamedTracesUI extends Composite {
 					FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 					fileDialog.setOverwrite(true);
 					fileDialog.setText(EXPORT_TITLE);
-					fileDialog.setFilterExtensions(new String[]{NamedTraces.FILTER_EXTENSION});
-					fileDialog.setFilterNames(new String[]{NamedTraces.FILTER_NAME});
+					fileDialog.setFilterExtensions(NamedTraces.FILTER_EXTENSION);
+					fileDialog.setFilterNames(NamedTraces.FILTER_NAME);
 					fileDialog.setFileName(NamedTraces.FILE_NAME);
 					fileDialog.setFilterPath(preferenceStore.getString(PreferenceSupplier.P_NAMED_TRACES_TEMPLATE_FOLDER));
 					String path = fileDialog.open();
@@ -360,7 +360,7 @@ public class NamedTracesUI extends Composite {
 
 	private void updateInput(String identifier) {
 
-		List<Object> input = new ArrayList<Object>();
+		List<Object> input = new ArrayList<>();
 		if(allowNoSelection) {
 			input.add(NO_SELECTION);
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/wizards/PageLibrarySearch.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/wizards/PageLibrarySearch.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -190,7 +190,7 @@ public class PageLibrarySearch extends AbstractExtendedWizardPage implements IEx
 		SashForm sashForm = new SashForm(composite, SWT.VERTICAL);
 		createTargetList(sashForm);
 		createDetailsSection(sashForm);
-		sashForm.setWeights(new int[]{1, 1});
+		sashForm.setWeights(1, 1);
 	}
 
 	private void createToolbarInfoTop(Composite parent) {
@@ -326,7 +326,7 @@ public class PageLibrarySearch extends AbstractExtendedWizardPage implements IEx
 		createColumnSection(sashForm);
 		createMoleculeSection(sashForm);
 		createLiteratureSection(sashForm);
-		sashForm.setWeights(new int[]{1, 1, 1, 1});
+		sashForm.setWeights(1, 1, 1, 1);
 	}
 
 	private void createFlavorMarkerSection(Composite parent) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.classification.ui/src/org/eclipse/chemclipse/xxd/classification/ui/swt/ClassificationDictionaryEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.classification.ui/src/org/eclipse/chemclipse/xxd/classification/ui/swt/ClassificationDictionaryEditor.java
@@ -276,8 +276,8 @@ public class ClassificationDictionaryEditor extends Composite implements IChange
 
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText(IMPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{ClassificationDictionary.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{ClassificationDictionary.FILTER_NAME});
+				fileDialog.setFilterExtensions(ClassificationDictionary.FILTER_EXTENSION);
+				fileDialog.setFilterNames(ClassificationDictionary.FILTER_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathImport());
 				String path = fileDialog.open();
 				if(path != null) {
@@ -306,8 +306,8 @@ public class ClassificationDictionaryEditor extends Composite implements IChange
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 				fileDialog.setOverwrite(true);
 				fileDialog.setText(EXPORT_TITLE);
-				fileDialog.setFilterExtensions(new String[]{ClassificationDictionary.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{ClassificationDictionary.FILTER_NAME});
+				fileDialog.setFilterExtensions(ClassificationDictionary.FILTER_EXTENSION);
+				fileDialog.setFilterNames(ClassificationDictionary.FILTER_NAME);
 				fileDialog.setFileName(ClassificationDictionary.FILE_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getListPathExport());
 				String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx.ui/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/ui/processors/ChromatogramFileExportProcessSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx.ui/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/ui/processors/ChromatogramFileExportProcessSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -96,8 +96,8 @@ public class ChromatogramFileExportProcessSupplier implements IProcessTypeSuppli
 							FileDialog fileDialog = new FileDialog(display.getActiveShell(), SWT.SAVE);
 							fileDialog.setOverwrite(true);
 							fileDialog.setText(VersionConstants.DESCRIPTION_CHROMATOGRAM);
-							fileDialog.setFilterExtensions(new String[]{VersionConstants.FILTER_EXTENSION_CHROMATOGRAM});
-							fileDialog.setFilterNames(new String[]{VersionConstants.FILTER_NAME_CHROMATOGRAM});
+							fileDialog.setFilterExtensions(VersionConstants.FILTER_EXTENSION_CHROMATOGRAM);
+							fileDialog.setFilterNames(VersionConstants.FILTER_NAME_CHROMATOGRAM);
 							fileDialog.setFileName(fileName);
 							fileDialog.setFilterPath(PreferenceSupplier.getListPathExport());
 							String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/internal/wizards/FileSettingsWizardPage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/internal/wizards/FileSettingsWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -198,8 +198,8 @@ public class FileSettingsWizardPage extends AbstractAnalysisWizardPage {
 
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText("Import");
-				fileDialog.setFilterExtensions(new String[]{PcaExtractionFileText.FILTER_EXTENSION + ";" + PcaExtractionFileBinary.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{PcaExtractionFileText.FILTER_NAME + ";" + PcaExtractionFileBinary.FILTER_NAME});
+				fileDialog.setFilterExtensions(PcaExtractionFileText.FILTER_EXTENSION + ";" + PcaExtractionFileBinary.FILTER_EXTENSION);
+				fileDialog.setFilterNames(PcaExtractionFileText.FILTER_NAME + ";" + PcaExtractionFileBinary.FILTER_NAME);
 				fileDialog.setFilterPath(PreferenceSupplier.getPathImportFile());
 				String path = fileDialog.open();
 				if(path != null) {
@@ -229,8 +229,8 @@ public class FileSettingsWizardPage extends AbstractAnalysisWizardPage {
 
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 				fileDialog.setText(PcaExtractionFileText.DESCRIPTION);
-				fileDialog.setFilterExtensions(new String[]{PcaExtractionFileText.FILTER_EXTENSION});
-				fileDialog.setFilterNames(new String[]{PcaExtractionFileText.FILTER_NAME});
+				fileDialog.setFilterExtensions(PcaExtractionFileText.FILTER_EXTENSION);
+				fileDialog.setFilterNames(PcaExtractionFileText.FILTER_NAME);
 				fileDialog.setOverwrite(true);
 				fileDialog.setFilterPath(PreferenceSupplier.getPathExportFile());
 				String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/internal/wizards/FilesLongFormatSettingsWizardPage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/internal/wizards/FilesLongFormatSettingsWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -255,8 +255,8 @@ public class FilesLongFormatSettingsWizardPage extends AbstractAnalysisWizardPag
 
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText("Import");
-				fileDialog.setFilterExtensions(new String[]{PcaExtractionFileLongText.FILTER_EXTENSION + ";"});
-				fileDialog.setFilterNames(new String[]{PcaExtractionFileLongText.FILTER_NAME + ";"});
+				fileDialog.setFilterExtensions(PcaExtractionFileLongText.FILTER_EXTENSION + ";");
+				fileDialog.setFilterNames(PcaExtractionFileLongText.FILTER_NAME + ";");
 				fileDialog.setFilterPath(PreferenceSupplier.getPathImportFile());
 				String path = fileDialog.open();
 				if(path != null) {
@@ -283,8 +283,8 @@ public class FilesLongFormatSettingsWizardPage extends AbstractAnalysisWizardPag
 
 				FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 				fileDialog.setText("Import");
-				fileDialog.setFilterExtensions(new String[]{PcaExtractionFileLongText.FILTER_EXTENSION + ";"});
-				fileDialog.setFilterNames(new String[]{PcaExtractionFileLongText.FILTER_NAME + ";"});
+				fileDialog.setFilterExtensions(PcaExtractionFileLongText.FILTER_EXTENSION + ";");
+				fileDialog.setFilterNames(PcaExtractionFileLongText.FILTER_NAME + ";");
 				fileDialog.setFilterPath(PreferenceSupplier.getPathImportFile());
 				String path = fileDialog.open();
 				if(path != null) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/internal/wizards/PeakFilesWizardPage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/internal/wizards/PeakFilesWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -38,7 +38,7 @@ public class PeakFilesWizardPage extends DataInputPageWizard {
 	@Override
 	protected void addFiles() {
 
-		InputWizardSettings inputWizardSettings = InputWizardSettings.create(Activator.getDefault().getPreferenceStore(), PreferenceSupplier.N_INPUT_FILE, new DataType[]{DataType.MSD, DataType.CSD});
+		InputWizardSettings inputWizardSettings = InputWizardSettings.create(Activator.getDefault().getPreferenceStore(), PreferenceSupplier.N_INPUT_FILE, DataType.MSD, DataType.CSD);
 		inputWizardSettings.setTitle("Peak Input Files");
 		inputWizardSettings.setDescription("This wizard lets you select several peak input files.");
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/AnalysisEditorUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/AnalysisEditorUI.java
@@ -501,8 +501,8 @@ public class AnalysisEditorUI extends Composite implements IExtendedPartUI {
 				if(samples != null) {
 					FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.READ_ONLY);
 					fileDialog.setText("Import");
-					fileDialog.setFilterExtensions(new String[]{SampleTemplateIO.FILTER_EXTENSION});
-					fileDialog.setFilterNames(new String[]{SampleTemplateIO.FILTER_NAME});
+					fileDialog.setFilterExtensions(SampleTemplateIO.FILTER_EXTENSION);
+					fileDialog.setFilterNames(SampleTemplateIO.FILTER_NAME);
 					fileDialog.setFilterPath(PreferenceSupplier.getPathImportFile());
 					String path = fileDialog.open();
 					if(path != null) {
@@ -536,8 +536,8 @@ public class AnalysisEditorUI extends Composite implements IExtendedPartUI {
 					FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 					fileDialog.setOverwrite(true);
 					fileDialog.setText("Export");
-					fileDialog.setFilterExtensions(new String[]{SampleTemplateIO.FILTER_EXTENSION});
-					fileDialog.setFilterNames(new String[]{SampleTemplateIO.FILTER_NAME});
+					fileDialog.setFilterExtensions(SampleTemplateIO.FILTER_EXTENSION);
+					fileDialog.setFilterNames(SampleTemplateIO.FILTER_NAME);
 					fileDialog.setFileName(SampleTemplateIO.FILE_NAME);
 					fileDialog.setFilterPath(PreferenceSupplier.getPathExportFile());
 					String path = fileDialog.open();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedFeatureListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedFeatureListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -443,8 +443,8 @@ public class ExtendedFeatureListUI extends Composite implements IExtendedPartUI 
 					FileDialog fileDialog = new FileDialog(Display.getCurrent().getActiveShell(), SWT.SAVE);
 					fileDialog.setOverwrite(true);
 					fileDialog.setText("Export");
-					fileDialog.setFilterExtensions(new String[]{FeatureDataMatrixIO.FILTER_EXTENSION});
-					fileDialog.setFilterNames(new String[]{FeatureDataMatrixIO.FILTER_NAME});
+					fileDialog.setFilterExtensions(FeatureDataMatrixIO.FILTER_EXTENSION);
+					fileDialog.setFilterNames(FeatureDataMatrixIO.FILTER_NAME);
 					fileDialog.setFileName(FeatureDataMatrixIO.FILE_NAME);
 					fileDialog.setFilterPath(PreferenceSupplier.getPathExportFile());
 					String path = fileDialog.open();

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/internal/core/support/ChromatogramTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/internal/core/support/ChromatogramTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Lablicate GmbH.
+ * Copyright (c) 2011, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -60,7 +60,7 @@ public class ChromatogramTestCase {
 			try (BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(new FileOutputStream(chromatogramFile), 2048)) {
 				int count;
 				int buffer = 2048;
-				byte data[] = new byte[buffer];
+				byte[] data = new byte[buffer];
 				while((count = zipInputStream.read(data, 0, buffer)) != -1) {
 					bufferedOutputStream.write(data, 0, count);
 				}

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/firstderivative/core/FirstDerivativePeakDetector_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/firstderivative/core/FirstDerivativePeakDetector_2_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -58,9 +58,9 @@ public class FirstDerivativePeakDetector_2_Test extends FirstDerivativeSlopesTes
 	public void testDetectPeakStart_1() throws SecurityException, NoSuchMethodException, IllegalArgumentException, IllegalAccessException, InvocationTargetException {
 
 		Integer result;
-		method = firstDerivativePeakDetectorClass.getDeclaredMethod("detectPeakStart", new Class[]{IFirstDerivativeDetectorSlopes.class, Integer.TYPE, Integer.TYPE, Double.TYPE});
+		method = firstDerivativePeakDetectorClass.getDeclaredMethod("detectPeakStart", IFirstDerivativeDetectorSlopes.class, Integer.TYPE, Integer.TYPE, Double.TYPE);
 		method.setAccessible(true);
-		result = (Integer)method.invoke(firstDerivativePeakDetector, new Object[]{slopes, 1, 0, 0.05d});
+		result = (Integer)method.invoke(firstDerivativePeakDetector, slopes, 1, 0, 0.05d);
 		/*
 		 * The peak starts at scan 4 and has a scan offset of 0 (means starts at
 		 * scan 1).
@@ -72,13 +72,13 @@ public class FirstDerivativePeakDetector_2_Test extends FirstDerivativeSlopesTes
 	public void testDetectPeakMaximum_1() throws SecurityException, NoSuchMethodException, IllegalArgumentException, IllegalAccessException, InvocationTargetException {
 
 		Integer result;
-		method = firstDerivativePeakDetectorClass.getDeclaredMethod("detectPeakMaximum", new Class[]{IFirstDerivativeDetectorSlopes.class, Integer.TYPE, Integer.TYPE});
+		method = firstDerivativePeakDetectorClass.getDeclaredMethod("detectPeakMaximum", IFirstDerivativeDetectorSlopes.class, Integer.TYPE, Integer.TYPE);
 		method.setAccessible(true);
 		/*
 		 * Start the search at the peak beginning at scan 4 and has a scan
 		 * offset of 0 (means starts at scan 1).
 		 */
-		result = (Integer)method.invoke(firstDerivativePeakDetector, new Object[]{slopes, 4, 0});
+		result = (Integer)method.invoke(firstDerivativePeakDetector, slopes, 4, 0);
 		/*
 		 * The peak maximum is at scan 12.
 		 */
@@ -89,16 +89,16 @@ public class FirstDerivativePeakDetector_2_Test extends FirstDerivativeSlopesTes
 	public void testDetectPeakStop_1() throws SecurityException, NoSuchMethodException, IllegalArgumentException, IllegalAccessException, InvocationTargetException {
 
 		Integer result;
-		method = firstDerivativePeakDetectorClass.getDeclaredMethod("detectPeakStop", new Class[]{IFirstDerivativeDetectorSlopes.class, Integer.TYPE, Integer.TYPE});
+		method = firstDerivativePeakDetectorClass.getDeclaredMethod("detectPeakStop", IFirstDerivativeDetectorSlopes.class, Integer.TYPE, Integer.TYPE);
 		method.setAccessible(true);
 		/*
 		 * Start the search at the peak maximum at scan 12 and has a scan offset
 		 * of 0 (means starts at scan 1).
 		 */
-		result = (Integer)method.invoke(firstDerivativePeakDetector, new Object[]{slopes, 12, 0});
+		result = (Integer)method.invoke(firstDerivativePeakDetector, slopes, 12, 0);
 		/*
 		 * The peak stop is at scan 26.
 		 */
-		assertEquals( Integer.valueOf(26), result,"detectPeakStop");
+		assertEquals(Integer.valueOf(26), result, "detectPeakStop");
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/firstderivative/core/FirstDerivativePeakDetector_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/peak/detector/supplier/firstderivative/core/FirstDerivativePeakDetector_3_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -37,9 +37,9 @@ public class FirstDerivativePeakDetector_3_Test {
 
 		RawPeak rawPeak = new RawPeak(25, 26, 27);
 		Boolean result;
-		Method method = firstDerivativePeakDetectorClass.getDeclaredMethod("isValidRawPeak", new Class[]{IRawPeak.class});
+		Method method = firstDerivativePeakDetectorClass.getDeclaredMethod("isValidRawPeak", IRawPeak.class);
 		method.setAccessible(true);
-		result = (Boolean)method.invoke(firstDerivativePeakDetector, new Object[]{rawPeak});
+		result = (Boolean)method.invoke(firstDerivativePeakDetector, rawPeak);
 		assertEquals(Boolean.valueOf(true), result, "detectPeakStart");
 	}
 
@@ -48,9 +48,9 @@ public class FirstDerivativePeakDetector_3_Test {
 
 		RawPeak rawPeak = new RawPeak(25, 25, 26);
 		Boolean result;
-		Method method = firstDerivativePeakDetectorClass.getDeclaredMethod("isValidRawPeak", new Class[]{IRawPeak.class});
+		Method method = firstDerivativePeakDetectorClass.getDeclaredMethod("isValidRawPeak", IRawPeak.class);
 		method.setAccessible(true);
-		result = (Boolean)method.invoke(firstDerivativePeakDetector, new Object[]{rawPeak});
+		result = (Boolean)method.invoke(firstDerivativePeakDetector, rawPeak);
 		assertEquals(Boolean.valueOf(false), result, "detectPeakStart");
 	}
 }


### PR DESCRIPTION
I can't find the @sonarlint rules for these, but they go like this:
* Move the array designator to the type so the reader doesn't get confused.
* You can omit the array creation when the input parameter is already set to one.

I just find it more readable.