### PR TITLE
Reduce the complexity of the scan table by removing the edit functions.

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanTableUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanTableUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,6 @@ package org.eclipse.chemclipse.ux.extension.xxd.ui.swt;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -23,25 +22,17 @@ import org.eclipse.chemclipse.csd.model.core.IScanCSD;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IScan;
-import org.eclipse.chemclipse.msd.model.core.IIon;
-import org.eclipse.chemclipse.msd.model.core.ILibraryMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
-import org.eclipse.chemclipse.msd.model.implementation.Ion;
 import org.eclipse.chemclipse.msd.swt.ui.support.DatabaseFileSupport;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.support.events.IChemClipseEvents;
-import org.eclipse.chemclipse.support.ui.events.IKeyEventProcessor;
-import org.eclipse.chemclipse.support.ui.menu.ITableMenuEntry;
-import org.eclipse.chemclipse.support.ui.swt.ExtendedTableViewer;
-import org.eclipse.chemclipse.support.ui.swt.ITableSettings;
 import org.eclipse.chemclipse.swt.ui.components.ISearchListener;
 import org.eclipse.chemclipse.swt.ui.components.InformationUI;
 import org.eclipse.chemclipse.swt.ui.components.SearchSupportUI;
-import org.eclipse.chemclipse.swt.ui.notifier.UpdateNotifierUI;
 import org.eclipse.chemclipse.swt.ui.support.Colors;
 import org.eclipse.chemclipse.ux.extension.ui.support.DataUpdateSupport;
 import org.eclipse.chemclipse.ux.extension.ui.swt.IExtendedPartUI;
@@ -50,16 +41,11 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageScans;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.ScanDataSupport;
 import org.eclipse.chemclipse.vsd.model.core.IScanVSD;
-import org.eclipse.chemclipse.wsd.model.core.IScanSignalWSD;
 import org.eclipse.chemclipse.wsd.model.core.IScanWSD;
-import org.eclipse.chemclipse.wsd.model.core.implementation.ScanSignalWSD;
 import org.eclipse.e4.ui.di.Focus;
 import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CLabel;
-import org.eclipse.swt.events.KeyAdapter;
-import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -71,89 +57,37 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.MessageBox;
-import org.eclipse.swt.widgets.Shell;
-import org.eclipse.swt.widgets.Table;
-import org.eclipse.swt.widgets.Text;
 
 public class ExtendedScanTableUI extends Composite implements IExtendedPartUI {
 
 	private static final Logger logger = Logger.getLogger(ExtendedScanTableUI.class);
 
-	private final ScanDataSupport scanDataSupport = new ScanDataSupport();
-
 	private AtomicReference<Composite> toolbarMain = new AtomicReference<>();
-	private Button buttonToolbarInfo;
+	private AtomicReference<Button> buttonToolbarInfo = new AtomicReference<>();
 	private AtomicReference<InformationUI> toolbarInfoTop = new AtomicReference<>();
 	private AtomicReference<InformationUI> toolbarInfoBottom = new AtomicReference<>();
-	private Button buttonToolbarSearch;
+	private AtomicReference<Button> buttonToolbarSearch = new AtomicReference<>();
 	private AtomicReference<SearchSupportUI> toolbarSearch = new AtomicReference<>();
-	private Button buttonToolbarEdit;
-	private AtomicReference<Composite> toolbarEdit = new AtomicReference<>();
 	private AtomicReference<TracesClipboardUI> tracesClipboardControl = new AtomicReference<>();
-	private Button buttonSaveScan;
-	private ScanWebIdentifierUI scanWebIdentifierUI; // show database link
-
-	private CLabel labelOptimized;
-	private Button buttonDeleteOptimized;
-
-	private Label labelX;
-	private Text textX;
-	private Label labelY;
-	private Text textY;
+	private AtomicReference<Button> buttonSaveScan = new AtomicReference<>();
+	private AtomicReference<ScanWebIdentifierUI> scanWebIdentifierUI = new AtomicReference<>();
+	private AtomicReference<CLabel> labelOptimized = new AtomicReference<>();
+	private AtomicReference<Button> buttonDeleteOptimized = new AtomicReference<>();
+	private AtomicReference<ScanTableUI> scanTableControl = new AtomicReference<>();
 	/*
 	 * The object could be a IScan or IPeak
 	 */
-	private ScanTableUI scanTableUI;
 	private Object object;
-
-	private DeleteMenuEntry deleteMenuEntry;
-	private DeleteKeyEventProcessor deleteKeyEventProcessor;
-	/*
-	 * Set whether to force the edit modus.
-	 */
-	private boolean forceEnableEditModus = false;
-	private boolean fireUpdate = true;
-
-	private EditListener editListener = null;
-
-	private class DeleteMenuEntry implements ITableMenuEntry {
-
-		@Override
-		public String getName() {
-
-			return "Delete Traces";
-		}
-
-		@Override
-		public String getCategory() {
-
-			return ""; // Must be empty to be placed on the main menu level.
-		}
-
-		@Override
-		public void execute(ExtendedTableViewer extendedTableViewer) {
-
-			deleteTraces(extendedTableViewer.getTable().getShell());
-		}
-	}
-
-	private class DeleteKeyEventProcessor implements IKeyEventProcessor {
-
-		@Override
-		public void handleEvent(ExtendedTableViewer extendedTableViewer, KeyEvent e) {
-
-			if(e.keyCode == SWT.DEL) {
-				deleteTraces(e.display.getActiveShell());
-			}
-		}
-	}
 
 	public ExtendedScanTableUI(Composite parent, int style) {
 
 		super(parent, style);
 		createControl();
+	}
+
+	public ScanTableUI getScanTableUI() {
+
+		return scanTableControl.get();
 	}
 
 	private String getLastTopic(List<String> topics) {
@@ -190,63 +124,13 @@ public class ExtendedScanTableUI extends Composite implements IExtendedPartUI {
 		updateObject();
 	}
 
-	public void addEditListener(EditListener editListener) {
-
-		this.editListener = editListener;
-	}
-
-	/**
-	 * By default, an update is fired when modifying the scan.
-	 * If this value is set to false, no update will be fired.
-	 * 
-	 * @param fireUpdate
-	 */
-	protected void setFireUpdate(boolean fireUpdate) {
-
-		this.fireUpdate = fireUpdate;
-	}
-
-	protected void forceEnableEditModus(boolean forceEnableEditModus) {
-
-		this.forceEnableEditModus = forceEnableEditModus;
-		enableEditModus();
-	}
-
-	/**
-	 * Enable or disable the edit functionality.
-	 * It is disabled by default.
-	 * 
-	 * @param enabled
-	 */
-	private void enableEditModus(boolean enabled) {
-
-		enableToolbar(toolbarEdit, buttonToolbarEdit, IMAGE_EDIT, TOOLTIP_EDIT, enabled);
-		buttonToolbarEdit.setEnabled(enabled);
-
-		scanTableUI.setEditEnabled(enabled);
-		ITableSettings tableSettings = scanTableUI.getTableSettings();
-		if(enabled) {
-			tableSettings.addMenuEntry(deleteMenuEntry);
-			tableSettings.addKeyEventProcessor(deleteKeyEventProcessor);
-		} else {
-			tableSettings.removeMenuEntry(deleteMenuEntry);
-			tableSettings.removeKeyEventProcessor(deleteKeyEventProcessor);
-		}
-
-		scanTableUI.applySettings(tableSettings);
-		Composite main = toolbarMain.get();
-		main.layout(true);
-		main.redraw();
-	}
-
 	private void updateObject() {
 
 		setInfoTop();
 		setInfoBottom();
-		scanTableUI.setInput(getScan());
-		scanWebIdentifierUI.setInput(getScan());
+		scanTableControl.get().setInput(getScan());
+		scanWebIdentifierUI.get().setInput(getScan());
 		tracesClipboardControl.get().updateOption();
-		updateEditFields();
 		updateButtonStatus();
 
 		if(toolbarSearch.get().isVisible()) {
@@ -258,54 +142,13 @@ public class ExtendedScanTableUI extends Composite implements IExtendedPartUI {
 
 		String searchText = toolbarSearch.get().getSearchText();
 		boolean caseSensitive = toolbarSearch.get().isSearchCaseSensitive();
-		scanTableUI.setSearchText(searchText, caseSensitive);
-	}
-
-	private void updateEditFields() {
-
-		List<TableViewerColumn> tableViewerColumns = scanTableUI.getTableViewerColumns();
-		if(tableViewerColumns.size() >= 2) {
-			/*
-			 * Add Signal
-			 */
-			String titleX = tableViewerColumns.get(0).getColumn().getText();
-			labelX.setText(titleX + ":");
-			textX.setToolTipText(titleX);
-
-			String titleY = tableViewerColumns.get(1).getColumn().getText();
-			labelY.setText(titleY + ":");
-			textY.setToolTipText(titleY);
-
-			toolbarEdit.get().layout(true);
-		}
-	}
-
-	private boolean enableEditModus() {
-
-		boolean isLibraryMassSpectrum = false;
-		enableEditModus(false);
-
-		IScan scan = getScan();
-		if(scan != null) {
-			isLibraryMassSpectrum = (scan instanceof ILibraryMassSpectrum);
-			if(forceEnableEditModus || isLibraryMassSpectrum) {
-				enableEditModus(true);
-			}
-		}
-		return isLibraryMassSpectrum;
+		scanTableControl.get().setSearchText(searchText, caseSensitive);
 	}
 
 	private void setInfoTop() {
 
-		IScan scan = getScan();
-		boolean isLibraryMassSpectrum = enableEditModus();
-
-		if(forceEnableEditModus || isLibraryMassSpectrum) {
-			String editInformation = scanTableUI.isEditEnabled() ? "Edit is enabled." : "Edit is disabled.";
-			toolbarInfoTop.get().setText(scanDataSupport.getScanLabel(scan) + " - " + editInformation);
-		} else {
-			toolbarInfoTop.get().setText(scanDataSupport.getScanLabel(scan));
-		}
+		ScanDataSupport scanDataSupport = new ScanDataSupport();
+		toolbarInfoTop.get().setText(scanDataSupport.getScanLabel(getScan()));
 	}
 
 	private void setInfoBottom() {
@@ -342,12 +185,8 @@ public class ExtendedScanTableUI extends Composite implements IExtendedPartUI {
 		GridLayout layout = new GridLayout(1, true);
 		composite.setLayout(layout);
 
-		deleteMenuEntry = new DeleteMenuEntry();
-		deleteKeyEventProcessor = new DeleteKeyEventProcessor();
-
 		createToolbarMain(composite);
 		createToolbarInfoTop(composite);
-		createToolbarEdit(composite);
 		createToolbarSearch(composite);
 		createTable(composite);
 		createToolbarInfoBottom(composite);
@@ -357,35 +196,41 @@ public class ExtendedScanTableUI extends Composite implements IExtendedPartUI {
 
 	private void initialize() {
 
-		enableToolbar(toolbarInfoTop, buttonToolbarInfo, IApplicationImage.IMAGE_INFO, TOOLTIP_INFO, true);
-		enableToolbar(toolbarSearch, buttonToolbarSearch, IMAGE_SEARCH, TOOLTIP_SEARCH, false);
-		enableToolbar(toolbarEdit, buttonToolbarEdit, IMAGE_EDIT, TOOLTIP_EDIT, false);
-		enableToolbar(toolbarInfoBottom, buttonToolbarInfo, IApplicationImage.IMAGE_INFO, TOOLTIP_INFO, true);
-
-		enableEditModus(false); // Disable the edit modus by default.
+		enableToolbar(toolbarInfoTop, buttonToolbarInfo.get(), IApplicationImage.IMAGE_INFO, TOOLTIP_INFO, true);
+		enableToolbar(toolbarSearch, buttonToolbarSearch.get(), IMAGE_SEARCH, TOOLTIP_SEARCH, false);
+		enableToolbar(toolbarInfoBottom, buttonToolbarInfo.get(), IApplicationImage.IMAGE_INFO, TOOLTIP_INFO, true);
 	}
 
 	private void createToolbarMain(Composite parent) {
 
 		Composite composite = new Composite(parent, SWT.NONE);
 		composite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		composite.setLayout(new GridLayout(10, false));
+		composite.setLayout(new GridLayout(9, false));
 
-		labelOptimized = createInfoLabelOptimized(composite);
-		buttonToolbarInfo = createButtonToggleToolbar(composite, Arrays.asList(toolbarInfoTop, toolbarInfoBottom), IMAGE_INFO, TOOLTIP_INFO);
-		buttonToolbarSearch = createButtonToggleToolbar(composite, toolbarSearch, IMAGE_SEARCH, TOOLTIP_SEARCH);
-		buttonToolbarEdit = createButtonToggleToolbar(composite, toolbarEdit, IMAGE_EDIT, TOOLTIP_EDIT);
+		createInfoLabelOptimized(composite);
+		createButtonToggleInfo(composite);
+		createButtonToggleSearch(composite);
 		createTracesClipboardUI(composite);
-		scanWebIdentifierUI = createScanWebIdentifierUI(composite);
+		createScanWebIdentifierUI(composite);
 		createResetButton(composite);
-		buttonSaveScan = createSaveButton(composite);
-		buttonDeleteOptimized = createDeleteOptimizedButton(composite);
+		createSaveButton(composite);
+		createDeleteOptimizedButton(composite);
 		createSettingsButton(composite);
 
 		toolbarMain.set(composite);
 	}
 
-	private CLabel createInfoLabelOptimized(Composite parent) {
+	private void createButtonToggleInfo(Composite parent) {
+
+		buttonToolbarInfo.set(createButtonToggleToolbar(parent, Arrays.asList(toolbarInfoTop, toolbarInfoBottom), IMAGE_INFO, TOOLTIP_INFO));
+	}
+
+	private void createButtonToggleSearch(Composite parent) {
+
+		buttonToolbarSearch.set(createButtonToggleToolbar(parent, toolbarSearch, IMAGE_SEARCH, TOOLTIP_SEARCH));
+	}
+
+	private void createInfoLabelOptimized(Composite parent) {
 
 		CLabel label = createInfoLabel(parent);
 		label.addMouseListener(new MouseAdapter() {
@@ -398,7 +243,8 @@ public class ExtendedScanTableUI extends Composite implements IExtendedPartUI {
 				}
 			}
 		});
-		return label;
+
+		labelOptimized.set(label);
 	}
 
 	private CLabel createInfoLabel(Composite parent) {
@@ -425,9 +271,9 @@ public class ExtendedScanTableUI extends Composite implements IExtendedPartUI {
 		IScan scan = getScan();
 		tracesClipboardControl.get().setInput(scan);
 		tracesClipboardControl.get().setEnabled(scan instanceof IScanMSD || scan instanceof IScanWSD);
-		buttonSaveScan.setEnabled(isSaveEnabled());
-		buttonDeleteOptimized.setEnabled(isOptimizedScan());
-		updateLabel(labelOptimized, isOptimizedScan() ? "Optimized" : "");
+		buttonSaveScan.get().setEnabled(isSaveEnabled());
+		buttonDeleteOptimized.get().setEnabled(isOptimizedScan());
+		updateLabel(labelOptimized.get(), isOptimizedScan() ? "Optimized" : "");
 	}
 
 	private void updateLabel(CLabel label, String message) {
@@ -500,7 +346,7 @@ public class ExtendedScanTableUI extends Composite implements IExtendedPartUI {
 		});
 	}
 
-	private Button createSaveButton(Composite parent) {
+	private void createSaveButton(Composite parent) {
 
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Save the scan.");
@@ -535,10 +381,11 @@ public class ExtendedScanTableUI extends Composite implements IExtendedPartUI {
 				}
 			}
 		});
-		return button;
+
+		buttonSaveScan.set(button);
 	}
 
-	private Button createDeleteOptimizedButton(Composite parent) {
+	private void createDeleteOptimizedButton(Composite parent) {
 
 		Button button = new Button(parent, SWT.PUSH);
 		button.setToolTipText("Delete the optimized scan.");
@@ -551,7 +398,8 @@ public class ExtendedScanTableUI extends Composite implements IExtendedPartUI {
 				deleteOptimizedScan(e.widget.getDisplay());
 			}
 		});
-		return button;
+
+		buttonDeleteOptimized.set(button);
 	}
 
 	private void createSettingsButton(Composite parent) {
@@ -584,23 +432,6 @@ public class ExtendedScanTableUI extends Composite implements IExtendedPartUI {
 		return informationUI;
 	}
 
-	private void createToolbarEdit(Composite parent) {
-
-		Composite composite = new Composite(parent, SWT.NONE);
-		GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
-		composite.setLayoutData(gridData);
-		composite.setLayout(new GridLayout(6, false));
-
-		labelX = createLabel(composite);
-		textX = createText(composite);
-		labelY = createLabel(composite);
-		textY = createText(composite);
-		createButtonAdd(composite);
-		createButtonDelete(composite);
-
-		toolbarEdit.set(composite);
-	}
-
 	private void createToolbarSearch(Composite parent) {
 
 		SearchSupportUI searchSupportUI = new SearchSupportUI(parent, SWT.NONE);
@@ -617,92 +448,18 @@ public class ExtendedScanTableUI extends Composite implements IExtendedPartUI {
 		toolbarSearch.set(searchSupportUI);
 	}
 
-	private ScanWebIdentifierUI createScanWebIdentifierUI(Composite parent) {
+	private void createScanWebIdentifierUI(Composite parent) {
 
-		return new ScanWebIdentifierUI(parent, SWT.NONE);
-	}
-
-	private Text createText(Composite parent) {
-
-		Text text = new Text(parent, SWT.BORDER);
-		text.setText("");
-		text.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		return text;
-	}
-
-	private Label createLabel(Composite parent) {
-
-		Label label = new Label(parent, SWT.NONE);
-		label.setText("");
-		return label;
-	}
-
-	private void createButtonAdd(Composite parent) {
-
-		Button button = new Button(parent, SWT.PUSH);
-		button.setText("");
-		button.setToolTipText("Add the scan signal.");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_ADD, IApplicationImageProvider.SIZE_16x16));
-		button.addSelectionListener(new SelectionAdapter() {
-
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-
-				IScan scan = getScan();
-				if(scan != null) {
-					addSignal(e.display.getActiveShell());
-					scanTableUI.updateScan();
-					fireEditEvent();
-				} else {
-					MessageDialog.openError(e.display.getActiveShell(), "Add Signal", "Please load a scan first.");
-				}
-			}
-		});
-	}
-
-	private void createButtonDelete(Composite parent) {
-
-		Button button = new Button(parent, SWT.PUSH);
-		button.setText("");
-		button.setToolTipText("Delete the scan signals.");
-		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_DELETE, IApplicationImageProvider.SIZE_16x16));
-		button.addSelectionListener(new SelectionAdapter() {
-
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-
-				deleteTraces(e.display.getActiveShell());
-				scanTableUI.updateScan();
-				fireEditEvent();
-			}
-		});
+		scanWebIdentifierUI.set(new ScanWebIdentifierUI(parent, SWT.NONE));
 	}
 
 	private void createTable(Composite parent) {
 
-		scanTableUI = new ScanTableUI(parent, SWT.VIRTUAL | SWT.BORDER | SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION);
+		ScanTableUI scanTableUI = new ScanTableUI(parent, SWT.VIRTUAL | SWT.BORDER | SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION);
 		scanTableUI.getTable().setLayoutData(new GridData(GridData.FILL_BOTH));
+		scanTableUI.setEditEnabled(false);
 
-		Table table = scanTableUI.getTable();
-		table.addSelectionListener(new SelectionAdapter() {
-
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-
-				super.widgetSelected(e);
-				fireEditEvent();
-			}
-		});
-
-		table.addKeyListener(new KeyAdapter() {
-
-			@Override
-			public void keyReleased(KeyEvent e) {
-
-				super.keyReleased(e);
-				fireEditEvent();
-			}
-		});
+		scanTableControl.set(scanTableUI);
 	}
 
 	private void applySettings() {
@@ -713,127 +470,5 @@ public class ExtendedScanTableUI extends Composite implements IExtendedPartUI {
 	private void reset() {
 
 		updateObject();
-	}
-
-	private void deleteTraces(Shell shell) {
-
-		MessageBox messageBox = new MessageBox(shell, SWT.ICON_QUESTION | SWT.YES | SWT.NO);
-		messageBox.setText("Delete Signals");
-		messageBox.setMessage("Would you like to delete the selected signals?");
-		if(messageBox.open() == SWT.YES) {
-			/*
-			 * Delete the signal
-			 */
-			Iterator<?> iterator = scanTableUI.getStructuredSelection().iterator();
-			while(iterator.hasNext()) {
-				Object object = iterator.next();
-				deleteSignal(object);
-			}
-
-			scanTableUI.refresh();
-			fireScanUpdate();
-		}
-	}
-
-	private void deleteSignal(Object signal) {
-
-		IScan scan = getScan();
-		if(scan instanceof IScanCSD scanCSD) {
-			/*
-			 * CSD
-			 */
-			scanCSD.adjustTotalSignal(0.0f);
-		} else if(scan instanceof IScanMSD scanMSD) {
-			/*
-			 * MSD
-			 */
-			if(signal instanceof IIon ion) {
-				scanMSD.removeIon(ion);
-			}
-		} else if(scan instanceof IScanWSD scanWSD) {
-			/*
-			 * WSD
-			 */
-			if(signal instanceof IScanSignalWSD signalWSD) {
-				scanWSD.removeScanSignal(signalWSD);
-			}
-		} else if(scan instanceof IScanVSD) {
-			/*
-			 * VSD
-			 */
-			// Not supported yet.
-		}
-	}
-
-	private void addSignal(Shell shell) {
-
-		String x = textX.getText().trim();
-		String y = textY.getText().trim();
-
-		if("".equals(x) || "".equals(y)) {
-			MessageDialog.openError(shell, "Add Signal", "The values must be not empty.");
-		} else {
-			try {
-				/*
-				 * Add the signal.
-				 */
-				IScan scan = getScan();
-				if(scan instanceof IScanCSD scanCSD) {
-					/*
-					 * CSD
-					 */
-					float valueY = Float.parseFloat(y);
-					scanCSD.adjustTotalSignal(valueY);
-				} else if(scan instanceof IScanMSD scanMSD) {
-					/*
-					 * MSD
-					 */
-					double valueX = Double.parseDouble(x);
-					float valueY = Float.parseFloat(y);
-					scanMSD.addIon(new Ion(valueX, valueY));
-				} else if(scan instanceof IScanWSD scanWSD) {
-					/*
-					 * WSD
-					 */
-					float valueX = Float.parseFloat(x);
-					float valueY = Float.parseFloat(y);
-					scanWSD.addScanSignal(new ScanSignalWSD(valueX, valueY));
-				} else if(scan instanceof IScanVSD) {
-					/*
-					 * VSD
-					 */
-					// Not supported yet.
-				}
-
-				textX.setText("");
-				textY.setText("");
-				scanTableUI.refresh();
-				fireScanUpdate();
-
-			} catch(Exception e) {
-				MessageDialog.openError(shell, "Add Signal", "Something has gone wrong to add the signal.");
-			}
-		}
-	}
-
-	private void fireScanUpdate() {
-
-		/*
-		 * Fire an update.
-		 */
-		if(fireUpdate) {
-			if(object instanceof IScan scan) {
-				UpdateNotifierUI.update(getDisplay(), scan);
-			} else if(object instanceof IPeak peak) {
-				UpdateNotifierUI.update(getDisplay(), peak);
-			}
-		}
-	}
-
-	private void fireEditEvent() {
-
-		if(editListener != null) {
-			editListener.modify();
-		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSubtractScanUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSubtractScanUI.java
@@ -30,6 +30,7 @@ import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.support.CalculationType;
 import org.eclipse.chemclipse.model.targets.TargetSupport;
+import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
@@ -54,6 +55,8 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.Clipboard;
 import org.eclipse.swt.dnd.TextTransfer;
 import org.eclipse.swt.dnd.Transfer;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.FillLayout;
@@ -72,10 +75,9 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 
 	private static final Logger logger = Logger.getLogger(ExtendedSubtractScanUI.class);
 
-	private TabFolder tabFolder;
-	private ScanChartUI scanChartUI;
-	private ExtendedScanTableUI extendedScanTableUI;
-
+	private AtomicReference<TabFolder> tabFolderControl = new AtomicReference<>();
+	private AtomicReference<ScanChartUI> scanChartControl = new AtomicReference<>();
+	private AtomicReference<ExtendedScanTableUI> extendedScanTableControl = new AtomicReference<>();
 	private AtomicReference<Button> buttonSelectedScanControl = new AtomicReference<>();
 	private AtomicReference<Button> buttonCombinedScanControl = new AtomicReference<>();
 	private AtomicReference<Button> buttonComparisonScanControl = new AtomicReference<>();
@@ -155,7 +157,7 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 		composite.setLayoutData(new GridData(GridData.FILL_BOTH));
 		composite.setLayout(new GridLayout(1, true));
 
-		tabFolder = new TabFolder(composite, SWT.BOTTOM);
+		TabFolder tabFolder = new TabFolder(composite, SWT.BOTTOM);
 		tabFolder.setBackground(getDisplay().getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
 		tabFolder.setLayoutData(new GridData(GridData.FILL_BOTH));
 		tabFolder.addSelectionListener(new SelectionAdapter() {
@@ -167,6 +169,7 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 			}
 		});
 
+		tabFolderControl.set(tabFolder);
 		createScanChart(tabFolder);
 		createScanTable(tabFolder);
 	}
@@ -179,8 +182,9 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 		composite.setLayout(new GridLayout(1, true));
 		tabItem.setControl(composite);
 
-		scanChartUI = new ScanChartUI(composite, SWT.BORDER);
+		ScanChartUI scanChartUI = new ScanChartUI(composite, SWT.BORDER);
 		scanChartUI.setLayoutData(new GridData(GridData.FILL_BOTH));
+		scanChartControl.set(scanChartUI);
 	}
 
 	private void createScanTable(TabFolder tabFolder) {
@@ -192,12 +196,30 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 		composite.setLayout(new GridLayout(1, true));
 		tabItem.setControl(composite);
 
-		extendedScanTableUI = new ExtendedScanTableUI(composite, SWT.NONE);
+		ExtendedScanTableUI extendedScanTableUI = new ExtendedScanTableUI(composite, SWT.NONE);
 		extendedScanTableUI.setLayoutData(new GridData(GridData.FILL_BOTH));
-		extendedScanTableUI.forceEnableEditModus(true);
-		extendedScanTableUI.setFireUpdate(false);
+		ScanTableUI scanTableUI = extendedScanTableUI.getScanTableUI();
+		scanTableUI.getTable().addKeyListener(new KeyAdapter() {
 
-		extendedScanTableUI.addEditListener(() -> saveSessionMassSpectrum(null, scanMSD));
+			@Override
+			public void keyReleased(KeyEvent e) {
+
+				if(e.keyCode == SWT.DEL) {
+					if(scanMSD != null) {
+						for(Object object : scanTableUI.getStructuredSelection().toArray()) {
+							if(object instanceof IIon ion) {
+								scanMSD.removeIon(ion);
+							}
+						}
+						saveSessionMassSpectrum(null, scanMSD);
+						updateScanData(scanMSD);
+					}
+				}
+			}
+
+		});
+
+		extendedScanTableControl.set(extendedScanTableUI);
 	}
 
 	private void createAddSelectedScanButton(Composite parent) {
@@ -374,22 +396,22 @@ public class ExtendedSubtractScanUI extends Composite implements IExtendedPartUI
 
 	private void updateScanData(IScanMSD scanMSD) {
 
-		if(tabFolder != null && scanChartUI != null) {
-			/*
-			 * Chart
-			 */
-			if(scanMSD == null) {
-				scanChartUI.deleteSeries();
-				scanChartUI.getBaseChart().redraw();
-			} else {
-				scanChartUI.setInput(scanMSD);
-			}
-			/*
-			 * Table
-			 */
-			if(extendedScanTableUI.isVisible()) {
-				extendedScanTableUI.setInput(scanMSD);
-			}
+		/*
+		 * Chart
+		 */
+		ScanChartUI scanChartUI = scanChartControl.get();
+		if(scanMSD == null) {
+			scanChartUI.deleteSeries();
+			scanChartUI.getBaseChart().redraw();
+		} else {
+			scanChartUI.setInput(scanMSD);
+		}
+		/*
+		 * Table
+		 */
+		ExtendedScanTableUI extendedScanTableUI = extendedScanTableControl.get();
+		if(extendedScanTableUI.isVisible()) {
+			extendedScanTableUI.setInput(scanMSD);
 		}
 
 		updateWidgets();


### PR DESCRIPTION
To edit a mass spectrum is a valid operation, but it should be handled separately. In most of the cases, edit is not needed or even more not allowed. Hence, simplify the table.