### PR TITLE
Avoid notificaton spam when deleting multiple targets in Peak/Scan list

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/operations/DeleteTargetsOperation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/operations/DeleteTargetsOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -78,21 +78,8 @@ public class DeleteTargetsOperation extends AbstractOperation {
 	public IStatus execute(IProgressMonitor monitor, IAdaptable info) throws ExecutionException {
 
 		targetSupplier.getTargets().removeAll(targetsToDelete);
-		update(ExtensionMessages.targetsDeleted);
+
 		return Status.OK_STATUS;
-	}
-
-	private void update(String message) {
-
-		UpdateNotifierUI.update(display, IChemClipseEvents.TOPIC_IDENTIFICATION_TARGETS_UPDATE_SELECTION, message);
-		chromatogramSelection.getChromatogram().setDirty(true);
-		if(targetSupplier instanceof IPeak peak) {
-			chromatogramSelection.setSelectedPeak(peak);
-			UpdateNotifierUI.update(display, peak);
-		} else if(targetSupplier instanceof IScan scan) {
-			chromatogramSelection.getSelectedScan();
-			UpdateNotifierUI.update(display, scan);
-		}
 	}
 
 	@Override
@@ -111,7 +98,20 @@ public class DeleteTargetsOperation extends AbstractOperation {
 	public IStatus undo(IProgressMonitor monitor, IAdaptable info) throws ExecutionException {
 
 		targetSupplier.getTargets().addAll(targetsToDelete);
-		update(ExtensionMessages.targetsRestored);
+		notifyTargetsRestored();
 		return Status.OK_STATUS;
+	}
+
+	private void notifyTargetsRestored() {
+
+		UpdateNotifierUI.update(display, IChemClipseEvents.TOPIC_IDENTIFICATION_TARGETS_UPDATE_SELECTION, ExtensionMessages.targetsRestored);
+		chromatogramSelection.getChromatogram().setDirty(true);
+		if(targetSupplier instanceof IPeak peak) {
+			chromatogramSelection.setSelectedPeak(peak);
+			UpdateNotifierUI.update(display, peak);
+		} else if(targetSupplier instanceof IScan scan) {
+			chromatogramSelection.getSelectedScan();
+			UpdateNotifierUI.update(display, scan);
+		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
@@ -62,6 +62,7 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.dialogs.ClassifierDialog;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.dialogs.InternalStandardDialog;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.help.HelpContext;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.support.TableConfigSupport;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.operations.DeletePeaksOperation;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.operations.DeleteScanTargetsOperation;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.operations.DeleteTargetsOperation;
@@ -460,7 +461,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 			} else if(matchesKeyPress("Classifier", e)) {
 				modifyClassifier(display);
 			} else if(matchesKeyPress("DeleteTargets", e)) {
-				deleteTargetsAll(e.display);
+				deleteTargetsAll();
 			} else if(matchesKeyPress("Unknown", e)) {
 				addTargetsUnknown(e.display);
 			} else if(matchesKeyPress("Query", e)) {
@@ -623,12 +624,12 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 		}
 	}
 
-	private void deleteTargetsAll(Display display) {
+	private void deleteTargetsAll() {
 
 		for(Object object : tableViewer.get().getStructuredSelection().toList()) {
 			if(object instanceof ITargetSupplier targetSupplier) {
 				Set<IIdentificationTarget> targetsToDelete = targetSupplier.getTargets();
-				DeleteTargetsOperation deleteTargetsOperation = new DeleteTargetsOperation(display, chromatogramSelection, targetSupplier, targetsToDelete);
+				DeleteTargetsOperation deleteTargetsOperation = new DeleteTargetsOperation(getDisplay(), chromatogramSelection, targetSupplier, targetsToDelete);
 				deleteTargetsOperation.addContext(UndoContextFactory.getUndoContext());
 
 				try {
@@ -649,7 +650,9 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 			 * Send update.
 			 */
 			tableViewer.get().refresh();
-			UpdateNotifierUI.update(display, chromatogramSelection);
+			chromatogramSelection.getChromatogram().setDirty(true);
+			UpdateNotifierUI.update(getDisplay(), chromatogramSelection);
+			UpdateNotifierUI.update(getDisplay(), IChemClipseEvents.TOPIC_IDENTIFICATION_TARGETS_UPDATE_SELECTION, ExtensionMessages.targetsDeleted);
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedTargetsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedTargetsUI.java
@@ -46,6 +46,7 @@ import org.eclipse.chemclipse.ux.extension.ui.support.DataUpdateSupport;
 import org.eclipse.chemclipse.ux.extension.ui.swt.IExtendedPartUI;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.help.HelpContext;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.operations.DeleteTargetsOperation;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageLists;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageTargets;
@@ -706,7 +707,7 @@ public class ExtendedTargetsUI extends Composite implements IExtendedPartUI {
 		AtomicReference<TargetsListUI> targetList = getActiveTargetList();
 		List<IIdentificationTarget> selection = targetList.get().getStructuredSelection().toList();
 		if(getObject() instanceof ITargetSupplier targetSupplier) {
-			DeleteTargetsOperation deleteTargetsOperation = new DeleteTargetsOperation(display, chromatogramSelection, targetSupplier, selection);
+			DeleteTargetsOperation deleteTargetsOperation = new DeleteTargetsOperation(getDisplay(), chromatogramSelection, targetSupplier, selection);
 			deleteTargetsOperation.addContext(UndoContextFactory.getUndoContext());
 			try {
 				getOperationHistory().execute(deleteTargetsOperation, null, null);
@@ -721,7 +722,7 @@ public class ExtendedTargetsUI extends Composite implements IExtendedPartUI {
 
 		if(chromatogramSelection != null && getObject() instanceof ITargetSupplier targetSupplier) {
 			Set<IIdentificationTarget> targetsToDelete = targetSupplier.getTargets();
-			DeleteTargetsOperation deleteTargetsOperation = new DeleteTargetsOperation(display, chromatogramSelection, targetSupplier, targetsToDelete);
+			DeleteTargetsOperation deleteTargetsOperation = new DeleteTargetsOperation(getDisplay(), chromatogramSelection, targetSupplier, targetsToDelete);
 			deleteTargetsOperation.addContext(UndoContextFactory.getUndoContext());
 			try {
 				getOperationHistory().execute(deleteTargetsOperation, null, null);
@@ -744,7 +745,7 @@ public class ExtendedTargetsUI extends Composite implements IExtendedPartUI {
 
 		setChromatogramDirty();
 		updateTargets(display);
-		UpdateNotifierUI.update(display, IChemClipseEvents.TOPIC_EDITOR_CHROMATOGRAM_UPDATE, "Targets have been deleted.");
+		UpdateNotifierUI.update(display, IChemClipseEvents.TOPIC_EDITOR_CHROMATOGRAM_UPDATE, ExtensionMessages.targetsDeleted);
 	}
 
 	private void addTarget(Display display, IIdentificationTarget identificationTarget) {


### PR DESCRIPTION
In a populated Peak/Scan list press <kbd>CTRL</kbd> + <kbd>A</kbd> and then <kbd>CTRL</kbd> + <kbd>D</kbd> to clear targets of multiple peaks. This will trigger an update for each deleted peak consecutively which then bubbles through all the open parts. Takes a while until it finishes and even while not being a loop it is laggy and unpolished. I moved all the delete notifications outside the undo operation because in this case you may want to notify in bulk instead of per peak/scan. This was actually already there, so the extra notifications were overdone.