### PR TITLE
Undo some method references to lambdas

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/swt/RetentionIndexAssignerEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/swt/RetentionIndexAssignerEditor.java
@@ -199,7 +199,7 @@ public class RetentionIndexAssignerEditor extends Composite implements IChangeLi
 
 		SearchSupportUI searchSupportUI = new SearchSupportUI(parent, SWT.NONE);
 		searchSupportUI.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		searchSupportUI.setSearchListener(tableViewer.get()::setSearchText);
+		searchSupportUI.setSearchListener((searchText, caseSensitive) -> tableViewer.get().setSearchText(searchText, caseSensitive));
 
 		toolbarSearch.set(searchSupportUI);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/swt/RetentionIndexMarkerEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/swt/RetentionIndexMarkerEditor.java
@@ -221,7 +221,7 @@ public class RetentionIndexMarkerEditor extends Composite implements IChangeList
 
 		SearchSupportUI searchSupportUI = new SearchSupportUI(parent, SWT.NONE);
 		searchSupportUI.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		searchSupportUI.setSearchListener(tableViewer.get()::setSearchText);
+		searchSupportUI.setSearchListener((searchText, caseSensitive) -> tableViewer.get().setSearchText(searchText, caseSensitive));
 
 		toolbarSearch.set(searchSupportUI);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/swt/ExtendedWellDataUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/swt/ExtendedWellDataUI.java
@@ -145,7 +145,7 @@ public class ExtendedWellDataUI extends Composite implements IExtendedPartUI {
 
 		SearchSupportUI searchSupportUI = new SearchSupportUI(parent, SWT.NONE);
 		searchSupportUI.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		searchSupportUI.setSearchListener(tableViewer.get()::setSearchText);
+		searchSupportUI.setSearchListener((searchText, caseSensitive) -> tableViewer.get().setSearchText(searchText, caseSensitive));
 
 		toolbarSearch.set(searchSupportUI);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/locations/UserLocationsSettingsEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/locations/UserLocationsSettingsEditor.java
@@ -187,7 +187,7 @@ public class UserLocationsSettingsEditor implements SettingsUIProvider.SettingsU
 
 		SearchSupportUI searchSupportUI = new SearchSupportUI(parent, SWT.NONE);
 		searchSupportUI.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		searchSupportUI.setSearchListener(listControl.get()::setSearchText);
+		searchSupportUI.setSearchListener((searchText, caseSensitive) -> listControl.get().setSearchText(searchText, caseSensitive));
 
 		toolbarSearch.set(searchSupportUI);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/instruments/InstrumentsSettingsEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/instruments/InstrumentsSettingsEditor.java
@@ -184,7 +184,7 @@ public class InstrumentsSettingsEditor implements SettingsUIProvider.SettingsUIC
 
 		SearchSupportUI searchSupportUI = new SearchSupportUI(parent, SWT.NONE);
 		searchSupportUI.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		searchSupportUI.setSearchListener(listUI::setSearchText);
+		searchSupportUI.setSearchListener((searchText, caseSensitive) -> listUI.setSearchText(searchText, caseSensitive));
 
 		toolbarSearch.set(searchSupportUI);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangesEditorUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangesEditorUI.java
@@ -208,7 +208,7 @@ public class TimeRangesEditorUI extends Composite implements IChangeListener, IE
 
 		SearchSupportUI searchSupportUI = new SearchSupportUI(parent, SWT.NONE);
 		searchSupportUI.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		searchSupportUI.setSearchListener(listControl.get()::setSearchText);
+		searchSupportUI.setSearchListener((searchText, caseSensitive) -> listControl.get().setSearchText(searchText, caseSensitive));
 
 		toolbarSearch.set(searchSupportUI);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedEditHistoryUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedEditHistoryUI.java
@@ -202,7 +202,7 @@ public class ExtendedEditHistoryUI extends Composite implements IExtendedPartUI 
 
 		SearchSupportUI searchSupportUI = new SearchSupportUI(parent, SWT.NONE);
 		searchSupportUI.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		searchSupportUI.setSearchListener(tableViewer.get()::setSearchText);
+		searchSupportUI.setSearchListener((searchText, caseSensitive) -> tableViewer.get().setSearchText(searchText, caseSensitive));
 
 		toolbarSearch.set(searchSupportUI);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedLiteratureUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedLiteratureUI.java
@@ -126,7 +126,7 @@ public class ExtendedLiteratureUI extends Composite implements IExtendedPartUI {
 
 		SearchSupportUI searchSupportUI = new SearchSupportUI(parent, SWT.NONE);
 		searchSupportUI.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		searchSupportUI.setSearchListener(literatureControl.get()::updateSearchResult);
+		searchSupportUI.setSearchListener((searchText, caseSensitive) -> literatureControl.get().updateSearchResult(searchText, caseSensitive));
 
 		toolbarSearch.set(searchSupportUI);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSequenceExplorerUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSequenceExplorerUI.java
@@ -148,7 +148,7 @@ public class ExtendedSequenceExplorerUI extends Composite implements IExtendedPa
 
 		SearchSupportUI searchSupportUI = new SearchSupportUI(parent, SWT.NONE);
 		searchSupportUI.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		searchSupportUI.setSearchListener(sequenceFilesUI::setSearchText);
+		searchSupportUI.setSearchListener((searchText, caseSensitive) -> sequenceFilesUI.setSearchText(searchText, caseSensitive));
 
 		return searchSupportUI;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSynonymsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSynonymsUI.java
@@ -95,7 +95,7 @@ public class ExtendedSynonymsUI extends LibraryInformationComposite implements I
 
 		SearchSupportUI searchSupportUI = new SearchSupportUI(parent, SWT.NONE);
 		searchSupportUI.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		searchSupportUI.setSearchListener(listControl.get()::setSearchText);
+		searchSupportUI.setSearchListener((searchText, caseSensitive) -> listControl.get().setSearchText(searchText, caseSensitive));
 
 		toolbarSearch.set(searchSupportUI);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/targets/TargetsSettingsEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/targets/TargetsSettingsEditor.java
@@ -199,7 +199,7 @@ public class TargetsSettingsEditor extends Composite implements SettingsUIProvid
 
 		SearchSupportUI searchSupportUI = new SearchSupportUI(parent, SWT.NONE);
 		searchSupportUI.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		searchSupportUI.setSearchListener(targetTemplateListControl.get()::setSearchText);
+		searchSupportUI.setSearchListener((searchText, caseSensitive) -> targetTemplateListControl.get().setSearchText(searchText, caseSensitive));
 
 		toolbarSearch.set(searchSupportUI);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/traces/NamedTracesSettingsEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/traces/NamedTracesSettingsEditor.java
@@ -183,7 +183,7 @@ public class NamedTracesSettingsEditor implements SettingsUIProvider.SettingsUIC
 
 		SearchSupportUI searchSupportUI = new SearchSupportUI(parent, SWT.NONE);
 		searchSupportUI.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		searchSupportUI.setSearchListener(listUI::setSearchText);
+		searchSupportUI.setSearchListener((searchText, caseSensitive) -> listUI.setSearchText(searchText, caseSensitive));
 
 		toolbarSearch.set(searchSupportUI);
 	}


### PR DESCRIPTION
Fixes problems coming from
https://github.com/eclipse-chemclipse/chemclipse/pull/2733 caused by method references evaluating "too eager" in the cases where AtomicReferences are used causing NPEs.
There are few cases like in NamedTracesSettingsEditor reverted to lambda for the sake of safety as the actual instance of the given class whose method is referenced is instantiated post the method reference, in theory this should work fine but in order to not do extensive testing they are made lambdas too.