### PR TITLE
Cancel running jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
 		MAVEN_OPTS = '-Xmx2048m'
 	}
 	options {
-		disableConcurrentBuilds()
+		disableConcurrentBuilds(abortPrevious: true)
 		buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '1'))
 	}
 	stages {


### PR DESCRIPTION
If there are multiple PRs merged, each will queue a build which will lead to big delay in getting a build of tip of the branch published to the p2 repo. Skip previous builds if new build is queued to reduce that time.