### PR TITLE
Fix Peak Quantifier (ISTD) menu icon

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse/plugin.xml
@@ -5,7 +5,7 @@
          point="org.eclipse.chemclipse.chromatogram.xxd.quantifier.peakQuantifierSupplier">
       <PeakQuantifierSupplier
             description="This quantifier handles to execute a peak quantitation via internal standards."
-            id="org.eclipse.chemclipse.chromatogram.msd.quantitation.supplier.chemclipse.peak.istd"
+            id="org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse.peak.istd"
             peakQuantifier="org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse.core.PeakQuantifierISTD"
             peakQuantifierName="Peak Quantifier (ISTD)"
             peakQuantifierSettings="org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse.settings.PeakQuantifierSettings">


### PR DESCRIPTION
Split from https://github.com/eclipse-chemclipse/chemclipse/pull/2701 because if I am forced to change the filter ID instead of just the menu icon reference, then this suddenly requires https://github.com/eclipse-chemclipse/chemclipse/pull/2124 to resolve backwards compatibility.