### PR TITLE
Fix reading mzML instrument

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/META-INF/MANIFEST.MF
@@ -24,8 +24,7 @@ Bundle-ActivationPolicy: lazy
 Import-Package: jakarta.xml.bind,
  jakarta.xml.bind.annotation,
  jakarta.xml.bind.annotation.adapters
-Export-Package: org.eclipse.chemclipse.msd.converter.supplier.mzml,
- org.eclipse.chemclipse.msd.converter.supplier.mzml.converter,
+Export-Package: org.eclipse.chemclipse.msd.converter.supplier.mzml.converter,
  org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.io,
  org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model,
  org.eclipse.chemclipse.msd.converter.supplier.mzml.io,

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/MetadataReader110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/MetadataReader110.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.converter.supplier.mzml.io;
 
+import java.util.List;
+
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.support.history.EditInformation;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.CVParamType;
@@ -20,6 +22,7 @@ import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.InstrumentC
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.MzMLType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.ParamGroupType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.ProcessingMethodType;
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.ReferenceableParamGroupRefType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.SampleListType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.SampleType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.SoftwareType;
@@ -37,6 +40,7 @@ public class MetadataReader110 {
 				}
 			}
 		}
+
 		SampleListType sampleList = mzML.getSampleList();
 		if(sampleList != null) {
 			for(SampleType sample : sampleList.getSample()) {
@@ -47,13 +51,19 @@ public class MetadataReader110 {
 				}
 			}
 		}
+
 		for(InstrumentConfigurationType instrument : mzML.getInstrumentConfigurationList().getInstrumentConfiguration()) {
-			for(CVParamType cvParam : instrument.getCvParam()) {
-				if(cvParam.getAccession().equals("MS:1000554")) {
-					chromatogram.setInstrument(cvParam.getName());
+
+			List<ReferenceableParamGroupRefType> referenceableParamGroupRef = instrument.getReferenceableParamGroupRef();
+			if(referenceableParamGroupRef != null) {
+				for(ReferenceableParamGroupRefType referenceableParamGroupRefType : referenceableParamGroupRef) {
+					readInstrument(referenceableParamGroupRefType.getRef().getCvParam(), chromatogram);
 				}
 			}
+
+			readInstrument(instrument.getCvParam(), chromatogram);
 		}
+
 		for(DataProcessingType dataProcessing : mzML.getDataProcessingList().getDataProcessing()) {
 			for(ProcessingMethodType processingMethod : dataProcessing.getProcessingMethod()) {
 				SoftwareType software = (SoftwareType)processingMethod.getSoftwareRef();
@@ -64,6 +74,18 @@ public class MetadataReader110 {
 				}
 			}
 		}
+
 		return chromatogram;
+	}
+
+	private static void readInstrument(List<CVParamType> cvParams, IChromatogram chromatogram) {
+
+		for(CVParamType cvParam : cvParams) {
+			if(cvParam.getAccession().equals("MS:1000529") && cvParam.getName().equals("instrument serial number")) {
+				continue;
+			} else {
+				chromatogram.setInstrument(cvParam.getName());
+			}
+		}
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverterTinyProteoWizard10_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverterTinyProteoWizard10_ITest.java
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorChromatogram;
@@ -36,7 +35,7 @@ public class ChromatogramImportConverterTinyProteoWizard10_ITest {
 	private IVendorChromatogram chromatogram;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_TINY_PWIZ_1_0);
 		ChromatogramImportConverter converter = new ChromatogramImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverterTinyProteoWizard110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverterTinyProteoWizard110_ITest.java
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorChromatogram;
@@ -36,7 +35,7 @@ public class ChromatogramImportConverterTinyProteoWizard110_ITest {
 	private IVendorChromatogram chromatogram;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_TINY_PWIZ_1_1);
 		ChromatogramImportConverter converter = new ChromatogramImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportExport110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportExport110_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.TestPathHelper;
@@ -38,7 +37,7 @@ public class ChromatogramImportExport110_ITest {
 	private File fileExport;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		/*
 		 * Import

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverter110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverter110_ITest.java
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorMassSpectra;
@@ -36,7 +35,7 @@ public class MassSpectrumImportConverter110_ITest {
 	private IVendorMassSpectra massSpectra;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_TINY1_1_1);
 		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverterCentroided110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverterCentroided110_ITest.java
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorMassSpectra;
@@ -36,7 +35,7 @@ public class MassSpectrumImportConverterCentroided110_ITest {
 	private IVendorMassSpectra massSpectra;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_TINY1_CENTROIDED_1_1);
 		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverterCompressed110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumImportConverterCompressed110_ITest.java
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorMassSpectra;
@@ -36,7 +35,7 @@ public class MassSpectrumImportConverterCompressed110_ITest {
 	private IVendorMassSpectra massSpectra;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_TINY1_COMPRESSED_1_1);
 		MassSpectrumImportConverter converter = new MassSpectrumImportConverter();


### PR DESCRIPTION
I accidentally hardcoded it to only read
```ini
[Term]
id: MS:1000554
name: LCQ Deca
def: "ThermoFinnigan LCQ Deca." [PSI:MS]
is_a: MS:1000125 ! Thermo Finnigan instrument model
```
because I misunderstood the ontology. Also @proteowizard does this
```xml
<referenceableParamGroupList count="1">
  <referenceableParamGroup id="CommonInstrumentParams">
    <cvParam cvRef="MS" accession="MS:1000556" name="LTQ Orbitrap XL" value=""/>
    <cvParam cvRef="MS" accession="MS:1000529" name="instrument serial number" value=""/>
  </referenceableParamGroup>
</referenceableParamGroupList>
```
which is now also understood.