### PR TITLE
Align metadata fields and measurement info model in Area % reports

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/io/ReportWriter2.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/io/ReportWriter2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -69,7 +69,7 @@ public class ReportWriter2 {
 	private void printHeader(PrintWriter printWriter, IChromatogram chromatogram) {
 
 		printWriter.println("File Name: " + chromatogram.getName());
-		printWriter.println("Sample Name: " + chromatogram.getDataName());
+		printWriter.println("Sample Name: " + chromatogram.getSampleName());
 		printWriter.println("Additional Info: " + chromatogram.getDetailedInfo() + " " + chromatogram.getMiscInfo()); // Don't change without team feedback.
 		printWriter.println("Acquisition Date: " + dateFormat.format(chromatogram.getDate()));
 		printWriter.println("Operator: " + chromatogram.getOperator());

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/io/ReportWriter3.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/io/ReportWriter3.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -62,7 +62,7 @@ public class ReportWriter3 {
 	private void printHeader(PrintWriter printWriter, IChromatogram chromatogram) {
 
 		printWriter.println("Filename: " + chromatogram.getName());
-		printWriter.println("Sample Name: " + chromatogram.getDataName());
+		printWriter.println("Sample Name: " + chromatogram.getSampleName());
 		printWriter.println("Additional Info: " + chromatogram.getDetailedInfo() + " " + chromatogram.getMiscInfo()); // Don't change without team feedback.
 		printWriter.println("Acquisition Date: " + dateFormat.format(chromatogram.getDate()));
 		printWriter.println("Operator: " + chromatogram.getOperator());


### PR DESCRIPTION
It might make sense for the sample name field to match both the header information displayed in the UI and the reports. Also, I tend to set the sample name more often than the data name in the converters, so this enhances the chances of reporting meaningful descriptions.