### PR TITLE
Try to improve Data Explorer performance

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/converter/AbstractSupplierFileIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/converter/AbstractSupplierFileIdentifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -52,13 +52,13 @@ public abstract class AbstractSupplierFileIdentifier implements ISupplierFileIde
 		List<ISupplier> list = new ArrayList<>();
 		if(file.isFile()) {
 			for(ISupplier supplier : getSuppliers()) {
-				if(isValidFileSupplier(file, supplier) && isMatchMagicNumber(file)) {
+				if(isValidFileSupplier(file, supplier) && isMatch(file)) {
 					list.add(supplier);
 				}
 			}
 		} else if(file.isDirectory()) {
 			for(ISupplier supplier : getSuppliers()) {
-				if(isValidDirectorySupplier(file, supplier) && isMatchMagicNumber(file)) {
+				if(isValidDirectorySupplier(file, supplier) && isMatch(file)) {
 					list.add(supplier);
 				}
 			}
@@ -151,22 +151,13 @@ public abstract class AbstractSupplierFileIdentifier implements ISupplierFileIde
 	}
 
 	@Override
-	public boolean isMatchMagicNumber(File file) {
+	public boolean isMatch(File file) {
 
 		for(ISupplier supplier : getSuppliers()) {
 			if(supplier.isMatchMagicNumber(file)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	@Override
-	public boolean isMatchContent(File file) {
-
-		for(ISupplier supplier : getSuppliers()) {
-			if(supplier.isMatchMagicNumber(file) && supplier.isMatchContent(file)) {
-				return true;
+				if(supplier.isMatchContent(file)) {
+					return true;
+				}
 			}
 		}
 		return false;

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/converter/ISupplierFileIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/converter/ISupplierFileIdentifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -79,26 +79,13 @@ public interface ISupplierFileIdentifier extends SupplierContext {
 	Collection<ISupplier> getSuppliers(File file);
 
 	/**
-	 * Try to match the magic number of the file format.
-	 * If true, it's pretty likely that the format can be imported.
-	 * 
+	 * Checks if a file can be handled by the supplier.
+	 *
 	 * @param file
 	 * @return boolean
 	 */
-	default boolean isMatchMagicNumber(File file) {
+	default boolean isMatch(File file) {
 
 		return false;
-	}
-
-	/**
-	 * We go a bit deeper to confirm and find the data type if necessary.
-	 * If not required, simply leave this out.
-	 * 
-	 * @param file
-	 * @return boolean
-	 */
-	default boolean isMatchContent(File file) {
-
-		return true;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/MultiDataExplorerTreeUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/MultiDataExplorerTreeUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -294,7 +294,7 @@ public class MultiDataExplorerTreeUI extends Composite implements IExtendedPartU
 
 	private void createSettingsButton(Composite parent) {
 
-		createSettingsButton(parent, getPreferencePages(), (ISettingsHandler) display -> {
+		createSettingsButton(parent, getPreferencePages(), (ISettingsHandler)display -> {
 
 			updateUserLocations();
 			setSupplierFileEditorSupport();
@@ -622,12 +622,10 @@ public class MultiDataExplorerTreeUI extends Composite implements IExtendedPartU
 					continue;
 				}
 				for(ISupplierFileIdentifier supplierFileIdentifier : map.keySet()) {
-					if(supplierFileIdentifier.isMatchContent(file)) {
-						Collection<ISupplier> suppliers = map.get(supplierFileIdentifier);
-						for(ISupplier supplier : suppliers) {
-							if(supplier.isMatchMagicNumber(file) && supplier.isMatchContent(file)) {
-								supplierSet.add(supplier);
-							}
+					Collection<ISupplier> suppliers = map.get(supplierFileIdentifier);
+					for(ISupplier supplier : suppliers) {
+						if(supplier.isMatchMagicNumber(file) && supplier.isMatchContent(file)) {
+							supplierSet.add(supplier);
 						}
 					}
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/MultiDataExplorerTreeUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/MultiDataExplorerTreeUI.java
@@ -743,7 +743,7 @@ public class MultiDataExplorerTreeUI extends Composite implements IExtendedPartU
 
 			Collection<ISupplierFileIdentifier> identifiers = getIdentifierSupplier().apply(file).keySet();
 			for(ISupplierFileIdentifier identifier : identifiers) {
-				if(!identifier.isMatchMagicNumber(file) || !identifier.isMatchContent(file)) {
+				if(!identifier.isMatch(file)) {
 					continue;
 				}
 				if(identifier instanceof ISupplierFileEditorSupport fileEditorSupport) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ChromatogramEditor3x.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ChromatogramEditor3x.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -261,8 +261,8 @@ public class ChromatogramEditor3x extends EditorPart implements IChromatogramEdi
 	private boolean isMatch(File file, ISupplierFileIdentifier supplierFileIdentifier) {
 
 		boolean isMatch = false;
-		if(supplierFileIdentifier != null && file != null && file.exists() && supplierFileIdentifier.isSupplierFile(file)) {
-			if(supplierFileIdentifier.isMatchMagicNumber(file) && supplierFileIdentifier.isMatchContent(file)) {
+		if(file != null && file.exists()) {
+			if(supplierFileIdentifier != null && supplierFileIdentifier.isSupplierFile(file) && supplierFileIdentifier.isMatch(file)) {
 				isMatch = true;
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/runnables/SequenceFileRunnable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/runnables/SequenceFileRunnable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -96,7 +96,7 @@ public class SequenceFileRunnable implements IRunnableWithProgress {
 	private boolean isSequenceFile(File file) {
 
 		if(supplierEditorSupport.isSupplierFile(file)) {
-			if(supplierEditorSupport.isMatchMagicNumber(file) && supplierEditorSupport.isMatchContent(file)) {
+			if(supplierEditorSupport.isMatch(file)) {
 				return true;
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/src/org/eclipse/chemclipse/xxd/process/files/SupplierFileIdentifierCache.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/src/org/eclipse/chemclipse/xxd/process/files/SupplierFileIdentifierCache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -57,7 +57,6 @@ public class SupplierFileIdentifierCache implements Function<File, Map<ISupplier
 			list = new LinkedHashMap<>();
 			for(ISupplierFileIdentifier supplierFileIdentifier : fileIdentifiers) {
 				Collection<ISupplier> suppliers = supplierFileIdentifier.getSuppliers(file);
-				suppliers.removeIf(s -> !s.isMatchMagicNumber(file) || !s.isMatchContent(file));
 				if(!suppliers.isEmpty()) {
 					list.put(supplierFileIdentifier, Collections.unmodifiableCollection(suppliers));
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/src/org/eclipse/chemclipse/xxd/process/support/ChromatogramTypeSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/src/org/eclipse/chemclipse/xxd/process/support/ChromatogramTypeSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -139,9 +139,7 @@ public class ChromatogramTypeSupport {
 
 	public boolean isSupplierFile(ISupplierFileIdentifier supplierFileIdentifier, File file) {
 
-		if(supplierFileIdentifier.isSupplierFile(file) //
-				&& supplierFileIdentifier.isMatchMagicNumber(file) //
-				&& supplierFileIdentifier.isMatchContent(file)) {
+		if(supplierFileIdentifier.isSupplierFile(file) && supplierFileIdentifier.isMatch(file)) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
https://github.com/eclipse-chemclipse/chemclipse/pull/2614 has too many performance implications so I essentially revert it. File content matches are inherently I/O heavy, and they still block the UI. This tries to reduce it further.