### PR TITLE
Add settings to disable expensive Data Explorer filtering and labelling

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/preferences/PreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/preferences/PreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.ui.preferences;
 
+import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.LabelFieldEditor;
+import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpacerFieldEditor;
 import org.eclipse.chemclipse.ux.extension.ui.Activator;
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
@@ -33,6 +35,10 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 		addField(new BooleanFieldEditor(PreferenceSupplierDataExplorer.P_OPEN_FIRST_DATA_MATCH_ONLY, "Open First Data Match Only", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplierDataExplorer.P_OPEN_EDITOR_MULTIPLE_TIMES, "Open Editor Multiple Times", getFieldEditorParent()));
+		addField(new SpacerFieldEditor(getFieldEditorParent()));
+		addField(new LabelFieldEditor("Uncheck for better performance:", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplierDataExplorer.P_FILTER_FILES, "Only show applicable files.", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplierDataExplorer.P_SHOW_ICONS, "Display icons matching the file type.", getFieldEditorParent()));
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/preferences/PreferenceSupplierDataExplorer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/preferences/PreferenceSupplierDataExplorer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -41,6 +41,15 @@ public class PreferenceSupplierDataExplorer extends AbstractPreferenceSupplier i
 	public static final String P_USER_LOCATIONS_TEMPLATE_FOLDER = "userLocationsTemplateFolder";
 	public static final String DEF_USER_LOCATIONS_TEMPLATE_FOLDER = "";
 
+	/*
+	 * Performance related workarounds. Set to false for less pretty but faster.
+	 */
+	public static final String P_FILTER_FILES = "filterFiles";
+	public static final boolean DEF_FILTER_FILES = true;
+
+	public static final String P_SHOW_ICONS = "showIcons";
+	public static final boolean DEF_SHOW_ICONS = true;
+
 	public static IPreferenceSupplier INSTANCE() {
 
 		return INSTANCE(PreferenceSupplierDataExplorer.class);
@@ -65,6 +74,9 @@ public class PreferenceSupplierDataExplorer extends AbstractPreferenceSupplier i
 		putDefault(P_USER_LOCATIONS, DEF_USER_LOCATIONS);
 
 		putDefault(P_USER_LOCATIONS_TEMPLATE_FOLDER, DEF_USER_LOCATIONS_TEMPLATE_FOLDER);
+
+		putDefault(P_FILTER_FILES, DEF_FILTER_FILES);
+		putDefault(P_SHOW_ICONS, DEF_SHOW_ICONS);
 	}
 
 	public static String getSelectedDrivePath() {
@@ -145,5 +157,15 @@ public class PreferenceSupplierDataExplorer extends AbstractPreferenceSupplier i
 	public static void setUserLocationsTemplateFolder(String filterPath) {
 
 		INSTANCE().set(P_USER_LOCATIONS_TEMPLATE_FOLDER, filterPath);
+	}
+
+	public static boolean filterFiles() {
+
+		return INSTANCE().getBoolean(P_FILTER_FILES);
+	}
+
+	public static boolean showIcons() {
+
+		return INSTANCE().getBoolean(P_SHOW_ICONS);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/DataExplorerLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/DataExplorerLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -25,6 +25,7 @@ import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.ux.extension.ui.editors.EditorDescriptor;
+import org.eclipse.chemclipse.ux.extension.ui.preferences.PreferenceSupplierDataExplorer;
 import org.eclipse.chemclipse.ux.extension.ui.swt.IdentifierCacheSupport;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -99,28 +100,30 @@ public class DataExplorerLabelProvider extends ColumnLabelProvider implements IL
 			if(file.getName().equals("") || file.getParent() == null) {
 				descriptor = ApplicationImageFactory.getInstance().getImageDescriptor(IApplicationImage.IMAGE_DRIVE, IApplicationImageProvider.SIZE_16x16);
 			} else {
-				Map<ISupplierFileIdentifier, Collection<ISupplier>> map = supplierFunction.apply(file);
-				for(Collection<ISupplier> suppliers : map.values()) {
-					for(ISupplier supplier : suppliers) {
-						EditorDescriptor editorDescriptor = Adapters.adapt(supplier, EditorDescriptor.class);
-						if(editorDescriptor != null) {
-							ImageDescriptor imageDescriptor = editorDescriptor.getImageDescriptor();
-							if(imageDescriptor != null) {
-								descriptor = imageDescriptor;
-								break;
+				if(PreferenceSupplierDataExplorer.showIcons()) {
+					Map<ISupplierFileIdentifier, Collection<ISupplier>> map = supplierFunction.apply(file);
+					for(Collection<ISupplier> suppliers : map.values()) {
+						for(ISupplier supplier : suppliers) {
+							EditorDescriptor editorDescriptor = Adapters.adapt(supplier, EditorDescriptor.class);
+							if(editorDescriptor != null) {
+								ImageDescriptor imageDescriptor = editorDescriptor.getImageDescriptor();
+								if(imageDescriptor != null) {
+									descriptor = imageDescriptor;
+									break;
+								}
 							}
 						}
 					}
-				}
-				/*
-				 * Try to get the data type image.
-				 */
-				if(descriptor == null) {
-					Collection<ISupplierFileIdentifier> identifier = map.keySet();
-					for(ISupplierFileIdentifier fileIdentifier : identifier) {
-						descriptor = getImageDescriptor(fileIdentifier, file);
-						if(descriptor != null) {
-							break;
+					/*
+					 * Try to get the data type image.
+					 */
+					if(descriptor == null) {
+						Collection<ISupplierFileIdentifier> identifier = map.keySet();
+						for(ISupplierFileIdentifier fileIdentifier : identifier) {
+							descriptor = getImageDescriptor(fileIdentifier, file);
+							if(descriptor != null) {
+								break;
+							}
 						}
 					}
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/LazyFileExplorerContentProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/LazyFileExplorerContentProvider.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executors;
 
 import org.eclipse.chemclipse.container.definition.IFileContentProvider;
 import org.eclipse.chemclipse.container.support.FileContainerSupport;
+import org.eclipse.chemclipse.ux.extension.ui.preferences.PreferenceSupplierDataExplorer;
 import org.eclipse.jface.viewers.ILazyTreeContentProvider;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.Viewer;
@@ -170,7 +171,12 @@ public class LazyFileExplorerContentProvider implements ILazyTreeContentProvider
 			return cached;
 		}
 		if(file.isDirectory()) {
-			File[] childs = file.listFiles(LazyFileExplorerContentProvider.this);
+			File[] childs;
+			if(PreferenceSupplierDataExplorer.filterFiles()) {
+				childs = file.listFiles(LazyFileExplorerContentProvider.this);
+			} else {
+				childs = file.listFiles();
+			}
 			// null check is required here, e.g. if the directory can't be read/accessed list returns null
 			if(childs != null) {
 				Arrays.sort(childs);


### PR DESCRIPTION
The Data Explorer does an expensive check to make sure it can handle the file. Then it repeats the same check again to apply an icon to it. This is fine for folders with a reasonable amount of files on a fast local hard drive, but it is degrading performance on network drives that respond slowly or are limited in bandwidth. For power users who know their files, this adds two new settings:

<img width="803" height="381" alt="grafik" src="https://github.com/user-attachments/assets/dbaa1708-099d-4566-8dd2-e854e4315a34" />

This will quickly parse files and folders at the expense of also showing irrelevant files and only generic icons.

<img width="457" height="902" alt="grafik" src="https://github.com/user-attachments/assets/0dbf28a2-80b4-4151-93ff-92cc4752fa30" />

As this is a usability downgrade, I kept the defaults as is. You have to opt-in for these changes.