### PR TITLE
Uncouple the unknown marker number of traces from copy traces to clipboard

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/model/TracesSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/model/TracesSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 Lablicate GmbH.
+ * Copyright (c) 2022, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -48,10 +48,9 @@ public class TracesSupport {
 		preferenceStore.setValue(PreferenceSupplier.P_TRACES_EXPORT_OPTION, tracesExportOption.name());
 	}
 
-	public static String getTraces(Object scan) {
+	public static String getTraces(IScan scan, int maxCopyTraces) {
 
 		String traces;
-		int maxCopyTraces = getNumberOfTraces();
 		boolean sortTraces = isSortTraces();
 
 		if(scan instanceof IScanMSD scanMSD) {
@@ -67,9 +66,9 @@ public class TracesSupport {
 		return traces;
 	}
 
-	public static void copyTracesToClipboard(Display display, TracesExportOption tracesExportOption, Object scan) {
+	public static void copyTracesToClipboard(Display display, TracesExportOption tracesExportOption, IScan scan, int maxCopyTraces) {
 
-		String traces = getTraces(scan);
+		String traces = getTraces(scan, maxCopyTraces);
 		if(!traces.isEmpty()) {
 			switch(tracesExportOption) {
 				case NAMED_TRACE:
@@ -115,11 +114,6 @@ public class TracesSupport {
 		}
 
 		return scanInstance;
-	}
-
-	private static int getNumberOfTraces() {
-
-		return preferenceStore.getInt(PreferenceSupplier.P_MAX_COPY_SCAN_TRACES);
 	}
 
 	private static boolean isSortTraces() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferencePageTargets.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferencePageTargets.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,7 @@ package org.eclipse.chemclipse.ux.extension.xxd.ui.preferences;
 import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.ExtendedIntegerFieldEditor;
 import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.FloatFieldEditor;
 import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpacerFieldEditor;
+import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpinnerFieldEditor;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ScanWebIdentifierUI;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.swt.TargetWebIdentifierUI;
@@ -66,6 +67,7 @@ public class PreferencePageTargets extends FieldEditorPreferencePage implements 
 		addField(new FloatFieldEditor(PreferenceSupplier.P_MATCH_QUALITY_UNKNOWN_TARGET, "Match Quality (Unknown Target)", PreferenceSupplier.MIN_MATCH_QUALITY, PreferenceSupplier.MAX_MATCH_QUALITY, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_UNKNOWN_TARGET_ADD_RETENTION_INDEX, "Add Retention Index (Unknown Target)", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_VERIFY_UNKNOWN_TARGET, "Verify (Unknown Target)", getFieldEditorParent()));
+		addField(new SpinnerFieldEditor(PreferenceSupplier.P_MAX_UNKNOWN_TRACES, "Show Traces", PreferenceSupplier.MIN_TRACES, PreferenceSupplier.MAX_TRACES, getFieldEditorParent()));
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
@@ -250,6 +250,8 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final boolean DEF_SCAN_CHART_ENABLE_COMPRESS = false;
 	public static final String P_MAX_COPY_SCAN_TRACES = "maxCopyScanTraces";
 	public static final int DEF_MAX_COPY_SCAN_TRACES = DEF_SCAN_TRACES;
+	public static final String P_MAX_UNKNOWN_TRACES = "maxUnknownTraces";
+	public static final int DEF_MAX_UNKNOWN_TRACES = DEF_SCAN_TRACES;
 	public static final String P_SORT_COPY_TRACES = "sortCopyTraces";
 	public static final boolean DEF_SORT_COPY_TRACES = true;
 	public static final String P_TRACES_EXPORT_OPTION = "tracesExportOption";
@@ -1024,6 +1026,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 		putDefault(P_RETENTION_INDEX_DEVIATION_ABS_OK, DEF_RETENTION_INDEX_DEVIATION_ABS_OK);
 		putDefault(P_RETENTION_INDEX_DEVIATION_ABS_WARN, DEF_RETENTION_INDEX_DEVIATION_ABS_WARN);
 		putDefault(P_ADD_UNKNOWN_AFTER_DELETE_TARGETS_ALL, DEF_ADD_UNKNOWN_AFTER_DELETE_TARGETS_ALL);
+		putDefault(P_MAX_UNKNOWN_TRACES, DEF_MAX_UNKNOWN_TRACES);
 		putDefault(P_MATCH_QUALITY_UNKNOWN_TARGET, DEF_MATCH_QUALITY_UNKNOWN_TARGET);
 		putDefault(P_UNKNOWN_TARGET_ADD_RETENTION_INDEX, DEF_UNKNOWN_TARGET_ADD_RETENTION_INDEX);
 		putDefault(P_VERIFY_UNKNOWN_TARGET, DEF_VERIFY_UNKNOWN_TARGET);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/support/IdentificationTargetSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/support/IdentificationTargetSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,6 +24,8 @@ public class IdentificationTargetSupport {
 
 	private static final String IDENTIFIER_UNKNOWN = "Manual Identification";
 
+	private static final IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
+
 	public static IIdentificationTarget getTargetUnknown(IScan scan) {
 
 		IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
@@ -38,7 +40,8 @@ public class IdentificationTargetSupport {
 	public static String getUnknownTargetName(IScan scan, boolean addRetentionIndex) {
 
 		StringBuilder builder = new StringBuilder();
-		String traces = TracesSupport.getTraces(scan);
+		int maxCopyTraces = getNumberOfTraces();
+		String traces = TracesSupport.getTraces(scan, maxCopyTraces);
 
 		builder.append("Unknown");
 		if(!traces.isEmpty()) {
@@ -58,5 +61,10 @@ public class IdentificationTargetSupport {
 		}
 
 		return builder.toString();
+	}
+
+	private static int getNumberOfTraces() {
+
+		return preferenceStore.getInt(PreferenceSupplier.P_MAX_UNKNOWN_TRACES);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
@@ -462,7 +462,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 			} else if(matchesKeyPress("DeleteTargets", e)) {
 				deleteTargetsAll(e.display);
 			} else if(matchesKeyPress("Unknown", e)) {
-				addTargetsUnknown(e.display);
+				addTargetsUnknown();
 			} else if(matchesKeyPress("Query", e)) {
 				scanIdentifierControl.get().runIdentification();
 				tableViewer.get().refresh();
@@ -669,7 +669,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 		return null;
 	}
 
-	private void addTargetsUnknown(Display display) {
+	private void addTargetsUnknown() {
 
 		for(Object object : tableViewer.get().getStructuredSelection().toList()) {
 			IScan scan = getScan(object);
@@ -685,10 +685,10 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 		 * Send update.
 		 */
 		tableViewer.get().refresh();
-		UpdateNotifierUI.update(display, chromatogramSelection);
+		UpdateNotifierUI.update(getDisplay(), chromatogramSelection);
 
 		chromatogramSelection.getChromatogram().setDirty(true);
-		UpdateNotifierUI.update(display, IChemClipseEvents.TOPIC_EDITOR_CHROMATOGRAM_UPDATE, "Peaks/Scans unknown targets have been set.");
+		UpdateNotifierUI.update(getDisplay(), IChemClipseEvents.TOPIC_EDITOR_CHROMATOGRAM_UPDATE, "Peaks/Scans unknown targets have been set.");
 	}
 
 	private void propagateSelection(Display display) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/TracesClipboardUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/TracesClipboardUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,8 +18,11 @@ import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.model.TracesExportOption;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.model.TracesSupport;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferenceSupplier;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -32,6 +35,8 @@ import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 
 public class TracesClipboardUI extends Composite {
+
+	private static final IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
 
 	private AtomicReference<Button> buttonClipboard = new AtomicReference<>();
 	private IScan scan = null;
@@ -119,7 +124,13 @@ public class TracesClipboardUI extends Composite {
 
 		if(scan != null) {
 			TracesExportOption tracesExportOption = TracesSupport.getTracesExportOption();
-			TracesSupport.copyTracesToClipboard(display, tracesExportOption, scan);
+			int maxCopyTraces = getNumberOfTraces();
+			TracesSupport.copyTracesToClipboard(display, tracesExportOption, scan, maxCopyTraces);
 		}
+	}
+
+	private static int getNumberOfTraces() {
+
+		return preferenceStore.getInt(PreferenceSupplier.P_MAX_COPY_SCAN_TRACES);
 	}
 }


### PR DESCRIPTION
It is a different settings page (Scans vs. Targets) which is hard to understand. Also they conflict in a way that people want to copy as many masses as possible into the clipboard for export or overlay plotting and only few in the unknown label to not clutter the interface.