### PR TITLE
Avoid authorship with nicknames in JavaDoc

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.converter/src/org/eclipse/chemclipse/chromatogram/alignment/converter/retentionindices/RetentionIndicesConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.converter/src/org/eclipse/chemclipse/chromatogram/alignment/converter/retentionindices/RetentionIndicesConverterSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,8 +24,6 @@ import org.eclipse.chemclipse.chromatogram.alignment.converter.exceptions.NoRete
  * It offers some convenient methods for getting information about the
  * registered converters.<br/>
  * SWT FileDialog may use it to set the correct dialog information.
- * 
- * @author eselmeister
  */
 public class RetentionIndicesConverterSupport implements IRetentionIndicesConverterSupport {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.model/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndex.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.model/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndex.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -44,7 +44,7 @@ public class RetentionIndex implements IRetentionIndex, Comparable<IRetentionInd
 		return retentionTime;
 	}
 
-	/**
+	/*
 	 * The retention time range should be scalable. eselmeister 19.11.2008
 	 */
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.model/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndices.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.model/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndices.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,9 +20,6 @@ import org.eclipse.chemclipse.chromatogram.alignment.model.exceptions.NoRetentio
 import org.eclipse.chemclipse.chromatogram.alignment.model.exceptions.RetentionIndexExistsException;
 import org.eclipse.chemclipse.chromatogram.alignment.model.exceptions.RetentionIndexValueException;
 
-/**
- * @author eselmeister
- */
 public class RetentionIndices implements IRetentionIndices {
 
 	private List<IRetentionIndex> retentionIndices;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/result/IChromatogramFilterResult.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/result/IChromatogramFilterResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,9 +12,6 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.filter.result;
 
-/**
- * @author eselmeister
- */
 public interface IChromatogramFilterResult {
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/result/IPeakFilterResult.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/result/IPeakFilterResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,9 +12,6 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.filter.result;
 
-/**
- * @author eselmeister
- */
 public interface IPeakFilterResult {
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/detector/BackfoldingShifter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/detector/BackfoldingShifter.java
@@ -50,8 +50,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * , Pool, W. G. and deLeeuw, J. W. and van de Graaf, B., 1997<br/>
  * "Automated processing of GC/MS data: Quantification of the signals of individual components"
  * , Pool, W. G. and deLeeuw, J. W. and van de Graaf, B., 1997<br/>
- * 
- * @author eselmeister
  */
 public class BackfoldingShifter implements IBackfoldingShifter {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/support/BackfoldingDetectorSlope.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/support/BackfoldingDetectorSlope.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Lablicate GmbH.
+ * Copyright (c) 2011, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,12 +15,10 @@ package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.supp
 import org.eclipse.chemclipse.chromatogram.peak.detector.support.DetectorSlope;
 import org.eclipse.chemclipse.numeric.core.IPoint;
 
-/**
- * @author eselmeister
- */
 public class BackfoldingDetectorSlope extends DetectorSlope implements IBackfoldingDetectorSlope {
 
 	public BackfoldingDetectorSlope(IPoint p1, IPoint p2, int retentionTime) {
+
 		super(p1, p2, retentionTime);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/support/BackfoldingDetectorSlopes.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/support/BackfoldingDetectorSlopes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Lablicate GmbH.
+ * Copyright (c) 2011, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,15 +12,13 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.support;
 
-import org.eclipse.chemclipse.model.signals.ITotalScanSignals;
 import org.eclipse.chemclipse.chromatogram.peak.detector.support.DetectorSlopes;
+import org.eclipse.chemclipse.model.signals.ITotalScanSignals;
 
-/**
- * @author eselmeister
- */
 public class BackfoldingDetectorSlopes extends DetectorSlopes implements IBackfoldingDetectorSlopes {
 
 	public BackfoldingDetectorSlopes(ITotalScanSignals totalIonSignals) {
+
 		super(totalIonSignals);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/support/IBackfoldingDetectorSlope.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/support/IBackfoldingDetectorSlope.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Lablicate GmbH.
+ * Copyright (c) 2011, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,8 +14,5 @@ package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.supp
 
 import org.eclipse.chemclipse.chromatogram.peak.detector.support.IDetectorSlope;
 
-/**
- * @author eselmeister
- */
 public interface IBackfoldingDetectorSlope extends IDetectorSlope {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/support/IBackfoldingDetectorSlopes.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/backfolding/support/IBackfoldingDetectorSlopes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Lablicate GmbH.
+ * Copyright (c) 2011, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,8 +14,5 @@ package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.supp
 
 import org.eclipse.chemclipse.chromatogram.peak.detector.support.IDetectorSlopes;
 
-/**
- * @author eselmeister
- */
 public interface IBackfoldingDetectorSlopes extends IDetectorSlopes {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/calculator/CodaCalculator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/calculator/CodaCalculator.java
@@ -21,8 +21,6 @@ import org.eclipse.chemclipse.numeric.statistics.Calculations;
 // TODO JUnit
 /**
  * This class implements the basic coda algorithm.
- * 
- * @author eselmeister
  */
 public class CodaCalculator {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/calculator/MassChromatographicQualityCalculator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/calculator/MassChromatographicQualityCalculator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Lablicate GmbH.
+ * Copyright (c) 2011, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,9 +15,6 @@ package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.calculator;
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.exceptions.CodaCalculatorException;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
 
-/**
- * @author eselmeister
- */
 public class MassChromatographicQualityCalculator {
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/exceptions/CodaCalculatorException.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/coda/exceptions/CodaCalculatorException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Lablicate GmbH.
+ * Copyright (c) 2011, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,9 +12,6 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.exceptions;
 
-/**
- * @author eselmeister
- */
 public class CodaCalculatorException extends Exception {
 
 	/**
@@ -24,10 +21,12 @@ public class CodaCalculatorException extends Exception {
 	private static final long serialVersionUID = 3534005973969512859L;
 
 	public CodaCalculatorException() {
+
 		super();
 	}
 
 	public CodaCalculatorException(String message) {
+
 		super(message);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.ui/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/ui/preferences/IonInputValidator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.ui/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/denoising/ui/preferences/IonInputValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2025 Lablicate GmbH.
+ * Copyright (c) 2010, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,9 +14,6 @@ package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.ui.pre
 
 import org.eclipse.jface.dialogs.IInputValidator;
 
-/**
- * @author eselmeister
- */
 public class IonInputValidator implements IInputValidator {
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/result/IMassSpectrumFilterResult.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/result/IMassSpectrumFilterResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,9 +14,6 @@ package org.eclipse.chemclipse.chromatogram.msd.filter.result;
 
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
 
-/**
- * @author eselmeister
- */
 public interface IMassSpectrumFilterResult {
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/chromatogram/ChromatogramIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/src/org/eclipse/chemclipse/chromatogram/msd/identifier/chromatogram/ChromatogramIdentifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,8 +30,6 @@ import org.eclipse.core.runtime.Platform;
 
 /**
  * Use the methods of this class to identify a chromatogram.
- * 
- * @author eselmeister
  */
 public class ChromatogramIdentifier {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/core/AbstractPeakDetectorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/core/AbstractPeakDetectorSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,9 +18,6 @@ import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.peak.detector.exceptions.NoPeakDetectorAvailableException;
 
-/**
- * @author eselmeister
- */
 public abstract class AbstractPeakDetectorSupport<S extends IPeakDetectorSupplier> implements IPeakDetectorSupport {
 
 	List<S> suppliers;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/support/DetectorSlope.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/support/DetectorSlope.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,9 +15,6 @@ package org.eclipse.chemclipse.chromatogram.peak.detector.support;
 import org.eclipse.chemclipse.numeric.core.IPoint;
 import org.eclipse.chemclipse.numeric.geometry.Slope;
 
-/**
- * @author eselmeister
- */
 public class DetectorSlope extends Slope implements IDetectorSlope {
 
 	private int retentionTime;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/support/IDetectorSlope.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/support/IDetectorSlope.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,9 +14,6 @@ package org.eclipse.chemclipse.chromatogram.peak.detector.support;
 
 import org.eclipse.chemclipse.numeric.geometry.ISlope;
 
-/**
- * @author eselmeister
- */
 public interface IDetectorSlope extends ISlope {
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/chromatogram/ChromatogramIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/chromatogram/ChromatogramIdentifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,8 +29,6 @@ import org.eclipse.core.runtime.Platform;
 
 /**
  * Use the methods of this class to identify a chromatogram.
- * 
- * @author eselmeister
  */
 public class ChromatogramIdentifier {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/chromatogram/ChromatogramIntegrator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/chromatogram/ChromatogramIntegrator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -40,8 +40,6 @@ import org.eclipse.core.runtime.Platform;
  * XCalibur<br/>
  * Not all of these are pure mass spectrometric evaluation tools, but may give a
  * hint how to solve some basic problems.
- *
- * @author eselmeister
  */
 public class ChromatogramIntegrator {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/chromatogram/IChromatogramIntegratorSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/chromatogram/IChromatogramIntegratorSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,9 +14,6 @@ package org.eclipse.chemclipse.chromatogram.xxd.integrator.core.chromatogram;
 
 import org.eclipse.chemclipse.chromatogram.xxd.integrator.core.settings.chromatogram.IChromatogramIntegrationSettings;
 
-/**
- * @author eselmeister
- */
 public interface IChromatogramIntegratorSupplier {
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/chromatogram/IChromatogramIntegratorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/chromatogram/IChromatogramIntegratorSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,9 +16,6 @@ import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.xxd.integrator.exceptions.NoIntegratorAvailableException;
 
-/**
- * @author eselmeister
- */
 public interface IChromatogramIntegratorSupport {
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/combined/ICombinedIntegratorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/combined/ICombinedIntegratorSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,9 +16,6 @@ import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.xxd.integrator.exceptions.NoIntegratorAvailableException;
 
-/**
- * @author eselmeister
- */
 public interface ICombinedIntegratorSupport {
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/peaks/IPeakIntegratorSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/peaks/IPeakIntegratorSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,9 +14,6 @@ package org.eclipse.chemclipse.chromatogram.xxd.integrator.core.peaks;
 
 import org.eclipse.chemclipse.chromatogram.xxd.integrator.core.settings.peaks.IPeakIntegrationSettings;
 
-/**
- * @author eselmeister
- */
 public interface IPeakIntegratorSupplier {
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/peaks/IPeakIntegratorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/peaks/IPeakIntegratorSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,9 +16,6 @@ import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.xxd.integrator.exceptions.NoIntegratorAvailableException;
 
-/**
- * @author eselmeister
- */
 public interface IPeakIntegratorSupport {
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/peaks/PeakIntegrator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/peaks/PeakIntegrator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -44,8 +44,6 @@ import org.eclipse.core.runtime.Platform;
  * XCalibur<br/>
  * Not all of these are pure mass spectrometric evaluation tools, but may give a
  * hint how to solve some basic problems.
- *
- * @author eselmeister
  */
 public class PeakIntegrator {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/peaks/PeakIntegratorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/peaks/PeakIntegratorSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,9 +17,6 @@ import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.xxd.integrator.exceptions.NoIntegratorAvailableException;
 
-/**
- * @author eselmeister
- */
 public class PeakIntegratorSupport implements IPeakIntegratorSupport {
 
 	List<IPeakIntegratorSupplier> suppliers;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/settings/BaselineSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/settings/BaselineSupport.java
@@ -14,15 +14,13 @@ package org.eclipse.chemclipse.chromatogram.xxd.integrator.core.settings;
 
 import org.eclipse.chemclipse.model.baseline.IBaselineModel;
 
-/**
- * @author eselmeister
- */
 public class BaselineSupport implements IBaselineSupport {
 
 	private IBaselineModel baselineModel;
 	private IBaselineModel baselineModelModified;
 
 	public BaselineSupport() {
+
 		baselineModel = null;
 		baselineModelModified = null;
 	}
@@ -31,6 +29,7 @@ public class BaselineSupport implements IBaselineSupport {
 	 * BaselineSupport gets a deep copy from
 	 */
 	public BaselineSupport(IBaselineModel baselineModel) {
+
 		if(baselineModel != null) {
 			this.baselineModel = baselineModel;
 			this.baselineModelModified = baselineModel.makeDeepCopy();

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/settings/peaks/IReportDecider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/core/settings/peaks/IReportDecider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.integrator.core.settings.peaks;
 
-import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.chromatogram.xxd.integrator.core.settings.IIntegrationSettings;
+import org.eclipse.chemclipse.model.core.IPeak;
 
 /**
  * All implementing classes have to decide if a peak should be reported or not.<br/>
@@ -24,8 +24,6 @@ import org.eclipse.chemclipse.chromatogram.xxd.integrator.core.settings.IIntegra
  * 1000.<br/>
  * To take effect in the {@link ISettingStatus}, the class has to register
  * itself at a class, which implements {@link IIntegrationSettings}.
- * 
- * @author eselmeister
  */
 public interface IReportDecider {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/AbstractPeakIntegrationResults.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/AbstractPeakIntegrationResults.java
@@ -16,9 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-/**
- * @author eselmeister
- */
 public abstract class AbstractPeakIntegrationResults implements IPeakIntegrationResults {
 
 	private List<IPeakIntegrationResult> peakIntegrationResults;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/support/SegmentAreaCalculator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/support/SegmentAreaCalculator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,8 +27,6 @@ import org.eclipse.chemclipse.numeric.exceptions.SolverException;
  * There is also a special case, where the peak baseline crosses the background
  * baseline. In this case the areas of two triangles with different area signs
  * will be integrated.
- * 
- * @author eselmeister
  */
 public class SegmentAreaCalculator {
 
@@ -36,6 +34,7 @@ public class SegmentAreaCalculator {
 	 * This class should have only static methods.
 	 */
 	private SegmentAreaCalculator() {
+
 	}
 
 	public static double calculateSegmentArea(ISegment segment) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/chromatogram/ChromatogramConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/chromatogram/ChromatogramConverterSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,8 +22,6 @@ import org.eclipse.chemclipse.processing.DataCategory;
  * It offers some convenient methods for getting information about the
  * registered converters.<br/>
  * SWT FileDialog may use it to set the correct dialog information.
- * 
- * @author eselmeister
  */
 public class ChromatogramConverterSupport extends AbstractConverterSupport implements IChromatogramConverterSupport {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/signals/ExtendedTotalScanSignal.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/signals/ExtendedTotalScanSignal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,6 @@ package org.eclipse.chemclipse.model.signals;
 /**
  * What's the difference between {@link TotalScanSignal} and {@link ExtendedTotalScanSignal}?<br/>
  * The extended total ion signal allows also negative total signals.
- * 
- * @author eselmeister
  */
 public class ExtendedTotalScanSignal extends AbstractTotalScanSignal implements ITotalScanSignal {
 
@@ -24,6 +22,7 @@ public class ExtendedTotalScanSignal extends AbstractTotalScanSignal implements 
 	 * No limits like in TotalIonSignal.
 	 */
 	public ExtendedTotalScanSignal(int retentionTime, float retentionIndex, float totalSignal) {
+
 		setRetentionTime(retentionTime);
 		setRetentionIndex(retentionIndex);
 		setTotalSignal(totalSignal);

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/signals/TotalScanSignal.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/signals/TotalScanSignal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,8 +14,6 @@ package org.eclipse.chemclipse.model.signals;
 
 /**
  * If you need signals with a negative total signal range, use {@link ExtendedTotalScanSignal}.
- * 
- * @author eselmeister
  */
 public class TotalScanSignal extends AbstractTotalScanSignal implements ITotalScanSignal {
 
@@ -27,6 +25,7 @@ public class TotalScanSignal extends AbstractTotalScanSignal implements ITotalSc
 	 * @param totalSignal
 	 */
 	public TotalScanSignal(int retentionTime, float retentionIndex, float totalSignal) {
+
 		this(retentionTime, retentionIndex, totalSignal, true);
 	}
 
@@ -40,6 +39,7 @@ public class TotalScanSignal extends AbstractTotalScanSignal implements ITotalSc
 	 * @param validatePositive
 	 */
 	public TotalScanSignal(int retentionTime, float retentionIndex, float totalSignal, boolean validatePositive) {
+
 		if(retentionTime >= 0) {
 			setRetentionTime(retentionTime);
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/BackgroundAbundanceRange.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/BackgroundAbundanceRange.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,6 @@ package org.eclipse.chemclipse.model.support;
 /**
  * This class can be used to represent a valid background abundance range.<br/>
  * It evaluates the constructor parameters and corrects them to a valid state.
- * 
- * @author eselmeister
  */
 public class BackgroundAbundanceRange implements IBackgroundAbundanceRange {
 
@@ -35,6 +33,7 @@ public class BackgroundAbundanceRange implements IBackgroundAbundanceRange {
 	 * @param stopBackgroundAbundance
 	 */
 	public BackgroundAbundanceRange(float startBackgroundAbundance, float stopBackgroundAbundance) {
+
 		if(startBackgroundAbundance < MIN_BACKGROUND_ABUNDANCE || startBackgroundAbundance > MAX_BACKGROUND_ABUNDANCE) {
 			startBackgroundAbundance = MIN_BACKGROUND_ABUNDANCE;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/IAnalysisSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/IAnalysisSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,9 +14,6 @@ package org.eclipse.chemclipse.model.support;
 
 import java.util.List;
 
-/**
- * @author eselmeister
- */
 public interface IAnalysisSupport {
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/IIntegrationConstraints.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/IIntegrationConstraints.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,9 +14,6 @@ package org.eclipse.chemclipse.model.support;
 
 import java.io.Serializable;
 
-/**
- * @author eselmeister
- */
 public interface IIntegrationConstraints extends Serializable {
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/IScanRange.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/IScanRange.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,9 +15,6 @@ package org.eclipse.chemclipse.model.support;
 
 import org.eclipse.chemclipse.model.core.IScan;
 
-/**
- * @author eselmeister
- */
 public interface IScanRange {
 
 	int MIN_SCAN = 1;

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/IntegrationConstraint.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/IntegrationConstraint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,8 +17,6 @@ package org.eclipse.chemclipse.model.support;
  * If you would like to suppress an integration with another baseline and other
  * corrections, you can add a constraint to the peak.<br/>
  * But keep in mind, it depends on the integrator to follow such constraints.
- * 
- * @author eselmeister
  */
 public enum IntegrationConstraint {
 	LEAVE_PEAK_AS_IT_IS; // no baseline correction, no other correction

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/IntegrationConstraints.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/IntegrationConstraints.java
@@ -15,9 +15,6 @@ package org.eclipse.chemclipse.model.support;
 import java.util.HashSet;
 import java.util.Set;
 
-/**
- * @author eselmeister
- */
 public class IntegrationConstraints implements IIntegrationConstraints {
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/RetentionTimeRange.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/RetentionTimeRange.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,15 +13,13 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.model.support;
 
-/**
- * @author eselmeister
- */
 public class RetentionTimeRange implements IRetentionTimeRange {
 
 	private int startRetentionTime;
 	private int stopRetentionTime;
 
 	public RetentionTimeRange(IRetentionTimeRange range) {
+
 		this(range.getStartRetentionTime(), range.getStopRetentionTime());
 	}
 
@@ -32,6 +30,7 @@ public class RetentionTimeRange implements IRetentionTimeRange {
 	 * @param stopRetentionTime
 	 */
 	public RetentionTimeRange(int startRetentionTime, int stopRetentionTime) {
+
 		if(startRetentionTime < 0) {
 			startRetentionTime = 0;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/updates/IChromatogramUpdateListener.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/updates/IChromatogramUpdateListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,13 +12,14 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.model.updates;
 
+import org.eclipse.chemclipse.model.core.AbstractChromatogram;
+
 /**
  * All classes which should be informed if values of the chromatogram have been
  * changed must implement this interface.<br/>
  * The controller for instance of the graphical representation of a chromatogram
  * will announce himself to the chromatogram.
  * 
- * @author eselmeister
  * @see AbstractChromatogram
  * @see IUpdater
  */

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/updates/IUpdater.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/updates/IUpdater.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,6 @@ package org.eclipse.chemclipse.model.updates;
  * Each time some values has been changed, e.g. abundance of mass spectrum x,
  * the controller will be informed, that the model has been edited.
  * 
- * @author eselmeister
  * @see IChromatogramUpdateListener
  */
 public interface IUpdater {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.ui/src/org/eclipse/chemclipse/msd/converter/ui/adapter/ChromatogramPropertySource.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.ui/src/org/eclipse/chemclipse/msd/converter/ui/adapter/ChromatogramPropertySource.java
@@ -25,8 +25,6 @@ import org.eclipse.ui.views.properties.TextPropertyDescriptor;
 /**
  * This class is responsible for representing chromatogram values in the
  * properties view.
- * 
- * @author eselmeister
  */
 public abstract class ChromatogramPropertySource implements IPropertySource {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/massspectrum/IMassSpectrumConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/massspectrum/IMassSpectrumConverterSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,9 +16,6 @@ package org.eclipse.chemclipse.msd.converter.massspectrum;
 import org.eclipse.chemclipse.converter.core.IConverterSupport;
 import org.eclipse.chemclipse.processing.DataCategory;
 
-/**
- * @author eselmeister
- */
 public interface IMassSpectrumConverterSupport extends IConverterSupport {
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/massspectrum/IMassSpectrumExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/massspectrum/IMassSpectrumExportConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,9 +21,6 @@ import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-/**
- * @author eselmeister
- */
 public interface IMassSpectrumExportConverter extends IExportConverter {
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/massspectrum/IMassSpectrumSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/massspectrum/IMassSpectrumSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,8 +14,5 @@ package org.eclipse.chemclipse.msd.converter.massspectrum;
 
 import org.eclipse.chemclipse.processing.converter.ISupplier;
 
-/**
- * @author eselmeister
- */
 public interface IMassSpectrumSupplier extends ISupplier {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/massspectrum/MassSpectrumConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/massspectrum/MassSpectrumConverterSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,8 +20,6 @@ import org.eclipse.chemclipse.converter.core.AbstractConverterSupport;
  * It offers some convenient methods for getting information about the
  * registered converters.<br/>
  * SWT FileDialog may use it to set the correct dialog information.
- * 
- * @author eselmeister
  */
 public class MassSpectrumConverterSupport extends AbstractConverterSupport implements IMassSpectrumConverterSupport {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/peak/PeakConverterMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/peak/PeakConverterMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Lablicate GmbH.
+ * Copyright (c) 2011, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -41,8 +41,6 @@ import org.eclipse.core.runtime.Platform;
  * Be aware that some extensions could be directories and some could be files.
  * The following example gives some impressions:<br/>
  * Matlab Parafac Peaklist *.mpl<br/>
- * 
- * @author eselmeister
  */
 public class PeakConverterMSD {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/runtime/LinuxWineSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -80,7 +80,7 @@ public class LinuxWineSupport extends AbstractLinuxWineSupport implements IExten
 	private ProcessBuilder getOpenCommand() {
 
 		/*
-		 * "env WINEPREFIX=/home/eselmeister/.wine wine start C:\\programme\\nist\\MSSEARCH\\nistms.exe"
+		 * "env WINEPREFIX=$HOME/.wine wine start C:\\programme\\nist\\MSSEARCH\\nistms.exe"
 		 */
 		String nistms = getWineApplication().replace("$.exe", ".exe"); // run the GUI version
 		ProcessBuilder processBuilder = new ProcessBuilder("wine", "start", nistms);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier/src/org/eclipse/chemclipse/msd/identifier/comparison/MassSpectrumComparator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier/src/org/eclipse/chemclipse/msd/identifier/comparison/MassSpectrumComparator.java
@@ -49,8 +49,6 @@ import org.eclipse.core.runtime.Platform;
  * Database search will still use this feature but should be implemented in
  * another class to separate the two different concerns of comparison and
  * identification.
- *
- * @author eselmeister
  */
 public class MassSpectrumComparator {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier/src/org/eclipse/chemclipse/msd/identifier/comparison/MassSpectrumComparatorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier/src/org/eclipse/chemclipse/msd/identifier/comparison/MassSpectrumComparatorSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -25,8 +25,6 @@ import org.eclipse.chemclipse.msd.identifier.comparison.exceptions.NoMassSpectru
  * comparators.<br/>
  * A mass spectrum comparator can be used to determine the match quality of two
  * different mass spectra.
- * 
- * @author eselmeister
  */
 public class MassSpectrumComparatorSupport implements IMassSpectrumComparatorSupport {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractCombinedMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractCombinedMassSpectrum.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,8 +18,6 @@ package org.eclipse.chemclipse.msd.model.core;
  * It has no distinct retention time, retention index and scan number like
  * (@link: AbstractRegularMassSpectrum).<br/>
  * Instead of the range is marked, e.g. startScan, stopScan.
- * 
- * @author eselmeister
  */
 public abstract class AbstractCombinedMassSpectrum extends AbstractScanMSD implements ICombinedMassSpectrum {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
  * 
  * Contributors:
  * Philip Wenig - initial API and implementation
+ * Alexander Kerner - implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.core;
 
@@ -21,8 +22,6 @@ import org.eclipse.core.runtime.Platform;
  * The serialization of ions is controlled by the corresponding mass
  * spectrum.
  *
- * @author eselmeister
- * @author <a href="mailto:alexander.kerner@openchrom.net">Alexander Kerner</a>
  * @see AbstractScanMSD
  */
 public abstract class AbstractIon implements IIon {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractMassSpectra.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractMassSpectra.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,10 +19,6 @@ import java.util.List;
 
 import org.eclipse.chemclipse.support.updates.IUpdateListener;
 
-/**
- * @author eselmeister
- * @author <a href="mailto:alexanderkerner24@gmail.com">Alexander Kerner</a>
- */
 public abstract class AbstractMassSpectra implements IMassSpectra {
 
 	private final List<IScanMSD> massSpectra;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractPeakMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractPeakMassSpectrum.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,9 +17,6 @@ import java.util.List;
 import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
 import org.eclipse.chemclipse.msd.model.implementation.PeakIon;
 
-/**
- * @author eselmeister
- */
 public abstract class AbstractPeakMassSpectrum extends AbstractRegularMassSpectrum implements IPeakMassSpectrum {
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/ICombinedLibraryMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/ICombinedLibraryMassSpectrum.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,8 +12,5 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.core;
 
-/**
- * @author eselmeister
- */
 public interface ICombinedLibraryMassSpectrum extends ICombinedMassSpectrum, ILibraryMassSpectrum {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IIonSerializable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IIonSerializable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,8 +17,6 @@ import java.io.Serializable;
 /**
  * This class is used to give ions an extended serializable
  * functionality.<br/>
- * 
- * @author eselmeister
  */
 public interface IIonSerializable extends Serializable {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IMassSpectrumCloneable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IMassSpectrumCloneable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,8 +19,6 @@ package org.eclipse.chemclipse.msd.model.core;
  * IMassSpectrum.<br/>
  * Clone and this interface methods perform a "deep copy" instead of a
  * "shallow copy" operation.
- * 
- * @author eselmeister
  */
 public interface IMassSpectrumCloneable extends Cloneable {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IMassSpectrumNormalizable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IMassSpectrumNormalizable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,8 +14,6 @@ package org.eclipse.chemclipse.msd.model.core;
 
 /**
  * This interface declares the functionality to normalize a mass spectrum.
- * 
- * @author eselmeister
  */
 public interface IMassSpectrumNormalizable {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IMassSpectrumSerializable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IMassSpectrumSerializable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,8 +17,6 @@ import java.io.Serializable;
 /**
  * This class is used to give mass spectrum an extended serializable
  * functionality.<br/>
- * 
- * @author eselmeister
  */
 public interface IMassSpectrumSerializable extends Serializable {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IPeakModelMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IPeakModelMSD.java
@@ -19,8 +19,6 @@ import org.eclipse.chemclipse.model.core.IPeakModel;
  * These are for example start retention time, stop retention time, background
  * abundance, peak maximum.<br/>
  * This model checks if all values are stored correctly.
- * 
- * @author eselmeister
  */
 public interface IPeakModelMSD extends IPeakModel {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IPeaksMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IPeaksMSD.java
@@ -17,9 +17,6 @@ import java.util.List;
 
 /**
  * This class stores a list of peaks.
- * 
- * @author eselmeister
- * 
  */
 public interface IPeaksMSD {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IonBounds.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IonBounds.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,8 +16,6 @@ package org.eclipse.chemclipse.msd.model.core;
  * This class stores two ions.<br/>
  * The lowest ion is the one with the lowest ion of a mass spectrum,
  * the highest with the highest ion of a mass spectrum.
- * 
- * @author eselmeister
  */
 public class IonBounds implements IIonBounds {
 
@@ -34,6 +32,7 @@ public class IonBounds implements IIonBounds {
 	 * @param highestIon
 	 */
 	public IonBounds(IIon lowestIon, IIon highestIon) {
+
 		if(lowestIon != null && highestIon != null) {
 			/*
 			 * Change the order if necessary.

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/PeakIonType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/PeakIonType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,15 +22,15 @@ package org.eclipse.chemclipse.msd.model.core;
  * (41,1 N0.2)<br/>
  * <br/>
  * There maybe some more types to be added here.
- * 
- * @author eselmeister
  */
 public enum PeakIonType {
+
 	NO_TYPE("no type stored"), B("B"), L("L"), N("N");
 
 	private String description;
 
 	private PeakIonType(String description) {
+
 		this.description = description;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/comparator/IonAbundanceComparator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/comparator/IonAbundanceComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,8 +21,6 @@ import org.eclipse.chemclipse.support.comparator.SortOrder;
 /**
  * This is the comparator to sort an list of ion values by its
  * abundance.
- * 
- * @author eselmeister
  */
 public class IonAbundanceComparator implements Comparator<IIon>, Serializable {
 
@@ -37,6 +35,7 @@ public class IonAbundanceComparator implements Comparator<IIon>, Serializable {
 	 * The sort order is per default value ascending.
 	 */
 	public IonAbundanceComparator() {
+
 		sortOrder = SortOrder.ASC;
 	}
 
@@ -47,6 +46,7 @@ public class IonAbundanceComparator implements Comparator<IIon>, Serializable {
 	 * @param sortOrder
 	 */
 	public IonAbundanceComparator(SortOrder sortOrder) {
+
 		this.sortOrder = sortOrder;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/support/IIonUniquenessValues.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/support/IIonUniquenessValues.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,9 +12,6 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.core.support;
 
-/**
- * @author eselmeister
- */
 public interface IIonUniquenessValues {
 
 	float MIN_PROBABILITY_VALUE = 0.0f;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/support/IonUniquenessValues.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/support/IonUniquenessValues.java
@@ -15,9 +15,6 @@ package org.eclipse.chemclipse.msd.model.core.support;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * @author eselmeister
- */
 public class IonUniquenessValues implements IIonUniquenessValues {
 
 	private static Map<Integer, Float> probabilityValues;

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/RegularMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/RegularMassSpectrum.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,8 +19,6 @@ import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 
 /**
  * If a new mass spectrum type should be implemented, extend the abstract class {@link AbstractScanMSD} and not this class.
- * 
- * @author eselmeister
  */
 public class RegularMassSpectrum extends AbstractRegularMassSpectrum implements IRegularMassSpectrum {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/notifier/IUpdater.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/notifier/IUpdater.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,8 +22,6 @@ import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD
  * chromatogram selection object from its static inner class.<br/>
  * See org.eclipse.chemclipse.chromatogram.msd.filter.supplier.normalizer.ui ->
  * FilterHandler
- * 
- * @author eselmeister
  */
 public interface IUpdater {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/ExtractedIonSignalsModifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/ExtractedIonSignalsModifier.java
@@ -27,8 +27,6 @@ import org.eclipse.chemclipse.msd.model.exceptions.NoExtractedIonSignalStoredExc
 
 /**
  * This class offers several static methods to modify an {@link IExtractedIonSignals} instance.
- * 
- * @author eselmeister
  */
 public class ExtractedIonSignalsModifier {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/IExtractedIonSignals.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/IExtractedIonSignals.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,9 +23,6 @@ import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.support.IMarkedIons;
 import org.eclipse.chemclipse.msd.model.exceptions.NoExtractedIonSignalStoredException;
 
-/**
- * @author eselmeister
- */
 public interface IExtractedIonSignals {
 
 	/**

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/IIonRange.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/IIonRange.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,6 @@ package org.eclipse.chemclipse.msd.model.xic;
 /**
  * A ion range represents the start and stop ion value which should be
  * used for example to compare two mass spectra.
- * 
- * @author eselmeister
  */
 public interface IIonRange {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/IonRange.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/IonRange.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,6 @@ package org.eclipse.chemclipse.msd.model.xic;
 /**
  * This class can be used to represent a valid ion range.<br/>
  * It evaluates the constructor parameters and corrects them to a valid state.
- * 
- * @author eselmeister
  */
 public class IonRange implements IIonRange {
 
@@ -33,6 +31,7 @@ public class IonRange implements IIonRange {
 	 * @param stopIon
 	 */
 	public IonRange(int startIon, int stopIon) {
+
 		if(startIon > stopIon) {
 			int tmp = startIon;
 			startIon = stopIon;

--- a/chemclipse/plugins/org.eclipse.chemclipse.numeric/src/org/eclipse/chemclipse/numeric/equations/Equations.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.numeric/src/org/eclipse/chemclipse/numeric/equations/Equations.java
@@ -22,8 +22,6 @@ import org.eclipse.chemclipse.numeric.internal.gaussjordan.GaussJordan;
 
 /**
  * This class serves some static methods to create equations in many ways.<br/>
- * 
- * @author eselmeister
  */
 public class Equations {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.numeric/src/org/eclipse/chemclipse/numeric/equations/LinearEquation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.numeric/src/org/eclipse/chemclipse/numeric/equations/LinearEquation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,6 @@ package org.eclipse.chemclipse.numeric.equations;
 /**
  * This class represents a linear equation.<br/>
  * f(x) = ax + b
- * 
- * @author eselmeister
  */
 public class LinearEquation implements IEquation {
 
@@ -36,6 +34,7 @@ public class LinearEquation implements IEquation {
 	 * @param b
 	 */
 	public LinearEquation(double a, double b) {
+
 		this.a = a;
 		this.b = b;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.numeric/src/org/eclipse/chemclipse/numeric/geometry/Slope.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.numeric/src/org/eclipse/chemclipse/numeric/geometry/Slope.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,14 +17,13 @@ import org.eclipse.chemclipse.numeric.equations.Equations;
 
 /**
  * Calculates the slope between two points.
- * 
- * @author eselmeister
  */
 public class Slope implements ISlope {
 
 	private double slope;
 
 	public Slope(IPoint p1, IPoint p2) {
+
 		slope = Equations.calculateSlope(p1, p2);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.numeric/src/org/eclipse/chemclipse/numeric/miscellaneous/Evaluation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.numeric/src/org/eclipse/chemclipse/numeric/miscellaneous/Evaluation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,8 +14,6 @@ package org.eclipse.chemclipse.numeric.miscellaneous;
 
 /**
  * Offers some static methods for value evaluation.
- * 
- * @author eselmeister
  */
 public class Evaluation {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.progress.ui/src/org/eclipse/chemclipse/progress/ui/PluginStartup.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.progress.ui/src/org/eclipse/chemclipse/progress/ui/PluginStartup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,12 +14,8 @@ package org.eclipse.chemclipse.progress.ui;
 
 import org.eclipse.chemclipse.progress.core.StatusLineLogger;
 import org.eclipse.chemclipse.progress.ui.internal.core.UIStatusLineLogger;
-
 import org.eclipse.ui.IStartup;
 
-/**
- * @author eselmeister
- */
 public class PluginStartup implements IStartup {
 
 	private static UIStatusLineLogger uiStatusLineLogger;

--- a/chemclipse/plugins/org.eclipse.chemclipse.progress/src/org/eclipse/chemclipse/progress/core/InfoType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.progress/src/org/eclipse/chemclipse/progress/core/InfoType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,8 +14,6 @@ package org.eclipse.chemclipse.progress.core;
 
 /**
  * Stores some info types to show e.g. in the StatusLine.
- * 
- * @author eselmeister
  */
 public enum InfoType {
 	MESSAGE, ERROR_MESSAGE;


### PR DESCRIPTION
We already have full names in :copyright: headers and Git commits that tie developers to all the lines changed. Using nicknames in the official documentation seems awkward given that this is a commercial open-source project. Also, only a select few people used it on a few occasions.