### PR TITLE
Simply throw a PeakException if something gone wrong containing details.

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.firstderivative/src/org/eclipse/chemclipse/chromatogram/csd/peak/detector/supplier/firstderivative/core/PeakDetectorCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.firstderivative/src/org/eclipse/chemclipse/chromatogram/csd/peak/detector/supplier/firstderivative/core/PeakDetectorCSD.java
@@ -236,8 +236,6 @@ public class PeakDetectorCSD extends BasePeakDetector implements IPeakDetectorCS
 					peak.setDetectorDescription(translationService.translate("%FirstDerivative", Activator.getContributorURI()));
 					peaks.add(peak);
 				}
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector.supplier.firstderivative/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/supplier/firstderivative/core/PeakDetectorWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector.supplier.firstderivative/src/org/eclipse/chemclipse/chromatogram/wsd/peak/detector/supplier/firstderivative/core/PeakDetectorWSD.java
@@ -246,8 +246,6 @@ public class PeakDetectorWSD extends BasePeakDetector implements IPeakDetectorWS
 					peak.setDetectorDescription(translationService.translate("%FirstDerivative", Activator.getContributorURI()));
 					peaks.add(peak);
 				}
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/implementation/PeakModelCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/implementation/PeakModelCSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,7 +27,7 @@ public class PeakModelCSD extends AbstractPeakModelCSD implements IPeakModelCSD 
 		this(peakMaximum, peakIntensityValues, 0.0f, 0.0f);
 	}
 
-	public PeakModelCSD(IScan peakMaximum, IPeakIntensityValues peakIntensityValues, float startBackgroundAbundance, float stopBackgroundAbundance) throws IllegalArgumentException, PeakException {
+	public PeakModelCSD(IScan peakMaximum, IPeakIntensityValues peakIntensityValues, float startBackgroundAbundance, float stopBackgroundAbundance) throws PeakException {
 
 		super(peakMaximum, peakIntensityValues, startBackgroundAbundance, stopBackgroundAbundance);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeak.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeak.java
@@ -238,23 +238,23 @@ public abstract class AbstractPeak implements IPeak {
 	/**
 	 * If the peak model is null, forget about creating a peak and skip its
 	 * instantiation.<br/>
-	 * Throw a IllegalArgumentException instead.<br/>
+	 * Throw a PeakException instead.<br/>
 	 * Do not allow that parentChromatogram could be null.
 	 */
-	protected void validatePeakModel(IPeakModel peakModel) throws IllegalArgumentException {
+	protected void validatePeakModel(IPeakModel peakModel) throws PeakException {
 
 		if(peakModel == null) {
-			throw new IllegalArgumentException("The peak model must not be null");
+			throw new PeakException("The peak model must not be null");
 		}
 	}
 
-	protected void validateChromatogram(IChromatogram chromatogram) throws IllegalArgumentException {
+	protected void validateChromatogram(IChromatogram chromatogram) throws PeakException {
 
 		/*
 		 * Do not allow that the parentChromatogram is null.
 		 */
 		if(chromatogram == null) {
-			throw new IllegalArgumentException("The parent chromatogram must not be null");
+			throw new PeakException("The parent chromatogram must not be null");
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeakModel.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeakModel.java
@@ -75,7 +75,7 @@ public abstract class AbstractPeakModel extends AbstractPeakModelStrict implemen
 	 * @param startBackgroundAbundance
 	 * @param stopBackgroundAbundance
 	 */
-	protected AbstractPeakModel(IScan peakMaximum, IPeakIntensityValues peakIntensityValues, float startBackgroundAbundance, float stopBackgroundAbundance, boolean strictModel) throws IllegalArgumentException, PeakException {
+	protected AbstractPeakModel(IScan peakMaximum, IPeakIntensityValues peakIntensityValues, float startBackgroundAbundance, float stopBackgroundAbundance, boolean strictModel) throws PeakException {
 
 		super(peakMaximum, peakIntensityValues);
 		/*
@@ -164,7 +164,7 @@ public abstract class AbstractPeakModel extends AbstractPeakModelStrict implemen
 	}
 
 	@Override
-	public void replaceRetentionTimes(List<Integer> retentionTimes) throws IllegalArgumentException, PeakException {
+	public void replaceRetentionTimes(List<Integer> retentionTimes) throws PeakException {
 
 		peakIntensityValues.replaceRetentionTimes(retentionTimes);
 		calculatePeakModel();
@@ -268,16 +268,16 @@ public abstract class AbstractPeakModel extends AbstractPeakModelStrict implemen
 		temporarilyInfo.put(key, value);
 	}
 
-	private void checkModelConditions(IScan peakMaximum, IPeakIntensityValues peakIntensityValues) throws IllegalArgumentException, PeakException {
+	private void checkModelConditions(IScan peakMaximum, IPeakIntensityValues peakIntensityValues) throws PeakException {
 
 		if(peakMaximum == null) {
-			throw new IllegalArgumentException("The peak maximum must not be null.");
+			throw new PeakException("The peak maximum must not be null.");
 		}
 		/*
 		 * Test if there are intensity values stored.
 		 */
 		if(peakIntensityValues == null || peakIntensityValues.size() < IPeakModel.MINIMUM_SCANS) {
-			throw new IllegalArgumentException("The intensity values must not be null or must contain at least 3 key value pairs.");
+			throw new PeakException("The intensity values must not be null or must contain at least 3 key value pairs.");
 		}
 		/*
 		 * Check that the highest intensity is 100.0f. If it is more or less,
@@ -350,7 +350,7 @@ public abstract class AbstractPeakModel extends AbstractPeakModelStrict implemen
 		return Math.toDegrees(Math.atan(a / b));
 	}
 
-	private void calculatePeakModel() throws IllegalArgumentException, PeakException {
+	private void calculatePeakModel() throws PeakException {
 
 		checkModelConditions(peakMaximum, peakIntensityValues);
 		backgroundEquation = calculateBackgroundEquation(startBackgroundAbundance, stopBackgroundAbundance);

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/implementation/PeakModel.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/implementation/PeakModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,7 +22,7 @@ public class PeakModel extends AbstractPeakModel implements IPeakModel {
 
 	private static final long serialVersionUID = -5942483159915658483L;
 
-	public PeakModel(IScan peakMaximum, IPeakIntensityValues peakIntensityValues, float startBackgroundAbundance, float stopBackgroundAbundance) throws IllegalArgumentException, PeakException {
+	public PeakModel(IScan peakMaximum, IPeakIntensityValues peakIntensityValues, float startBackgroundAbundance, float stopBackgroundAbundance) throws PeakException {
 
 		/**
 		 * By default, the strict model is used to ensure backward compatibility.

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogramPeakMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractChromatogramPeakMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,10 +33,9 @@ public abstract class AbstractChromatogramPeakMSD extends AbstractPeakMSD implem
 	 * 
 	 * @param peakModel
 	 * @param chromatogram
-	 * @throws IllegalArgumentException
 	 * @throws PeakException
 	 */
-	protected AbstractChromatogramPeakMSD(IPeakModelMSD peakModel, IChromatogramMSD chromatogram) throws IllegalArgumentException, PeakException {
+	protected AbstractChromatogramPeakMSD(IPeakModelMSD peakModel, IChromatogramMSD chromatogram) throws PeakException {
 
 		super(peakModel);
 		validateChromatogram(chromatogram);
@@ -48,7 +47,7 @@ public abstract class AbstractChromatogramPeakMSD extends AbstractPeakMSD implem
 		this.chromatogram = chromatogram;
 	}
 
-	protected AbstractChromatogramPeakMSD(IPeakModelMSD peakModel, IChromatogramMSD chromatogram, String modelDescription) throws IllegalArgumentException, PeakException {
+	protected AbstractChromatogramPeakMSD(IPeakModelMSD peakModel, IChromatogramMSD chromatogram, String modelDescription) throws PeakException {
 
 		this(peakModel, chromatogram);
 		setModelDescription(modelDescription);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractPeakMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractPeakMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Lablicate GmbH.
+ * Copyright (c) 2011, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,18 +14,19 @@
 package org.eclipse.chemclipse.msd.model.core;
 
 import org.eclipse.chemclipse.model.core.AbstractPeak;
+import org.eclipse.chemclipse.model.exceptions.PeakException;
 
 public abstract class AbstractPeakMSD extends AbstractPeak implements IPeakMSD {
 
 	private final IPeakModelMSD peakModel;
 
-	protected AbstractPeakMSD(IPeakModelMSD peakModel) throws IllegalArgumentException {
+	protected AbstractPeakMSD(IPeakModelMSD peakModel) throws PeakException {
 
 		validatePeakModel(peakModel);
 		this.peakModel = peakModel;
 	}
 
-	protected AbstractPeakMSD(IPeakModelMSD peakModel, String modelDescription) throws IllegalArgumentException {
+	protected AbstractPeakMSD(IPeakModelMSD peakModel, String modelDescription) throws PeakException {
 
 		this(peakModel);
 		setModelDescription(modelDescription);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/ChromatogramPeakMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/ChromatogramPeakMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,11 +20,13 @@ import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 
 public class ChromatogramPeakMSD extends AbstractChromatogramPeakMSD implements IChromatogramPeakMSD {
 
-	public ChromatogramPeakMSD(IPeakModelMSD peakModel, IChromatogramMSD chromatogram) throws IllegalArgumentException, PeakException {
+	public ChromatogramPeakMSD(IPeakModelMSD peakModel, IChromatogramMSD chromatogram) throws PeakException {
+
 		super(peakModel, chromatogram);
 	}
 
-	public ChromatogramPeakMSD(IPeakModelMSD peakModel, IChromatogramMSD chromatogram, String modelDescription) throws IllegalArgumentException, PeakException {
+	public ChromatogramPeakMSD(IPeakModelMSD peakModel, IChromatogramMSD chromatogram, String modelDescription) throws PeakException {
+
 		super(peakModel, chromatogram, modelDescription);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/PeakModelMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/PeakModelMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,10 +27,12 @@ public class PeakModelMSD extends AbstractPeakModelMSD implements IPeakModelMSD 
 	private static final long serialVersionUID = -1550042043393366604L;
 
 	public PeakModelMSD(IPeakMassSpectrum peakMaximum, IPeakIntensityValues peakIntensityValues) throws IllegalArgumentException, PeakException {
+
 		this(peakMaximum, peakIntensityValues, 0, 0);
 	}
 
-	public PeakModelMSD(IPeakMassSpectrum peakMaximum, IPeakIntensityValues peakIntensityValues, float startBackgroundAbundance, float stopBackgroundAbundance) throws IllegalArgumentException, PeakException {
+	public PeakModelMSD(IPeakMassSpectrum peakMaximum, IPeakIntensityValues peakIntensityValues, float startBackgroundAbundance, float stopBackgroundAbundance) throws PeakException {
+
 		super(peakMaximum, peakIntensityValues, startBackgroundAbundance, stopBackgroundAbundance);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/implementation/PeakModelWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/implementation/PeakModelWSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,7 +27,7 @@ public class PeakModelWSD extends AbstractPeakModelWSD implements IPeakModelWSD 
 		this(peakMaximum, peakIntensityValues, 0.0f, 0.0f);
 	}
 
-	public PeakModelWSD(IScan peakMaximum, IPeakIntensityValues peakIntensityValues, float startBackgroundAbundance, float stopBackgroundAbundance) throws IllegalArgumentException, PeakException {
+	public PeakModelWSD(IScan peakMaximum, IPeakIntensityValues peakIntensityValues, float startBackgroundAbundance, float stopBackgroundAbundance) throws PeakException {
 
 		super(peakMaximum, peakIntensityValues, startBackgroundAbundance, stopBackgroundAbundance);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1001.java
@@ -197,8 +197,6 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1002.java
@@ -196,8 +196,6 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1003.java
@@ -190,8 +190,6 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1004.java
@@ -195,8 +195,6 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
@@ -213,8 +213,6 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
@@ -228,8 +228,6 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
@@ -230,8 +230,6 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
@@ -248,8 +248,6 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
@@ -307,8 +307,6 @@ public class ChromatogramReader_1300 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
@@ -307,8 +307,6 @@ public class ChromatogramReader_1301 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
@@ -317,8 +317,6 @@ public class ChromatogramReader_1400 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0701.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0701.java
@@ -211,8 +211,6 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0801.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0801.java
@@ -213,8 +213,6 @@ public class ChromatogramReader_0801 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0802.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0802.java
@@ -217,8 +217,6 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0803.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0803.java
@@ -259,8 +259,6 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0901.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0901.java
@@ -259,8 +259,6 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0902.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0902.java
@@ -260,8 +260,6 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0903.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0903.java
@@ -261,8 +261,6 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1001.java
@@ -260,8 +260,6 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1002.java
@@ -264,8 +264,6 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1003.java
@@ -312,8 +312,6 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1004.java
@@ -317,8 +317,6 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
@@ -338,8 +338,6 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
@@ -338,8 +338,6 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
@@ -338,8 +338,6 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
@@ -368,8 +368,6 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 				try {
 					IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, subMonitor.split(1));
 					chromatogram.getPeaks().add(peak);
-				} catch(IllegalArgumentException e) {
-					logger.warn(e);
 				} catch(PeakException e) {
 					logger.warn(e.getMessage());
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
@@ -372,8 +372,6 @@ public class ChromatogramReader_1300 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
@@ -372,8 +372,6 @@ public class ChromatogramReader_1301 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
@@ -380,8 +380,6 @@ public class ChromatogramReader_1400 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0701.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0701.java
@@ -83,8 +83,6 @@ public class PeakReader_0701 extends AbstractZipReader implements IPeakReader {
 			try {
 				IPeakMSD peak = readPeak(dataInputStream, monitor);
 				peaks.addPeak(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0801.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0801.java
@@ -85,8 +85,6 @@ public class PeakReader_0801 extends AbstractZipReader implements IPeakReader {
 			try {
 				IPeakMSD peak = readPeak(dataInputStream, monitor);
 				peaks.addPeak(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0802.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0802.java
@@ -88,8 +88,6 @@ public class PeakReader_0802 extends AbstractZipReader implements IPeakReader {
 			try {
 				IPeakMSD peak = readPeak(dataInputStream, monitor);
 				peaks.addPeak(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0803.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0803.java
@@ -88,8 +88,6 @@ public class PeakReader_0803 extends AbstractZipReader implements IPeakReader {
 			try {
 				IPeakMSD peak = readPeak(dataInputStream, monitor);
 				peaks.addPeak(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0901.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0901.java
@@ -88,8 +88,6 @@ public class PeakReader_0901 extends AbstractZipReader implements IPeakReader {
 			try {
 				IPeakMSD peak = readPeak(dataInputStream, monitor);
 				peaks.addPeak(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0902.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0902.java
@@ -90,8 +90,6 @@ public class PeakReader_0902 extends AbstractZipReader implements IPeakReader {
 			try {
 				IPeakMSD peak = readPeak(dataInputStream, monitor);
 				peaks.addPeak(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0903.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0903.java
@@ -90,8 +90,6 @@ public class PeakReader_0903 extends AbstractZipReader implements IPeakReader {
 			try {
 				IPeakMSD peak = readPeak(dataInputStream, monitor);
 				peaks.addPeak(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1001.java
@@ -90,8 +90,6 @@ public class PeakReader_1001 extends AbstractZipReader implements IPeakReader {
 			try {
 				IPeakMSD peak = readPeak(dataInputStream, monitor);
 				peaks.addPeak(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1002.java
@@ -95,8 +95,6 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 			try {
 				IPeakMSD peak = readPeak(dataInputStream, monitor);
 				peaks.addPeak(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1003.java
@@ -95,8 +95,6 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 			try {
 				IPeakMSD peak = readPeak(dataInputStream, monitor);
 				peaks.addPeak(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1004.java
@@ -96,8 +96,6 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 			try {
 				IPeakMSD peak = readPeak(dataInputStream, monitor);
 				peaks.addPeak(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1005.java
@@ -96,8 +96,6 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 			try {
 				IPeakMSD peak = readPeak(dataInputStream, monitor);
 				peaks.addPeak(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1006.java
@@ -97,8 +97,6 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 			try {
 				IPeakMSD peak = readPeak(dataInputStream, monitor);
 				peaks.addPeak(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1007.java
@@ -97,8 +97,6 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 			try {
 				IPeakMSD peak = readPeak(dataInputStream, monitor);
 				peaks.addPeak(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1100.java
@@ -102,8 +102,6 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 					IPeakMSD peak = readPeak(dataInputStream, monitor);
 					peaks.addPeak(peak);
 					subMonitor.worked(1);
-				} catch(IllegalArgumentException e) {
-					logger.warn(e);
 				} catch(PeakException e) {
 					logger.warn(e.getMessage());
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1300.java
@@ -105,8 +105,6 @@ public class PeakReader_1300 extends AbstractZipReader implements IPeakReader {
 					IPeakMSD peak = readPeak(dataInputStream);
 					peaks.addPeak(peak);
 					subMonitor.worked(1);
-				} catch(IllegalArgumentException e) {
-					logger.warn(e);
 				} catch(PeakException e) {
 					logger.warn(e.getMessage());
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1301.java
@@ -104,8 +104,6 @@ public class PeakReader_1301 extends AbstractZipReader implements IPeakReader {
 					IPeakMSD peak = readPeak(dataInputStream);
 					peaks.addPeak(peak);
 					subMonitor.worked(1);
-				} catch(IllegalArgumentException e) {
-					logger.warn(e);
 				} catch(PeakException e) {
 					logger.warn(e.getMessage());
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1400.java
@@ -104,8 +104,6 @@ public class PeakReader_1400 extends AbstractZipReader implements IPeakReader {
 					IPeakMSD peak = readPeak(dataInputStream);
 					peaks.addPeak(peak);
 					subMonitor.worked(1);
-				} catch(IllegalArgumentException e) {
-					logger.warn(e);
 				} catch(PeakException e) {
 					logger.warn(e.getMessage());
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
@@ -346,8 +346,6 @@ public class ChromatogramReader_1300 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakWSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
@@ -347,8 +347,6 @@ public class ChromatogramReader_1301 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakWSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
@@ -360,8 +360,6 @@ public class ChromatogramReader_1400 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakWSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1500.java
@@ -360,8 +360,6 @@ public class ChromatogramReader_1500 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakWSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1501.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1501.java
@@ -344,8 +344,6 @@ public class ChromatogramReader_1501 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakWSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1502.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1502.java
@@ -344,8 +344,6 @@ public class ChromatogramReader_1502 extends AbstractChromatogramReader implemen
 			try {
 				IChromatogramPeakWSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
-			} catch(IllegalArgumentException e) {
-				logger.warn(e);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
 			}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/ChromatogramPeak_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/ChromatogramPeak_2_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -52,7 +52,7 @@ public class ChromatogramPeak_2_Test extends ChromatogramPeakTestCase {
 	@Test
 	public void testConstructor_2() {
 
-		assertThrows(IllegalArgumentException.class, () -> {
+		assertThrows(PeakException.class, () -> {
 			peak = new ChromatogramPeakMSD(null, getChromatogram());
 		});
 	}
@@ -60,7 +60,7 @@ public class ChromatogramPeak_2_Test extends ChromatogramPeakTestCase {
 	@Test
 	public void testConstructor_3() {
 
-		assertThrows(IllegalArgumentException.class, () -> {
+		assertThrows(PeakException.class, () -> {
 			peak = new ChromatogramPeakMSD(getPeakModel(), null);
 		});
 	}
@@ -69,6 +69,6 @@ public class ChromatogramPeak_2_Test extends ChromatogramPeakTestCase {
 	public void testConstructor_4() {
 
 		Exception e = assertThrows(Exception.class, () -> new ChromatogramPeakMSD(null, null));
-		assertTrue(e instanceof IllegalArgumentException || e instanceof PeakException);
+		assertTrue(e instanceof PeakException);
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/ChromatogramPeaksTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/ChromatogramPeaksTestCase.java
@@ -90,7 +90,7 @@ abstract class ChromatogramPeaksTestCase {
 		chromatogram.recalculateRetentionTimes();
 	}
 
-	private void createPeak1() throws IllegalArgumentException, PeakException {
+	private void createPeak1() throws PeakException {
 
 		peakMaximum = new PeakMassSpectrum();
 		// remove some ions.
@@ -130,7 +130,7 @@ abstract class ChromatogramPeaksTestCase {
 		peak1 = new ChromatogramPeakMSD(peakModel, chromatogram);
 	}
 
-	private void createPeak2() throws IllegalArgumentException, PeakException {
+	private void createPeak2() throws PeakException {
 
 		peakMaximum = new PeakMassSpectrum();
 		// remove some ions.
@@ -165,7 +165,7 @@ abstract class ChromatogramPeaksTestCase {
 		peak2 = new ChromatogramPeakMSD(peakModel, chromatogram);
 	}
 
-	private void createPeak3() throws IllegalArgumentException, PeakException {
+	private void createPeak3() throws PeakException {
 
 		peakMaximum = new PeakMassSpectrum();
 		// remove some ions.

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/PeakModel_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/PeakModel_2_Test.java
@@ -19,6 +19,7 @@ import java.util.Map.Entry;
 import java.util.TreeMap;
 
 import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
+import org.eclipse.chemclipse.model.exceptions.PeakException;
 import org.eclipse.chemclipse.model.implementation.PeakIntensityValues;
 import org.eclipse.chemclipse.msd.model.core.IPeakIon;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -94,7 +95,7 @@ public class PeakModel_2_Test {
 	@Test
 	public void testConstruct_2() {
 
-		assertThrows(IllegalArgumentException.class, () -> {
+		assertThrows(PeakException.class, () -> {
 			peakModel = new PeakModelMSD(null, intensityValues, startBackgroundAbundance, stopBackgroundAbundance);
 		});
 	}
@@ -102,7 +103,7 @@ public class PeakModel_2_Test {
 	@Test
 	public void testConstruct_3() {
 
-		assertThrows(IllegalArgumentException.class, () -> {
+		assertThrows(PeakException.class, () -> {
 			peakModel = new PeakModelMSD(peakMaximum, null, startBackgroundAbundance, stopBackgroundAbundance);
 		});
 	}
@@ -110,7 +111,7 @@ public class PeakModel_2_Test {
 	@Test
 	public void testConstruct_4() {
 
-		assertThrows(IllegalArgumentException.class, () -> {
+		assertThrows(PeakException.class, () -> {
 			peakModel = new PeakModelMSD(null, null, startBackgroundAbundance, stopBackgroundAbundance);
 		});
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/PeakModel_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/PeakModel_3_Test.java
@@ -93,7 +93,7 @@ public class PeakModel_3_Test {
 			intensityValues.addIntensityValue(entry.getKey(), entry.getValue());
 		}
 		// ----------------------IntensityValues
-		assertThrows(IllegalArgumentException.class, () -> {
+		assertThrows(PeakException.class, () -> {
 			peakModel = new PeakModelMSD(peakMaximum, intensityValues, startBackgroundAbundance, stopBackgroundAbundance);
 		});
 	}
@@ -109,7 +109,7 @@ public class PeakModel_3_Test {
 			intensityValues.addIntensityValue(entry.getKey(), entry.getValue());
 		}
 		// ----------------------IntensityValues
-		assertThrows(IllegalArgumentException.class, () -> {
+		assertThrows(PeakException.class, () -> {
 			peakModel = new PeakModelMSD(peakMaximum, intensityValues, startBackgroundAbundance, stopBackgroundAbundance);
 		});
 	}
@@ -120,7 +120,7 @@ public class PeakModel_3_Test {
 		// ----------------------IntensityValues
 		intensityValues = new PeakIntensityValues();
 		// ----------------------IntensityValues
-		assertThrows(IllegalArgumentException.class, () -> {
+		assertThrows(PeakException.class, () -> {
 			peakModel = new PeakModelMSD(peakMaximum, intensityValues, startBackgroundAbundance, stopBackgroundAbundance);
 		});
 	}


### PR DESCRIPTION
Currently, the IllegalArgumentException creates some noise in the log file. It's ok if a certain peak can't be created.

```
!ENTRY org.eclipse.ui 4 0 2026-02-05 21:36:29.809
!MESSAGE Unhandled event loop exception
!STACK 0
java.lang.IllegalArgumentException: The intensity values must not be null or must contain at least 3 key value pairs.
	at org.eclipse.chemclipse.model.core.AbstractPeakModel.checkModelConditions(AbstractPeakModel.java:280)
	at org.eclipse.chemclipse.model.core.AbstractPeakModel.calculatePeakModel(AbstractPeakModel.java:355)
	at org.eclipse.chemclipse.model.core.AbstractPeakModel.<init>(AbstractPeakModel.java:93)
	at org.eclipse.chemclipse.model.implementation.PeakModel.<init>(PeakModel.java:31)
	at org.eclipse.chemclipse.msd.model.core.AbstractPeakModelMSD.<init>(AbstractPeakModelMSD.java:27)
	at org.eclipse.chemclipse.msd.model.implementation.PeakModelMSD.<init>(PeakModelMSD.java:34)
	at org.eclipse.chemclipse.msd.model.core.support.PeakBuilderMSD.createPeak(PeakBuilderMSD.java:268)
	at net.openchrom.xxd.process.supplier.templates.support.PeakSupport.extractChromatogramPeakMSD(PeakSupport.java:578)
	at net.openchrom.xxd.process.supplier.templates.support.PeakSupport.extractPeakByScanRange(PeakSupport.java:323)
	at net.openchrom.xxd.process.supplier.templates.support.PeakSupport.extractPeakByScanRange(PeakSupport.java:294)
	at net.openchrom.xxd.process.supplier.templates.support.PeakSupport.extractPeakByRetentionTime(PeakSupport.java:279)
	at com.lablicate.xxd.ui.editor.base.charts.ChromatogramChart.extractPeakFromUserSelection(ChromatogramChart.java:755)
	at com.lablicate.xxd.ui.editor.base.charts.ChromatogramChart.extractPeakFromUserSelection(ChromatogramChart.java:683)
	at com.lablicate.xxd.ui.editor.base.charts.ChromatogramChart.extractPeak(ChromatogramChart.java:845)
	at com.lablicate.xxd.ui.editor.base.charts.ChromatogramChart$4.update(ChromatogramChart.java:375)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.ranges.TimeRangesChart.fireUpdatePeakRange(TimeRangesChart.java:472)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.ranges.TimeRangesChart.handleMouseUpEvent(TimeRangesChart.java:236)
	at org.eclipse.swtchart.extensions.core.IEventHandler.handleEvent(IEventHandler.java:46)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:91)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5894)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1656)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:5109)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4546)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1147)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1038)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:677)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:583)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:173)
	at org.eclipse.chemclipse.rcp.app.ui.internal.support.ApplicationSupportDefault.start(ApplicationSupportDefault.java:26)
	at org.eclipse.chemclipse.rcp.app.ui.Application.start(Application.java:28)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:219)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:149)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:115)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:467)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:298)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:615)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:563)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1415)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1387)
```