### PR TITLE
Avoid path resolver where it is not required

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/META-INF/MANIFEST.MF
@@ -31,7 +31,8 @@ Require-Bundle: org.eclipse.core.runtime,
  com.fasterxml.jackson.core.jackson-core;bundle-version="2.7.1",
  org.eclipse.core.databinding;bundle-version="1.11.0",
  org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative,
- org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.firstderivative;bundle-version="0.9.0"
+ org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.firstderivative;bundle-version="0.9.0",
+ org.eclipse.chemclipse.msd.converter.supplier.amdis;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: org.osgi.framework;version="1.3.0",
  org.osgi.service.component;version="1.4.0"

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/PathResolver.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/PathResolver.java
@@ -34,10 +34,6 @@ public class PathResolver {
 	 */
 	public static File getFile(final Bundle bundle, final String path) throws IOException {
 
-		if(path == null || "".equals(path)) {
-			throw new IOException();
-		}
-
 		URL url = FileLocator.find(bundle, new Path(path), null);
 		return new File(FileLocator.resolve(url).getPath());
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak/src/org/eclipse/chemclipse/msd/classifier/supplier/molpeak/core/LibraryService.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak/src/org/eclipse/chemclipse/msd/classifier/supplier/molpeak/core/LibraryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,8 @@
  * Christoph Läubrich - adjust to new API / generics
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.classifier.supplier.molpeak.core;
+
+import java.io.IOException;
 
 import org.eclipse.chemclipse.model.exceptions.ValueMustNotBeNullException;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
@@ -44,6 +46,8 @@ public class LibraryService extends AbstractLibraryService implements ILibrarySe
 			processingInfo.setProcessingResult(massSpectra);
 		} catch(ValueMustNotBeNullException e) {
 			processingInfo.addErrorMessage("Base Peak Identifier", "The identification target is not available.");
+		} catch(IOException e) {
+			processingInfo.addErrorMessage("Base Peak Identifier", "Database not found.", e);
 		}
 
 		return processingInfo;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak/src/org/eclipse/chemclipse/msd/classifier/supplier/molpeak/identifier/BasePeakIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak/src/org/eclipse/chemclipse/msd/classifier/supplier/molpeak/identifier/BasePeakIdentifier.java
@@ -78,7 +78,6 @@ public class BasePeakIdentifier {
 
 	private final TargetBuilderMSD targetBuilder;
 	// These one's are run when initializing the class
-	private final IMassSpectra references = getStandardsMassSpectra();
 	private static final IScanMSD syringyl = getSyringyl();
 
 	private String massSpectraFiles;
@@ -235,8 +234,9 @@ public class BasePeakIdentifier {
 	 * @param identificationTarget
 	 * @param monitor
 	 * @return {@link IMassSpectra}
+	 * @throws IOException
 	 */
-	public IMassSpectra getMassSpectra(IIdentificationTarget identificationTarget) {
+	public IMassSpectra getMassSpectra(IIdentificationTarget identificationTarget) throws IOException {
 
 		IMassSpectra massSpectra = new MassSpectra();
 		if(identificationTarget != null) {
@@ -255,6 +255,7 @@ public class BasePeakIdentifier {
 					 * List mass spectra
 					 */
 					List<IScanMSD> identifiedMassSpectra = new ArrayList<>();
+					IMassSpectra references = getStandardsMassSpectra();
 					if(references != null) {
 						for(IScanMSD reference : references.getList()) {
 							/*
@@ -297,16 +298,12 @@ public class BasePeakIdentifier {
 		return massSpectrum;
 	}
 
-	private IMassSpectra getStandardsMassSpectra() {
+	private IMassSpectra getStandardsMassSpectra() throws IOException {
 
-		try {
-			File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), REFERENCES);
-			IProcessingInfo<IMassSpectra> processingInfo = DatabaseConverter.convert(file, new NullProgressMonitor());
-			return processingInfo.getProcessingResult();
-		} catch(IOException e) {
-			logger.warn(e);
-		}
-		return new MassSpectra();
+		Bundle bundle = FrameworkUtil.getBundle(getClass());
+		File file = PathResolver.getFile(bundle, REFERENCES);
+		IProcessingInfo<IMassSpectra> processingInfo = DatabaseConverter.convert(file, new NullProgressMonitor());
+		return processingInfo.getProcessingResult();
 	}
 
 	private void setLibraryInformationFields(ILibraryInformation libraryInformation, String name) {

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/internal/core/support/ChromatogramTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/internal/core/support/ChromatogramTestCase.java
@@ -22,7 +22,6 @@ import java.util.zip.ZipInputStream;
 
 import org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.TestPathHelper;
 import org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.exceptions.ClassifierException;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.settings.Delimiter;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -36,8 +35,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 @Disabled
 @TestInstance(Lifecycle.PER_CLASS)
@@ -51,11 +48,10 @@ public class ChromatogramTestCase {
 	public void setUp() throws IOException, ClassifierException {
 
 		PreferenceSupplier.setImportDelimiter(Delimiter.SEMICOLON);
-		Bundle bundle = FrameworkUtil.getBundle(getClass());
-		File file = PathResolver.getFile(bundle, TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_ZIP);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_ZIP);
 		try (ZipInputStream zipInputStream = new ZipInputStream(new FileInputStream(file))) {
 			zipInputStream.getNextEntry();
-			File folder = PathResolver.getFile(bundle, TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_FOLDER);
+			File folder = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_FOLDER);
 			chromatogramFile = new File(folder, File.separator + TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_NAME);
 			if(chromatogramFile.exists()) {
 				chromatogramFile.delete();

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/core/ChromatogramImporterTestCase.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.TestPathHelper;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @Disabled
 @TestInstance(Lifecycle.PER_CLASS)
@@ -44,7 +42,7 @@ public class ChromatogramImporterTestCase {
 		/*
 		 * Import
 		 */
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/calculator/MassChromatographicQualityCalculator_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/calculator/MassChromatographicQualityCalculator_1_ITest.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.TestPathHelper;
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.exceptions.CodaCalculatorException;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
@@ -34,7 +33,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassChromatographicQualityCalculator_1_ITest {
@@ -47,7 +45,7 @@ public class MassChromatographicQualityCalculator_1_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(importFile, new NullProgressMonitor());
 		IChromatogramMSD chromatogram = processingInfo.getProcessingResult();
 		codaThreshold = 0.7f;

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/calculator/MassChromatographicQualityResult_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/calculator/MassChromatographicQualityResult_1_ITest.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.TestPathHelper;
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.exceptions.CodaCalculatorException;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassChromatographicQualityResult_1_ITest {
@@ -44,7 +42,7 @@ public class MassChromatographicQualityResult_1_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(importFile, new NullProgressMonitor());
 		IChromatogramMSD chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/core/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/core/ChromatogramImporterTestCase.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.TestPathHelper;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
@@ -27,7 +26,6 @@ import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstan
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
-import org.osgi.framework.FrameworkUtil;
 
 @Disabled
 public class ChromatogramImporterTestCase {
@@ -41,7 +39,7 @@ public class ChromatogramImporterTestCase {
 		/*
 		 * Import
 		 */
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/internal/core/support/ChromatogramImporterTestCase.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.TestPathHelper;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
@@ -28,7 +27,6 @@ import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstan
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
-import org.osgi.framework.FrameworkUtil;
 
 @Disabled
 public class ChromatogramImporterTestCase {
@@ -42,7 +40,7 @@ public class ChromatogramImporterTestCase {
 		/*
 		 * Import
 		 */
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/process/supplier/peakidentification/io/PeakIdentificationBatchJobReader_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.fragment.test/src/org/eclipse/chemclipse/chromatogram/msd/process/supplier/peakidentification/io/PeakIdentificationBatchJobReader_1_ITest.java
@@ -22,13 +22,11 @@ import org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentificati
 import org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.model.IPeakIdentificationEntry;
 import org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.model.IPeakInputEntry;
 import org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification.model.IPeakIntegrationEntry;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakIdentificationBatchJobReader_1_ITest {
@@ -39,7 +37,7 @@ public class PeakIdentificationBatchJobReader_1_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_BATCH_PROCESS_JOB);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_BATCH_PROCESS_JOB);
 		batchProcessJob = reader.read(file, new NullProgressMonitor());
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/io/AMDISConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/io/AMDISConverter_1_ITest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.TestPathHelper;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.columns.IRetentionIndexEntry;
 import org.eclipse.chemclipse.model.columns.ISeparationColumnIndices;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -28,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class AMDISConverter_1_ITest {
@@ -38,7 +36,7 @@ public class AMDISConverter_1_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CALIBRATION_CAL_1);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_CALIBRATION_CAL_1);
 		AMDISConverter converter = new AMDISConverter();
 		IProcessingInfo<ISeparationColumnIndices> processingInfo = converter.parseRetentionIndices(file);
 		separationColumnIndices = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/io/AMDISConverter_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/io/AMDISConverter_2_ITest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.TestPathHelper;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.columns.IRetentionIndexEntry;
 import org.eclipse.chemclipse.model.columns.ISeparationColumnIndices;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -28,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class AMDISConverter_2_ITest {
@@ -38,7 +36,7 @@ public class AMDISConverter_2_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CALIBRATION_CAL_2);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_CALIBRATION_CAL_2);
 		AMDISConverter converter = new AMDISConverter();
 		IProcessingInfo<ISeparationColumnIndices> processingInfo = converter.parseRetentionIndices(file);
 		separationColumnIndices = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/io/MassLibConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/io/MassLibConverter_1_ITest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.TestPathHelper;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.columns.IRetentionIndexEntry;
 import org.eclipse.chemclipse.model.columns.ISeparationColumnIndices;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -28,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassLibConverter_1_ITest {
@@ -38,7 +36,7 @@ public class MassLibConverter_1_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CALIBRATION_INF_1);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_CALIBRATION_INF_1);
 		MassLibConverter converter = new MassLibConverter();
 		IProcessingInfo<ISeparationColumnIndices> processingInfo = converter.parseRetentionIndices(file);
 		separationColumnIndices = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/TestLibrary_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/TestLibrary_ITest.java
@@ -12,22 +12,19 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.io.StandardsReader;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class TestLibrary_ITest {
 
 	@Test
 	public void test1() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), StandardsReader.ALKANES);
-		assertTrue(file.exists());
+		StandardsReader standardsReader = new StandardsReader();
+		assertFalse(standardsReader.getStandardsMassSpectra().isEmpty());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/impl/RetentionIndexImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/impl/RetentionIndexImporterTestCase.java
@@ -12,18 +12,17 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.impl;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.model.RetentionIndexFileOption;
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.settings.RetentionIndexImporterSettings;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.AbstractChromatogram;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.INoiseCalculator;
 import org.eclipse.chemclipse.model.implementation.Chromatogram;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.junit.jupiter.api.Disabled;
-import org.osgi.framework.FrameworkUtil;
 
 @Disabled
 public class RetentionIndexImporterTestCase {
@@ -33,7 +32,7 @@ public class RetentionIndexImporterTestCase {
 	public IChromatogram getChromatogram(String relativePath) throws IOException {
 
 		IChromatogram chromatogram = new MyChromatogram();
-		chromatogram.setFile(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), (relativePath)));
+		chromatogram.setFile(new File((relativePath)));
 		Chromatogram chromatogramReference = new Chromatogram();
 		chromatogram.addReferencedChromatogram(chromatogramReference);
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/noise/dyson/core/NoiseCalculator_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/noise/dyson/core/NoiseCalculator_1_ITest.java
@@ -15,16 +15,15 @@ package org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.TestPathHelper;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.results.ChromatogramSegmentation;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class NoiseCalculator_1_ITest extends ChromatogramReaderTestCase {
@@ -35,7 +34,7 @@ public class NoiseCalculator_1_ITest extends ChromatogramReaderTestCase {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
+		fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
 		super.setUp();
 		noiseCalculator = new NoiseCalculator();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/noise/dyson/core/NoiseCalculator_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/noise/dyson/core/NoiseCalculator_2_ITest.java
@@ -15,16 +15,15 @@ package org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.TestPathHelper;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.results.ChromatogramSegmentation;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class NoiseCalculator_2_ITest extends ChromatogramReaderTestCase {
@@ -35,7 +34,7 @@ public class NoiseCalculator_2_ITest extends ChromatogramReaderTestCase {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2);
+		fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2);
 		super.setUp();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/noise/stein/core/NoiseCalculator_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/noise/stein/core/NoiseCalculator_1_ITest.java
@@ -15,16 +15,15 @@ package org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.TestPathHelper;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.results.ChromatogramSegmentation;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class NoiseCalculator_1_ITest extends ChromatogramReaderTestCase {
@@ -35,7 +34,7 @@ public class NoiseCalculator_1_ITest extends ChromatogramReaderTestCase {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
+		fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
 		super.setUp();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/noise/stein/core/NoiseCalculator_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/noise/stein/core/NoiseCalculator_2_ITest.java
@@ -15,16 +15,15 @@ package org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.TestPathHelper;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.results.ChromatogramSegmentation;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class NoiseCalculator_2_ITest extends ChromatogramReaderTestCase {
@@ -35,7 +34,7 @@ public class NoiseCalculator_2_ITest extends ChromatogramReaderTestCase {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2);
+		fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2);
 		super.setUp();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/meannormalizer/core/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/meannormalizer/core/ChromatogramImporterTestCase.java
@@ -16,7 +16,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer.TestPathHelper;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
@@ -26,7 +25,6 @@ import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstan
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
-import org.osgi.framework.FrameworkUtil;
 
 @Disabled
 public class ChromatogramImporterTestCase {
@@ -40,7 +38,7 @@ public class ChromatogramImporterTestCase {
 		/*
 		 * Import
 		 */
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/mediannormalizer/core/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/mediannormalizer/core/ChromatogramImporterTestCase.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer.TestPathHelper;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
@@ -27,7 +26,6 @@ import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstan
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
-import org.osgi.framework.FrameworkUtil;
 
 @Disabled
 public class ChromatogramImporterTestCase {
@@ -41,7 +39,7 @@ public class ChromatogramImporterTestCase {
 		/*
 		 * Import
 		 */
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/multiplier/core/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/multiplier/core/ChromatogramImporterTestCase.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.TestPathHelper;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -27,7 +26,6 @@ import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstan
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
-import org.osgi.framework.FrameworkUtil;
 
 @Disabled
 public class ChromatogramImporterTestCase {
@@ -41,7 +39,7 @@ public class ChromatogramImporterTestCase {
 		/*
 		 * Import
 		 */
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/normalizer/core/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/normalizer/core/ChromatogramImporterTestCase.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer.TestPathHelper;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
@@ -27,7 +26,6 @@ import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstan
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
-import org.osgi.framework.FrameworkUtil;
 
 @Disabled
 public class ChromatogramImporterTestCase {
@@ -41,7 +39,7 @@ public class ChromatogramImporterTestCase {
 		/*
 		 * Import
 		 */
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/processor/SavitzkyGolayProcessor_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/processor/SavitzkyGolayProcessor_1_ITest.java
@@ -15,12 +15,12 @@ package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.pr
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.TestPathHelper;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.settings.ChromatogramFilterSettings;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.signals.ITotalScanSignal;
 import org.eclipse.chemclipse.model.signals.ITotalScanSignals;
 import org.eclipse.chemclipse.model.signals.TotalScanSignal;
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class SavitzkyGolayProcessor_1_ITest {
@@ -45,7 +44,7 @@ public class SavitzkyGolayProcessor_1_ITest {
 		 * Signals
 		 */
 		totalScanSignals = new TotalScanSignals(5726);
-		try (BufferedReader reader = new BufferedReader(new FileReader(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1)))) {
+		try (BufferedReader reader = new BufferedReader(new FileReader(new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1)))) {
 			String line;
 			while((line = reader.readLine()) != null) {
 				String[] values = line.split(", ");

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/processor/SavitzkyGolayProcessor_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/processor/SavitzkyGolayProcessor_2_ITest.java
@@ -15,12 +15,12 @@ package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.pr
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.TestPathHelper;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.settings.ChromatogramFilterSettings;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.signals.ITotalScanSignal;
 import org.eclipse.chemclipse.model.signals.ITotalScanSignals;
 import org.eclipse.chemclipse.model.signals.TotalScanSignal;
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class SavitzkyGolayProcessor_2_ITest {
@@ -45,7 +44,7 @@ public class SavitzkyGolayProcessor_2_ITest {
 		 * Signals
 		 */
 		totalScanSignals = new TotalScanSignals(5726);
-		try (BufferedReader reader = new BufferedReader(new FileReader(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1)))) {
+		try (BufferedReader reader = new BufferedReader(new FileReader(new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1)))) {
 			String line;
 			while((line = reader.readLine()) != null) {
 				String[] values = line.split(", ");

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/processor/SavitzkyGolayProcessor_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/processor/SavitzkyGolayProcessor_3_ITest.java
@@ -15,12 +15,12 @@ package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.pr
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.TestPathHelper;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.settings.ChromatogramFilterSettings;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.signals.ITotalScanSignal;
 import org.eclipse.chemclipse.model.signals.ITotalScanSignals;
 import org.eclipse.chemclipse.model.signals.TotalScanSignal;
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class SavitzkyGolayProcessor_3_ITest {
@@ -45,7 +44,7 @@ public class SavitzkyGolayProcessor_3_ITest {
 		 * Signals
 		 */
 		totalScanSignals = new TotalScanSignals(5726);
-		try (BufferedReader reader = new BufferedReader(new FileReader(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1)))) {
+		try (BufferedReader reader = new BufferedReader(new FileReader(new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1)))) {
 			String line;
 			while((line = reader.readLine()) != null) {
 				String[] values = line.split(", ");

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/processor/SavitzkyGolayProcessor_4_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/processor/SavitzkyGolayProcessor_4_ITest.java
@@ -15,12 +15,12 @@ package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.pr
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.TestPathHelper;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.settings.ChromatogramFilterSettings;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.signals.ITotalScanSignal;
 import org.eclipse.chemclipse.model.signals.ITotalScanSignals;
 import org.eclipse.chemclipse.model.signals.TotalScanSignal;
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class SavitzkyGolayProcessor_4_ITest {
@@ -45,7 +44,7 @@ public class SavitzkyGolayProcessor_4_ITest {
 		 * Signals
 		 */
 		totalScanSignals = new TotalScanSignals(5726);
-		try (BufferedReader reader = new BufferedReader(new FileReader(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1)))) {
+		try (BufferedReader reader = new BufferedReader(new FileReader(new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1)))) {
 			String line;
 			while((line = reader.readLine()) != null) {
 				String[] values = line.split(", ");

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/processor/SavitzkyGolayProcessor_5_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/savitzkygolay/processor/SavitzkyGolayProcessor_5_ITest.java
@@ -15,12 +15,12 @@ package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.pr
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.TestPathHelper;
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.settings.ChromatogramFilterSettings;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.signals.ITotalScanSignal;
 import org.eclipse.chemclipse.model.signals.ITotalScanSignals;
 import org.eclipse.chemclipse.model.signals.TotalScanSignal;
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class SavitzkyGolayProcessor_5_ITest {
@@ -45,7 +44,7 @@ public class SavitzkyGolayProcessor_5_ITest {
 		 * Signals
 		 */
 		totalScanSignals = new TotalScanSignals(5726);
-		try (BufferedReader reader = new BufferedReader(new FileReader(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1)))) {
+		try (BufferedReader reader = new BufferedReader(new FileReader(new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1)))) {
 			String line;
 			while((line = reader.readLine()) != null) {
 				String[] values = line.split(", ");

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/unitsumnormalizer/core/ChromatogramImporterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/unitsumnormalizer/core/ChromatogramImporterTestCase.java
@@ -16,7 +16,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer.TestPathHelper;
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
@@ -26,7 +25,6 @@ import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstan
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
-import org.osgi.framework.FrameworkUtil;
 
 @Disabled
 public class ChromatogramImporterTestCase {
@@ -40,7 +38,7 @@ public class ChromatogramImporterTestCase {
 		/*
 		 * Import
 		 */
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/supplier/trapezoid/internal/core/ChromatogramImportOCBTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/supplier/trapezoid/internal/core/ChromatogramImportOCBTestCase.java
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.in
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
@@ -25,7 +24,6 @@ import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstan
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
-import org.osgi.framework.FrameworkUtil;
 
 @Disabled
 public class ChromatogramImportOCBTestCase {
@@ -36,7 +34,7 @@ public class ChromatogramImportOCBTestCase {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), chromatogramRelativePath);
+		File fileImport = new File(chromatogramRelativePath);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		IChromatogramMSD chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/supplier/trapezoid/internal/core/ChromatogramImportTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/supplier/trapezoid/internal/core/ChromatogramImportTestCase.java
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.in
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.ChromatogramSelectionMSD;
@@ -24,7 +23,6 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
-import org.osgi.framework.FrameworkUtil;
 
 @Disabled
 public class ChromatogramImportTestCase {
@@ -35,7 +33,7 @@ public class ChromatogramImportTestCase {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), chromatogramRelativePath);
+		File fileImport = new File(chromatogramRelativePath);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, new NullProgressMonitor());
 		IChromatogramMSD chromatogram = processingInfo.getProcessingResult();
 		chromatogramSelection = new ChromatogramSelectionMSD(chromatogram);

--- a/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/core/MagicNumberMatcher_10_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/core/MagicNumberMatcher_10_ITest.java
@@ -19,10 +19,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.converter.TestPathHelper;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class MagicNumberMatcher_10_ITest {
 
@@ -47,7 +45,7 @@ public class MagicNumberMatcher_10_ITest {
 	@Test
 	public void test1() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
 		assertTrue(magicNumberMatcher.checkFileFormat(file));
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/core/MagicNumberMatcher_11_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/core/MagicNumberMatcher_11_ITest.java
@@ -19,10 +19,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.converter.TestPathHelper;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class MagicNumberMatcher_11_ITest {
 
@@ -47,7 +45,7 @@ public class MagicNumberMatcher_11_ITest {
 	@Test
 	public void test1() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
 		assertFalse(magicNumberMatcher.checkFileFormat(file));
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/core/MagicNumberMatcher_4_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/core/MagicNumberMatcher_4_ITest.java
@@ -17,10 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.converter.TestPathHelper;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class MagicNumberMatcher_4_ITest {
 
@@ -40,7 +38,7 @@ public class MagicNumberMatcher_4_ITest {
 	@Test
 	public void test1() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
 		assertFalse(magicNumberMatcher.checkFileFormat(file));
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/core/MagicNumberMatcher_5_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/core/MagicNumberMatcher_5_ITest.java
@@ -17,10 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.converter.TestPathHelper;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class MagicNumberMatcher_5_ITest {
 
@@ -40,7 +38,7 @@ public class MagicNumberMatcher_5_ITest {
 	@Test
 	public void test1() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
 		assertTrue(magicNumberMatcher.checkFileFormat(file));
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/core/MagicNumberMatcher_6_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/core/MagicNumberMatcher_6_ITest.java
@@ -17,10 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.converter.TestPathHelper;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class MagicNumberMatcher_6_ITest {
 
@@ -40,7 +38,7 @@ public class MagicNumberMatcher_6_ITest {
 	@Test
 	public void test1() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
 		assertTrue(magicNumberMatcher.checkFileFormat(file));
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/core/MagicNumberMatcher_7_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/core/MagicNumberMatcher_7_ITest.java
@@ -17,10 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.converter.TestPathHelper;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class MagicNumberMatcher_7_ITest {
 
@@ -40,7 +38,7 @@ public class MagicNumberMatcher_7_ITest {
 	@Test
 	public void test1() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
 		assertFalse(magicNumberMatcher.checkFileFormat(file));
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/core/MagicNumberMatcher_8_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/core/MagicNumberMatcher_8_ITest.java
@@ -19,10 +19,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.converter.TestPathHelper;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class MagicNumberMatcher_8_ITest {
 
@@ -42,7 +40,7 @@ public class MagicNumberMatcher_8_ITest {
 	@Test
 	public void test1() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
 		assertFalse(magicNumberMatcher.checkFileFormat(file));
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/core/MagicNumberMatcher_9_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/core/MagicNumberMatcher_9_ITest.java
@@ -19,10 +19,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.converter.TestPathHelper;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class MagicNumberMatcher_9_ITest {
 
@@ -46,7 +44,7 @@ public class MagicNumberMatcher_9_ITest {
 	@Test
 	public void test1() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
 		assertTrue(magicNumberMatcher.checkFileFormat(file));
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/io/support/ArrayReader_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/io/support/ArrayReader_1_ITest.java
@@ -17,11 +17,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.converter.TestPathHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class ArrayReader_1_ITest {
 
@@ -38,7 +36,7 @@ public class ArrayReader_1_ITest {
 		 * F0 A7 C1 0B 04 9F 01 3B
 		 * 11110000 10100111 11000001 00001011 00000100 10011111 00000001 00111011
 		 */
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
 		arrayReader = new ArrayReaderTestImplementation(file);
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/io/support/ArrayReader_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/io/support/ArrayReader_2_ITest.java
@@ -17,11 +17,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.converter.TestPathHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class ArrayReader_2_ITest {
 
@@ -38,7 +36,7 @@ public class ArrayReader_2_ITest {
 		 * F0 A7 C1 0B 04 9F 01 3B
 		 * 11110000 10100111 11000001 00001011 00000100 10011111 00000001 00111011
 		 */
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
 		arrayReader = new ArrayReaderTestImplementation(file);
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/io/support/ArrayReader_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/io/support/ArrayReader_3_ITest.java
@@ -17,11 +17,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.converter.TestPathHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class ArrayReader_3_ITest {
 
@@ -38,7 +36,7 @@ public class ArrayReader_3_ITest {
 		 * F0 A7 C1 0B 04 9F 01 3B
 		 * 11110000 10100111 11000001 00001011 00000100 10011111 00000001 00111011
 		 */
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
 		arrayReader = new ArrayReaderTestImplementation(file);
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/io/support/ArrayReader_4_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/io/support/ArrayReader_4_ITest.java
@@ -17,13 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.converter.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ArrayReader_4_ITest {
@@ -41,7 +39,7 @@ public class ArrayReader_4_ITest {
 		 * F0 A7 C1 0B 04 9F 01 3B
 		 * 11110000 10100111 11000001 00001011 00000100 10011111 00000001 00111011
 		 */
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
 		arrayReader = new ArrayReaderTestImplementation(file);
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/io/support/ArrayReader_5_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/io/support/ArrayReader_5_ITest.java
@@ -17,13 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.converter.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ArrayReader_5_ITest {
@@ -42,7 +40,7 @@ public class ArrayReader_5_ITest {
 		 * F0 A7 C1 0B 04 9F 01 3B
 		 * 11110000 10100111 11000001 00001011 00000100 10011111 00000001 00111011
 		 */
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_BIN_TEST);
 		IArrayReader arrayReader = new ArrayReaderTestImplementation(file);
 		tmp = arrayReader.readBytes(prefix, 4);
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.keystore.fragment.test/src/org/eclipse/chemclipse/keystore/internal/support/KeyFileParser_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.keystore.fragment.test/src/org/eclipse/chemclipse/keystore/internal/support/KeyFileParser_1_ITest.java
@@ -20,13 +20,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.keystore.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class KeyFileParser_1_ITest {
@@ -36,7 +34,7 @@ public class KeyFileParser_1_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_KEYSTORE_I_TEST);
+		File file = new File(TestPathHelper.TESTFILE_KEYSTORE_I_TEST);
 		keyStore = KeyFileParser.readKeysFromFile(file);
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.keystore.fragment.test/src/org/eclipse/chemclipse/keystore/internal/support/KeyFileParser_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.keystore.fragment.test/src/org/eclipse/chemclipse/keystore/internal/support/KeyFileParser_2_ITest.java
@@ -21,13 +21,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.keystore.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class KeyFileParser_2_ITest {
@@ -37,7 +35,7 @@ public class KeyFileParser_2_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_KEYSTORE_II_TEST);
+		File file = new File(TestPathHelper.TESTFILE_KEYSTORE_II_TEST);
 		keyStore = KeyFileParser.readKeysFromFile(file);
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.keystore.fragment.test/src/org/eclipse/chemclipse/keystore/internal/support/KeyFileParser_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.keystore.fragment.test/src/org/eclipse/chemclipse/keystore/internal/support/KeyFileParser_3_ITest.java
@@ -20,13 +20,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.keystore.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class KeyFileParser_3_ITest {
@@ -36,7 +34,7 @@ public class KeyFileParser_3_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = new File(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_KEYSTORE_I_TEST), "-non-existant");
+		File file = new File(new File(TestPathHelper.TESTFILE_KEYSTORE_I_TEST), "-non-existant");
 		keyStore = KeyFileParser.readKeysFromFile(file);
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/src/org/eclipse/chemclipse/msd/converter/chromatogram/ChromatogramExportConverter_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/src/org/eclipse/chemclipse/msd/converter/chromatogram/ChromatogramExportConverter_1_Test.java
@@ -17,12 +17,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.TestPathHelper;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class validates the exceptions thrown by
@@ -47,7 +45,7 @@ public class ChromatogramExportConverter_1_Test {
 	public void testFileNotWritableException_1() throws IOException {
 
 		File file = null;
-		file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_EXPORT_CHROMATOGRAM_NOT_WRITEABLE);
+		file = new File(TestPathHelper.TESTFILE_EXPORT_CHROMATOGRAM_NOT_WRITEABLE);
 		file.setWritable(false);
 		IProcessingInfo<File> processingInfo = ec.convert(file, null, new NullProgressMonitor());
 		assertTrue(processingInfo.hasErrorMessages());

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/src/org/eclipse/chemclipse/msd/converter/chromatogram/ChromatogramImportConverter_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/src/org/eclipse/chemclipse/msd/converter/chromatogram/ChromatogramImportConverter_1_Test.java
@@ -17,13 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.msd.converter.TestPathHelper;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class validates the exceptions thrown by
@@ -48,7 +46,7 @@ public class ChromatogramImportConverter_1_Test {
 	public void testFileIsNotReadableException_1() throws IOException {
 
 		File file = null;
-		file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_NOT_READABLE);
+		file = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_NOT_READABLE);
 		file.setReadable(false);
 		IProcessingInfo<IChromatogram> processingInfo = ic.convert(file, new NullProgressMonitor());
 		assertTrue(processingInfo.hasErrorMessages());
@@ -61,7 +59,7 @@ public class ChromatogramImportConverter_1_Test {
 	public void testFileIsEmptyException_1() throws IOException {
 
 		File file = null;
-		file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_EMPTY);
+		file = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_EMPTY);
 		IProcessingInfo<IChromatogram> processingInfo = ic.convert(file, new NullProgressMonitor());
 		assertTrue(processingInfo.hasErrorMessages());
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/src/org/eclipse/chemclipse/msd/converter/massspectrum/AbstractMassSpectrumExportConverter_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/src/org/eclipse/chemclipse/msd/converter/massspectrum/AbstractMassSpectrumExportConverter_1_Test.java
@@ -17,14 +17,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.implementation.ScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class validates the exceptions thrown by
@@ -51,7 +49,7 @@ public class AbstractMassSpectrumExportConverter_1_Test {
 	public void testFileNotWritableException_1() throws IOException {
 
 		File file = null;
-		file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_EXPORT_MASSSPECTRUM_NOT_WRITEABLE);
+		file = new File(TestPathHelper.TESTFILE_EXPORT_MASSSPECTRUM_NOT_WRITEABLE);
 		file.setWritable(false);
 		IProcessingInfo<?> processingInfo = ec.convert(file, massSpectrum, false, new NullProgressMonitor());
 		assertTrue(processingInfo.hasErrorMessages());

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/src/org/eclipse/chemclipse/msd/converter/massspectrum/AbstractMassSpectrumImportConverter_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/src/org/eclipse/chemclipse/msd/converter/massspectrum/AbstractMassSpectrumImportConverter_1_Test.java
@@ -17,13 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class validates the exceptions thrown by
@@ -48,7 +46,7 @@ public class AbstractMassSpectrumImportConverter_1_Test {
 	public void testFileIsNotReadableException_1() throws IOException {
 
 		File file = null;
-		file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_MASSSPECTRUM_NOT_READABLE);
+		file = new File(TestPathHelper.TESTFILE_IMPORT_MASSSPECTRUM_NOT_READABLE);
 		file.setReadable(false);
 		IProcessingInfo<IMassSpectra> prcoessingInfo = importConverter.convert(file, new NullProgressMonitor());
 		assertTrue(prcoessingInfo.hasErrorMessages());
@@ -61,7 +59,7 @@ public class AbstractMassSpectrumImportConverter_1_Test {
 	public void testFileIsEmptyException_1() throws IOException {
 
 		File file = null;
-		file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_MASSSPECTRUM_EMPTY);
+		file = new File(TestPathHelper.TESTFILE_IMPORT_MASSSPECTRUM_EMPTY);
 		IProcessingInfo<IMassSpectra> prcoessingInfo = importConverter.convert(file, new NullProgressMonitor());
 		assertTrue(prcoessingInfo.hasErrorMessages());
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUImportConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUImportConverter_1_ITest.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.ELUReader;
@@ -35,7 +34,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ELUImportConverter_1_ITest {
@@ -47,7 +45,7 @@ public class ELUImportConverter_1_ITest {
 	public void setUp() throws IOException {
 
 		reader = new ELUReader();
-		file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PEAKS_1_ELU);
+		file = new File(TestPathHelper.TESTFILE_IMPORT_PEAKS_1_ELU);
 	}
 
 	@Test

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUImportConverter_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUImportConverter_2_ITest.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.ELUReader;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.preferences.PreferenceSupplier;
@@ -34,7 +33,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ELUImportConverter_2_ITest {
@@ -46,7 +44,7 @@ public class ELUImportConverter_2_ITest {
 	public void setUp() throws IOException {
 
 		reader = new ELUReader();
-		file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PEAKS_1_ELU);
+		file = new File(TestPathHelper.TESTFILE_IMPORT_PEAKS_1_ELU);
 	}
 
 	@Test

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUReader_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUReader_1_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.ELUReader;
 import org.eclipse.chemclipse.msd.model.core.IPeaksMSD;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ELUReader_1_ITest {
@@ -39,7 +37,7 @@ public class ELUReader_1_ITest {
 	public void setUp() throws IOException {
 
 		reader = new ELUReader();
-		file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PEAKS_1_ELU);
+		file = new File(TestPathHelper.TESTFILE_IMPORT_PEAKS_1_ELU);
 	}
 
 	@Test

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUReader_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUReader_2_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.ELUReader;
 import org.eclipse.chemclipse.msd.model.core.IPeaksMSD;
@@ -28,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ELUReader_2_ITest {
@@ -39,7 +37,7 @@ public class ELUReader_2_ITest {
 	public void setUp() throws IOException {
 
 		ELUReader reader = new ELUReader();
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PEAKS_1_ELU);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_PEAKS_1_ELU);
 		processingInfo = reader.read(file, new NullProgressMonitor());
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/io/AmdisMSPReader_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/io/AmdisMSPReader_1_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.MSPReader;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class AmdisMSPReader_1_ITest {
@@ -39,7 +37,7 @@ public class AmdisMSPReader_1_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PEAKS_1_MSP);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_PEAKS_1_MSP);
 		MSPReader reader = new MSPReader();
 		massSpectra = reader.read(file, new NullProgressMonitor());
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/io/AmdisMSPReader_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/io/AmdisMSPReader_2_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.MSPReader;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class AmdisMSPReader_2_ITest {
@@ -39,7 +37,7 @@ public class AmdisMSPReader_2_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PEAKS_2_MSP);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_PEAKS_2_MSP);
 		MSPReader reader = new MSPReader();
 		massSpectra = reader.read(file, new NullProgressMonitor());
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/io/AmdisMSPReader_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/io/AmdisMSPReader_3_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.MSPReader;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class AmdisMSPReader_3_ITest {
@@ -39,7 +37,7 @@ public class AmdisMSPReader_3_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PEAKS_3_MSP);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_PEAKS_3_MSP);
 		MSPReader reader = new MSPReader();
 		massSpectra = reader.read(file, new NullProgressMonitor());
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/io/AmdisMSPReader_4_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/io/AmdisMSPReader_4_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.MSPReader;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class AmdisMSPReader_4_ITest {
@@ -40,7 +38,7 @@ public class AmdisMSPReader_4_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PEAKS_4_MSP);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_PEAKS_4_MSP);
 		MSPReader reader = new MSPReader();
 		massSpectra = reader.read(file, new NullProgressMonitor());
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/io/AmdisMSPReader_5_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/io/AmdisMSPReader_5_ITest.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.MSPReader;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class AmdisMSPReader_5_ITest {
@@ -41,7 +39,7 @@ public class AmdisMSPReader_5_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PEAKS_5_MSP);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_PEAKS_5_MSP);
 		MSPReader reader = new MSPReader();
 		massSpectra = reader.read(file, new NullProgressMonitor());
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/io/AmdisMSPReader_6_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/io/AmdisMSPReader_6_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.MSPReader;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class AmdisMSPReader_6_ITest {
@@ -39,7 +37,7 @@ public class AmdisMSPReader_6_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PEAKS_6_MSP);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_PEAKS_6_MSP);
 		MSPReader reader = new MSPReader();
 		massSpectra = reader.read(file, new NullProgressMonitor());
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/io/AmdisMSPReader_7_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/io/AmdisMSPReader_7_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.MSPReader;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class AmdisMSPReader_7_ITest {
@@ -39,7 +37,7 @@ public class AmdisMSPReader_7_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PEAKS_7_MSP);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_PEAKS_7_MSP);
 		MSPReader reader = new MSPReader();
 		massSpectra = reader.read(file, new NullProgressMonitor());
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/Encoding_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/Encoding_1_ITest.java
@@ -15,9 +15,9 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.ImportConverterMslTestCase;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.model.IVendorLibraryMassSpectrum;
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Encoding_1_ITest extends ImportConverterMslTestCase {
@@ -35,7 +34,7 @@ public class Encoding_1_ITest extends ImportConverterMslTestCase {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_ENCODING_MSL);
+		importFile = new File(TestPathHelper.TESTFILE_IMPORT_ENCODING_MSL);
 		super.setUp();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLExportConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLExportConverter_1_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.database.IDatabaseExportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MSLExportConverter_1_ITest {
@@ -45,7 +43,7 @@ public class MSLExportConverter_1_ITest {
 	public void setUp() throws IOException {
 
 		exportConverter = new MSLDatabaseExportConverter();
-		File exportFolder = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTDIR_EXPORT);
+		File exportFolder = new File(TestPathHelper.TESTDIR_EXPORT);
 		exportFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_1_MSL);
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(56.3f, 7382.3f));

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLExportConverter_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLExportConverter_2_ITest.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.columns.ISeparationColumn;
 import org.eclipse.chemclipse.model.columns.SeparationColumnFactory;
 import org.eclipse.chemclipse.model.columns.SeparationColumnPackaging;
@@ -42,7 +41,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MSLExportConverter_2_ITest extends ImportConverterMslTestCase {
@@ -58,7 +56,7 @@ public class MSLExportConverter_2_ITest extends ImportConverterMslTestCase {
 		 * Export
 		 */
 		IDatabaseExportConverter exportConverter = new MSLDatabaseExportConverter();
-		File exportFolder = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTDIR_EXPORT);
+		File exportFolder = new File(TestPathHelper.TESTDIR_EXPORT);
 		File exportFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_2_MSL);
 		IVendorLibraryMassSpectrum scanMSD = new VendorLibraryMassSpectrum();
 		ILibraryInformation libraryInformationMS = scanMSD.getLibraryInformation();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLImportConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLImportConverter_1_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.database.IDatabaseImportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -25,7 +24,6 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MSLImportConverter_1_ITest {
@@ -44,7 +42,7 @@ public class MSLImportConverter_1_ITest {
 	@Test
 	public void testExceptions_2() throws IOException {
 
-		importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_EMPTY);
+		importFile = new File(TestPathHelper.TESTFILE_IMPORT_EMPTY);
 		IProcessingInfo<?> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
 		assertTrue(processingInfo.hasErrorMessages());
 	}
@@ -60,7 +58,7 @@ public class MSLImportConverter_1_ITest {
 	@Test
 	public void testExceptions_4() throws IOException {
 
-		importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_NOT_READABLE);
+		importFile = new File(TestPathHelper.TESTFILE_IMPORT_NOT_READABLE);
 		importFile.setReadable(false);
 		try {
 			IProcessingInfo<?> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLImportConverter_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLImportConverter_2_ITest.java
@@ -15,9 +15,9 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.ImportConverterMslTestCase;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.model.IVendorLibraryMassSpectrum;
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MSLImportConverter_2_ITest extends ImportConverterMslTestCase {
@@ -35,7 +34,7 @@ public class MSLImportConverter_2_ITest extends ImportConverterMslTestCase {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_GOLMDB_TEST_MSL);
+		importFile = new File(TestPathHelper.TESTFILE_IMPORT_GOLMDB_TEST_MSL);
 		super.setUp();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLImportConverter_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLImportConverter_3_ITest.java
@@ -16,11 +16,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.columns.ISeparationColumn;
 import org.eclipse.chemclipse.model.columns.SeparationColumnPackaging;
 import org.eclipse.chemclipse.model.identifier.IColumnIndexMarker;
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MSLImportConverter_3_ITest extends ImportConverterMslTestCase {
@@ -45,7 +44,7 @@ public class MSLImportConverter_3_ITest extends ImportConverterMslTestCase {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_DB_4);
+		importFile = new File(TestPathHelper.TESTFILE_IMPORT_DB_4);
 		super.setUp();
 		massSpectrum = (IVendorLibraryMassSpectrum)massSpectra.getMassSpectrum(1);
 		libraryInformation = massSpectrum.getLibraryInformation();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPExportConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPExportConverter_1_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.database.IDatabaseExportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MSPExportConverter_1_ITest {
@@ -45,7 +43,7 @@ public class MSPExportConverter_1_ITest {
 	public void setUp() throws IOException {
 
 		exportConverter = new MSPDatabaseExportConverter();
-		File exportFolder = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTDIR_EXPORT);
+		File exportFolder = new File(TestPathHelper.TESTDIR_EXPORT);
 		exportFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_MSP);
 		massSpectrum = new ScanMSD();
 		massSpectrum.addIon(new Ion(56.3f, 7382.3f));

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_1_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.database.IDatabaseImportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.ILibraryMassSpectrum;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MSPImportConverter_1_ITest {
@@ -40,7 +38,7 @@ public class MSPImportConverter_1_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_LIB_1_MSP);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_LIB_1_MSP);
 		IDatabaseImportConverter importConverter = new MSPDatabaseImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
 		massSpectra = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_2_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.database.IDatabaseImportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.ILibraryMassSpectrum;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MSPImportConverter_2_ITest {
@@ -40,7 +38,7 @@ public class MSPImportConverter_2_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_LIB_2_MSP);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_LIB_2_MSP);
 		IDatabaseImportConverter importConverter = new MSPDatabaseImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
 		massSpectra = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_3_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.database.IDatabaseImportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.ILibraryMassSpectrum;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MSPImportConverter_3_ITest {
@@ -40,7 +38,7 @@ public class MSPImportConverter_3_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_LIB_3_MSP);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_LIB_3_MSP);
 		IDatabaseImportConverter importConverter = new MSPDatabaseImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
 		massSpectra = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_4_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_4_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.database.IDatabaseImportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MSPImportConverter_4_ITest {
@@ -39,7 +37,7 @@ public class MSPImportConverter_4_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_LIB_4_MSP);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_LIB_4_MSP);
 		IDatabaseImportConverter importConverter = new MSPDatabaseImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
 		massSpectra = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_5_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_5_ITest.java
@@ -15,9 +15,9 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.ImportConverterMspTestCase;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.model.IVendorLibraryMassSpectrum;
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MSPImportConverter_5_ITest extends ImportConverterMspTestCase {
@@ -34,7 +33,7 @@ public class MSPImportConverter_5_ITest extends ImportConverterMspTestCase {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_GOLMDB_TEST_MSP);
+		importFile = new File(TestPathHelper.TESTFILE_IMPORT_GOLMDB_TEST_MSP);
 		super.setUp();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MassBankMS2ImportConverter_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MassBankMS2ImportConverter_ITest.java
@@ -15,9 +15,9 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.ImportConverterMspTestCase;
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassBankMS2ImportConverter_ITest extends ImportConverterMspTestCase {
@@ -36,7 +35,7 @@ public class MassBankMS2ImportConverter_ITest extends ImportConverterMspTestCase
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_MASSBANK_TEST_MSP);
+		importFile = new File(TestPathHelper.TESTFILE_IMPORT_MASSBANK_TEST_MSP);
 		super.setUp();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/internal/converter/SpecificationValidatorMSL_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/internal/converter/SpecificationValidatorMSL_1_Test.java
@@ -17,13 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class SpecificationValidatorMSL_1_Test {
@@ -34,13 +32,13 @@ public class SpecificationValidatorMSL_1_Test {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		spec = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.VALIDATOR_TEST_SPEC_MSL).getAbsolutePath();
+		spec = new File(TestPathHelper.VALIDATOR_TEST_SPEC_MSL).getAbsolutePath();
 	}
 
 	@Test
 	public void testValidateAgilentSpecification_1() throws IOException {
 
-		file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.VALIDATOR_TEST_MSL_1);
+		file = new File(TestPathHelper.VALIDATOR_TEST_MSL_1);
 		file = SpecificationValidatorMSL.validateSpecification(file);
 		assertEquals(spec, file.getAbsolutePath());
 	}
@@ -48,7 +46,7 @@ public class SpecificationValidatorMSL_1_Test {
 	@Test
 	public void testValidateAgilentSpecification_3() throws IOException {
 
-		file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.VALIDATOR_TEST_MSL_2);
+		file = new File(TestPathHelper.VALIDATOR_TEST_MSL_2);
 		file = SpecificationValidatorMSL.validateSpecification(file);
 		assertEquals(spec, file.getAbsolutePath());
 	}
@@ -56,7 +54,7 @@ public class SpecificationValidatorMSL_1_Test {
 	@Test
 	public void testValidateAgilentSpecification_4() throws IOException {
 
-		file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.VALIDATOR_TEST_MSL_3);
+		file = new File(TestPathHelper.VALIDATOR_TEST_MSL_3);
 		file = SpecificationValidatorMSL.validateSpecification(file);
 		assertEquals(spec, file.getAbsolutePath());
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/internal/converter/SpecificationValidatorMSP_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/internal/converter/SpecificationValidatorMSP_1_Test.java
@@ -17,13 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class SpecificationValidatorMSP_1_Test {
@@ -34,13 +32,13 @@ public class SpecificationValidatorMSP_1_Test {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		spec = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.VALIDATOR_TEST_SPEC_MSP).getAbsolutePath();
+		spec = new File(TestPathHelper.VALIDATOR_TEST_SPEC_MSP).getAbsolutePath();
 	}
 
 	@Test
 	public void testValidateSpecification_1() throws IOException {
 
-		file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.VALIDATOR_TEST_MSP_1);
+		file = new File(TestPathHelper.VALIDATOR_TEST_MSP_1);
 		file = SpecificationValidatorMSP.validateSpecification(file);
 		assertEquals(spec, file.getAbsolutePath());
 	}
@@ -48,7 +46,7 @@ public class SpecificationValidatorMSP_1_Test {
 	@Test
 	public void testValidateSpecification_3() throws IOException {
 
-		file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.VALIDATOR_TEST_MSP_2);
+		file = new File(TestPathHelper.VALIDATOR_TEST_MSP_2);
 		file = SpecificationValidatorMSP.validateSpecification(file);
 		assertEquals(spec, file.getAbsolutePath());
 	}
@@ -56,7 +54,7 @@ public class SpecificationValidatorMSP_1_Test {
 	@Test
 	public void testValidateSpecification_4() throws IOException {
 
-		file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.VALIDATOR_TEST_MSP_3);
+		file = new File(TestPathHelper.VALIDATOR_TEST_MSP_3);
 		file = SpecificationValidatorMSP.validateSpecification(file);
 		assertEquals(spec, file.getAbsolutePath());
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader_1_ITest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.ILibraryMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MSPReader_1_ITest {
@@ -41,7 +39,7 @@ public class MSPReader_1_ITest {
 	public void setUp() throws IOException {
 
 		MSPReader reader = new MSPReader();
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_SYNONYMS);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_SYNONYMS);
 		massSpectra = reader.read(file, new NullProgressMonitor());
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_1_ITest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.model.IVendorLibraryMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IIon;
@@ -34,7 +33,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumExportConverter_DB_1_ITest extends MassSpectrumExportConverterTestCase {
@@ -43,7 +41,7 @@ public class MassSpectrumExportConverter_DB_1_ITest extends MassSpectrumExportCo
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File exportFolder = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTDIR_EXPORT);
+		File exportFolder = new File(TestPathHelper.TESTDIR_EXPORT);
 		exportFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_1_MSL);
 		importFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_1_MSL);
 		super.setUp();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_2_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumExportConverter_DB_2_ITest extends MassSpectrumExportConverterTestCase {
@@ -42,7 +40,7 @@ public class MassSpectrumExportConverter_DB_2_ITest extends MassSpectrumExportCo
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File exportFolder = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTDIR_EXPORT);
+		File exportFolder = new File(TestPathHelper.TESTDIR_EXPORT);
 		exportFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_1_MSL);
 		importFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_1_MSL);
 		super.setUp();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_3_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumExportConverter_DB_3_ITest extends MassSpectrumExportConverterTestCase {
@@ -42,7 +40,7 @@ public class MassSpectrumExportConverter_DB_3_ITest extends MassSpectrumExportCo
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File exportFolder = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTDIR_EXPORT);
+		File exportFolder = new File(TestPathHelper.TESTDIR_EXPORT);
 		exportFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_1_MSL);
 		importFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_1_MSL);
 		super.setUp();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_4_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_4_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumExportConverter_DB_4_ITest extends MassSpectrumExportConverterTestCase {
@@ -41,7 +39,7 @@ public class MassSpectrumExportConverter_DB_4_ITest extends MassSpectrumExportCo
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File exportFolder = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTDIR_EXPORT);
+		File exportFolder = new File(TestPathHelper.TESTDIR_EXPORT);
 		exportFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_1_MSL);
 		importFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_1_MSL);
 		super.setUp();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_5_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_5_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IRegularLibraryMassSpectrum;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumExportConverter_DB_5_ITest extends MassSpectrumExportConverterTestCase {
@@ -41,7 +39,7 @@ public class MassSpectrumExportConverter_DB_5_ITest extends MassSpectrumExportCo
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File exportFolder = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTDIR_EXPORT);
+		File exportFolder = new File(TestPathHelper.TESTDIR_EXPORT);
 		exportFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_MSL_IDENTIFIER);
 		importFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_MSL_IDENTIFIER);
 		super.setUp();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumImportConverter_CHROMATOGRAM_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumImportConverter_CHROMATOGRAM_1_ITest.java
@@ -15,11 +15,11 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.io;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.model.IVendorLibraryMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumImportConverter_CHROMATOGRAM_1_ITest extends ImportConverterMslTestCase {
@@ -36,7 +35,7 @@ public class MassSpectrumImportConverter_CHROMATOGRAM_1_ITest extends ImportConv
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM);
+		importFile = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM);
 		super.setUp();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumImportConverter_DB_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumImportConverter_DB_1_ITest.java
@@ -15,11 +15,11 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.io;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.model.IVendorLibraryMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumImportConverter_DB_1_ITest extends ImportConverterMslTestCase {
@@ -36,7 +35,7 @@ public class MassSpectrumImportConverter_DB_1_ITest extends ImportConverterMslTe
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_DB_1);
+		importFile = new File(TestPathHelper.TESTFILE_IMPORT_DB_1);
 		super.setUp();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumImportConverter_DB_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumImportConverter_DB_2_ITest.java
@@ -15,16 +15,15 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.io;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.model.IVendorLibraryMassSpectrum;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumImportConverter_DB_2_ITest extends ImportConverterMslTestCase {
@@ -33,7 +32,7 @@ public class MassSpectrumImportConverter_DB_2_ITest extends ImportConverterMslTe
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_DB_2);
+		importFile = new File(TestPathHelper.TESTFILE_IMPORT_DB_2);
 		super.setUp();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumImportConverter_DB_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumImportConverter_DB_3_ITest.java
@@ -15,16 +15,15 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.io;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.model.IVendorLibraryMassSpectrum;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumImportConverter_DB_3_ITest extends ImportConverterMslTestCase {
@@ -33,7 +32,7 @@ public class MassSpectrumImportConverter_DB_3_ITest extends ImportConverterMslTe
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_DB_3);
+		importFile = new File(TestPathHelper.TESTFILE_IMPORT_DB_3);
 		super.setUp();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.cml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/cml/converter/MassSpectrumImportConverterSP03_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.cml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/cml/converter/MassSpectrumImportConverterSP03_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.msd.converter.supplier.cml.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.cml.model.VendorLibraryMassSpectrum;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumImportConverterSP03_ITest {
@@ -40,7 +38,7 @@ public class MassSpectrumImportConverterSP03_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_SP03);
+		File file = new File(TestPathHelper.TESTFILE_SP03);
 		DatabaseImportConverter importConverter = new DatabaseImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = importConverter.convert(file, new NullProgressMonitor());
 		massSpectrum = processingInfo.getProcessingResult().getMassSpectrum(1);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/excel/io/ChromatogramExport_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/excel/io/ChromatogramExport_1_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.converter.supplier.excel.TestPathHelper;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramExport_1_ITest {
@@ -43,11 +41,11 @@ public class ChromatogramExport_1_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 		new File(TestPathHelper.DIRECTORY_EXPORT_TEST).mkdirs();
-		file = new File(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.DIRECTORY_EXPORT_TEST) + File.separator + "Test.xlsx");
+		file = new File(new File(TestPathHelper.DIRECTORY_EXPORT_TEST) + File.separator + "Test.xlsx");
 	}
 
 	@AfterAll

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakExportConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakExportConverter_1_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MatlabParafacPeakExportConverter_1_ITest {
@@ -47,21 +45,21 @@ public class MatlabParafacPeakExportConverter_1_ITest {
 		 * Import
 		 */
 		MatlabParafacPeakImportConverter importConverter = new MatlabParafacPeakImportConverter();
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_MATLAB_PEAKS);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_MATLAB_PEAKS);
 		IProcessingInfo<IPeaksMSD> importProcessingInfo = importConverter.convert(importFile, new NullProgressMonitor());
 		peaks = importProcessingInfo.getProcessingResult();
 		/*
 		 * Export
 		 */
 		MatlabParafacPeakExportConverter exportConverter = new MatlabParafacPeakExportConverter();
-		File exportFile = new File(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_EXPORT_FOLDER), File.separator + TestPathHelper.TESTFILE_EXPORT_MATLAB_PEAKS);
+		File exportFile = new File(new File(TestPathHelper.TESTFILE_EXPORT_FOLDER), File.separator + TestPathHelper.TESTFILE_EXPORT_MATLAB_PEAKS);
 		IProcessingInfo<File> exportProcessingInfo = exportConverter.convert(exportFile, peaks, false, new NullProgressMonitor());
 		exportProcessingInfo.getProcessingResult();
 		/*
 		 * Re-Import
 		 */
 		importConverter = new MatlabParafacPeakImportConverter();
-		File reimportFile = new File(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_EXPORT_FOLDER), File.separator + TestPathHelper.TESTFILE_EXPORT_MATLAB_PEAKS);
+		File reimportFile = new File(new File(TestPathHelper.TESTFILE_EXPORT_FOLDER), File.separator + TestPathHelper.TESTFILE_EXPORT_MATLAB_PEAKS);
 		importProcessingInfo = importConverter.convert(reimportFile, new NullProgressMonitor());
 		peaks = importProcessingInfo.getProcessingResult();
 		peak = peaks.getPeaks().get(1);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakImportConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakImportConverter_1_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MatlabParafacPeakImportConverter_1_ITest {
@@ -44,7 +42,7 @@ public class MatlabParafacPeakImportConverter_1_ITest {
 	public void setUp() throws IOException {
 
 		MatlabParafacPeakImportConverter converter = new MatlabParafacPeakImportConverter();
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_MATLAB_PEAKS);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_MATLAB_PEAKS);
 		IProcessingInfo<IPeaksMSD> processingInfo = converter.convert(file, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 		peak = peaks.getPeaks().get(0);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakImportConverter_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakImportConverter_2_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MatlabParafacPeakImportConverter_2_ITest {
@@ -44,7 +42,7 @@ public class MatlabParafacPeakImportConverter_2_ITest {
 	public void setUp() throws IOException {
 
 		MatlabParafacPeakImportConverter converter = new MatlabParafacPeakImportConverter();
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_MATLAB_PEAKS);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_MATLAB_PEAKS);
 		IProcessingInfo<IPeaksMSD> processingInfo = converter.convert(file, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 		peak = peaks.getPeaks().get(1);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakImportConverter_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakImportConverter_3_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MatlabParafacPeakImportConverter_3_ITest {
@@ -44,7 +42,7 @@ public class MatlabParafacPeakImportConverter_3_ITest {
 	public void setUp() throws IOException {
 
 		MatlabParafacPeakImportConverter converter = new MatlabParafacPeakImportConverter();
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_MATLAB_PEAKS);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_MATLAB_PEAKS);
 		IProcessingInfo<IPeaksMSD> processingInfo = converter.convert(file, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 		peak = peaks.getPeaks().get(2);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakImportConverter_4_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakImportConverter_4_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IPeaksMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -26,7 +25,6 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MatlabParafacPeakImportConverter_4_ITest {
@@ -37,7 +35,7 @@ public class MatlabParafacPeakImportConverter_4_ITest {
 	public void testImport_1() {
 
 		assertThrows(NullPointerException.class, () -> {
-			File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_EMPTY);
+			File file = new File(TestPathHelper.TESTFILE_IMPORT_EMPTY);
 			converter.convert(file, new NullProgressMonitor());
 		});
 	}
@@ -45,7 +43,7 @@ public class MatlabParafacPeakImportConverter_4_ITest {
 	@Test
 	public void testImport_2() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_NOT_READABLE);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_NOT_READABLE);
 		file.setReadable(false);
 		IProcessingInfo<IPeaksMSD> processingInfo = converter.convert(file, new NullProgressMonitor());
 		assertNull(processingInfo.getProcessingResult());
@@ -56,7 +54,7 @@ public class MatlabParafacPeakImportConverter_4_ITest {
 	public void testImport_3() {
 
 		assertThrows(NullPointerException.class, () -> {
-			File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PEAKS);
+			File file = new File(TestPathHelper.TESTFILE_IMPORT_PEAKS);
 			converter.convert(file, new NullProgressMonitor());
 		});
 	}
@@ -65,7 +63,7 @@ public class MatlabParafacPeakImportConverter_4_ITest {
 	public void testImport_4() {
 
 		assertThrows(NullPointerException.class, () -> {
-			File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PEAKS_EXTENSION);
+			File file = new File(TestPathHelper.TESTFILE_IMPORT_PEAKS_EXTENSION);
 			converter.convert(file, new NullProgressMonitor());
 		});
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakImportConverter_5_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakImportConverter_5_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IPeaksMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MatlabParafacPeakImportConverter_5_ITest {
@@ -38,7 +36,7 @@ public class MatlabParafacPeakImportConverter_5_ITest {
 	public void setUp() throws IOException {
 
 		MatlabParafacPeakImportConverter converter = new MatlabParafacPeakImportConverter();
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PARAFAC_TEST_1);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_PARAFAC_TEST_1);
 		IProcessingInfo<IPeaksMSD> processingInfo = converter.convert(file, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakImportConverter_6_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakImportConverter_6_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IPeaksMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MatlabParafacPeakImportConverter_6_ITest {
@@ -38,7 +36,7 @@ public class MatlabParafacPeakImportConverter_6_ITest {
 	public void setUp() throws IOException {
 
 		MatlabParafacPeakImportConverter converter = new MatlabParafacPeakImportConverter();
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PARAFAC_TEST_2);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_PARAFAC_TEST_2);
 		IProcessingInfo<IPeaksMSD> processingInfo = converter.convert(file, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakImportConverter_7_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakImportConverter_7_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IPeaksMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MatlabParafacPeakImportConverter_7_ITest {
@@ -38,7 +36,7 @@ public class MatlabParafacPeakImportConverter_7_ITest {
 	public void setUp() throws IOException {
 
 		MatlabParafacPeakImportConverter converter = new MatlabParafacPeakImportConverter();
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PARAFAC_TEST_3);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_PARAFAC_TEST_3);
 		IProcessingInfo<IPeaksMSD> processingInfo = converter.convert(file, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakImportConverter_8_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/converter/MatlabParafacPeakImportConverter_8_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IPeaksMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MatlabParafacPeakImportConverter_8_ITest {
@@ -38,7 +36,7 @@ public class MatlabParafacPeakImportConverter_8_ITest {
 	public void setUp() throws IOException {
 
 		MatlabParafacPeakImportConverter converter = new MatlabParafacPeakImportConverter();
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PARAFAC_TEST_4);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_PARAFAC_TEST_4);
 		IProcessingInfo<IPeaksMSD> processingInfo = converter.convert(file, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mmass.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/converter/ProteinIdentification_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mmass.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/converter/ProteinIdentification_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IMassSpectrumPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ProteinIdentification_ITest {
@@ -42,7 +40,7 @@ public class ProteinIdentification_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_PROTEIN_IDENTIFICATION);
+		File importFile = new File(TestPathHelper.TESTFILE_PROTEIN_IDENTIFICATION);
 		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		massSpectrum = (IStandaloneMassSpectrum)processingInfo.getProcessingResult().getMassSpectrum(1);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mmass.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/converter/Tiny22_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mmass.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/converter/Tiny22_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.mmass.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
@@ -28,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Tiny22_ITest {
@@ -38,7 +36,7 @@ public class Tiny22_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_MMASS_TINY_22);
+		File importFile = new File(TestPathHelper.TESTFILE_MMASS_TINY_22);
 		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		massSpectrum = (IStandaloneMassSpectrum)processingInfo.getProcessingResult().getMassSpectrum(1);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMyoDta104_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMyoDta104_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorScan;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImportConverterMyoDta104_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramImportConverterMyoDta104_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_MYO_DTA_104);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_MYO_DTA_104);
 		ChromatogramImportConverter converter = new ChromatogramImportConverter();
 		IProcessingInfo<IChromatogramMSD> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		chromatogram = (VendorChromatogram)processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMyoDta105_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMyoDta105_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorScan;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImportConverterMyoDta105_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramImportConverterMyoDta105_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_MYO_DTA_105);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_MYO_DTA_105);
 		ChromatogramImportConverter converter = new ChromatogramImportConverter();
 		IProcessingInfo<IChromatogramMSD> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		chromatogram = (VendorChromatogram)processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportTiny105_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportTiny105_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorScan;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImportTiny105_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramImportTiny105_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_TINY_105);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_TINY_105);
 		ChromatogramImportConverter converter = new ChromatogramImportConverter();
 		IProcessingInfo<IChromatogramMSD> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		chromatogram = (VendorChromatogram)processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/MassSpectrumImportConverterMaldiAxima_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/MassSpectrumImportConverterMaldiAxima_ITest.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.time.ZoneId;
 import java.util.Date;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumImportConverterMaldiAxima_ITest {
@@ -41,7 +39,7 @@ public class MassSpectrumImportConverterMaldiAxima_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_MALDI_AXIMA_CFR);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_MALDI_AXIMA_CFR);
 		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		VendorMassSpectra massSpectra = (VendorMassSpectra)processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverterTinyProteoWizard10_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverterTinyProteoWizard10_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorChromatogram;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImportConverterTinyProteoWizard10_ITest {
@@ -40,7 +38,7 @@ public class ChromatogramImportConverterTinyProteoWizard10_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_TINY_PWIZ_1_0);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_TINY_PWIZ_1_0);
 		ChromatogramImportConverter converter = new ChromatogramImportConverter();
 		IProcessingInfo<IChromatogramMSD> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		chromatogram = (VendorChromatogram)processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverterTinyProteoWizard110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverterTinyProteoWizard110_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorChromatogram;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImportConverterTinyProteoWizard110_ITest {
@@ -40,7 +38,7 @@ public class ChromatogramImportConverterTinyProteoWizard110_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_TINY_PWIZ_1_1);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_TINY_PWIZ_1_1);
 		ChromatogramImportConverter converter = new ChromatogramImportConverter();
 		IProcessingInfo<IChromatogramMSD> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		chromatogram = (VendorChromatogram)processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportExport110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportExport110_ITest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -31,8 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImportExport110_ITest {
@@ -47,7 +44,6 @@ public class ChromatogramImportExport110_ITest {
 		 * Import
 		 */
 		String extensionPointImport = VersionConstants.CONVERTER_ID_CHROMATOGRAM;
-		Bundle bundle = FrameworkUtil.getBundle(getClass());
 		/*
 		 * Export/Reimport
 		 */
@@ -57,13 +53,13 @@ public class ChromatogramImportExport110_ITest {
 		/*
 		 * Import the chromatogram.
 		 */
-		File fileImport = PathResolver.getFile(bundle, TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
 		IProcessingInfo<IChromatogramMSD> processingInfoImport = ChromatogramConverterMSD.getInstance().convert(fileImport, extensionPointImport, new NullProgressMonitor());
 		IChromatogramMSD chromatogramImport = processingInfoImport.getProcessingResult();
 		/*
 		 * Export the chromatogram.
 		 */
-		fileExport = new File(PathResolver.getFile(bundle, TestPathHelper.DIRECTORY_EXPORT_TEST), File.separator + "Test.mzML");
+		fileExport = new File(TestPathHelper.DIRECTORY_EXPORT_TEST + File.separator + "Test.mzML");
 		IProcessingInfo<File> processingInfoExport = ChromatogramConverterMSD.getInstance().convert(fileExport, chromatogramImport, extensionPointExportReimport, new NullProgressMonitor());
 		fileExport = processingInfoExport.getProcessingResult();
 		/*

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverter110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverter110_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorMassSpectra;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorMassSpectra;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumImportConverter110_ITest {
@@ -40,7 +38,7 @@ public class MassSpectrumImportConverter110_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_TINY1_1_1);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_TINY1_1_1);
 		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		massSpectra = (VendorMassSpectra)processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverterCentroided110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverterCentroided110_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorMassSpectra;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorMassSpectra;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumImportConverterCentroided110_ITest {
@@ -40,7 +38,7 @@ public class MassSpectrumImportConverterCentroided110_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_TINY1_CENTROIDED_1_1);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_TINY1_CENTROIDED_1_1);
 		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		massSpectra = (VendorMassSpectra)processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverterCompressed110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverterCompressed110_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorMassSpectra;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorMassSpectra;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumImportConverterCompressed110_ITest {
@@ -40,7 +38,7 @@ public class MassSpectrumImportConverterCompressed110_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_TINY1_COMPRESSED_1_1);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_TINY1_COMPRESSED_1_1);
 		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		massSpectra = (VendorMassSpectra)processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramImportConverterTinyMzXML20_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramImportConverterTinyMzXML20_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorScan;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImportConverterTinyMzXML20_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramImportConverterTinyMzXML20_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_TINY1_MZXML20);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_TINY1_MZXML20);
 		ChromatogramImportConverter converter = new ChromatogramImportConverter();
 		IProcessingInfo<IChromatogramMSD> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		chromatogram = (VendorChromatogram)processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramImportConverterTinyMzXML30_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramImportConverterTinyMzXML30_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorScan;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImportConverterTinyMzXML30_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramImportConverterTinyMzXML30_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_TINY_MZXML30);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_TINY_MZXML30);
 		ChromatogramImportConverter converter = new ChromatogramImportConverter();
 		IProcessingInfo<IChromatogramMSD> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		chromatogram = (VendorChromatogram)processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumImportConverterTinyCentroidedMzXML30_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumImportConverterTinyCentroidedMzXML30_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorMassSpectra;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorMassSpectra;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumImportConverterTinyCentroidedMzXML30_ITest {
@@ -42,7 +40,7 @@ public class MassSpectrumImportConverterTinyCentroidedMzXML30_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_TINY1_CENTROIDED_MZXML30);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_TINY1_CENTROIDED_MZXML30);
 		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		IVendorMassSpectra massSpectra = (VendorMassSpectra)processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumImportConverterTinyCompressedMzXML30_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumImportConverterTinyCompressedMzXML30_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorMassSpectra;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorMassSpectra;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumImportConverterTinyCompressedMzXML30_ITest {
@@ -41,7 +39,7 @@ public class MassSpectrumImportConverterTinyCompressedMzXML30_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_TINY1_COMPRESSED_MZXML30);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_TINY1_COMPRESSED_MZXML30);
 		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		IVendorMassSpectra massSpectra = (VendorMassSpectra)processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumImportConverterTinyMzXML30_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumImportConverterTinyMzXML30_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorMassSpectra;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorMassSpectra;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumImportConverterTinyMzXML30_ITest {
@@ -41,7 +39,7 @@ public class MassSpectrumImportConverterTinyMzXML30_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_TINY1_MZXML30);
+		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_TINY1_MZXML30);
 		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		IVendorMassSpectra massSpectra = (VendorMassSpectra)processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.sirius.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/sirius/converter/SiriusImportConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.sirius.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/sirius/converter/SiriusImportConverter_1_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.sirius.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class SiriusImportConverter_1_ITest {
@@ -36,7 +34,7 @@ public class SiriusImportConverter_1_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_BICUCULLINE);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_BICUCULLINE);
 		SiriusImportConverter converter = new SiriusImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = converter.convert(file, new NullProgressMonitor());
 		massSpectra = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.sirius.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/sirius/io/SiriusReader_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.sirius.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/sirius/io/SiriusReader_1_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.supplier.sirius.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -25,7 +24,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class SiriusReader_1_ITest {
@@ -36,7 +34,7 @@ public class SiriusReader_1_ITest {
 	public void setUp() throws IOException {
 
 		SiriusReader reader = new SiriusReader();
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_KAEMPFEROL);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_KAEMPFEROL);
 		massSpectra = reader.read(file, new NullProgressMonitor());
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/internal/results/NistResultFileParser_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/internal/results/NistResultFileParser_1_Test.java
@@ -18,13 +18,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class NistResultFileParser_1_Test {
@@ -35,7 +33,7 @@ public class NistResultFileParser_1_Test {
 	public void setUp() throws IOException {
 
 		NistResultFileParser nistResultFileParser = new NistResultFileParser();
-		File results = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_NIST_SRCRESLT_1);
+		File results = new File(TestPathHelper.TESTFILE_NIST_SRCRESLT_1);
 		compounds = nistResultFileParser.getCompounds(results);
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/internal/results/NistResultFileParser_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/internal/results/NistResultFileParser_2_Test.java
@@ -17,13 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class NistResultFileParser_2_Test {
@@ -36,7 +34,7 @@ public class NistResultFileParser_2_Test {
 	public void setUp() throws IOException {
 
 		NistResultFileParser nistResultFileParser = new NistResultFileParser();
-		File results = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_NIST_SRCRESLT_2);
+		File results = new File(TestPathHelper.TESTFILE_NIST_SRCRESLT_2);
 		compounds = nistResultFileParser.getCompounds(results);
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/internal/results/NistResultFileParser_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/internal/results/NistResultFileParser_3_Test.java
@@ -17,13 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class NistResultFileParser_3_Test {
@@ -35,7 +33,7 @@ public class NistResultFileParser_3_Test {
 	public void setUp() throws IOException {
 
 		NistResultFileParser nistResultFileParser = new NistResultFileParser();
-		File results = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_NIST_SRCRESLT_2);
+		File results = new File(TestPathHelper.TESTFILE_NIST_SRCRESLT_2);
 		Compounds compounds = nistResultFileParser.getCompounds(results);
 		compound = compounds.getCompound(3);
 		hit = compound.getHit(3);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/internal/results/NistResultFileParser_4_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/internal/results/NistResultFileParser_4_Test.java
@@ -17,13 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class NistResultFileParser_4_Test {
@@ -35,7 +33,7 @@ public class NistResultFileParser_4_Test {
 	public void setUp() throws IOException {
 
 		NistResultFileParser nistResultFileParser = new NistResultFileParser();
-		File results = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_NIST_SRCRESLT_3);
+		File results = new File(TestPathHelper.TESTFILE_NIST_SRCRESLT_3);
 		Compounds compounds = nistResultFileParser.getCompounds(results);
 		compound = compounds.getCompound(1);
 		hit = compound.getHit(3);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/internal/results/NistResultFileParser_5_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/internal/results/NistResultFileParser_5_Test.java
@@ -17,13 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class NistResultFileParser_5_Test {
@@ -35,7 +33,7 @@ public class NistResultFileParser_5_Test {
 	public void setUp() throws IOException {
 
 		NistResultFileParser nistResultFileParser = new NistResultFileParser();
-		File results = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_NIST_SRCRESLT_3);
+		File results = new File(TestPathHelper.TESTFILE_NIST_SRCRESLT_3);
 		Compounds compounds = nistResultFileParser.getCompounds(results);
 		compound = compounds.getCompound(2);
 		hit = compound.getHit(2);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/internal/results/NistResultFileParser_6_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/internal/results/NistResultFileParser_6_Test.java
@@ -17,13 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class NistResultFileParser_6_Test {
@@ -35,7 +33,7 @@ public class NistResultFileParser_6_Test {
 	public void setUp() throws IOException {
 
 		NistResultFileParser nistResultFileParser = new NistResultFileParser();
-		File results = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_NIST_SRCRESLT_4);
+		File results = new File(TestPathHelper.TESTFILE_NIST_SRCRESLT_4);
 		Compounds compounds = nistResultFileParser.getCompounds(results);
 		compound = compounds.getCompound(2);
 		hit = compound.getHit(2);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/internal/results/NistResultFileParser_7_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/internal/results/NistResultFileParser_7_Test.java
@@ -17,13 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class NistResultFileParser_7_Test {
@@ -35,7 +33,7 @@ public class NistResultFileParser_7_Test {
 	public void setUp() throws IOException {
 
 		NistResultFileParser nistResultFileParser = new NistResultFileParser();
-		File results = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_NIST_SRCRESLT_5);
+		File results = new File(TestPathHelper.TESTFILE_NIST_SRCRESLT_5);
 		Compounds compounds = nistResultFileParser.getCompounds(results);
 		compound = compounds.getCompound(2);
 		hit = compound.getHit(2);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport_DOSDEVICES_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport_DOSDEVICES_1_ITest.java
@@ -18,11 +18,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class LinuxWineSupport_DOSDEVICES_1_ITest extends AbstractBackgroundTestCase {
 
@@ -34,8 +32,8 @@ public class LinuxWineSupport_DOSDEVICES_1_ITest extends AbstractBackgroundTestC
 	public void setUp() throws IOException {
 
 		super.setUp();
-		File testfileNistApplication = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_WINE_DOSDEVICES_NIST_APPLICATION);
-		nistApplicationPath = testfileNistApplication.getParent();
+		File testfileNistApplication = new File(TestPathHelper.TESTFILE_WINE_DOSDEVICES_NIST_APPLICATION);
+		nistApplicationPath = testfileNistApplication.getParentFile().getAbsolutePath();
 		runtimeSupport = new LinuxWineSupport(testfileNistApplication.getParentFile(), parameterBackground);
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport_DOSDEVICES_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport_DOSDEVICES_2_ITest.java
@@ -19,11 +19,9 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class LinuxWineSupport_DOSDEVICES_2_ITest extends AbstractBackgroundTestCase {
 
@@ -39,7 +37,7 @@ public class LinuxWineSupport_DOSDEVICES_2_ITest extends AbstractBackgroundTestC
 	@Test
 	public void testConstruct_1() throws IOException {
 
-		File nistApp = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_WINE_DOSDEVICES_NIST_APPLICATION);
+		File nistApp = new File(TestPathHelper.TESTFILE_WINE_DOSDEVICES_NIST_APPLICATION);
 		runtimeSupport = new LinuxWineSupport(nistApp.getParentFile(), parameterBackground);
 		assertNotNull(runtimeSupport);
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport_DRIVE_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport_DRIVE_1_ITest.java
@@ -18,11 +18,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class LinuxWineSupport_DRIVE_1_ITest extends AbstractBackgroundTestCase {
 
@@ -34,8 +32,8 @@ public class LinuxWineSupport_DRIVE_1_ITest extends AbstractBackgroundTestCase {
 	public void setUp() throws IOException {
 
 		super.setUp();
-		File nistApplication = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_WINE_DRIVE_NIST_APPLICATION);
-		nistApplicationPath = nistApplication.getParent();
+		File nistApplication = new File(TestPathHelper.TESTFILE_WINE_DRIVE_NIST_APPLICATION);
+		nistApplicationPath = nistApplication.getParentFile().getAbsolutePath();
 		runtimeSupport = new LinuxWineSupport(nistApplication.getParentFile(), parameterBackground);
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport_DRIVE_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport_DRIVE_2_ITest.java
@@ -20,11 +20,9 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class LinuxWineSupport_DRIVE_2_ITest extends AbstractBackgroundTestCase {
 
@@ -40,7 +38,7 @@ public class LinuxWineSupport_DRIVE_2_ITest extends AbstractBackgroundTestCase {
 	@Test
 	public void testConstruct_1() throws IOException {
 
-		File nistApp = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_WINE_DRIVE_NIST_APPLICATION);
+		File nistApp = new File(TestPathHelper.TESTFILE_WINE_DRIVE_NIST_APPLICATION);
 		runtimeSupport = new LinuxWineSupport(nistApp.getParentFile(), parameterBackground);
 		assertNotNull(runtimeSupport);
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport_DOSDEVICES_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport_DOSDEVICES_1_ITest.java
@@ -18,11 +18,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class MacWineSupport_DOSDEVICES_1_ITest extends AbstractBackgroundTestCase {
 
@@ -34,8 +32,8 @@ public class MacWineSupport_DOSDEVICES_1_ITest extends AbstractBackgroundTestCas
 	public void setUp() throws IOException {
 
 		super.setUp();
-		File nistApplication = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_WINE_DOSDEVICES_NIST_APPLICATION);
-		nistApplicationPath = nistApplication.getParent();
+		File nistApplication = new File(TestPathHelper.TESTFILE_WINE_DOSDEVICES_NIST_APPLICATION);
+		nistApplicationPath = nistApplication.getParentFile().getAbsolutePath();
 		runtimeSupport = new MacWineSupport(nistApplication.getParentFile(), parameterBackground);
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport_DOSDEVICES_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport_DOSDEVICES_2_ITest.java
@@ -19,11 +19,9 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class MacWineSupport_DOSDEVICES_2_ITest extends AbstractBackgroundTestCase {
 
@@ -39,7 +37,7 @@ public class MacWineSupport_DOSDEVICES_2_ITest extends AbstractBackgroundTestCas
 	@Test
 	public void testConstruct_1() throws IOException {
 
-		File nistApp = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_WINE_DOSDEVICES_NIST_APPLICATION);
+		File nistApp = new File(TestPathHelper.TESTFILE_WINE_DOSDEVICES_NIST_APPLICATION);
 		runtimeSupport = new MacWineSupport(nistApp.getParentFile(), parameterBackground);
 		assertNotNull(runtimeSupport);
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport_DRIVE_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport_DRIVE_1_ITest.java
@@ -18,11 +18,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class MacWineSupport_DRIVE_1_ITest extends AbstractBackgroundTestCase {
 
@@ -34,8 +32,8 @@ public class MacWineSupport_DRIVE_1_ITest extends AbstractBackgroundTestCase {
 	public void setUp() throws IOException {
 
 		super.setUp();
-		File nistApplication = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_WINE_DRIVE_NIST_APPLICATION);
-		nistApplicationPath = nistApplication.getParent();
+		File nistApplication = new File(TestPathHelper.TESTFILE_WINE_DRIVE_NIST_APPLICATION);
+		nistApplicationPath = nistApplication.getParentFile().getAbsolutePath();
 		runtimeSupport = new MacWineSupport(nistApplication.getParentFile(), parameterBackground);
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport_DRIVE_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/MacWineSupport_DRIVE_2_ITest.java
@@ -19,11 +19,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class MacWineSupport_DRIVE_2_ITest extends AbstractBackgroundTestCase {
 
@@ -39,7 +37,7 @@ public class MacWineSupport_DRIVE_2_ITest extends AbstractBackgroundTestCase {
 	@Test
 	public void testConstruct_1() throws IOException {
 
-		File nistApp = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_WINE_DRIVE_NIST_APPLICATION);
+		File nistApp = new File(TestPathHelper.TESTFILE_WINE_DRIVE_NIST_APPLICATION);
 		runtimeSupport = new MacWineSupport(nistApp.getParentFile(), parameterBackground);
 		assertNotNull(runtimeSupport);
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/WindowsSupport_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/WindowsSupport_1_ITest.java
@@ -18,11 +18,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class WindowsSupport_1_ITest extends AbstractBackgroundTestCase {
 
@@ -34,8 +32,8 @@ public class WindowsSupport_1_ITest extends AbstractBackgroundTestCase {
 	public void setUp() throws IOException {
 
 		super.setUp();
-		File nistApplication = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_WINDOWS_NIST_APPLICATION);
-		nistApplicationPath = nistApplication.getParent();
+		File nistApplication = new File(TestPathHelper.TESTFILE_WINDOWS_NIST_APPLICATION);
+		nistApplicationPath = nistApplication.getParentFile().getAbsolutePath();
 		runtimeSupport = new WindowsSupport(nistApplication.getParentFile(), parameterBackground);
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/WindowsSupport_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/WindowsSupport_2_ITest.java
@@ -20,11 +20,9 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.identifier.supplier.nist.TestPathHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class WindowsSupport_2_ITest extends AbstractBackgroundTestCase {
 
@@ -40,7 +38,7 @@ public class WindowsSupport_2_ITest extends AbstractBackgroundTestCase {
 	@Test
 	public void testConstruct_1() throws IOException {
 
-		File nistApp = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_WINDOWS_NIST_APPLICATION);
+		File nistApp = new File(TestPathHelper.TESTFILE_WINDOWS_NIST_APPLICATION);
 		runtimeSupport = new WindowsSupport(nistApp.getParentFile(), parameterBackground);
 		assertNotNull(runtimeSupport);
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogram_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogram_2_Test.java
@@ -14,13 +14,12 @@ package org.eclipse.chemclipse.msd.model.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.model.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.implementation.ChromatogramMSD;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class AbstractChromatogram_2_Test {
 
@@ -30,42 +29,42 @@ public class AbstractChromatogram_2_Test {
 	@Test
 	public void testExtractNameFromFile_1() throws IOException {
 
-		chromatogram.setFile(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_FILE_10102040_CDF));
+		chromatogram.setFile(new File(TestPathHelper.TESTFILE_IMPORT_FILE_10102040_CDF));
 		assertEquals("10.102040", chromatogram.extractNameFromFile(nameDefault));
 	}
 
 	@Test
 	public void testExtractNameFromFile_2() throws IOException {
 
-		chromatogram.setFile(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_FILE_102040_MZXML));
+		chromatogram.setFile(new File(TestPathHelper.TESTFILE_IMPORT_FILE_102040_MZXML));
 		assertEquals("102040", chromatogram.extractNameFromFile(nameDefault));
 	}
 
 	@Test
 	public void testExtractNameFromFile_3() throws IOException {
 
-		chromatogram.setFile(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_FILE_2012102040_SMS));
+		chromatogram.setFile(new File(TestPathHelper.TESTFILE_IMPORT_FILE_2012102040_SMS));
 		assertEquals("2012.102040", chromatogram.extractNameFromFile(nameDefault));
 	}
 
 	@Test
 	public void testExtractNameFromFile_4() throws IOException {
 
-		chromatogram.setFile(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_FILE_201220102078_SMS));
+		chromatogram.setFile(new File(TestPathHelper.TESTFILE_IMPORT_FILE_201220102078_SMS));
 		assertEquals("2012.20.102078", chromatogram.extractNameFromFile(nameDefault));
 	}
 
 	@Test
 	public void testExtractNameFromFile_5() throws IOException {
 
-		chromatogram.setFile(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_FILE_POLYETHYLENE_CDF));
+		chromatogram.setFile(new File(TestPathHelper.TESTFILE_IMPORT_FILE_POLYETHYLENE_CDF));
 		assertEquals("polyethylene", chromatogram.extractNameFromFile(nameDefault));
 	}
 
 	@Test
 	public void testExtractNameFromFile_6() throws IOException {
 
-		chromatogram.setFile(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_FILE_POLYETHYLENE_TEST));
+		chromatogram.setFile(new File(TestPathHelper.TESTFILE_IMPORT_FILE_POLYETHYLENE_TEST));
 		assertEquals(nameDefault, chromatogram.extractNameFromFile(nameDefault));
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogram_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogram_3_Test.java
@@ -14,13 +14,12 @@ package org.eclipse.chemclipse.msd.model.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.model.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.implementation.ChromatogramMSD;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class AbstractChromatogram_3_Test {
 
@@ -30,21 +29,21 @@ public class AbstractChromatogram_3_Test {
 	@Test
 	public void testExtractNameFromDirectory_1() throws IOException {
 
-		chromatogram.setFile(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_DIR_20120319));
+		chromatogram.setFile(new File(TestPathHelper.TESTFILE_IMPORT_DIR_20120319));
 		assertEquals("PW2012.03.19", chromatogram.extractNameFromFile(nameDefault));
 	}
 
 	@Test
 	public void testExtractNameFromDirectory_2() throws IOException {
 
-		chromatogram.setFile(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_DIR_20120320));
+		chromatogram.setFile(new File(TestPathHelper.TESTFILE_IMPORT_DIR_20120320));
 		assertEquals(nameDefault, chromatogram.extractNameFromFile(nameDefault));
 	}
 
 	@Test
 	public void testExtractNameFromDirectory_3() throws IOException {
 
-		chromatogram.setFile(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_DIR_20120321_1));
+		chromatogram.setFile(new File(TestPathHelper.TESTFILE_IMPORT_DIR_20120321_1));
 		assertEquals("PW20120321-1", chromatogram.extractNameFromFile(nameDefault));
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.nmr.converter.supplier.nmrml.fragment.test/src/org/eclipse/chemclipse/nmr/converter/supplier/nmrml/MMBBI_10M12_CE01_1a_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.nmr.converter.supplier.nmrml.fragment.test/src/org/eclipse/chemclipse/nmr/converter/supplier/nmrml/MMBBI_10M12_CE01_1a_ITest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IComplexSignalMeasurement;
 import org.eclipse.chemclipse.nmr.converter.supplier.nmrml.converter.ScanImportConverter;
 import org.eclipse.chemclipse.nmr.model.core.ISpectrumNMR;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MMBBI_10M12_CE01_1a_ITest {
@@ -39,7 +37,7 @@ public class MMBBI_10M12_CE01_1a_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.MMBBI_10M12_CE01_1a);
+		File file = new File(TestPathHelper.MMBBI_10M12_CE01_1a);
 		ScanImportConverter importConverter = new ScanImportConverter();
 		IProcessingInfo<ISpectrumNMR> processingInfo = importConverter.convert(file, new NullProgressMonitor());
 		spectrumNMR = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.pcr.converter.supplier.rdml.fragment.test/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/fragement/test/io/Test_5_Raw_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.pcr.converter.supplier.rdml.fragment.test/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/fragement/test/io/Test_5_Raw_ITest.java
@@ -22,7 +22,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.pcr.converter.supplier.rdml.core.PCRImportConverter;
 import org.eclipse.chemclipse.pcr.converter.supplier.rdml.fragment.test.TestPathHelper;
 import org.eclipse.chemclipse.pcr.model.core.IChannel;
@@ -34,7 +33,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Test_5_Raw_ITest {
@@ -44,7 +42,7 @@ public class Test_5_Raw_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_RAW_5);
+		File importFile = new File(TestPathHelper.TESTFILE_RAW_5);
 		IProcessingInfo<IPlate> importProcessingInfo = PCRImportConverter.getInstance().convert(importFile, new NullProgressMonitor());
 		plate = importProcessingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.pcr.converter.supplier.rdml.fragment.test/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/fragement/test/io/Test_Example_11_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.pcr.converter.supplier.rdml.fragment.test/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/fragement/test/io/Test_Example_11_ITest.java
@@ -22,7 +22,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.pcr.converter.supplier.rdml.core.PCRImportConverter;
 import org.eclipse.chemclipse.pcr.converter.supplier.rdml.fragment.test.TestPathHelper;
 import org.eclipse.chemclipse.pcr.model.core.IChannel;
@@ -34,7 +33,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Test_Example_11_ITest {
@@ -44,7 +42,7 @@ public class Test_Example_11_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.EXAMPLE_1_1);
+		File importFile = new File(TestPathHelper.EXAMPLE_1_1);
 		IProcessingInfo<IPlate> importProcessingInfo = PCRImportConverter.getInstance().convert(importFile, new NullProgressMonitor());
 		plate = importProcessingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.pcr.converter.supplier.rdml.fragment.test/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/fragement/test/io/Test_Example_12_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.pcr.converter.supplier.rdml.fragment.test/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/fragement/test/io/Test_Example_12_ITest.java
@@ -22,7 +22,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.pcr.converter.supplier.rdml.core.PCRImportConverter;
 import org.eclipse.chemclipse.pcr.converter.supplier.rdml.fragment.test.TestPathHelper;
 import org.eclipse.chemclipse.pcr.model.core.IChannel;
@@ -34,7 +33,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Test_Example_12_ITest {
@@ -44,7 +42,7 @@ public class Test_Example_12_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.EXAMPLE_1_2);
+		File importFile = new File(TestPathHelper.EXAMPLE_1_2);
 		IProcessingInfo<IPlate> importProcessingInfo = PCRImportConverter.getInstance().convert(importFile, new NullProgressMonitor());
 		plate = importProcessingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.pcr.converter.supplier.rdml.fragment.test/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/fragement/test/io/Test_Example_13_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.pcr.converter.supplier.rdml.fragment.test/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/fragement/test/io/Test_Example_13_ITest.java
@@ -22,7 +22,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.pcr.converter.supplier.rdml.core.PCRImportConverter;
 import org.eclipse.chemclipse.pcr.converter.supplier.rdml.fragment.test.TestPathHelper;
 import org.eclipse.chemclipse.pcr.model.core.IChannel;
@@ -34,7 +33,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Test_Example_13_ITest {
@@ -44,7 +42,7 @@ public class Test_Example_13_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.EXAMPLE_1_3);
+		File importFile = new File(TestPathHelper.EXAMPLE_1_3);
 		IProcessingInfo<IPlate> importProcessingInfo = PCRImportConverter.getInstance().convert(importFile, new NullProgressMonitor());
 		plate = importProcessingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.fragment.test/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/io/PlateExport_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.fragment.test/src/org/eclipse/chemclipse/pcr/report/supplier/tabular/excel/io/PlateExport_1_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.pcr.converter.core.IPlateExportConverter;
 import org.eclipse.chemclipse.pcr.model.core.IPlate;
 import org.eclipse.chemclipse.pcr.model.core.Plate;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PlateExport_1_ITest {
@@ -44,7 +42,7 @@ public class PlateExport_1_ITest {
 	public void setUp() throws IOException {
 
 		new File(DIRECTORY_EXPORT_TEST).mkdirs();
-		File path = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), DIRECTORY_EXPORT_TEST);
+		File path = new File(DIRECTORY_EXPORT_TEST);
 		file = new File(path, File.separator + "ExcelReport.xlsx");
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.rcp.app.fragment.test/src/org/eclipse/chemclipse/rcp/app/profiles/Profiles_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.rcp.app.fragment.test/src/org/eclipse/chemclipse/rcp/app/profiles/Profiles_1_ITest.java
@@ -18,19 +18,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.rcp.app.TestPathHelper;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.FrameworkUtil;
 
 public class Profiles_1_ITest {
 
 	@Test
 	public void test1() throws CoreException, IOException {
 
-		File file = new File(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_EXPORT_DIR), TestPathHelper.TESTFILE_EXPORT_NAME);
+		File file = new File(new File(TestPathHelper.TESTFILE_EXPORT_DIR), TestPathHelper.TESTFILE_EXPORT_NAME);
 		try {
 			Profiles.exportProfile(file);
 			assertTrue(file.delete());
@@ -47,7 +45,7 @@ public class Profiles_1_ITest {
 	@Test
 	public void test2() throws CoreException, IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_PREFS_1);
+		File file = new File(TestPathHelper.TESTFILE_IMPORT_PREFS_1);
 		IStatus status = Profiles.importProfile(file);
 		assertEquals(IStatus.OK, status.getCode());
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.vsd.converter.supplier.cml.test/src/org/eclipse/chemclipse/vsd/converter/supplier/cml/test/But2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.vsd.converter.supplier.cml.test/src/org/eclipse/chemclipse/vsd/converter/supplier/cml/test/But2_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.cml.converter.ScanImportConverter;
 import org.eclipse.chemclipse.vsd.converter.supplier.cml.model.IVendorSpectrumVSD;
@@ -28,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class But2_ITest {
@@ -38,7 +36,7 @@ public class But2_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.BUT2);
+		File file = new File(TestPathHelper.BUT2);
 		ScanImportConverter importConverter = new ScanImportConverter();
 		IProcessingInfo<ISpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
 		spectrumVSD = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.vsd.converter.supplier.cml.test/src/org/eclipse/chemclipse/vsd/converter/supplier/cml/test/PCLANIL_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.vsd.converter.supplier.cml.test/src/org/eclipse/chemclipse/vsd/converter/supplier/cml/test/PCLANIL_ITest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.cml.converter.ScanImportConverter;
 import org.eclipse.chemclipse.vsd.converter.supplier.cml.model.IVendorSpectrumVSD;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PCLANIL_ITest {
@@ -39,7 +37,7 @@ public class PCLANIL_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.PCLANIL);
+		File file = new File(TestPathHelper.PCLANIL);
 		ScanImportConverter importConverter = new ScanImportConverter();
 		IProcessingInfo<ISpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
 		spectrumVSD = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.cml.test/src/org/eclipse/chemclipse/wsd/converter/supplier/cml/test/Spectrum4_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.cml.test/src/org/eclipse/chemclipse/wsd/converter/supplier/cml/test/Spectrum4_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.supplier.cml.converter.ScanImportConverter;
 import org.eclipse.chemclipse.wsd.converter.supplier.cml.model.IVendorSpectrumWSD;
@@ -28,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Spectrum4_ITest {
@@ -38,7 +36,7 @@ public class Spectrum4_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.SPECTRUM4);
+		File file = new File(TestPathHelper.SPECTRUM4);
 		ScanImportConverter importConverter = new ScanImportConverter();
 		IProcessingInfo<ISpectrumWSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
 		spectrumWSD = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/wsd/converter/supplier/mzml/converter/ChromatogramImportConverterHandCrafted110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/wsd/converter/supplier/mzml/converter/ChromatogramImportConverterHandCrafted110_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.supplier.mzml.TestPathHelper;
 import org.eclipse.chemclipse.wsd.converter.supplier.mzml.model.IVendorChromatogram;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImportConverterHandCrafted110_ITest {
@@ -39,7 +37,7 @@ public class ChromatogramImportConverterHandCrafted110_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File importFile = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_PDA_HANDCRAFTED);
+		File importFile = new File(TestPathHelper.TESTFILE_PDA_HANDCRAFTED);
 		ChromatogramImportConverter converter = new ChromatogramImportConverter();
 		IProcessingInfo<IChromatogramWSD> processingInfo = converter.convert(importFile, new NullProgressMonitor());
 		chromatogram = (VendorChromatogram)processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.scf.fragment.test/src/org/eclipse/chemclipse/wsd/converter/supplier/scf/io/ABCZ_F_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.scf.fragment.test/src/org/eclipse/chemclipse/wsd/converter/supplier/scf/io/ABCZ_F_ITest.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.time.ZoneId;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.chromatogram.ChromatogramConverterWSD;
 import org.eclipse.chemclipse.wsd.converter.supplier.scf.SCF;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ABCZ_F_ITest {
@@ -39,7 +37,7 @@ public class ABCZ_F_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), SCF.TESTFILE_IMPORT_ABCZ_F);
+		File fileImport = new File(SCF.TESTFILE_IMPORT_ABCZ_F);
 		IProcessingInfo<IChromatogramWSD> processingInfo = ChromatogramConverterWSD.getInstance().convert(fileImport, SCF.EXTENSION_POINT_ID, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.spectroml.test/src/org/eclipse/chemclipse/wsd/converter/supplier/cml/test/SpectroML_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.spectroml.test/src/org/eclipse/chemclipse/wsd/converter/supplier/cml/test/SpectroML_ITest.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.time.ZoneId;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.supplier.spectroml.converter.ScanImportConverter;
 import org.eclipse.chemclipse.wsd.converter.supplier.spectroml.model.IVendorSpectrumWSD;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class SpectroML_ITest {
@@ -39,7 +37,7 @@ public class SpectroML_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.SAMPLE);
+		File file = new File(TestPathHelper.SAMPLE);
 		ScanImportConverter importConverter = new ScanImportConverter();
 		IProcessingInfo<ISpectrumWSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
 		spectrumWSD = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.csv.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/ChromatogramReader_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.csv.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/ChromatogramReader_1_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.settings.Delimiter;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_ITest {
@@ -56,13 +54,13 @@ public class ChromatogramReader_1_ITest {
 		/*
 		 * Import the chromatogram.
 		 */
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
 		IProcessingInfo<IChromatogramMSD> processingInfoImport = ChromatogramConverterMSD.getInstance().convert(fileImport, extensionPointImport, new NullProgressMonitor());
 		IChromatogramMSD chromatogramImport = processingInfoImport.getProcessingResult();
 		/*
 		 * Export the chromatogram.
 		 */
-		fileExport = new File(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.DIRECTORY_EXPORT_TEST), File.separator + "Test.csv");
+		fileExport = new File(new File(TestPathHelper.DIRECTORY_EXPORT_TEST), File.separator + "Test.csv");
 		IProcessingInfo<File> processingInfoExport = ChromatogramConverterMSD.getInstance().convert(fileExport, chromatogramImport, extensionPointExportReimport, new NullProgressMonitor());
 		fileExport = processingInfoExport.getProcessingResult();
 		/*

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.csv.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/ChromatogramWriter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.csv.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/ChromatogramWriter_1_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramWriter_1_ITest {
@@ -43,10 +41,10 @@ public class ChromatogramWriter_1_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
-		file = new File(PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.DIRECTORY_EXPORT_TEST), File.separator + "Test.csv");
+		file = new File(new File(TestPathHelper.DIRECTORY_EXPORT_TEST), File.separator + "Test.csv");
 	}
 
 	@AfterAll

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Banana_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Banana_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.supplier.jcampdx.converter.ChromatogramImportConverter;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Banana_ITest {
@@ -36,7 +34,7 @@ public class Banana_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.BANANA);
+		File file = new File(TestPathHelper.BANANA);
 		ChromatogramImportConverter chromatogramImportConverter = new ChromatogramImportConverter();
 		IProcessingInfo<IChromatogramCSD> processingInfo = chromatogramImportConverter.convert(file, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/BrukerAFFN_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/BrukerAFFN_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IComplexSignalMeasurement;
 import org.eclipse.chemclipse.nmr.converter.supplier.jcampdx.converter.ScanImportConverterNMR;
 import org.eclipse.chemclipse.nmr.model.core.ISpectrumNMR;
@@ -28,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class BrukerAFFN_ITest {
@@ -38,7 +36,7 @@ public class BrukerAFFN_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.REAL_SPECTRUM_ASCII_FREE_FORMAT_NUMERIC);
+		File file = new File(TestPathHelper.REAL_SPECTRUM_ASCII_FREE_FORMAT_NUMERIC);
 		ScanImportConverterNMR importConverter = new ScanImportConverterNMR();
 		IProcessingInfo<ISpectrumNMR> processingInfo = importConverter.convert(file, new NullProgressMonitor());
 		complexSignalMeasurement = processingInfo.getProcessingResult().getComplexSignalMeasurements().iterator().next();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Chromatogram_01_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Chromatogram_01_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.msd.converter.supplier.jcampdx.converter.ChromatogramImportConverter;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Chromatogram_01_ITest {
@@ -40,7 +38,7 @@ public class Chromatogram_01_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.CHROMATOGRAM_01);
+		File file = new File(TestPathHelper.CHROMATOGRAM_01);
 		ChromatogramImportConverter chromatogramImportConverter = new ChromatogramImportConverter();
 		IProcessingInfo<IChromatogramMSD> processingInfo = chromatogramImportConverter.convert(file, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Cinnamon_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Cinnamon_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.supplier.jcampdx.converter.ChromatogramImportConverter;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Cinnamon_ITest {
@@ -36,7 +34,7 @@ public class Cinnamon_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.CINNAMON);
+		File file = new File(TestPathHelper.CINNAMON);
 		ChromatogramImportConverter chromatogramImportConverter = new ChromatogramImportConverter();
 		IProcessingInfo<IChromatogramCSD> processingInfo = chromatogramImportConverter.convert(file, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedDecrease1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedDecrease1_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.converter.ScanImportConverter;
 import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class FixedDecrease1_ITest {
@@ -37,7 +35,7 @@ public class FixedDecrease1_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.FIXDEC1);
+		File file = new File(TestPathHelper.FIXDEC1);
 		ScanImportConverter importConverter = new ScanImportConverter();
 		IProcessingInfo<ISpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
 		spectrumVSD = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedIncrease1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedIncrease1_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.converter.ScanImportConverter;
 import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class FixedIncrease1_ITest {
@@ -37,7 +35,7 @@ public class FixedIncrease1_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.FIXINC1);
+		File file = new File(TestPathHelper.FIXINC1);
 		ScanImportConverter importConverter = new ScanImportConverter();
 		IProcessingInfo<ISpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
 		spectrumVSD = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedIncrease2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedIncrease2_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.converter.ScanImportConverter;
 import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class FixedIncrease2_ITest {
@@ -37,7 +35,7 @@ public class FixedIncrease2_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.FIXINC2);
+		File file = new File(TestPathHelper.FIXINC2);
 		ScanImportConverter importConverter = new ScanImportConverter();
 		IProcessingInfo<ISpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
 		spectrumVSD = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Ginger_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Ginger_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.supplier.jcampdx.converter.ChromatogramImportConverter;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Ginger_ITest {
@@ -36,7 +34,7 @@ public class Ginger_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.GINGER);
+		File file = new File(TestPathHelper.GINGER);
 		ChromatogramImportConverter chromatogramImportConverter = new ChromatogramImportConverter();
 		IProcessingInfo<IChromatogramCSD> processingInfo = chromatogramImportConverter.convert(file, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Grape_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Grape_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.supplier.jcampdx.converter.ScanImportConverter;
 import org.eclipse.chemclipse.wsd.model.core.ISpectrumWSD;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Grape_ITest {
@@ -37,7 +35,7 @@ public class Grape_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.GRAPE);
+		File file = new File(TestPathHelper.GRAPE);
 		ScanImportConverter importConverter = new ScanImportConverter();
 		IProcessingInfo<ISpectrumWSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
 		spectrumWSD = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Guava_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Guava_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.supplier.jcampdx.converter.ChromatogramImportConverter;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Guava_ITest {
@@ -36,7 +34,7 @@ public class Guava_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.GUAVA);
+		File file = new File(TestPathHelper.GUAVA);
 		ChromatogramImportConverter chromatogramImportConverter = new ChromatogramImportConverter();
 		IProcessingInfo<IChromatogramCSD> processingInfo = chromatogramImportConverter.convert(file, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_0_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_0_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.database.DatabaseConverter;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Heptane_0_ITest {
@@ -39,7 +37,7 @@ public class Heptane_0_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.HEPTANE_0);
+		File file = new File(TestPathHelper.HEPTANE_0);
 		IProcessingInfo<IMassSpectra> processingInfo = DatabaseConverter.convert(file, new NullProgressMonitor());
 		massSpectra = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_1_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.database.DatabaseConverter;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Heptane_1_ITest {
@@ -43,7 +41,7 @@ public class Heptane_1_ITest {
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex1(SeparationColumnType.NON_POLAR);
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex2(SeparationColumnType.POLAR);
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex3(SeparationColumnType.SEMI_POLAR);
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.HEPTANE_1);
+		File file = new File(TestPathHelper.HEPTANE_1);
 		IProcessingInfo<IMassSpectra> processingInfo = DatabaseConverter.convert(file, new NullProgressMonitor());
 		massSpectra = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_2_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.database.DatabaseConverter;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Heptane_2_ITest {
@@ -43,7 +41,7 @@ public class Heptane_2_ITest {
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex1(SeparationColumnType.NON_POLAR);
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex2(SeparationColumnType.POLAR);
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex3(SeparationColumnType.SEMI_POLAR);
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.HEPTANE_2);
+		File file = new File(TestPathHelper.HEPTANE_2);
 		IProcessingInfo<IMassSpectra> processingInfo = DatabaseConverter.convert(file, new NullProgressMonitor());
 		massSpectra = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_3_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.database.DatabaseConverter;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Heptane_3_ITest {
@@ -43,7 +41,7 @@ public class Heptane_3_ITest {
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex1(SeparationColumnType.NON_POLAR);
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex2(SeparationColumnType.POLAR);
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex3(SeparationColumnType.SEMI_POLAR);
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.HEPTANE_3);
+		File file = new File(TestPathHelper.HEPTANE_3);
 		IProcessingInfo<IMassSpectra> processingInfo = DatabaseConverter.convert(file, new NullProgressMonitor());
 		massSpectra = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_X_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_X_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.database.DatabaseConverter;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Heptane_X_ITest {
@@ -43,7 +41,7 @@ public class Heptane_X_ITest {
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex1(SeparationColumnType.NON_POLAR);
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex2(SeparationColumnType.POLAR);
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex3(SeparationColumnType.SEMI_POLAR);
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.HEPTANE_X);
+		File file = new File(TestPathHelper.HEPTANE_X);
 		IProcessingInfo<IMassSpectra> processingInfo = DatabaseConverter.convert(file, new NullProgressMonitor());
 		massSpectra = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/JCAMPTestPolys_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/JCAMPTestPolys_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.converter.ScanImportConverter;
 import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class JCAMPTestPolys_ITest {
@@ -37,7 +35,7 @@ public class JCAMPTestPolys_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.JTPOLYS);
+		File file = new File(TestPathHelper.JTPOLYS);
 		ScanImportConverter importConverter = new ScanImportConverter();
 		IProcessingInfo<ISpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
 		spectrumVSD = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Lime_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Lime_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.supplier.jcampdx.converter.ChromatogramImportConverter;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Lime_ITest {
@@ -36,7 +34,7 @@ public class Lime_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.LIME);
+		File file = new File(TestPathHelper.LIME);
 		ChromatogramImportConverter chromatogramImportConverter = new ChromatogramImportConverter();
 		IProcessingInfo<IChromatogramCSD> processingInfo = chromatogramImportConverter.convert(file, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/PacDecreasing_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/PacDecreasing_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.converter.ScanImportConverter;
 import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PacDecreasing_ITest {
@@ -37,7 +35,7 @@ public class PacDecreasing_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.PACDEC1);
+		File file = new File(TestPathHelper.PACDEC1);
 		ScanImportConverter importConverter = new ScanImportConverter();
 		IProcessingInfo<ISpectrumVSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
 		spectrumVSD = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/PassionFruit_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/PassionFruit_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.supplier.jcampdx.converter.ChromatogramImportConverter;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PassionFruit_ITest {
@@ -36,7 +34,7 @@ public class PassionFruit_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.PASSION_FRUIT);
+		File file = new File(TestPathHelper.PASSION_FRUIT);
 		ChromatogramImportConverter chromatogramImportConverter = new ChromatogramImportConverter();
 		IProcessingInfo<IChromatogramCSD> processingInfo = chromatogramImportConverter.convert(file, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Pepsi_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Pepsi_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.supplier.jcampdx.converter.ScanImportConverter;
 import org.eclipse.chemclipse.wsd.model.core.ISpectrumWSD;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Pepsi_ITest {
@@ -37,7 +35,7 @@ public class Pepsi_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.PEPSI);
+		File file = new File(TestPathHelper.PEPSI);
 		ScanImportConverter importConverter = new ScanImportConverter();
 		IProcessingInfo<ISpectrumWSD> processingInfo = importConverter.convert(file, new NullProgressMonitor());
 		spectrumWSD = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Piment_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Piment_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.supplier.jcampdx.converter.ChromatogramImportConverter;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class Piment_ITest {
@@ -36,7 +34,7 @@ public class Piment_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File file = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.PIMENT);
+		File file = new File(TestPathHelper.PIMENT);
 		ChromatogramImportConverter chromatogramImportConverter = new ChromatogramImportConverter();
 		IProcessingInfo<IChromatogramCSD> processingInfo = chromatogramImportConverter.convert(file, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/MethodReaderTest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/MethodReaderTest.java
@@ -26,9 +26,9 @@ import java.net.URL;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
+import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
 import org.eclipse.chemclipse.processing.methods.ProcessEntry;
-import org.eclipse.chemclipse.processing.methods.IProcessEntryContainer;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.methods.MethodExportConverter;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.methods.MethodImportConverter;

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1001_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1001_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_FID_1001_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_FID_1001_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1001);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1001);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1002_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1002_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_FID_1002_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_FID_1002_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1002);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1002);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1003_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1003_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_FID_1003_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_FID_1003_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1003);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1003);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1004_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1004_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_FID_1004_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_FID_1004_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1004);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1004);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1005_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1005_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_FID_1005_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_FID_1005_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1005);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1005);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1006_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1006_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_FID_1006_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_FID_1006_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1006);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1006);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1007_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1007_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_FID_1007_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_FID_1007_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1007);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1007);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1100_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1100_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_FID_1100_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_FID_1100_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1100);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1100);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1300_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1300_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_FID_1300_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_FID_1300_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1300);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1300);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1301_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1301_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_FID_1301_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_FID_1301_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1301);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1301);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1400_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1400_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_FID_1400_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_FID_1400_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1400);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1400);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1500_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1500_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_FID_1500_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_FID_1500_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1500);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1500);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1501_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_FID_1501_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_FID_1501_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_FID_1501_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1501);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1501);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0701_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0701_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_0701_ITest {
@@ -40,7 +38,7 @@ public class ChromatogramReader_1_MSD_0701_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0701);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0701);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0801_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0801_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_0801_ITest {
@@ -40,7 +38,7 @@ public class ChromatogramReader_1_MSD_0801_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0801);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0801);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0802_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0802_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_0802_ITest {
@@ -40,7 +38,7 @@ public class ChromatogramReader_1_MSD_0802_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0802);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0802);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0803_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0803_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_0803_ITest {
@@ -40,7 +38,7 @@ public class ChromatogramReader_1_MSD_0803_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0803);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0803);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0901_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0901_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_0901_ITest {
@@ -40,7 +38,7 @@ public class ChromatogramReader_1_MSD_0901_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0901);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0901);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0902_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0902_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_0902_ITest {
@@ -40,7 +38,7 @@ public class ChromatogramReader_1_MSD_0902_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0902);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0902);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0903_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_0903_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_0903_ITest {
@@ -40,7 +38,7 @@ public class ChromatogramReader_1_MSD_0903_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0903);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0903);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1001_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1001_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_1001_ITest {
@@ -40,7 +38,7 @@ public class ChromatogramReader_1_MSD_1001_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1001);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1001);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1002_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1002_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_1002_ITest {
@@ -40,7 +38,7 @@ public class ChromatogramReader_1_MSD_1002_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1002);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1002);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1003_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1003_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_1003_ITest {
@@ -40,7 +38,7 @@ public class ChromatogramReader_1_MSD_1003_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1003);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1003);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1004_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1004_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_1004_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_MSD_1004_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1004);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1004);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1005_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1005_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_1005_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_MSD_1005_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1005);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1005);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1006_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1006_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_1006_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_MSD_1006_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1006);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1006);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1007_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1007_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_1007_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_MSD_1007_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1007);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1007);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1100_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1100_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_1100_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_MSD_1100_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1100);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1100);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1300_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1300_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_1300_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_MSD_1300_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1300);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1300);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1301_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1301_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_1301_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_MSD_1301_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1301);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1301);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1400_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1400_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_1400_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_MSD_1400_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1400);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1400);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1500_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1500_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 
@@ -42,7 +40,7 @@ public class ChromatogramReader_1_MSD_1500_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1500);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1500);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1501_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_1_MSD_1501_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_1_MSD_1501_ITest {
@@ -41,7 +39,7 @@ public class ChromatogramReader_1_MSD_1501_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1501);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1501);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0701_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0701_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_0701_ITest {
@@ -40,7 +38,7 @@ public class ChromatogramReader_2_MSD_0701_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_0701);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_0701);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0801_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0801_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_0801_ITest {
@@ -40,7 +38,7 @@ public class ChromatogramReader_2_MSD_0801_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_0801);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_0801);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0802_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0802_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_0802_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_2_MSD_0802_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_0802);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_0802);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0803_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0803_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_0803_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_2_MSD_0803_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_0803);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_0803);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0901_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0901_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_0901_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_2_MSD_0901_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_0901);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_0901);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0902_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0902_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_0902_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_2_MSD_0902_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_0902);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_0902);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0903_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_0903_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 /**
  * NOTE:
@@ -51,7 +49,7 @@ public class ChromatogramReader_2_MSD_0903_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_0903);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_0903);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1001_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1001_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_1001_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_2_MSD_1001_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1001);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1001);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1002_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1002_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_1002_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_2_MSD_1002_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1002);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1002);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1003_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1003_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_1003_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_2_MSD_1003_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1003);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1003);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1004_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1004_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_1004_ITest {
@@ -43,7 +41,7 @@ public class ChromatogramReader_2_MSD_1004_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1004);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1004);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1005_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1005_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_1005_ITest {
@@ -43,7 +41,7 @@ public class ChromatogramReader_2_MSD_1005_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1005);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1005);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1006_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1006_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_1006_ITest {
@@ -43,7 +41,7 @@ public class ChromatogramReader_2_MSD_1006_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1006);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1006);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1007_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1007_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_1007_ITest {
@@ -43,7 +41,7 @@ public class ChromatogramReader_2_MSD_1007_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1007);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1007);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1100_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1100_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_1100_ITest {
@@ -43,7 +41,7 @@ public class ChromatogramReader_2_MSD_1100_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1100);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1100);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1300_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1300_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_1300_ITest {
@@ -43,7 +41,7 @@ public class ChromatogramReader_2_MSD_1300_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1300);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1300);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1301_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1301_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_1301_ITest {
@@ -43,7 +41,7 @@ public class ChromatogramReader_2_MSD_1301_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1301);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1301);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1400_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1400_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_1400_ITest {
@@ -43,7 +41,7 @@ public class ChromatogramReader_2_MSD_1400_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1400);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1400);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1500_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1500_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_1500_ITest {
@@ -43,7 +41,7 @@ public class ChromatogramReader_2_MSD_1500_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1500);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1500);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1501_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_2_MSD_1501_ITest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_2_MSD_1501_ITest {
@@ -43,7 +41,7 @@ public class ChromatogramReader_2_MSD_1501_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1501);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_2_MSD_1501);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1001_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1001_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.model.core.IScan;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_FID_1001_ITest {
@@ -39,7 +37,7 @@ public class ChromatogramReader_3_FID_1001_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1001);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1001);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1002_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1002_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.model.core.IScan;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_FID_1002_ITest {
@@ -39,7 +37,7 @@ public class ChromatogramReader_3_FID_1002_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1002);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1002);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1003_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1003_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.model.core.IScan;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_FID_1003_ITest {
@@ -39,7 +37,7 @@ public class ChromatogramReader_3_FID_1003_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1003);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1003);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1004_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1004_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.model.core.IScan;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_FID_1004_ITest {
@@ -39,7 +37,7 @@ public class ChromatogramReader_3_FID_1004_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1004);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1004);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1005_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1005_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.model.core.IScan;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_FID_1005_ITest {
@@ -39,7 +37,7 @@ public class ChromatogramReader_3_FID_1005_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1005);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1005);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1006_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1006_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.model.core.IScan;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_FID_1006_ITest {
@@ -39,7 +37,7 @@ public class ChromatogramReader_3_FID_1006_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1006);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1006);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1007_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1007_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.model.core.IScan;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_FID_1007_ITest {
@@ -39,7 +37,7 @@ public class ChromatogramReader_3_FID_1007_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1007);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1007);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1100_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1100_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.model.core.IScan;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_FID_1100_ITest {
@@ -39,7 +37,7 @@ public class ChromatogramReader_3_FID_1100_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1100);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1100);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1300_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1300_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.model.core.IScan;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_FID_1300_ITest {
@@ -39,7 +37,7 @@ public class ChromatogramReader_3_FID_1300_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1300);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1300);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1301_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1301_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.model.core.IScan;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_FID_1301_ITest {
@@ -39,7 +37,7 @@ public class ChromatogramReader_3_FID_1301_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1301);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1301);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1400_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1400_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.model.core.IScan;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_FID_1400_ITest {
@@ -39,7 +37,7 @@ public class ChromatogramReader_3_FID_1400_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1400);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1400);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1500_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1500_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.model.core.IScan;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_FID_1500_ITest {
@@ -39,7 +37,7 @@ public class ChromatogramReader_3_FID_1500_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1500);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1500);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1501_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_FID_1501_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.model.core.IScan;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_FID_1501_ITest {
@@ -39,7 +37,7 @@ public class ChromatogramReader_3_FID_1501_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1501);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1501);
 		IProcessingInfo<IChromatogramCSD> processingInfo = ChromatogramConverterCSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1001_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1001_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_MSD_1001_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_3_MSD_1001_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1001);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1001);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1002_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1002_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_MSD_1002_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_3_MSD_1002_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1002);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1002);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1003_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1003_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_MSD_1003_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_3_MSD_1003_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1003);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1003);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1004_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1004_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_MSD_1004_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_3_MSD_1004_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1004);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1004);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1005_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1005_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_MSD_1005_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_3_MSD_1005_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1005);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1005);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1006_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1006_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_MSD_1006_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_3_MSD_1006_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1006);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1006);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1007_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1007_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_MSD_1007_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_3_MSD_1007_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1007);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1007);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1100_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1100_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_MSD_1100_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_3_MSD_1100_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1100);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1100);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1300_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1300_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_MSD_1300_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_3_MSD_1300_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1300);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1300);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1301_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1301_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_MSD_1301_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_3_MSD_1301_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1301);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1301);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1400_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1400_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_MSD_1400_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_3_MSD_1400_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1400);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1400);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1500_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1500_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_MSD_1500_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_3_MSD_1500_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1500);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1500);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1501_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_3_MSD_1501_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_3_MSD_1501_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_3_MSD_1501_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1501);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_3_FID_1501);
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_4_DAD_1501_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/ChromatogramReader_4_DAD_1501_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.chromatogram.ChromatogramConverterWSD;
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramReader_4_DAD_1501_ITest {
@@ -42,7 +40,7 @@ public class ChromatogramReader_4_DAD_1501_ITest {
 	public void setUp() throws IOException {
 
 		PreferenceSupplier.setForceLoadAlternateDetector(true);
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_4_DAD_1501);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_4_DAD_1501);
 		IProcessingInfo<IChromatogramWSD> processingInfo = ChromatogramConverterWSD.getInstance().convert(fileImport, VersionConstants.CONVERTER_ID_CHROMATOGRAM, new NullProgressMonitor());
 		chromatogram = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_0801_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_0801_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_0801_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_0801_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0801);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0801);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_0802_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_0802_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_0802_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_0802_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0802);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0802);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_0803_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_0803_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_0803_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_0803_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0803);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0803);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_0901_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_0901_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_0901_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_0901_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0901);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0901);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_0902_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_0902_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_0902_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_0902_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0902);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0902);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_0903_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_0903_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_0903_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_0903_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0903);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_0903);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1001_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1001_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_1001_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_1001_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1001);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1001);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1002_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1002_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_1002_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_1002_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1002);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1002);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1003_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1003_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_1003_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_1003_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1003);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1003);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1004_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1004_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_1004_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_1004_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1004);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1004);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1005_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1005_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_1005_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_1005_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1005);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1005);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1006_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1006_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_1006_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_1006_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1006);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1006);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1007_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1007_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_1007_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_1007_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1007);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1007);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1100_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1100_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_1100_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_1100_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1100);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1100);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1300_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1300_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_1300_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_1300_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1300);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1300);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1301_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1301_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_1301_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_1301_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1301);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1301);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1400_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1400_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_1400_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_1400_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1400);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1400);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1500_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1500_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_1500_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_1500_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1500);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1500);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1501_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/io/PeakReader_1_MSD_1501_ITest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import org.eclipse.chemclipse.converter.PathResolver;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.peak.PeakConverterMSD;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.osgi.framework.FrameworkUtil;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class PeakReader_1_MSD_1501_ITest {
@@ -43,7 +41,7 @@ public class PeakReader_1_MSD_1501_ITest {
 	@BeforeAll
 	public void setUp() throws IOException {
 
-		File fileImport = PathResolver.getFile(FrameworkUtil.getBundle(getClass()), TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1501);
+		File fileImport = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM_1_MSD_1501);
 		IProcessingInfo<IPeaksMSD> processingInfo = PeakConverterMSD.convert(fileImport, VersionConstants.CONVERTER_ID_PEAKS, new NullProgressMonitor());
 		peaks = processingInfo.getProcessingResult();
 	}


### PR DESCRIPTION
This is a follow-up to https://github.com/eclipse-chemclipse/chemclipse/pull/2639. OSGi path resolving is only required at runtime when a package is compiled to jar but not at unit test time. Maybe this was required a few years ago, but no more, so this can be simplified.