### PR TITLE
Add rebindable hotkeys to the peak/scan list

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/events/CopyToClipboardEvent.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/events/CopyToClipboardEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,14 +21,12 @@ import org.eclipse.swt.widgets.Display;
 
 public class CopyToClipboardEvent implements IKeyEventProcessor {
 
-	public static final int KEY_CODE_C = 99;
-
 	private CopyToClipboardProvider copyToClipboardProvider = new CopyToClipboardProvider();
 
 	@Override
 	public void handleEvent(ExtendedTableViewer extendedTableViewer, KeyEvent e) {
 
-		if(e.stateMask == SWT.MOD1 && e.keyCode == KEY_CODE_C) {
+		if(e.stateMask == SWT.MOD1 && e.keyCode == 'c') {
 			Clipboard clipboard = new Clipboard(Display.getDefault());
 			copyToClipboardProvider.copyToClipboard(clipboard, extendedTableViewer);
 			clipboard.dispose();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
@@ -751,4 +751,108 @@
         </description>
     </fontDefinition>
 </extension>
+<extension
+         point="org.eclipse.ui.commands">
+      <category
+            name="Peaks/Scans"
+            description="Related to peaks and scans in chromatography"
+            id="org.eclipse.chemclipse.ux.extension.xxd.ui.PeaksScans">
+      </category>
+      <command
+            name="Query Database"
+            description="Query against a reference database"
+            categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeaksScans"
+            id="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList.Query">
+      </command>
+      <command
+            name="Mark Unknown"
+            description="Set as unknown and annotate with highest masses"
+            categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeaksScans"
+            id="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList.Unknown">
+      </command>
+      <command
+            name="Delete Targets"
+            description="Clear all database query matches."
+            categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeaksScans"
+            id="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList.DeleteTargets">
+      </command>
+      <command
+            name="Classifier"
+            description="Edit the list of classifiers."
+            categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeaksScans"
+            id="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList.Classifier">
+      </command>
+      <command
+            name="Internal Standard"
+            description="Set internal standards."
+            categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeaksScans"
+            id="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList.InternalStandard">
+      </command>
+      <command
+            name="Active Analysis"
+            description="Set as active for analysis."
+            categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeaksScans"
+            id="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList.ActiveAnalysis">
+      </command>
+      <command
+            name="Inactivate Analysis"
+            description="Set as inactive for analysis."
+            categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeaksScans"
+            id="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList.InactiveAnalysis">
+      </command>
+   </extension>
+<extension
+	point="org.eclipse.ui.contexts">
+	<context
+		name="Peak/Scan List"
+		description="A list of peaks and scans"
+		id="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList"
+		parentId="org.eclipse.ui.contexts.window">
+	</context>
+</extension>
+   <extension
+         point="org.eclipse.ui.bindings">
+      <key
+            commandId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList.Query"
+            contextId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M1+Q">
+      </key>
+      <key
+            commandId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList.Unknown"
+            contextId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M1+U">
+      </key>
+      <key
+            commandId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList.DeleteTargets"
+            contextId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M1+D">
+      </key>
+      <key
+            commandId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList.Classifier"
+            contextId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M1+G">
+      </key>
+      <key
+            commandId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList.InternalStandard"
+            contextId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M1+S">
+      </key>
+      <key
+            commandId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList.ActiveAnalysis"
+            contextId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M1+I">
+      </key>
+      <key
+            commandId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList.InactiveAnalysis"
+            contextId="org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M1+M3+I">
+      </key>
+   </extension>
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
@@ -80,6 +80,10 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.swt.PeakScanListUIConfig.Inter
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.operations.IOperationHistory;
 import org.eclipse.core.commands.operations.OperationHistoryFactory;
+import org.eclipse.jface.bindings.TriggerSequence;
+import org.eclipse.jface.bindings.keys.KeySequence;
+import org.eclipse.jface.bindings.keys.KeyStroke;
+import org.eclipse.jface.bindings.keys.SWTKeySupport;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.window.Window;
@@ -99,6 +103,8 @@ import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swtchart.extensions.core.IKeyboardSupport;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.contexts.IContextService;
+import org.eclipse.ui.keys.IBindingService;
 
 public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI, ConfigurableUI<PeakScanListUIConfig> {
 
@@ -107,6 +113,11 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 	private static final String MENU_CATEGORY = "Peaks/Scans";
 	private static final String DESCRIPTION_PEAKS = "Number Peaks:";
 	private static final String DESCRIPTION_SCANS = "Scans:";
+
+	private static final String KEY_CLASS_PREFIX = "org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList.";
+
+	private IContextService contextService = (IContextService)PlatformUI.getWorkbench().getService(IContextService.class);
+	private IBindingService bindingService = PlatformUI.getWorkbench().getService(IBindingService.class);
 
 	private AtomicReference<Composite> toolbarMain = new AtomicReference<>();
 	private AtomicReference<Button> buttonToolbarInfo = new AtomicReference<>();
@@ -138,6 +149,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 	public ExtendedPeakScanListUI(Composite parent, int style) {
 
 		super(parent, style);
+		contextService.activateContext("org.eclipse.chemclipse.ux.extension.xxd.ui.PeakScanList");
 		createControl();
 	}
 
@@ -454,30 +466,28 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 			@Override
 			public void handleEvent(ExtendedTableViewer extendedTableViewer, KeyEvent e) {
 
-				if(e.keyCode == SWT.DEL) {
+				if(matchesKeyPress("InternalStandard", e)) {
+					modifyInternalStandards(display);
+				} else if(matchesKeyPress("Classifier", e)) {
+					modifyClassifier(display);
+				} else if(matchesKeyPress("DeleteTargets", e)) {
+					deleteTargetsAll(e.display);
+				} else if(matchesKeyPress("Unknown", e)) {
+					addTargetsUnknown(e.display);
+				} else if(matchesKeyPress("Query", e)) {
+					scanIdentifierControl.get().runIdentification(e.display);
+					tableViewer.get().refresh();
+					UpdateNotifierUI.update(display, chromatogramSelection);
+				} else if(matchesKeyPress("ActiveAnalysis", e)) {
+					setPeaksActiveForAnalysis(true);
+				} else if(matchesKeyPress("InactiveAnalysis", e)) {
+					setPeaksActiveForAnalysis(false);
+				} else if(e.keyCode == SWT.DEL) {
 					deletePeaksOrIdentifications(display);
 				} else if((e.stateMask & SWT.MOD1) == SWT.MOD1) {
-					if(e.keyCode == IKeyboardSupport.KEY_CODE_LC_I) {
-						if((e.stateMask & SWT.MOD3) == SWT.MOD3) {
-							setPeaksActiveForAnalysis(false); // CTRL + ALT + i
-						} else {
-							setPeaksActiveForAnalysis(true); // CTRL + i
-						}
-					} else if(e.keyCode == IKeyboardSupport.KEY_CODE_LC_S) {
-						modifyInternalStandards(display); // CTRL + s
-					} else if(e.keyCode == IKeyboardSupport.KEY_CODE_LC_G) {
-						modifyClassifier(display); // CTRL + g
-					} else if(e.keyCode == IKeyboardSupport.KEY_CODE_LC_D) {
-						deleteTargetsAll(e.display); // CTRL + d
-					} else if(e.keyCode == IKeyboardSupport.KEY_CODE_LC_U) {
-						addTargetsUnknown(e.display); // CTRL + u
-					} else if(e.keyCode == IKeyboardSupport.KEY_CODE_LC_Q) {
-						scanIdentifierControl.get().runIdentification(e.display); // CTRL + q
-						tableViewer.get().refresh();
-						UpdateNotifierUI.update(display, chromatogramSelection);
-					} else if(e.keyCode == IKeyboardSupport.KEY_CODE_LC_A) {
+					if(e.keyCode == IKeyboardSupport.KEY_CODE_LC_A) {
 						if(showPeakProfilesSelectionAll) {
-							propagateSelection(display);
+							propagateSelection(display); // CTRL + A
 						}
 					}
 				} else {
@@ -485,6 +495,18 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 				}
 			}
 		});
+	}
+
+	private boolean matchesKeyPress(String commandSuffix, KeyEvent e) {
+
+		TriggerSequence triggerSequence = bindingService.getBestActiveBindingFor(KEY_CLASS_PREFIX + commandSuffix);
+		if(triggerSequence instanceof KeySequence keySequence) {
+			KeyStroke[] bindingStrokes = keySequence.getKeyStrokes();
+			int accelerator = SWTKeySupport.convertEventToUnmodifiedAccelerator(e);
+			KeyStroke eventStroke = SWTKeySupport.convertAcceleratorToKeyStroke(accelerator);
+			return bindingStrokes.length > 0 && bindingStrokes[0].equals(eventStroke);
+		}
+		return false;
 	}
 
 	private IOperationHistory getOperationHistory() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/MoleculeUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/MoleculeUI.java
@@ -50,7 +50,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swtchart.extensions.clipboard.ImageArrayTransfer;
-import org.eclipse.swtchart.extensions.core.IKeyboardSupport;
 
 public class MoleculeUI extends Composite implements IExtendedPartUI {
 
@@ -178,7 +177,7 @@ public class MoleculeUI extends Composite implements IExtendedPartUI {
 			@Override
 			public void keyReleased(KeyEvent e) {
 
-				if(e.stateMask == SWT.MOD1 && e.keyCode == IKeyboardSupport.KEY_CODE_LC_C) {
+				if(e.stateMask == SWT.MOD1 && e.keyCode == 'c') {
 					ImageData imageData = imageMolecule.getImageData();
 					if(imageData != null) {
 						Clipboard clipboard = new Clipboard(e.display);


### PR DESCRIPTION
I like the default mnemonics, but some may be difficult to reach yet pressed pretty often. To make everyone happy and to self-document better, I made them rebindable in the system preferences under `Keys` using [Workbench Key Bindings](https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Fguide%2FwrkAdv_keyBindings_contexts.htm).