### PR TITLE
Mark peaks imported from AMDIS as deconvoluted

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/ELUReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/ELUReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -28,6 +28,7 @@ import org.apache.commons.io.FileUtils;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
+import org.eclipse.chemclipse.model.core.PeakType;
 import org.eclipse.chemclipse.model.implementation.PeakIntensityValues;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.preferences.PreferenceSupplier;
@@ -268,6 +269,7 @@ public class ELUReader implements IPeakReader {
 				IPeakModelMSD peakModel = new PeakModelMSD(peakMassSpectrum, peakIntensityValues, 0.0f, 0.0f);
 				extractScanRange(peakModel, peakData);
 				peak = new PeakMSD(peakModel, "AMDIS (ELU)");
+				peak.setPeakType(PeakType.DD);
 				peak.setTemporaryData(header);
 			} catch(Exception e) {
 				logger.warn("PeakModel fails for AMDIS (ELU) component: " + header);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUImportConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUImportConverter_1_ITest.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import org.eclipse.chemclipse.model.core.PeakType;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.ELUReader;
@@ -42,7 +43,7 @@ public class ELUImportConverter_1_ITest {
 	private File file;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		reader = new ELUReader();
 		file = new File(TestPathHelper.TESTFILE_IMPORT_PEAKS_1_ELU);
@@ -57,6 +58,7 @@ public class ELUImportConverter_1_ITest {
 		IProcessingInfo<IPeaksMSD> processingInfo = reader.read(file, new NullProgressMonitor());
 		List<IPeakMSD> peaks = processingInfo.getProcessingResult().getPeaks();
 		IPeakMSD peak1 = peaks.get(0);
+		assertEquals(peak1.getPeakType(), PeakType.DD);
 
 		assertEquals(14, peak1.getPeakModel().getTemporarilyInfo(IPeakReader.TEMP_INFO_START_SCAN));
 		assertEquals(23, peak1.getPeakModel().getTemporarilyInfo(IPeakReader.TEMP_INFO_STOP_SCAN));

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUImportConverter_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUImportConverter_2_ITest.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import org.eclipse.chemclipse.model.core.PeakType;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.ELUReader;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.preferences.PreferenceSupplier;
@@ -41,7 +42,7 @@ public class ELUImportConverter_2_ITest {
 	private File file;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		reader = new ELUReader();
 		file = new File(TestPathHelper.TESTFILE_IMPORT_PEAKS_1_ELU);
@@ -57,6 +58,8 @@ public class ELUImportConverter_2_ITest {
 		List<IPeakMSD> peaks = processingInfo.getProcessingResult().getPeaks();
 
 		IPeakMSD peak1 = peaks.get(0);
+		assertEquals(peak1.getPeakType(), PeakType.DD);
+
 		IPeakMassSpectrum peakMassSpectrum1 = peak1.getPeakModel().getPeakMassSpectrum();
 		List<IIon> ions1 = peakMassSpectrum1.getIons();
 

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUReader_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/elu/ELUReader_1_ITest.java
@@ -34,7 +34,7 @@ public class ELUReader_1_ITest {
 	private File file;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		reader = new ELUReader();
 		file = new File(TestPathHelper.TESTFILE_IMPORT_PEAKS_1_ELU);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/Encoding_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/Encoding_1_ITest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.ImportConverterMslTestCase;
@@ -32,7 +31,7 @@ public class Encoding_1_ITest extends ImportConverterMslTestCase {
 
 	@Override
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		importFile = new File(TestPathHelper.TESTFILE_IMPORT_ENCODING_MSL);
 		super.setUp();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLExportConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLExportConverter_1_ITest.java
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msl;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.database.IDatabaseExportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
@@ -40,7 +39,7 @@ public class MSLExportConverter_1_ITest {
 	private IMassSpectra massSpectra;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		exportConverter = new MSLDatabaseExportConverter();
 		File exportFolder = new File(TestPathHelper.TESTDIR_EXPORT);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLExportConverter_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLExportConverter_2_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
@@ -50,7 +49,7 @@ public class MSLExportConverter_2_ITest extends ImportConverterMslTestCase {
 
 	@Override
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		/*
 		 * Export

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLImportConverter_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLImportConverter_2_ITest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.ImportConverterMslTestCase;
@@ -32,7 +31,7 @@ public class MSLImportConverter_2_ITest extends ImportConverterMslTestCase {
 
 	@Override
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		importFile = new File(TestPathHelper.TESTFILE_IMPORT_GOLMDB_TEST_MSL);
 		super.setUp();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLImportConverter_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msl/MSLImportConverter_3_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
@@ -42,7 +41,7 @@ public class MSLImportConverter_3_ITest extends ImportConverterMslTestCase {
 
 	@Override
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		importFile = new File(TestPathHelper.TESTFILE_IMPORT_DB_4);
 		super.setUp();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPExportConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPExportConverter_1_ITest.java
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msp;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.database.IDatabaseExportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
@@ -40,7 +39,7 @@ public class MSPExportConverter_1_ITest {
 	private IMassSpectra massSpectra;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		exportConverter = new MSPDatabaseExportConverter();
 		File exportFolder = new File(TestPathHelper.TESTDIR_EXPORT);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_1_ITest.java
@@ -16,7 +16,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.database.IDatabaseImportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
@@ -36,7 +35,7 @@ public class MSPImportConverter_1_ITest {
 	private IMassSpectra massSpectra;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_LIB_1_MSP);
 		IDatabaseImportConverter importConverter = new MSPDatabaseImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_2_ITest.java
@@ -16,7 +16,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.database.IDatabaseImportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
@@ -36,7 +35,7 @@ public class MSPImportConverter_2_ITest {
 	private IMassSpectra massSpectra;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_LIB_2_MSP);
 		IDatabaseImportConverter importConverter = new MSPDatabaseImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_3_ITest.java
@@ -16,7 +16,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.database.IDatabaseImportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
@@ -36,7 +35,7 @@ public class MSPImportConverter_3_ITest {
 	private IMassSpectra massSpectra;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_LIB_3_MSP);
 		IDatabaseImportConverter importConverter = new MSPDatabaseImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_4_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_4_ITest.java
@@ -16,7 +16,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.database.IDatabaseImportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
@@ -35,7 +34,7 @@ public class MSPImportConverter_4_ITest {
 	private IMassSpectra massSpectra;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File importFile = new File(TestPathHelper.TESTFILE_IMPORT_LIB_4_MSP);
 		IDatabaseImportConverter importConverter = new MSPDatabaseImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_5_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MSPImportConverter_5_ITest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.io.ImportConverterMspTestCase;
@@ -31,7 +30,7 @@ public class MSPImportConverter_5_ITest extends ImportConverterMspTestCase {
 
 	@Override
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		importFile = new File(TestPathHelper.TESTFILE_IMPORT_GOLMDB_TEST_MSP);
 		super.setUp();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MassBankMS2ImportConverter_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/converter/msp/MassBankMS2ImportConverter_ITest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
@@ -33,7 +32,7 @@ public class MassBankMS2ImportConverter_ITest extends ImportConverterMspTestCase
 
 	@Override
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		importFile = new File(TestPathHelper.TESTFILE_IMPORT_MASSBANK_TEST_MSP);
 		super.setUp();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/ImportConverterMslTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/ImportConverterMslTestCase.java
@@ -14,7 +14,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.amdis.io;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.database.IDatabaseImportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msl.MSLDatabaseImportConverter;
@@ -32,10 +31,10 @@ public class ImportConverterMslTestCase {
 	protected IDatabaseImportConverter importConverter;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		importConverter = new MSLDatabaseImportConverter();
-		IProcessingInfo<?> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
-		massSpectra = (IMassSpectra)processingInfo.getProcessingResult();
+		IProcessingInfo<IMassSpectra> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());
+		massSpectra = processingInfo.getProcessingResult();
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/ImportConverterMspTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/ImportConverterMspTestCase.java
@@ -14,7 +14,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.amdis.io;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.database.IDatabaseImportConverter;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.msp.MSPDatabaseImportConverter;
@@ -32,7 +31,7 @@ public class ImportConverterMspTestCase {
 	protected IDatabaseImportConverter importConverter;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		importConverter = new MSPDatabaseImportConverter();
 		IProcessingInfo<IMassSpectra> processingInfo = importConverter.convert(importFile, new NullProgressMonitor());

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverterTestCase.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverterTestCase.java
@@ -14,7 +14,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.amdis.io;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.database.IDatabaseExportConverter;
 import org.eclipse.chemclipse.msd.converter.database.IDatabaseImportConverter;
@@ -38,7 +37,7 @@ public class MassSpectrumExportConverterTestCase {
 	protected IDatabaseImportConverter importConverter;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		exportConverter = new MSLDatabaseExportConverter();
 		importConverter = new MSLDatabaseImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_1_ITest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.model.IVendorLibraryMassSpectrum;
@@ -39,7 +38,7 @@ public class MassSpectrumExportConverter_DB_1_ITest extends MassSpectrumExportCo
 
 	@Override
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File exportFolder = new File(TestPathHelper.TESTDIR_EXPORT);
 		exportFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_1_MSL);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_2_ITest.java
@@ -16,7 +16,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.io;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IIon;
@@ -38,7 +37,7 @@ public class MassSpectrumExportConverter_DB_2_ITest extends MassSpectrumExportCo
 
 	@Override
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File exportFolder = new File(TestPathHelper.TESTDIR_EXPORT);
 		exportFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_1_MSL);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_3_ITest.java
@@ -16,7 +16,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.io;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IIon;
@@ -38,7 +37,7 @@ public class MassSpectrumExportConverter_DB_3_ITest extends MassSpectrumExportCo
 
 	@Override
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File exportFolder = new File(TestPathHelper.TESTDIR_EXPORT);
 		exportFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_1_MSL);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_4_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_4_ITest.java
@@ -16,7 +16,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.io;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IIon;
@@ -37,7 +36,7 @@ public class MassSpectrumExportConverter_DB_4_ITest extends MassSpectrumExportCo
 
 	@Override
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File exportFolder = new File(TestPathHelper.TESTDIR_EXPORT);
 		exportFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_1_MSL);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_5_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumExportConverter_DB_5_ITest.java
@@ -16,7 +16,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.amdis.io;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
@@ -37,7 +36,7 @@ public class MassSpectrumExportConverter_DB_5_ITest extends MassSpectrumExportCo
 
 	@Override
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File exportFolder = new File(TestPathHelper.TESTDIR_EXPORT);
 		exportFile = new File(exportFolder, File.separator + TestPathHelper.TESTFILE_EXPORT_DB_MSL_IDENTIFIER);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumImportConverter_CHROMATOGRAM_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumImportConverter_CHROMATOGRAM_1_ITest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,7 +32,7 @@ public class MassSpectrumImportConverter_CHROMATOGRAM_1_ITest extends ImportConv
 
 	@Override
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		importFile = new File(TestPathHelper.TESTFILE_IMPORT_CHROMATOGRAM);
 		super.setUp();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumImportConverter_DB_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumImportConverter_DB_1_ITest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,7 +32,7 @@ public class MassSpectrumImportConverter_DB_1_ITest extends ImportConverterMslTe
 
 	@Override
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		importFile = new File(TestPathHelper.TESTFILE_IMPORT_DB_1);
 		super.setUp();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumImportConverter_DB_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumImportConverter_DB_2_ITest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.model.IVendorLibraryMassSpectrum;
@@ -30,7 +29,7 @@ public class MassSpectrumImportConverter_DB_2_ITest extends ImportConverterMslTe
 
 	@Override
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		importFile = new File(TestPathHelper.TESTFILE_IMPORT_DB_2);
 		super.setUp();

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumImportConverter_DB_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MassSpectrumImportConverter_DB_3_ITest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.TestPathHelper;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.model.IVendorLibraryMassSpectrum;
@@ -30,7 +29,7 @@ public class MassSpectrumImportConverter_DB_3_ITest extends ImportConverterMslTe
 
 	@Override
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		importFile = new File(TestPathHelper.TESTFILE_IMPORT_DB_3);
 		super.setUp();


### PR DESCRIPTION
This classification is important for the user to know, for example, when deciding whether to use a peak for quantitation or not. Also, deconvoluted peaks are serialized in a different, more complicated manner, so knowing that in advance helps converter development.