### PR TITLE
Just show the PeakException message instead of the complete stack trace.

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.firstderivative/src/org/eclipse/chemclipse/chromatogram/csd/peak/detector/supplier/firstderivative/core/PeakDetectorCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.firstderivative/src/org/eclipse/chemclipse/chromatogram/csd/peak/detector/supplier/firstderivative/core/PeakDetectorCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -239,7 +239,7 @@ public class PeakDetectorCSD extends BasePeakDetector implements IPeakDetectorCS
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		chromatogram.setDirty(true);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector.supplier.firstderivative/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/supplier/firstderivative/core/PeakDetectorWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector.supplier.firstderivative/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/supplier/firstderivative/core/PeakDetectorWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -249,7 +249,7 @@ public class PeakDetectorWSD extends BasePeakDetector implements IPeakDetectorWS
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeakModel.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeakModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -285,7 +285,7 @@ public abstract class AbstractPeakModel extends AbstractPeakModelStrict implemen
 		 */
 		Map.Entry<Integer, Float> entry = peakIntensityValues.getHighestIntensityValue();
 		if(entry == null) {
-			throw new PeakException("There must be at least one intensity value stored with a relative intensity of IPeakIntensityValues.MAX_INTENSITY.");
+			throw new PeakException("Failed ot create the peak: there must be at least one intensity value stored with a relative intensity of IPeakIntensityValues.MAX_INTENSITY.");
 		}
 		/*
 		 * Sets the peak maximum retention time.

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeakModel.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeakModel.java
@@ -285,7 +285,7 @@ public abstract class AbstractPeakModel extends AbstractPeakModelStrict implemen
 		 */
 		Map.Entry<Integer, Float> entry = peakIntensityValues.getHighestIntensityValue();
 		if(entry == null) {
-			throw new PeakException("Failed ot create the peak: there must be at least one intensity value stored with a relative intensity of IPeakIntensityValues.MAX_INTENSITY.");
+			throw new PeakException("Failed to create the peak: there must be at least one intensity value stored with a relative intensity of IPeakIntensityValues.MAX_INTENSITY.");
 		}
 		/*
 		 * Sets the peak maximum retention time.

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/io/MatlabParafacPeakReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac/src/org/eclipse/chemclipse/msd/converter/supplier/matlab/parafac/io/MatlabParafacPeakReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Lablicate GmbH.
+ * Copyright (c) 2011, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -113,7 +113,7 @@ public class MatlabParafacPeakReader implements IPeakReader {
 		} catch(PeakException e) {
 			processingMessage = new ProcessingMessage(MessageType.WARN, "Import Peak", getMessage("The peak couldn't be created", peakSupport.getModelDescription(), file.getAbsolutePath()));
 			processingInfo.addMessage(processingMessage);
-			logger.warn(e);
+			logger.warn(e.getMessage());
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/custom/PeakDetectorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/custom/PeakDetectorSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -112,7 +112,7 @@ public class PeakDetectorSupport {
 				}
 			}
 		} catch(PeakException e) {
-			logger.warn(e);
+			logger.warn(e.getMessage());
 		}
 
 		return peak;
@@ -156,7 +156,7 @@ public class PeakDetectorSupport {
 				}
 			}
 		} catch(PeakException e) {
-			logger.warn(e);
+			logger.warn(e.getMessage());
 		}
 
 		return peak;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakChartUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -661,7 +661,7 @@ public class ExtendedPeakChartUI extends Composite implements IExtendedPartUI {
 					peakSplitted = manualPeakDetector.calculatePeak(chromatogram, startRetentionTime, stopRetentionTime, startAbundance, stopAbundance);
 				}
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		} else if(peak instanceof IChromatogramPeakCSD chromatogramPeakCSD) {
 			/*
@@ -674,7 +674,7 @@ public class ExtendedPeakChartUI extends Composite implements IExtendedPartUI {
 					peakSplitted = manualPeakDetector.calculatePeak(chromatogram, startRetentionTime, stopRetentionTime, startAbundance, stopAbundance);
 				}
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakDetectorUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakDetectorUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1018,7 +1018,7 @@ public class ExtendedPeakDetectorUI extends Composite implements IExtendedPartUI
 				IChromatogramPeakMSD chromatogramPeak = manualPeakDetector.calculatePeak(chromatogram, startRetentionTime, stopRetentionTime, startAbundance, stopAbundance);
 				peak = chromatogramPeak;
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		} else if(chromatogramSelection instanceof IChromatogramSelectionCSD chromatogramSelectionCSD) {
 			/*
@@ -1030,7 +1030,7 @@ public class ExtendedPeakDetectorUI extends Composite implements IExtendedPartUI
 				IChromatogramPeakCSD chromatogramPeak = manualPeakDetector.calculatePeak(chromatogram, startRetentionTime, stopRetentionTime, startAbundance, stopAbundance);
 				peak = chromatogramPeak;
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		} else if(chromatogramSelection instanceof IChromatogramSelectionWSD chromatogramSelectionWSD) {
 			/*
@@ -1042,7 +1042,7 @@ public class ExtendedPeakDetectorUI extends Composite implements IExtendedPartUI
 				IChromatogramPeakWSD chromatogramPeak = manualPeakDetector.calculatePeak(chromatogram, startRetentionTime, stopRetentionTime, startAbundance, stopAbundance);
 				peak = chromatogramPeak;
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1001.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -200,7 +200,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		if(closeStream) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1002.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -199,7 +199,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		if(closeStream) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1003.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -193,7 +193,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1004.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -198,7 +198,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		if(closeStream) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -216,7 +216,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		if(closeStream) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -231,7 +231,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -233,7 +233,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		if(closeStream) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -251,7 +251,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -310,7 +310,7 @@ public class ChromatogramReader_1300 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -310,7 +310,7 @@ public class ChromatogramReader_1301 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -320,7 +320,7 @@ public class ChromatogramReader_1400 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0701.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0701.java
@@ -213,7 +213,7 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0801.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0801.java
@@ -215,7 +215,7 @@ public class ChromatogramReader_0801 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		if(closeStream) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0802.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0802.java
@@ -219,7 +219,7 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		if(closeStream) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0803.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0803.java
@@ -261,7 +261,7 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0901.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0901.java
@@ -261,7 +261,7 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0902.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0902.java
@@ -262,7 +262,7 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0903.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0903.java
@@ -263,7 +263,7 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1001.java
@@ -262,7 +262,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		if(closeStream) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1002.java
@@ -266,7 +266,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		if(closeStream) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1003.java
@@ -314,7 +314,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1004.java
@@ -319,7 +319,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
@@ -340,7 +340,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
@@ -340,7 +340,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
@@ -340,7 +340,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
@@ -370,7 +370,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 				} catch(IllegalArgumentException e) {
 					logger.warn(e);
 				} catch(PeakException e) {
-					logger.warn(e);
+					logger.warn(e.getMessage());
 				}
 			}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -374,7 +374,7 @@ public class ChromatogramReader_1300 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
@@ -374,7 +374,7 @@ public class ChromatogramReader_1301 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -382,7 +382,7 @@ public class ChromatogramReader_1400 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0701.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0701.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -86,7 +86,7 @@ public class PeakReader_0701 extends AbstractZipReader implements IPeakReader {
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		dataInputStream.close();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0801.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0801.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -88,7 +88,7 @@ public class PeakReader_0801 extends AbstractZipReader implements IPeakReader {
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		dataInputStream.close();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0802.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0802.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -91,7 +91,7 @@ public class PeakReader_0802 extends AbstractZipReader implements IPeakReader {
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		dataInputStream.close();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0803.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0803.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -91,7 +91,7 @@ public class PeakReader_0803 extends AbstractZipReader implements IPeakReader {
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		dataInputStream.close();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0901.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0901.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -91,7 +91,7 @@ public class PeakReader_0901 extends AbstractZipReader implements IPeakReader {
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		dataInputStream.close();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0902.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0902.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -93,7 +93,7 @@ public class PeakReader_0902 extends AbstractZipReader implements IPeakReader {
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		dataInputStream.close();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0903.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0903.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -93,7 +93,7 @@ public class PeakReader_0903 extends AbstractZipReader implements IPeakReader {
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		dataInputStream.close();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1001.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -93,7 +93,7 @@ public class PeakReader_1001 extends AbstractZipReader implements IPeakReader {
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		dataInputStream.close();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1002.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -98,7 +98,7 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		dataInputStream.close();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1003.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -98,7 +98,7 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		dataInputStream.close();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1004.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -99,7 +99,7 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		dataInputStream.close();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1005.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -99,7 +99,7 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		dataInputStream.close();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1006.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -100,7 +100,7 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		dataInputStream.close();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1007.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -100,7 +100,7 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 		dataInputStream.close();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1100.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -105,7 +105,7 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 				} catch(IllegalArgumentException e) {
 					logger.warn(e);
 				} catch(PeakException e) {
-					logger.warn(e);
+					logger.warn(e.getMessage());
 				}
 			}
 		} finally {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1300.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -108,7 +108,7 @@ public class PeakReader_1300 extends AbstractZipReader implements IPeakReader {
 				} catch(IllegalArgumentException e) {
 					logger.warn(e);
 				} catch(PeakException e) {
-					logger.warn(e);
+					logger.warn(e.getMessage());
 				}
 			}
 		} finally {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1301.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -107,7 +107,7 @@ public class PeakReader_1301 extends AbstractZipReader implements IPeakReader {
 				} catch(IllegalArgumentException e) {
 					logger.warn(e);
 				} catch(PeakException e) {
-					logger.warn(e);
+					logger.warn(e.getMessage());
 				}
 			}
 		} finally {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1400.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -107,7 +107,7 @@ public class PeakReader_1400 extends AbstractZipReader implements IPeakReader {
 				} catch(IllegalArgumentException e) {
 					logger.warn(e);
 				} catch(PeakException e) {
-					logger.warn(e);
+					logger.warn(e.getMessage());
 				}
 			}
 		} finally {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -349,7 +349,7 @@ public class ChromatogramReader_1300 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
@@ -350,7 +350,7 @@ public class ChromatogramReader_1301 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -363,7 +363,7 @@ public class ChromatogramReader_1400 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1500.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -363,7 +363,7 @@ public class ChromatogramReader_1500 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1501.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1501.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -347,7 +347,7 @@ public class ChromatogramReader_1501 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1502.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1502.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -347,7 +347,7 @@ public class ChromatogramReader_1502 extends AbstractChromatogramReader implemen
 			} catch(IllegalArgumentException e) {
 				logger.warn(e);
 			} catch(PeakException e) {
-				logger.warn(e);
+				logger.warn(e.getMessage());
 			}
 		}
 


### PR DESCRIPTION
Simply display the following message in the log:
`Failed to create the peak: there must be at least one intensity value stored with a relative intensity of IPeakIntensityValues.MAX_INTENSITY.`

instead of showing the complete stack trace:

```
org.eclipse.chemclipse.model.exceptions.PeakException: There must be at least one intensity value stored with a relative intensity of IPeakIntensityValues.MAX_INTENSITY.
	at org.eclipse.chemclipse.model.core.AbstractPeakModel.checkModelConditions(AbstractPeakModel.java:288)
	at org.eclipse.chemclipse.model.core.AbstractPeakModel.calculatePeakModel(AbstractPeakModel.java:355)
	at org.eclipse.chemclipse.model.core.AbstractPeakModel.<init>(AbstractPeakModel.java:93)
	at org.eclipse.chemclipse.model.implementation.PeakModel.<init>(PeakModel.java:31)
	at org.eclipse.chemclipse.msd.model.core.AbstractPeakModelMSD.<init>(AbstractPeakModelMSD.java:27)
	at org.eclipse.chemclipse.msd.model.implementation.PeakModelMSD.<init>(PeakModelMSD.java:34)
	at org.eclipse.chemclipse.msd.model.core.support.PeakBuilderMSD.createPeak(PeakBuilderMSD.java:139)
	at org.eclipse.chemclipse.msd.model.core.support.PeakBuilderMSD.createPeak(PeakBuilderMSD.java:62)
	at net.openchrom.xxd.process.supplier.templates.support.PeakSupport.extractChromatogramPeakMSD(PeakSupport.java:571)
	at net.openchrom.xxd.process.supplier.templates.support.PeakSupport.extractPeakByScanRange(PeakSupport.java:323)
	at net.openchrom.xxd.process.supplier.templates.support.PeakSupport.extractPeakByScanRange(PeakSupport.java:294)
	at net.openchrom.xxd.process.supplier.templates.peaks.PeakDetector.setPeakByRetentionTimeRange(PeakDetector.java:171)
	at net.openchrom.xxd.process.supplier.templates.peaks.PeakDetector.setPeakBySettings(PeakDetector.java:146)
	at net.openchrom.xxd.process.supplier.templates.peaks.PeakDetector.applySettingsSeparated(PeakDetector.java:138)
	at net.openchrom.xxd.process.supplier.templates.peaks.PeakDetector.applySettingsCombined(PeakDetector.java:131)
	at net.openchrom.xxd.process.supplier.templates.peaks.PeakDetector.applyDetector(PeakDetector.java:105)
	at net.openchrom.xxd.process.supplier.templates.peaks.PeakDetector.detect(PeakDetector.java:53)
	at com.lablicate.xxd.quantitation.supplier.compounds.core.ChromatogramProcessor.detectPeaks(ChromatogramProcessor.java:112)
	at com.lablicate.xxd.quantitation.supplier.compounds.core.ChromatogramProcessor.detectPeaks(ChromatogramProcessor.java:77)
	at com.lablicate.xxd.processor.supplier.simplequant.core.QuantitationBatchProcessor.runQuantitation(QuantitationBatchProcessor.java:105)
	at com.lablicate.xxd.processor.supplier.simplequant.core.QuantitationBatchProcessor.run(QuantitationBatchProcessor.java:63)
	at com.lablicate.xxd.processor.supplier.simplequant.ui.internal.runnables.BatchProcessRunnable.run(BatchProcessRunnable.java:42)
	at org.eclipse.jface.operation.ModalContext$ModalContextThread.run(ModalContext.java:123)
```
