### PR TITLE
Reduce error log message by throwing a peak instead of arg. exception

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeakModel.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeakModel.java
@@ -271,13 +271,13 @@ public abstract class AbstractPeakModel extends AbstractPeakModelStrict implemen
 	private void checkModelConditions(IScan peakMaximum, IPeakIntensityValues peakIntensityValues) throws IllegalArgumentException, PeakException {
 
 		if(peakMaximum == null) {
-			throw new IllegalArgumentException("The peak maximum must not be null.");
+			throw new PeakException("The peak maximum must not be null.");
 		}
 		/*
 		 * Test if there are intensity values stored.
 		 */
 		if(peakIntensityValues == null || peakIntensityValues.size() < IPeakModel.MINIMUM_SCANS) {
-			throw new IllegalArgumentException("The intensity values must not be null or must contain at least 3 key value pairs.");
+			throw new PeakException("The intensity values must not be null or must contain at least 3 key value pairs.");
 		}
 		/*
 		 * Check that the highest intensity is 100.0f. If it is more or less,


### PR DESCRIPTION
Avoid verbose log message like:

```
!ENTRY org.eclipse.ui 4 0 2026-02-05 21:36:29.809
!MESSAGE Unhandled event loop exception
!STACK 0
java.lang.IllegalArgumentException: The intensity values must not be null or must contain at least 3 key value pairs.
	at org.eclipse.chemclipse.model.core.AbstractPeakModel.checkModelConditions(AbstractPeakModel.java:280)
	at org.eclipse.chemclipse.model.core.AbstractPeakModel.calculatePeakModel(AbstractPeakModel.java:355)
	at org.eclipse.chemclipse.model.core.AbstractPeakModel.<init>(AbstractPeakModel.java:93)
	at org.eclipse.chemclipse.model.implementation.PeakModel.<init>(PeakModel.java:31)
	at org.eclipse.chemclipse.msd.model.core.AbstractPeakModelMSD.<init>(AbstractPeakModelMSD.java:27)
	at org.eclipse.chemclipse.msd.model.implementation.PeakModelMSD.<init>(PeakModelMSD.java:34)
	at org.eclipse.chemclipse.msd.model.core.support.PeakBuilderMSD.createPeak(PeakBuilderMSD.java:268)
	at net.openchrom.xxd.process.supplier.templates.support.PeakSupport.extractChromatogramPeakMSD(PeakSupport.java:578)
	at net.openchrom.xxd.process.supplier.templates.support.PeakSupport.extractPeakByScanRange(PeakSupport.java:323)
	at net.openchrom.xxd.process.supplier.templates.support.PeakSupport.extractPeakByScanRange(PeakSupport.java:294)
	at net.openchrom.xxd.process.supplier.templates.support.PeakSupport.extractPeakByRetentionTime(PeakSupport.java:279)
	at com.lablicate.xxd.ui.editor.base.charts.ChromatogramChart.extractPeakFromUserSelection(ChromatogramChart.java:755)
	at com.lablicate.xxd.ui.editor.base.charts.ChromatogramChart.extractPeakFromUserSelection(ChromatogramChart.java:683)
	at com.lablicate.xxd.ui.editor.base.charts.ChromatogramChart.extractPeak(ChromatogramChart.java:845)
	at com.lablicate.xxd.ui.editor.base.charts.ChromatogramChart$4.update(ChromatogramChart.java:375)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.ranges.TimeRangesChart.fireUpdatePeakRange(TimeRangesChart.java:472)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.ranges.TimeRangesChart.handleMouseUpEvent(TimeRangesChart.java:236)
	at org.eclipse.swtchart.extensions.core.IEventHandler.handleEvent(IEventHandler.java:46)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:91)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5894)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1656)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:5109)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4546)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1147)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1038)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:677)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:583)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:173)
	at org.eclipse.chemclipse.rcp.app.ui.internal.support.ApplicationSupportDefault.start(ApplicationSupportDefault.java:26)
	at org.eclipse.chemclipse.rcp.app.ui.Application.start(Application.java:28)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:219)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:149)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:115)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:467)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:298)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:615)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:563)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1415)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1387)
```