### PR TITLE
Don't try to process non-existing .ocm files

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
@@ -326,7 +326,7 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 	private void processChromatogram(IChromatogramSelection chromatogramSelection) {
 
 		File file = new File(preferenceStore.getString(PreferenceSupplier.P_CHROMATOGRAM_LOAD_PROCESS_METHOD));
-		if(chromatogramSelection != null) {
+		if(file.exists() && chromatogramSelection != null) {
 			try {
 				ProgressMonitorDialog dialog = new ProgressMonitorDialog(shell);
 				dialog.run(false, false, monitor -> {


### PR DESCRIPTION
It is a user setting. Files vanish or move. No need to throw.

Closes https://github.com/eclipse-chemclipse/chemclipse/issues/2679