### PR TITLE
Javadoc error fixes (take 2)

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/calculator/SubtractCalculator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/calculator/SubtractCalculator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -37,9 +37,6 @@ public class SubtractCalculator {
 
 	/**
 	 * Subtracts the mass spectrum stored in the filter settings from each scan of the chromatogram selection.
-	 * 
-	 * @param chromatogramSelection
-	 * @param filterSettings
 	 */
 	public void subtractPeakMassSpectraFromChromatogramSelection(IChromatogramSelectionMSD chromatogramSelection, ChromatogramFilterSettings filterSettings) {
 
@@ -89,9 +86,6 @@ public class SubtractCalculator {
 
 	/**
 	 * Subtracts the mass spectrum stored in the filter settings from each peak.
-	 * 
-	 * @param chromatogramSelection
-	 * @param peakFilterSettings
 	 */
 	public void subtractPeakMassSpectra(List<IPeakMSD> peaks, PeakFilterSettings peakFilterSettings) {
 
@@ -157,10 +151,6 @@ public class SubtractCalculator {
 
 	/**
 	 * Returns a map of the normalized mass spectrum.
-	 * 
-	 * @param massSpectrum
-	 * @param useNominalMasses
-	 * @return Map
 	 */
 	public Map<Double, Float> getMassSpectrumMap(IScanMSD massSpectrum, boolean useNominalMasses, boolean normalize) {
 
@@ -206,10 +196,6 @@ public class SubtractCalculator {
 	/**
 	 * Uses the mass spectrum map to calculate the intensity that shall be subtracted
 	 * from the given mass spectrum.
-	 * 
-	 * @param targetMassSpectrum
-	 * @param subtractMassSpectrumMap
-	 * @param useNominalMasses
 	 */
 	public void adjustIntensityValues(IScanMSD targetMassSpectrum, Map<Double, Float> subtractMassSpectrumMap, boolean useNominalMasses, boolean useNormalize) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/massspectrum/MassSpectrumFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/massspectrum/MassSpectrumFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -54,11 +54,6 @@ public class MassSpectrumFilter {
 	 * Applies the specified filter (filterID) with the given {@link IMassSpectrumFilterSettings} on the {@link IScanMSD} .<br/>
 	 * The filter can be supported as a plugin through the extension point
 	 * mechanism.
-	 * 
-	 * @param massSpectrum
-	 * @param massSpectrumFilterSettings
-	 * @param filterId
-	 * @return {@link IProcessingInfo}
 	 */
 	public static IProcessingInfo<IMassSpectrumFilterResult> applyFilter(IScanMSD massSpectrum, IMassSpectrumFilterSettings massSpectrumFilterSettings, String filterId, IProgressMonitor monitor) {
 
@@ -68,11 +63,6 @@ public class MassSpectrumFilter {
 	/**
 	 * Applies the specified filter, but retrieves the IMassSpectrumFilterSettings dynamically.<br/>
 	 * See also method: applyFilter(IMassSpectrum massSpectrum, IMassSpectrumFilterSettings massSpectrumFilterSettings, String filterId, IProgressMonitor monitor)
-	 * 
-	 * @param massSpectrum
-	 * @param filterId
-	 * @param monitor
-	 * @return {@link IProcessingInfo}
 	 */
 	public static IProcessingInfo<IMassSpectrumFilterResult> applyFilter(IScanMSD massSpectrum, String filterId, IProgressMonitor monitor) {
 
@@ -83,12 +73,6 @@ public class MassSpectrumFilter {
 	 * Applies the specified filter (filterID) with the given {@link IMassSpectrumFilterSettings} on the mass spectra list .<br/>
 	 * The filter can be supported as a plugin through the extension point
 	 * mechanism.
-	 * 
-	 * @param List
-	 *            <IMassSpectrum> massSpectra
-	 * @param massSpectraFilterSettings
-	 * @param filterId
-	 * @return {@link IProcessingInfo}
 	 */
 	public static IProcessingInfo<IMassSpectrumFilterResult> applyFilter(List<IScanMSD> massSpectra, IMassSpectrumFilterSettings massSpectraFilterSettings, String filterId, IProgressMonitor monitor) {
 
@@ -106,12 +90,6 @@ public class MassSpectrumFilter {
 	/**
 	 * Applies the specified filter, but retrieves the IMassSpectrumFilterSettings dynamically.<br/>
 	 * See also method: applyFilter(List<IMassSpectrum> massSpectra, IMassSpectrumFilterSettings massSpectrumFilterSettings, String filterId, IProgressMonitor monitor)
-	 * 
-	 * @param List
-	 *            <IMassSpectrum> massSpectra
-	 * @param filterId
-	 * @param monitor
-	 * @return {@link IProcessingInfo}
 	 */
 	public static IProcessingInfo<IMassSpectrumFilterResult> applyFilter(List<IScanMSD> massSpectra, String filterId, IProgressMonitor monitor) {
 
@@ -120,8 +98,6 @@ public class MassSpectrumFilter {
 
 	/**
 	 * Returns the mass spectrum filter support instance.
-	 * 
-	 * @return {@link IMassSpectrumFilterSupport}
 	 */
 	public static IMassSpectrumFilterSupport getMassSpectrumFilterSupport() {
 
@@ -175,9 +151,6 @@ public class MassSpectrumFilter {
 	/**
 	 * Returns an {@link IMassSpectrumFilter} instance or null if none is
 	 * available.
-	 * 
-	 * @param filterId
-	 * @return IConfigurationElement
 	 */
 	private static IConfigurationElement getConfigurationElement(final String filterId) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/peak/PeakFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/peak/PeakFilter.java
@@ -57,11 +57,6 @@ public class PeakFilter {
 	 * Applies the specified filter (filterID) with the given {@link IPeakFilterSettings} on the {@link IPeak} .<br/>
 	 * The filter can be supported as a plugin through the extension point
 	 * mechanism.
-	 * 
-	 * @param peak
-	 * @param peakFilterSettings
-	 * @param filterId
-	 * @return {@link IProcessingInfo}
 	 */
 	public static IProcessingInfo<IPeakFilterResult> applyFilter(IPeakMSD peak, IPeakFilterSettings peakFilterSettings, String filterId, IProgressMonitor monitor) {
 
@@ -71,11 +66,6 @@ public class PeakFilter {
 	/**
 	 * Applies the specified filter, but retrieves the IPeakFilterSettings dynamically.<br/>
 	 * See also method: applyFilter(IPeakMSD peak, IPeakFilterSettings peakFilterSettings, String filterId, IProgressMonitor monitor)
-	 * 
-	 * @param peak
-	 * @param filterId
-	 * @param monitor
-	 * @return {@link IProcessingInfo}
 	 */
 	public static IProcessingInfo<IPeakFilterResult> applyFilter(IPeakMSD peak, String filterId, IProgressMonitor monitor) {
 
@@ -86,12 +76,6 @@ public class PeakFilter {
 	 * Applies the specified filter (filterID) with the given {@link IPeakFilterSettings} on the peak list .<br/>
 	 * The filter can be supported as a plugin through the extension point
 	 * mechanism.
-	 * 
-	 * @param List
-	 *            <IPeakMSD> peaks
-	 * @param peakFilterSettings
-	 * @param filterId
-	 * @return {@link IProcessingInfo}
 	 */
 	public static IProcessingInfo<IPeakFilterResult> applyFilter(List<IPeakMSD> peaks, IPeakFilterSettings peakFilterSettings, String filterId, IProgressMonitor monitor) {
 
@@ -109,12 +93,6 @@ public class PeakFilter {
 	/**
 	 * Applies the specified filter, but retrieves the IPeakFilterSettings dynamically.<br/>
 	 * See also method: applyFilter(List<IPeakMSD> peaks, IPeakFilterSettings peakFilterSettings, String filterId, IProgressMonitor monitor)
-	 * 
-	 * @param List
-	 *            <IPeakMSD> peaks
-	 * @param filterId
-	 * @param monitor
-	 * @return {@link IProcessingInfo}
 	 */
 	public static IProcessingInfo<IPeakFilterResult> applyFilter(List<IPeakMSD> peaks, String filterId, IProgressMonitor monitor) {
 
@@ -125,11 +103,6 @@ public class PeakFilter {
 	 * Applies the specified filter (filterID) with the given {@link IPeakFilterSettings} on the peaks stored in the chromatogram selection.<br/>
 	 * The filter can be supported as a plugin through the extension point
 	 * mechanism.
-	 * 
-	 * @param chromatogramSelection
-	 * @param peakFilterSettings
-	 * @param filterId
-	 * @return {@link IProcessingInfo}
 	 */
 	public static IProcessingInfo<IPeakFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, IPeakFilterSettings peakFilterSettings, String filterId, IProgressMonitor monitor) {
 
@@ -139,11 +112,6 @@ public class PeakFilter {
 	/**
 	 * Applies the specified filter, but retrieves the IPeakFilterSettings dynamically.<br/>
 	 * See also method: applyFilter(IChromatogramSelectionMSD chromatogramSelection, IPeakFilterSettings peakFilterSettings, String filterId, IProgressMonitor monitor)
-	 * 
-	 * @param chromatogramSelection
-	 * @param filterId
-	 * @param monitor
-	 * @return {@link IProcessingInfo}
 	 */
 	public static IProcessingInfo<IPeakFilterResult> applyFilter(IChromatogramSelectionMSD chromatogramSelection, String filterId, IProgressMonitor monitor) {
 
@@ -152,8 +120,6 @@ public class PeakFilter {
 
 	/**
 	 * Returns the peak filter support instance.
-	 * 
-	 * @return {@link IPeakFilterSupport}
 	 */
 	public static IPeakFilterSupport getPeakFilterSupport() {
 
@@ -208,9 +174,6 @@ public class PeakFilter {
 	/**
 	 * Returns an {@link IPeakFilter} instance or null if none is
 	 * available.
-	 * 
-	 * @param filterId
-	 * @return IConfigurationElement
 	 */
 	private static IConfigurationElement getConfigurationElement(final String filterId) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification/src/org/eclipse/chemclipse/chromatogram/msd/process/supplier/peakidentification/model/PeakOutputEntry.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.process.supplier.peakidentification/src/org/eclipse/chemclipse/chromatogram/msd/process/supplier/peakidentification/model/PeakOutputEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,9 +19,6 @@ public class PeakOutputEntry implements IPeakOutputEntry {
 
 	/**
 	 * Set the output file path and the converter id.
-	 * 
-	 * @param outputFile
-	 * @param converterId
 	 */
 	public PeakOutputEntry(String outputFolder, String converterId) {
 		if(outputFolder != null && converterId != null) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/support/IDetectorSlopes.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/support/IDetectorSlopes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,53 +20,38 @@ public interface IDetectorSlopes {
 
 	/**
 	 * Adds a {@link DetectorSlope} object.
-	 * 
-	 * @param detectorSlope
 	 */
 	void add(IDetectorSlope detectorSlope);
 
 	/**
 	 * Returns a DetectorSlope object or null, if no object is available.
-	 * 
-	 * @param scan
-	 * @return IDetectorSlope
 	 */
 	IDetectorSlope getDetectorSlope(int scan);
 
 	/**
 	 * Calculates for each stored slope value a smoothed moving average value.<br/>
 	 * The window size declares the width of the moving window.
-	 * 
-	 * @param int
 	 */
 	void calculateMovingAverage(int windowSize);
 
 	/**
 	 * Calculates for each stored slope value a Savitzky-Golay smooothed value.<br/>
 	 * The window size declares the filter width of the Savitzky-Golay filter.
-	 * 
-	 * @param int
 	 */
 	void calculateSavitzkyGolaySmooth(int windowSize);
 
 	/**
 	 * Returns the size of the slope list.
-	 * 
-	 * @return int
 	 */
 	int size();
 
 	/**
 	 * Returns the start scan.
-	 * 
-	 * @return
 	 */
 	int getStartScan();
 
 	/**
 	 * Returns the stop scan.
-	 * 
-	 * @return
 	 */
 	int getStopScan();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.filter/src/org/eclipse/chemclipse/chromatogram/wsd/filter/core/peak/PeakFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.filter/src/org/eclipse/chemclipse/chromatogram/wsd/filter/core/peak/PeakFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -54,11 +54,6 @@ public class PeakFilter {
 	 * Applies the specified filter (filterID) with the given {@link IPeakFilterSettings} on the {@link IPeak} .<br/>
 	 * The filter can be supported as a plugin through the extension point
 	 * mechanism.
-	 * 
-	 * @param peak
-	 * @param peakFilterSettings
-	 * @param filterId
-	 * @return {@link IProcessingInfo}
 	 */
 	public static IProcessingInfo<IPeakFilterResult> applyFilter(IPeakWSD peak, IPeakFilterSettings peakFilterSettings, String filterId, IProgressMonitor monitor) {
 
@@ -76,11 +71,6 @@ public class PeakFilter {
 	/**
 	 * Applies the specified filter, but retrieves the IPeakFilterSettings dynamically.<br/>
 	 * See also method: applyFilter(IPeakMSD peak, IPeakFilterSettings peakFilterSettings, String filterId, IProgressMonitor monitor)
-	 * 
-	 * @param peak
-	 * @param filterId
-	 * @param monitor
-	 * @return {@link IProcessingInfo}
 	 */
 	public static IProcessingInfo<IPeakFilterResult> applyFilter(IPeakWSD peak, String filterId, IProgressMonitor monitor) {
 
@@ -99,12 +89,6 @@ public class PeakFilter {
 	 * Applies the specified filter (filterID) with the given {@link IPeakFilterSettings} on the peak list .<br/>
 	 * The filter can be supported as a plugin through the extension point
 	 * mechanism.
-	 * 
-	 * @param List
-	 *            <IPeakMSD> peaks
-	 * @param peakFilterSettings
-	 * @param filterId
-	 * @return {@link IProcessingInfo}
 	 */
 	public static IProcessingInfo<IPeakFilterResult> applyFilter(List<IPeakWSD> peaks, IPeakFilterSettings peakFilterSettings, String filterId, IProgressMonitor monitor) {
 
@@ -122,12 +106,6 @@ public class PeakFilter {
 	/**
 	 * Applies the specified filter, but retrieves the IPeakFilterSettings dynamically.<br/>
 	 * See also method: applyFilter(List<IPeakMSD> peaks, IPeakFilterSettings peakFilterSettings, String filterId, IProgressMonitor monitor)
-	 * 
-	 * @param List
-	 *            <IPeakMSD> peaks
-	 * @param filterId
-	 * @param monitor
-	 * @return {@link IProcessingInfo}
 	 */
 	public static IProcessingInfo<IPeakFilterResult> applyFilter(List<IPeakWSD> peaks, String filterId, IProgressMonitor monitor) {
 
@@ -146,11 +124,6 @@ public class PeakFilter {
 	 * Applies the specified filter (filterID) with the given {@link IPeakFilterSettings} on the peaks stored in the chromatogram selection.<br/>
 	 * The filter can be supported as a plugin through the extension point
 	 * mechanism.
-	 * 
-	 * @param chromatogramSelection
-	 * @param peakFilterSettings
-	 * @param filterId
-	 * @return {@link IProcessingInfo}
 	 */
 	public static IProcessingInfo<IPeakFilterResult> applyFilter(IChromatogramSelectionWSD chromatogramSelection, IPeakFilterSettings peakFilterSettings, String filterId, IProgressMonitor monitor) {
 
@@ -168,11 +141,6 @@ public class PeakFilter {
 	/**
 	 * Applies the specified filter, but retrieves the IPeakFilterSettings dynamically.<br/>
 	 * See also method: applyFilter(IChromatogramSelectionMSD chromatogramSelection, IPeakFilterSettings peakFilterSettings, String filterId, IProgressMonitor monitor)
-	 * 
-	 * @param chromatogramSelection
-	 * @param filterId
-	 * @param monitor
-	 * @return {@link IProcessingInfo}
 	 */
 	public static IProcessingInfo<IPeakFilterResult> applyFilter(IChromatogramSelectionWSD chromatogramSelection, String filterId, IProgressMonitor monitor) {
 
@@ -189,8 +157,6 @@ public class PeakFilter {
 
 	/**
 	 * Returns the peak filter support instance.
-	 * 
-	 * @return {@link IPeakFilterSupport}
 	 */
 	public static IPeakFilterSupport getPeakFilterSupport() {
 
@@ -235,9 +201,6 @@ public class PeakFilter {
 	/**
 	 * Returns an {@link IPeakFilter} instance or null if none is
 	 * available.
-	 * 
-	 * @param filterId
-	 * @return IConfigurationElement
 	 */
 	private static IConfigurationElement getConfigurationElement(final String filterId) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/chromatogram/IChromatogramConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/chromatogram/IChromatogramConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,8 +29,6 @@ public interface IChromatogramConverter<P extends IPeak, C extends IChromatogram
 	 * about all valid and registered chromatogram converters.<br/>
 	 * It can be used to get more information about the registered converters
 	 * such like filter names, file extensions.
-	 *
-	 * @return ChromatogramConverterSupport
 	 */
 	IChromatogramConverterSupport getChromatogramConverterSupport();
 
@@ -41,11 +39,6 @@ public interface IChromatogramConverter<P extends IPeak, C extends IChromatogram
 	 * available.<br/>
 	 * If no converter was available, a
 	 * NoChromatogramConverterAvailableException will be thrown.
-	 *
-	 * @param chromatogram
-	 * @param converterId
-	 * @param monitor
-	 * @return {@link IProcessingInfo}
 	 */
 	IProcessingInfo<IChromatogramOverview> convertOverview(File file, String converterId, IProgressMonitor monitor);
 
@@ -58,28 +51,16 @@ public interface IChromatogramConverter<P extends IPeak, C extends IChromatogram
 	 * For example that the file is not readable or the file is not existent.<br/>
 	 * If no converter was able to read the file, a
 	 * NoChromatogramConverterAvailableException will be thrown.
-	 *
-	 * @param chromatogram
-	 * @param converterId
-	 * @param monitor
-	 * @return {@link IProcessingInfo}
 	 */
 	IProcessingInfo<C> convert(File file, String converterId, IProgressMonitor monitor);
 
 	/**
 	 * If no suitable parser was found, null will be returned.
-	 *
-	 * @param file
-	 * @param overview
-	 * @param monitor
-	 * @return {@link IProcessingInfo}
 	 */
 	IProcessingInfo<C> getChromatogram(File file, boolean overview, IProgressMonitor monitor);
 
 	/**
 	 * Maybe override to add your own methods.
-	 *
-	 * @param processingInfo
 	 */
 	void postProcessChromatogram(IProcessingInfo<C> processingInfo, IProgressMonitor monitor);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/support/FileParserSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/support/FileParserSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,11 +24,6 @@ public class FileParserSupport {
 	/**
 	 * The first matched/sorted file is returned that matches the prefix and extension pattern.
 	 * Null if none could be matched.
-	 * 
-	 * @param directory
-	 * @param filePrefix
-	 * @param fileExtension
-	 * @return {@link File}
 	 */
 	public static File matchFile(File directory, String filePrefix, String fileExtension) {
 
@@ -41,11 +36,6 @@ public class FileParserSupport {
 	/**
 	 * The first matched/sorted file is returned that matches the prefix and extension pattern.
 	 * Null if none could be matched.
-	 * 
-	 * @param directory
-	 * @param filePrefix
-	 * @param fileExtension
-	 * @return {@link File}
 	 */
 	public static File matchFile(File directory, Set<String> filePrefixes, String fileExtension) {
 
@@ -55,11 +45,6 @@ public class FileParserSupport {
 
 	/**
 	 * A list of files is returned that matches the prefix and extension pattern.
-	 * 
-	 * @param directory
-	 * @param filePrefix
-	 * @param fileExtension
-	 * @return {@link List}
 	 */
 	public static List<File> match(File directory, Set<String> filePrefixes, String fileExtension) {
 
@@ -90,10 +75,6 @@ public class FileParserSupport {
 	/**
 	 * Try to get the file given by the directory and name.
 	 * Additional tries to lower and upper case of the name are performed to get the file.
-	 * 
-	 * @param baseFileDirectory
-	 * @param name
-	 * @return {@link File}
 	 */
 	public static File find(String directory, String name) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IChromatogram.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IChromatogram.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -71,38 +71,28 @@ public interface IChromatogram extends SegmentedMeasurement, IMeasurement, IChro
 	 * by clicking on save. Simply, the converter id
 	 * is set to "", so that the software asks how to save
 	 * the chromatogram.
-	 * 
-	 * @param finalized
 	 */
 	void setFinalized(boolean finalized);
 
 	/**
 	 * The converter sets its id if the chromatogram is writable by the
 	 * converter.
-	 * 
-	 * @param id
 	 */
 	void setConverterId(String id);
 
 	/**
 	 * Returns the converter id. If the chromatogram is not writable, null or ""
 	 * will be returned.
-	 * 
-	 * @return String
 	 */
 	String getConverterId();
 
 	/**
 	 * Adds a scan to the chromatogram.
-	 * 
-	 * @param scan
 	 */
 	void addScan(IScan scan);
 
 	/**
 	 * Adds the scans to the chromatogram.
-	 * 
-	 * @param scans
 	 */
 	void addScans(List<IScan> scans);
 
@@ -111,9 +101,6 @@ public interface IChromatogram extends SegmentedMeasurement, IMeasurement, IChro
 	 * retention times should be recalculated, call
 	 * chromatogram.recalculateRetentionTimes().<br/>
 	 * If no scan was available, null will be returned.
-	 * 
-	 * @param scan
-	 * @return IScan
 	 */
 	IScan getScan(int scan);
 
@@ -121,9 +108,6 @@ public interface IChromatogram extends SegmentedMeasurement, IMeasurement, IChro
 	 * Returns the list of stored scans.
 	 * Please use it only to iterate the stored scans.
 	 * Modifications on the list may cause problems.
-	 * 
-	 * @param scan
-	 * @return List<IScan>
 	 */
 	List<IScan> getScans();
 
@@ -133,8 +117,6 @@ public interface IChromatogram extends SegmentedMeasurement, IMeasurement, IChro
 	 * chromatogram.recalculateRetentionTimes().<br/>
 	 * You can also add several scans, and call
 	 * chromatogram.recalculateRetentionTimes() afterwards.
-	 * 
-	 * @param scan
 	 */
 	void removeScan(int scan);
 
@@ -149,9 +131,6 @@ public interface IChromatogram extends SegmentedMeasurement, IMeasurement, IChro
 	 * chromatogram.recalculateRetentionTimes().<br/>
 	 * You can also remove several scans, and call
 	 * chromatogram.recalculateRetentionTimes() afterwards.
-	 * 
-	 * @param from
-	 * @param to
 	 */
 	void removeScans(int from, int to);
 
@@ -163,15 +142,11 @@ public interface IChromatogram extends SegmentedMeasurement, IMeasurement, IChro
 
 	/**
 	 * Returns the currently used noise calculator.
-	 * 
-	 * @return {@link INoiseCalculator}
 	 */
 	INoiseCalculator getNoiseCalculator();
 
 	/**
 	 * Sets the currently used noise calculator.
-	 * 
-	 * @param noiseCalculator
 	 */
 	void setNoiseCalculator(INoiseCalculator noiseCalculator);
 
@@ -182,37 +157,24 @@ public interface IChromatogram extends SegmentedMeasurement, IMeasurement, IChro
 
 	/**
 	 * Calculates the signal to noise (S/N) ratio of the given abundance.
-	 * 
-	 * @param abundance
-	 * @return float
 	 */
 	float getSignalToNoiseRatio(float abundance);
 
 	/**
 	 * Returns the chromatogram name from a directory.
 	 * E.g., if the filename is /.../chrom.D/DATA.MS, chrom will be returned.
-	 * 
-	 * @param file
-	 * @param nameDefault
-	 * @return String
 	 */
 	String extractNameFromDirectory(String nameDefault, String directoryExtension);
 
 	/**
 	 * Returns the chromatogram name from a file.
 	 * E.g., if the filename is /.../chrom.csv, chrom will be returned.
-	 * 
-	 * @param file
-	 * @param nameDefault
-	 * @return String
 	 */
 	String extractNameFromFile(String nameDefault);
 
 	/**
 	 * Returns the master chromatogram if it is set.
 	 * This method may return null.
-	 * 
-	 * @return {@link IChromatogram}
 	 */
 	IChromatogram getMasterChromatogram();
 
@@ -220,22 +182,16 @@ public interface IChromatogram extends SegmentedMeasurement, IMeasurement, IChro
 	 * Stores a list of referenced chromatograms.
 	 * Some vendors store more than one chromatogram in one file.
 	 * This should be part of further improvements how to handle this issue.
-	 * 
-	 * @return {@link IChromatogram}
 	 */
 	List<IChromatogram> getReferencedChromatograms();
 
 	/**
 	 * Add a referenced chromatogram.
-	 * 
-	 * @param chromatogram
 	 */
 	void addReferencedChromatogram(IChromatogram chromatogram);
 
 	/**
 	 * Removes a referenced chromatogram.
-	 * 
-	 * @param chromatogram
 	 */
 	void removeReferencedChromatogram(IChromatogram chromatogram);
 
@@ -248,8 +204,6 @@ public interface IChromatogram extends SegmentedMeasurement, IMeasurement, IChro
 
 	/**
 	 * Marks that this chromatogram has been set to unload modus.
-	 * 
-	 * @return
 	 */
 	boolean isUnloaded();
 
@@ -257,23 +211,16 @@ public interface IChromatogram extends SegmentedMeasurement, IMeasurement, IChro
 	 * This methods checks whether different scan cycles are contained.
 	 * All scans of one cycle shall be displayed in TIC mode with the
 	 * summed signal.
-	 * 
-	 * @return boolean
 	 */
 	boolean containsScanCycles();
 
 	/**
 	 * Returns the scans identified by the scan cycle id.
-	 * 
-	 * @param cycleNumber
-	 * @return List<IScan>
 	 */
 	List<IScan> getScanCycleScans(int cycleNumber);
 
 	/**
 	 * Returns the chromatogram method.
-	 * 
-	 * @return IMethod
 	 */
 	IMethod getMethod();
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/ILibraryInformation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/ILibraryInformation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2025 Lablicate GmbH.
+ * Copyright (c) 2010, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,8 +23,6 @@ public interface ILibraryInformation extends IClassifier, Serializable {
 
 	/**
 	 * Returns the name of the library mass spectrum.
-	 * 
-	 * @return String
 	 */
 	String getName();
 
@@ -35,23 +33,17 @@ public interface ILibraryInformation extends IClassifier, Serializable {
 
 	/**
 	 * Returns the list of synonyms or an empty list.
-	 * 
-	 * @return {@link Set}
 	 */
 	Set<String> getSynonyms();
 
 	/**
 	 * Sets the synonyms.
 	 * The set must be not null.
-	 * 
-	 * @param synonyms
 	 */
 	void setSynonyms(Set<String> synonyms);
 
 	/**
 	 * Returns CAS number of the library mass spectrum.
-	 * 
-	 * @return String
 	 */
 	String getCasNumber();
 
@@ -62,8 +54,6 @@ public interface ILibraryInformation extends IClassifier, Serializable {
 
 	/**
 	 * Add an additional CAS numbers.
-	 * 
-	 * @param casNumber
 	 */
 	void addCasNumber(String casNumber);
 
@@ -71,8 +61,6 @@ public interface ILibraryInformation extends IClassifier, Serializable {
 
 	/**
 	 * Returns an unmodifiable list of the CAS numbers.
-	 * 
-	 * @return List<String>
 	 */
 	List<String> getCasNumbers();
 
@@ -83,8 +71,6 @@ public interface ILibraryInformation extends IClassifier, Serializable {
 
 	/**
 	 * Returns the formula of the library mass spectrum.
-	 * 
-	 * @return String
 	 */
 	String getFormula();
 
@@ -95,8 +81,6 @@ public interface ILibraryInformation extends IClassifier, Serializable {
 
 	/**
 	 * Returns the SMILES of the library mass spectrum.
-	 * 
-	 * @return String
 	 */
 	String getSmiles();
 
@@ -107,8 +91,6 @@ public interface ILibraryInformation extends IClassifier, Serializable {
 
 	/**
 	 * Returns the InChI of the library mass spectrum.
-	 * 
-	 * @return String
 	 */
 	String getInChI();
 
@@ -123,8 +105,6 @@ public interface ILibraryInformation extends IClassifier, Serializable {
 
 	/**
 	 * Returns the mol weight of the library mass spectrum.
-	 * 
-	 * @return String
 	 */
 	double getMolWeight();
 
@@ -147,8 +127,6 @@ public interface ILibraryInformation extends IClassifier, Serializable {
 
 	/**
 	 * Returns comments of the library mass spectrum.
-	 * 
-	 * @return String
 	 */
 	String getComments();
 
@@ -160,8 +138,6 @@ public interface ILibraryInformation extends IClassifier, Serializable {
 	/**
 	 * Returns the reference id.
 	 * This field is used to track internal references.
-	 * 
-	 * @return String
 	 */
 	String getReferenceIdentifier();
 
@@ -173,15 +149,11 @@ public interface ILibraryInformation extends IClassifier, Serializable {
 
 	/**
 	 * Returns miscellaneous information ...
-	 * 
-	 * @return String
 	 */
 	String getMiscellaneous();
 
 	/**
 	 * Sets miscellaneous information ...
-	 * 
-	 * @return String
 	 */
 	void setMiscellaneous(String miscellaneous);
 
@@ -195,15 +167,11 @@ public interface ILibraryInformation extends IClassifier, Serializable {
 
 	/**
 	 * Returns the contributor information.
-	 * 
-	 * @return String
 	 */
 	String getContributor();
 
 	/**
 	 * Sets the contributor information.
-	 * 
-	 * @return String
 	 */
 	void setContributor(String contributor);
 
@@ -220,8 +188,6 @@ public interface ILibraryInformation extends IClassifier, Serializable {
 	/**
 	 * Returns an unmodifiable list of the available column
 	 * index markers in the correct sort order.
-	 * 
-	 * @return {@link List}
 	 */
 	List<IColumnIndexMarker> getColumnIndexMarkers();
 
@@ -234,8 +200,6 @@ public interface ILibraryInformation extends IClassifier, Serializable {
 	/**
 	 * Returns an unmodifiable list of the available
 	 * flavor markers.
-	 * 
-	 * @return {@link List}
 	 */
 	List<IFlavorMarker> getFlavorMarkers();
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/supplier/IMeasurementProcessSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/supplier/IMeasurementProcessSupplier.java
@@ -30,14 +30,8 @@ public interface IMeasurementProcessSupplier<ConfigType> extends IProcessSupplie
 	 * 
 	 * @param measurements
 	 *            the measurements to process
-	 * @param processorId
-	 *            the id of the processor to apply
 	 * @param processSettings
 	 *            the settings to use or <code>null</code> if default settings are in effect
-	 * @param messageConsumer
-	 *            the consumer to listen for feedback messages
-	 * @param monitor
-	 *            the monitor to use to report progress
 	 * @return the collection of processed measurements
 	 */
 	Collection<? extends IMeasurement> applyProcessor(Collection<? extends IMeasurement> measurements, ConfigType processSettings, ProcessExecutionContext context);

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/targets/TargetSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/targets/TargetSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,9 +23,6 @@ public class TargetSupport {
 
 	/**
 	 * Returns the best target string representation or "" if none is available.
-	 * 
-	 * @param object
-	 * @return {@link String}
 	 */
 	public static String getBestTargetLibraryField(ITargetSupplier targetSupplier) {
 
@@ -43,9 +40,6 @@ public class TargetSupport {
 
 	/**
 	 * Return the best identification target. May return null.
-	 * 
-	 * @param object
-	 * @return {@link IIdentificationTarget}
 	 */
 	public static IIdentificationTarget getBestIdentificationTarget(ITargetSupplier targetSupplier) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/AbstractWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/AbstractWriter.java
@@ -82,9 +82,6 @@ public abstract class AbstractWriter {
 
 	/**
 	 * Makes a deep copy of the mass spectrum, normalizes it and removes too low abundances.
-	 * 
-	 * @param massSpectrum
-	 * @return {@link IScanMSD}
 	 */
 	protected IScanMSD getOptimizedMassSpectrum(IScanMSD massSpectrum) {
 
@@ -97,9 +94,6 @@ public abstract class AbstractWriter {
 
 	/**
 	 * Removes the ions below the given minimum abundance.
-	 * 
-	 * @param normalizedMassSpectrum
-	 * @param minimumAbundance
 	 */
 	protected void removeIonsWithAnTooLowAbundance(IScanMSD normalizedMassSpectrum, float minimumAbundance) {
 
@@ -139,9 +133,6 @@ public abstract class AbstractWriter {
 
 	/**
 	 * Returns the name information from the mass spectrum.
-	 * 
-	 * @param massSpectrum
-	 * @return String
 	 */
 	protected String getNameField(IScanMSD massSpectrum, IIdentificationTarget identificationTarget) {
 
@@ -171,9 +162,6 @@ public abstract class AbstractWriter {
 
 	/**
 	 * This method returns the identification target or null if there is none.
-	 * 
-	 * @param massSpectrum
-	 * @return
 	 */
 	protected IIdentificationTarget getIdentificationTarget(IScanMSD massSpectrum) {
 
@@ -209,9 +197,6 @@ public abstract class AbstractWriter {
 
 	/**
 	 * Returns the CAS number information from the mass spectrum.
-	 * 
-	 * @param massSpectrum
-	 * @return String
 	 */
 	protected String getCasNumberField(IIdentificationTarget identificationTarget) {
 
@@ -342,9 +327,6 @@ public abstract class AbstractWriter {
 
 	/**
 	 * Returns the comments information from the mass spectrum.
-	 * 
-	 * @param massSpectrum
-	 * @return String
 	 */
 	protected String getCommentsField(IScanMSD massSpectrum) {
 
@@ -358,9 +340,6 @@ public abstract class AbstractWriter {
 
 	/**
 	 * Returns the source information from the mass spectrum.
-	 * 
-	 * @param massSpectrum
-	 * @return String
 	 */
 	protected String getSourceField(IScanMSD massSpectrum, IIdentificationTarget identificationTarget) {
 
@@ -378,9 +357,6 @@ public abstract class AbstractWriter {
 
 	/**
 	 * Returns the retention time information from the mass spectrum.
-	 * 
-	 * @param massSpectrum
-	 * @return String
 	 */
 	protected String getRetentionTimeField(IScanMSD massSpectrum) {
 
@@ -396,9 +372,6 @@ public abstract class AbstractWriter {
 
 	/**
 	 * Returns the retention time information from the mass spectrum.
-	 * 
-	 * @param massSpectrum
-	 * @return String
 	 */
 	protected String getRelativeRetentionTimeField(IScanMSD massSpectrum) {
 
@@ -414,9 +387,6 @@ public abstract class AbstractWriter {
 
 	/**
 	 * Returns the retention index information from the mass spectrum.
-	 * 
-	 * @param massSpectrum
-	 * @return String
 	 */
 	protected String getRetentionIndexField(IScanMSD massSpectrum) {
 
@@ -432,9 +402,6 @@ public abstract class AbstractWriter {
 
 	/**
 	 * Returns the name information from the mass spectrum.
-	 * 
-	 * @param massSpectrum
-	 * @return String
 	 */
 	protected String getNumberOfPeaks(IScanMSD massSpectrum) {
 
@@ -446,9 +413,6 @@ public abstract class AbstractWriter {
 
 	/**
 	 * Returns the formula information from the mass spectrum.
-	 * 
-	 * @param massSpectrum
-	 * @return String
 	 */
 	protected String getFormulaField(IScanMSD massSpectrum) {
 
@@ -462,9 +426,6 @@ public abstract class AbstractWriter {
 
 	/**
 	 * Returns the MW information from the mass spectrum.
-	 * 
-	 * @param massSpectrum
-	 * @return String
 	 */
 	protected String getMWField(IScanMSD massSpectrum) {
 
@@ -576,9 +537,6 @@ public abstract class AbstractWriter {
 
 	/**
 	 * Returns the mass spectra in the convenient AMDIS format.
-	 * 
-	 * @param massSpectrum
-	 * @return String
 	 */
 	protected String getIonsFormatMSL(IScanMSD massSpectrum) {
 
@@ -626,9 +584,6 @@ public abstract class AbstractWriter {
 
 	/**
 	 * Returns the mass spectra in the convenient AMDIS format.
-	 * 
-	 * @param massSpectrum
-	 * @return String
 	 */
 	protected String getIonsFormatMSP(IScanMSD massSpectrum) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/core/support/Identifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/core/support/Identifier.java
@@ -24,8 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
-import org.eclipse.chemclipse.converter.exceptions.NoConverterAvailableException;
 import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
@@ -84,12 +82,6 @@ public class Identifier {
 
 	/**
 	 * Performs a mass spectrum identification.
-	 *
-	 * @param massSpectrumList
-	 * @param searchSettings
-	 * @param monitor
-	 * @return IMassSpectrumIdentificationResults
-	 * @throws FileNotFoundException
 	 */
 	public IMassSpectra runMassSpectrumIdentification(List<IScanMSD> massSpectrumList, ISearchSettings searchSettings, IProgressMonitor monitor) throws FileNotFoundException {
 
@@ -162,12 +154,6 @@ public class Identifier {
 
 	/**
 	 * Performs a peak identification.
-	 *
-	 * @param peaks
-	 * @param searchSettings
-	 * @param monitor
-	 * @return IPeakIdentificationResults
-	 * @throws FileNotFoundException
 	 */
 	public IPeakIdentificationResults runPeakIdentification(List<? extends IPeakMSD> peaks, ISearchSettings searchSettings, IProcessingInfo<?> processingInfo, IProgressMonitor monitor) throws FileNotFoundException {
 
@@ -448,14 +434,6 @@ public class Identifier {
 
 	/**
 	 * Prepares the files.
-	 *
-	 * @param runtimeSupport
-	 * @param monitor
-	 * @param peaks
-	 * @throws NoConverterAvailableException
-	 * @throws IOException
-	 * @throws FileIsNotWriteableException
-	 * @throws FileNotFoundException
 	 */
 	private void prepareFiles(IExtendedRuntimeSupport runtimeSupport, IMassSpectra massSpectra, IProgressMonitor monitor) throws IOException {
 
@@ -498,13 +476,6 @@ public class Identifier {
 
 	/**
 	 * Runs the NIST application.
-	 * 
-	 * @param runtimeSupport
-	 * @param maxProcessTime
-	 * @param waitTime
-	 * @param monitor
-	 * @return Compounds
-	 * @throws IOException
 	 */
 	private Compounds runNistApplication(final IExtendedRuntimeSupport runtimeSupport, final long maxProcessTime, int waitTime, final IProgressMonitor monitor) throws IOException {
 
@@ -594,11 +565,6 @@ public class Identifier {
 
 	/**
 	 * Get the result.
-	 *
-	 * @param peak
-	 * @param compound
-	 * @param peakIdentifierSettings
-	 * @return {@link INistPeakIdentificationResults}
 	 */
 	public IPeakIdentificationResults getPeakIdentificationResults(Compounds compounds, List<? extends IPeakMSD> peaks, ISearchSettings searchSettings, IProcessingInfo<?> processingInfo) {
 
@@ -678,10 +644,6 @@ public class Identifier {
 
 	/**
 	 * Returns the identification entry or null if something has gone wrong.
-	 *
-	 * @param compound
-	 * @param index
-	 * @return {@link INistPeakIdentificationEntry}
 	 */
 	public IIdentificationTarget getPeakIdentificationEntry(Compound compound, int index) {
 
@@ -713,13 +675,6 @@ public class Identifier {
 
 	/**
 	 * Assigns the mass spectrum compounds.
-	 *
-	 * @param compounds
-	 * @param massSpectra
-	 * @param identificationResults
-	 * @param searchSettings
-	 * @param monitor
-	 * @return INistMassSpectrumIdentificationResults
 	 */
 	private IIdentificationResults assignMassSpectrumCompounds(List<Compound> compounds, List<IScanMSD> massSpectra, IIdentificationResults identificationResults, ISearchSettings searchSettings, IProgressMonitor monitor) {
 
@@ -756,11 +711,6 @@ public class Identifier {
 
 	/**
 	 * Returns the mass spectrum identification result.
-	 *
-	 * @param massSpectrum
-	 * @param compound
-	 * @param searchSettings
-	 * @return INistMassSpectrumIdentificationResult
 	 */
 	public IIdentificationResult getMassSpectrumIdentificationResult(IScanMSD massSpectrum, Compound compound, ISearchSettings searchSettings) {
 
@@ -792,9 +742,6 @@ public class Identifier {
 
 	/**
 	 * Returns the mass spectrum identification entry.
-	 *
-	 * @param hit
-	 * @return INistMassSpectrumIdentificationEntry
 	 */
 	public IIdentificationTarget getMassSpectrumIdentificationEntry(Hit hit, Compound compound) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.processing.supplier.base.ui/src/org/eclipse/chemclipse/nmr/processing/supplier/base/ui/SliderUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.processing.supplier.base.ui/src/org/eclipse/chemclipse/nmr/processing/supplier/base/ui/SliderUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -45,13 +45,6 @@ public class SliderUI {
 	private Composite composite;
 	private Collection<DoubleConsumer> consumers = new CopyOnWriteArrayList<>();
 
-	/**
-	 *
-	 * @param composite
-	 * @param range
-	 * @param min
-	 * @param fractionDigits
-	 */
 	public SliderUI(Composite parent) {
 
 		scaleFactor = (int)Math.pow(10, 0);
@@ -184,8 +177,6 @@ public class SliderUI {
 
 	/**
 	 * Increments the slider by multiples of the page increment
-	 *
-	 * @param incrementValue
 	 */
 	public void increment(int incrementValue) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.processing.supplier.base/src/org/eclipse/chemclipse/nmr/processing/supplier/base/settings/ChemicalShiftCalibrationSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.processing.supplier.base/src/org/eclipse/chemclipse/nmr/processing/supplier/base/settings/ChemicalShiftCalibrationSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,8 +32,6 @@ public class ChemicalShiftCalibrationSettings {
 	 * getLocationOfCauchyDistribution returns the location parameter of the used
 	 * Cauchy Distribution. The location refers to the peak maximum of the internal
 	 * standard and corresponds to the chemical shift value in ppm.
-	 *
-	 * @param getLocationOfCauchyDistribution
 	 */
 	public double getLocationOfCauchyDistribution() {
 
@@ -45,8 +43,6 @@ public class ChemicalShiftCalibrationSettings {
 	 * Cauchy Distribution.
 	 * <p>
 	 * By default, the value is set to 0.
-	 *
-	 * @param setLocationOfCauchyDistribution
 	 */
 	public void setLocationOfCauchyDistribution(double locationOfCauchyDistribution) {
 
@@ -57,8 +53,6 @@ public class ChemicalShiftCalibrationSettings {
 	 * getScaleOfCauchyDistribution returns the scale parameter of the used Cauchy
 	 * Distribution. The parameter scales the intensity of the distribution to suit
 	 * the intensity of observed peak of the internal standard.
-	 *
-	 * @param getScaleOfCauchyDistribution
 	 */
 	public double getScaleOfCauchyDistribution() {
 
@@ -71,8 +65,6 @@ public class ChemicalShiftCalibrationSettings {
 	 * Only values greater than zero are allowed.
 	 * <p>
 	 * By default, the value is set to 0.01.
-	 *
-	 * @param setScaleOfCauchyDistribution
 	 */
 	public void setScaleOfCauchyDistribution(double scaleOfCauchyDistribution) {
 
@@ -84,8 +76,6 @@ public class ChemicalShiftCalibrationSettings {
 	 * Distribution. This parameter describes the width of the considered section
 	 * around the observed peak of the internal standard and is used to define the
 	 * peak width.
-	 *
-	 * @param getRangeOfCauchyDistribution
 	 */
 	public double getRangeOfCauchyDistribution() {
 
@@ -97,8 +87,6 @@ public class ChemicalShiftCalibrationSettings {
 	 * Distribution.
 	 * <p>
 	 * By default, the value is set to 2.
-	 *
-	 * @param setRangeOfCauchyDistribution
 	 */
 	public void setRangeOfCauchyDistribution(double rangeOfCauchyDistribution) {
 
@@ -109,8 +97,6 @@ public class ChemicalShiftCalibrationSettings {
 	 * getRangeAroundCalibrationSignal returns the range parameter used for the
 	 * selection of the calibration signal. This parameter describes the width of
 	 * the considered section around the observed peak of the internal standard.
-	 *
-	 * @param getRangeAroundCalibrationSignal
 	 */
 	public double getRangeAroundCalibrationSignal() {
 
@@ -126,8 +112,6 @@ public class ChemicalShiftCalibrationSettings {
 	 * It can be assumed that deviations (if any) are covered by this range from
 	 * 0.05 to -0.05 ppm. A larger range means that impurities or other peaks could
 	 * be misused for calibration.
-	 *
-	 * @param setRangeAroundCalibrationSignal
 	 */
 	public void setRangeAroundCalibrationSignal(double rangeAroundCalibrationSignal) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/supplier/IProcessorPreferences.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/supplier/IProcessorPreferences.java
@@ -73,7 +73,6 @@ public interface IProcessorPreferences<SettingType> {
 	/**
 	 * constructs a new settings instance from the current user settings
 	 * 
-	 * @param settingsClass
 	 * @return the currently stored user settings for this processor
 	 */
 	default SettingType getUserSettings() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/preferences/fieldeditors/SpinnerFieldEditor2.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/preferences/fieldeditors/SpinnerFieldEditor2.java
@@ -88,10 +88,6 @@ public class SpinnerFieldEditor2 extends FieldEditor {
 	 *            the name of the preference this field editor works on
 	 * @param labelText
 	 *            the label text of the field editor
-	 * @param min
-	 *            Minimal value
-	 * @param max
-	 *            Maximal value
 	 * @param strategy
 	 *            either <code>VALIDATE_ON_KEY_STROKE</code> to perform
 	 *            on the fly checking (the default), or <code>VALIDATE_ON_FOCUS_LOST</code> to

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/AbstractMacWineSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/runtime/AbstractMacWineSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,8 +24,6 @@ public abstract class AbstractMacWineSupport extends AbstractWineRuntimeSupport 
 	 * /Users/chemclipse/.wine/drive_c/Programme/NIST/MSSEARCH/nistms$.exe
 	 * /Users/chemclipse/.wine/dosdevices/c:/Programme/NIST/MSSEARCH/nistms$.exe
 	 * 
-	 * @param application
-	 * @param parameter
 	 * @param macWineBinary
 	 *            (e.g. "/Applications/Wine.app")
 	 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/settings/parser/SettingsClassParser.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/settings/parser/SettingsClassParser.java
@@ -73,9 +73,6 @@ public class SettingsClassParser<SettingType> implements SettingsParser<SettingT
 
 	/**
 	 * parses a given class for annotations and generate {@link InputValue}s from it
-	 * 
-	 * @param clazz
-	 * @return
 	 */
 	@Override
 	public List<InputValue> getInputValues() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/traces/TraceFactory.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/traces/TraceFactory.java
@@ -41,9 +41,6 @@ public class TraceFactory {
 
 	/**
 	 * Returns the list as string.
-	 * 
-	 * @param traces
-	 * @return String
 	 */
 	public static String getTracesAsString(List<ITrace> traces) {
 
@@ -58,9 +55,6 @@ public class TraceFactory {
 	/**
 	 * Returns null if valid.
 	 * Otherwise, the invalid characters are returned, separated by a whitespace.
-	 * 
-	 * @param line
-	 * @return String
 	 */
 	public static String validate(String line) {
 
@@ -128,9 +122,6 @@ public class TraceFactory {
 	/**
 	 * Determine the trace type (TraceHighResMSD, TraceGenericDelta, TraceTandemMSD or TraceGeneric) by the given line.
 	 * May return null.
-	 * 
-	 * @param content
-	 * @return Class<? extends ITrace>
 	 */
 	public static Class<? extends ITrace> getTraceType(String line, DetectorType detectorType) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/src/org/eclipse/chemclipse/swt/ui/support/IColorScheme.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/src/org/eclipse/chemclipse/swt/ui/support/IColorScheme.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,30 +18,21 @@ public interface IColorScheme {
 
 	/**
 	 * Returns the size.
-	 * 
-	 * @return int
 	 */
 	int size();
 
 	/**
 	 * Returns the next color.
-	 * 
-	 * @return Color
 	 */
 	Color getNextColor();
 
 	/**
 	 * Returns the previous color.
-	 * 
-	 * @return Color
 	 */
 	Color getPreviousColor();
 
 	/**
 	 * Return the color, given by number.
-	 * 
-	 * @param i
-	 * @return Color
 	 */
 	Color getColor(int i);
 
@@ -52,9 +43,6 @@ public interface IColorScheme {
 
 	/**
 	 * Return the current color.
-	 * 
-	 * @param i
-	 * @return Color
 	 */
 	Color getColor();
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.tsd.converter/src/org/eclipse/chemclipse/tsd/converter/core/matcher/TraceRangeMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.tsd.converter/src/org/eclipse/chemclipse/tsd/converter/core/matcher/TraceRangeMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Lablicate GmbH.
+ * Copyright (c) 2024, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -67,9 +67,6 @@ public class TraceRangeMatcher {
 
 	/**
 	 * Before using this method, run compileRetentionTimeFocusMap(...)
-	 * 
-	 * @param retentionTime
-	 * @return {@link Boolean}
 	 */
 	public boolean isRetentionTimeInFocus(int retentionTime) {
 
@@ -125,8 +122,6 @@ public class TraceRangeMatcher {
 
 	/**
 	 * The value map is either a index, mz or index, wavelength map.
-	 * 
-	 * @param valueMap
 	 */
 	public void applyTraceIndices(Map<Integer, Double> valueMap) {
 
@@ -151,9 +146,6 @@ public class TraceRangeMatcher {
 
 	/**
 	 * Return the trace ranges for a given retention time.
-	 * 
-	 * @param retentionTime
-	 * @return List<TraceRange>
 	 */
 	public List<TraceRange2D> getTraceRanges(int retentionTime) {
 
@@ -173,12 +165,6 @@ public class TraceRangeMatcher {
 
 	/**
 	 * Returns the indices for a given range.
-	 * 
-	 * @param retentionTime
-	 * @param traceRanges
-	 * @param start
-	 * @param stop
-	 * @return Set<Integer>
 	 */
 	public Set<Integer> getTraceIndices(int retentionTime, int start, int stop) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/explorer/ISelectionView.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/explorer/ISelectionView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,8 +16,6 @@ public interface ISelectionView {
 
 	/**
 	 * Returns whether the part is visible or not.
-	 * 
-	 * @return boolean
 	 */
 	boolean isPartVisible();
 
@@ -28,8 +26,6 @@ public interface ISelectionView {
 
 	/**
 	 * Checks if the part is visible and the document is not null.
-	 * 
-	 * @param chromatogramSelection
 	 */
 	boolean doUpdate(Object document);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/parts/AbstractUpdater.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/parts/AbstractUpdater.java
@@ -37,9 +37,6 @@ public abstract class AbstractUpdater<T extends Composite> {
 
 	/**
 	 * Create the part with the given main topic.
-	 * 
-	 * @param parent
-	 * @param topic
 	 */
 	protected AbstractUpdater(String topic, DataUpdateSupport dataUpdateSupport) {
 
@@ -48,9 +45,6 @@ public abstract class AbstractUpdater<T extends Composite> {
 
 	/**
 	 * Create the part with the given main topic and the main control.
-	 * 
-	 * @param topic
-	 * @param control
 	 */
 	protected AbstractUpdater(String topic, T control, DataUpdateSupport dataUpdateSupport) {
 
@@ -91,8 +85,6 @@ public abstract class AbstractUpdater<T extends Composite> {
 	/**
 	 * Return the control of this part.
 	 * This could be null if it has been not set yet.
-	 * 
-	 * @return T
 	 */
 	protected T getControl() {
 
@@ -119,10 +111,6 @@ public abstract class AbstractUpdater<T extends Composite> {
 	/**
 	 * Implement to update the object of the given topic.
 	 * If consuming the topic was successful, return true.
-	 * 
-	 * @param objects
-	 * @param topic
-	 * @return boolean
 	 */
 	protected abstract boolean updateData(List<Object> objects, String topic);
 
@@ -137,9 +125,6 @@ public abstract class AbstractUpdater<T extends Composite> {
 
 	/**
 	 * Returns whether this topic shall be consumed or not.
-	 * 
-	 * @param topic
-	 * @return boolean
 	 */
 	protected boolean isUpdateTopic(String topic) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/views/WelcomeViewExtensionHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/views/WelcomeViewExtensionHandler.java
@@ -98,8 +98,6 @@ public class WelcomeViewExtensionHandler {
 	/**
 	 * Constructs a {@link WelcomeViewExtensionHandler} with the given parameters
 	 * 
-	 * @param parent
-	 *            the parent for new Tile objects
 	 * @param tileContainer
 	 *            the label provider to use for the selection dialog
 	 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangeSelector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangeSelector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -48,11 +48,6 @@ public class TimeRangeSelector {
 
 	/**
 	 * This method may return null.
-	 * 
-	 * @param baseChart
-	 * @param event
-	 * @param timeRanges
-	 * @return TimeRange
 	 */
 	public static TimeRange selectRange(BaseChart baseChart, int xEvent, int xStart, int xStop, TimeRanges timeRanges) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakScanListUIConfig.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakScanListUIConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -40,7 +40,6 @@ public interface PeakScanListUIConfig extends IToolbarConfig, TableConfig {
 	/**
 	 * Sets whether this list displays scans
 	 * 
-	 * @param show
 	 * @param inRange
 	 *            if true only select in given range, ignored when show is false
 	 */
@@ -49,7 +48,6 @@ public interface PeakScanListUIConfig extends IToolbarConfig, TableConfig {
 	/**
 	 * Sets whether this list displays peaks
 	 * 
-	 * @param showScans
 	 * @param inRange
 	 *            if true only select in given range, ignored when show is false
 	 */
@@ -59,8 +57,6 @@ public interface PeakScanListUIConfig extends IToolbarConfig, TableConfig {
 
 	/**
 	 * The interaction mode to use
-	 * 
-	 * @param interactionMode
 	 */
 	void setInteractionMode(InteractionMode interactionMode);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ProxyTableLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ProxyTableLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -113,8 +113,6 @@ public class ProxyTableLabelProvider implements ITableLabelProvider, IAdaptable,
 
 	/**
 	 * Updates the provider to the one that can be adapted from the given object
-	 * 
-	 * @param item
 	 */
 	public void setProxy(ITableLabelProvider proxy) {
 


### PR DESCRIPTION
Remove javadoc that don't contribute anything that the javadoc tool wouldn't figure on its own. These are main source of error due to not being in sync with renames.