### PR TITLE
Revert "Type the peak model interfaces"

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/support/TargetBuilderCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/support/TargetBuilderCSD.java
@@ -15,6 +15,7 @@ package org.eclipse.chemclipse.chromatogram.csd.identifier.support;
 import org.eclipse.chemclipse.csd.model.core.IPeakCSD;
 import org.eclipse.chemclipse.csd.model.core.IScanCSD;
 import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.exceptions.ReferenceMustNotBeNullException;
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
@@ -31,12 +32,14 @@ public class TargetBuilderCSD {
 
 		IIdentificationTarget identificationTarget = null;
 		try {
-			IScanCSD scan = peakCSD.getPeakModel().getPeakMaximum();
-			ILibraryInformation libraryInformation = UnknownTargetBuilder.getLibraryInformationUnknown(scan, targetUnknownSettings, "");
-			IComparisonResult comparisonResult = UnknownTargetBuilder.getComparisonResultUnknown(targetUnknownSettings.getMatchQuality());
-			identificationTarget = new IdentificationTarget(libraryInformation, comparisonResult);
-			identificationTarget.setIdentifier(identifier);
-			peakCSD.getTargets().add(identificationTarget);
+			IScan scan = peakCSD.getPeakModel().getPeakMaximum();
+			if(scan instanceof IScanCSD unknown) {
+				ILibraryInformation libraryInformation = UnknownTargetBuilder.getLibraryInformationUnknown(unknown, targetUnknownSettings, "");
+				IComparisonResult comparisonResult = UnknownTargetBuilder.getComparisonResultUnknown(targetUnknownSettings.getMatchQuality());
+				identificationTarget = new IdentificationTarget(libraryInformation, comparisonResult);
+				identificationTarget.setIdentifier(identifier);
+				peakCSD.getTargets().add(identificationTarget);
+			}
 		} catch(ReferenceMustNotBeNullException e) {
 			logger.warn(e);
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/support/TargetBuilderWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/support/TargetBuilderWSD.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.exceptions.ReferenceMustNotBeNullException;
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
@@ -38,13 +39,15 @@ public class TargetBuilderWSD {
 
 		IIdentificationTarget identificationTarget = null;
 		try {
-			IScanWSD scan = peakWSD.getPeakModel().getPeakMaximum();
-			String traces = extractTraces(scan, targetUnknownSettings);
-			ILibraryInformation libraryInformation = UnknownTargetBuilder.getLibraryInformationUnknown(scan, targetUnknownSettings, traces);
-			IComparisonResult comparisonResult = UnknownTargetBuilder.getComparisonResultUnknown(targetUnknownSettings.getMatchQuality());
-			identificationTarget = new IdentificationTarget(libraryInformation, comparisonResult);
-			identificationTarget.setIdentifier(identifier);
-			peakWSD.getTargets().add(identificationTarget);
+			IScan scan = peakWSD.getPeakModel().getPeakMaximum();
+			if(scan instanceof IScanWSD unknown) {
+				String traces = extractTraces(unknown, targetUnknownSettings);
+				ILibraryInformation libraryInformation = UnknownTargetBuilder.getLibraryInformationUnknown(unknown, targetUnknownSettings, traces);
+				IComparisonResult comparisonResult = UnknownTargetBuilder.getComparisonResultUnknown(targetUnknownSettings.getMatchQuality());
+				identificationTarget = new IdentificationTarget(libraryInformation, comparisonResult);
+				identificationTarget.setIdentifier(identifier);
+				peakWSD.getTargets().add(identificationTarget);
+			}
 		} catch(ReferenceMustNotBeNullException e) {
 			logger.warn(e);
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/supplier/trapezoid/processor/PeakIntegrator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/supplier/trapezoid/processor/PeakIntegrator.java
@@ -36,6 +36,7 @@ import org.eclipse.chemclipse.model.core.IMarkedTrace;
 import org.eclipse.chemclipse.model.core.IMarkedTraces;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IPeakModel;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.core.ISignal;
 import org.eclipse.chemclipse.model.implementation.IntegrationEntry;
 import org.eclipse.chemclipse.model.support.IntegrationConstraint;
@@ -271,23 +272,25 @@ public class PeakIntegrator extends AbstractIntegrator {
 			IPeakModelWSD peakModel = peakWSD.getPeakModel();
 			double integratedAreaTIC = calculateTICPeakArea(peak, baselineSupport, includeBackground, useAreaConstraint);
 
-			IScanWSD scan = peakModel.getPeakMaximum();
+			IScan scan = peakModel.getPeakMaximum();
 			IIntegrationEntry integrationEntry;
-			if(!markedTraces.isEmpty() && !markedTraces.getTraces().contains(IMarkedTrace.TOTAL_SIGNAL_AS_INT)) {
-				Set<Integer> wavelengths = markedTraces.getTraces();
-				WavelengthPercentages wavelengthPercentages = new WavelengthPercentages(scan);
-				/*
-				 * Calculate the percentage integrated area for each selected ion.
-				 */
-				for(Integer wavelength : wavelengths) {
-					float correctionFactor = wavelengthPercentages.getPercentage(wavelength) / WavelengthPercentages.MAX_PERCENTAGE;
-					double integratedArea = integratedAreaTIC * correctionFactor;
-					integrationEntry = new IntegrationEntry(wavelength, integratedArea * scaleFactor);
+			if(scan instanceof IScanWSD scanWSD) {
+				if(!markedTraces.isEmpty() && !markedTraces.getTraces().contains(IMarkedTrace.TOTAL_SIGNAL_AS_INT)) {
+					Set<Integer> wavelengths = markedTraces.getTraces();
+					WavelengthPercentages wavelengthPercentages = new WavelengthPercentages(scanWSD);
+					/*
+					 * Calculate the percentage integrated area for each selected ion.
+					 */
+					for(Integer wavelength : wavelengths) {
+						float correctionFactor = wavelengthPercentages.getPercentage(wavelength) / WavelengthPercentages.MAX_PERCENTAGE;
+						double integratedArea = integratedAreaTIC * correctionFactor;
+						integrationEntry = new IntegrationEntry(wavelength, integratedArea * scaleFactor);
+						integrationEntries.add(integrationEntry);
+					}
+				} else {
+					integrationEntry = new IntegrationEntry(ISignal.TOTAL_INTENSITY, integratedAreaTIC * scaleFactor);
 					integrationEntries.add(integrationEntry);
 				}
-			} else {
-				integrationEntry = new IntegrationEntry(ISignal.TOTAL_INTENSITY, integratedAreaTIC * scaleFactor);
-				integrationEntries.add(integrationEntry);
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/AbstractPeakModelCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/AbstractPeakModelCSD.java
@@ -25,16 +25,4 @@ public abstract class AbstractPeakModelCSD extends PeakModel implements IPeakMod
 
 		super(peakMaximum, peakIntensityValues, startBackgroundAbundance, stopBackgroundAbundance);
 	}
-
-	@Override
-	public IScanCSD getPeakMaximum() {
-
-		return (IScanCSD)super.getPeakMaximum();
-	}
-
-	@Override
-	public IScanCSD getPeakScan(int retentionTime) {
-
-		return (IScanCSD)super.getPeakScan(retentionTime);
-	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/IPeakModelCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/core/IPeakModelCSD.java
@@ -15,10 +15,4 @@ package org.eclipse.chemclipse.csd.model.core;
 import org.eclipse.chemclipse.model.core.IPeakModel;
 
 public interface IPeakModelCSD extends IPeakModel {
-
-	@Override
-	IScanCSD getPeakMaximum();
-
-	@Override
-	IScanCSD getPeakScan(int retentionTime);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.fsd.model/src/org/eclipse/chemclipse/fsd/model/core/IPeakModelFSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.fsd.model/src/org/eclipse/chemclipse/fsd/model/core/IPeakModelFSD.java
@@ -15,10 +15,4 @@ package org.eclipse.chemclipse.fsd.model.core;
 import org.eclipse.chemclipse.model.core.IPeakModel;
 
 public interface IPeakModelFSD extends IPeakModel {
-
-	@Override
-	IScanFSD getPeakMaximum();
-
-	@Override
-	IScanFSD getPeakScan(int retentionTime);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.fsd.model/src/org/eclipse/chemclipse/fsd/model/core/implementation/AbstractPeakModelFSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.fsd.model/src/org/eclipse/chemclipse/fsd/model/core/implementation/AbstractPeakModelFSD.java
@@ -13,7 +13,6 @@
 package org.eclipse.chemclipse.fsd.model.core.implementation;
 
 import org.eclipse.chemclipse.fsd.model.core.IPeakModelFSD;
-import org.eclipse.chemclipse.fsd.model.core.IScanFSD;
 import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.exceptions.PeakException;
@@ -26,17 +25,5 @@ public abstract class AbstractPeakModelFSD extends PeakModel implements IPeakMod
 	protected AbstractPeakModelFSD(IScan peakMaximum, IPeakIntensityValues peakIntensityValues, float startBackgroundIntensity, float stopBackgroundIntensity) throws IllegalArgumentException, PeakException {
 
 		super(peakMaximum, peakIntensityValues, startBackgroundIntensity, stopBackgroundIntensity);
-	}
-
-	@Override
-	public IScanFSD getPeakMaximum() {
-
-		return (IScanFSD)super.getPeakMaximum();
-	}
-
-	@Override
-	public IScanFSD getPeakScan(int retentionTime) {
-
-		return (IScanFSD)super.getPeakScan(retentionTime);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractPeakModelMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractPeakModelMSD.java
@@ -54,16 +54,4 @@ public abstract class AbstractPeakModelMSD extends PeakModel implements IPeakMod
 		}
 		return null;
 	}
-
-	@Override
-	public IScanMSD getPeakMaximum() {
-
-		return (IScanMSD)super.getPeakMaximum();
-	}
-
-	@Override
-	public IScanMSD getPeakScan(int retentionTime) {
-
-		return (IScanMSD)super.getPeakScan(retentionTime);
-	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IPeakModelMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IPeakModelMSD.java
@@ -60,10 +60,4 @@ public interface IPeakModelMSD extends IPeakModel {
 	 * @return IMassSpectrum
 	 */
 	IPeakMassSpectrum getPeakMassSpectrum(int retentionTime);
-
-	@Override
-	IScanMSD getPeakMaximum();
-
-	@Override
-	IScanMSD getPeakScan(int retentionTime);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakTracesUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakTracesUI.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogramPeak;
 import org.eclipse.chemclipse.model.core.IPeak;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -441,14 +442,16 @@ public class ExtendedPeakTracesUI extends Composite implements IExtendedPartUI {
 			}
 		} else if(peak instanceof IPeakWSD peakWSD) {
 			IPeakModelWSD peakModelWSD = peakWSD.getPeakModel();
-			IScanWSD scanWSD = peakModelWSD.getPeakMaximum();
-			int maxDeleteTraces = scanWSD.getNumberOfScanSignals() - 1;
-			if(traces.size() >= maxDeleteTraces) {
-				MessageDialog.openInformation(display.getActiveShell(), CATEGORY, "It's not possible to delete all wavelengths.");
-			} else {
-				scanWSD.removeScanSignals(traces);
-				updatePeak();
-				UpdateNotifierUI.update(display, peak);
+			IScan scan = peakModelWSD.getPeakMaximum();
+			if(scan instanceof IScanWSD scanWSD) {
+				int maxDeleteTraces = scanWSD.getNumberOfScanSignals() - 1;
+				if(traces.size() >= maxDeleteTraces) {
+					MessageDialog.openInformation(display.getActiveShell(), CATEGORY, "It's not possible to delete all wavelengths.");
+				} else {
+					scanWSD.removeScanSignals(traces);
+					updatePeak();
+					UpdateNotifierUI.update(display, peak);
+				}
 			}
 		}
 		if(peak instanceof IChromatogramPeak chromatogramPeak) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/core/AbtractPeakModelVSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/core/AbtractPeakModelVSD.java
@@ -25,16 +25,4 @@ public abstract class AbtractPeakModelVSD extends PeakModel implements IPeakMode
 
 		super(peakMaximum, peakIntensityValues, startBackgroundAbundance, stopBackgroundAbundance);
 	}
-
-	@Override
-	public IScanVSD getPeakMaximum() {
-
-		return (IScanVSD)super.getPeakMaximum();
-	}
-
-	@Override
-	public IScanVSD getPeakScan(int retentionTime) {
-
-		return (IScanVSD)super.getPeakScan(retentionTime);
-	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/core/IPeakModelVSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/core/IPeakModelVSD.java
@@ -15,10 +15,4 @@ package org.eclipse.chemclipse.vsd.model.core;
 import org.eclipse.chemclipse.model.core.IPeakModel;
 
 public interface IPeakModelVSD extends IPeakModel {
-
-	@Override
-	IScanVSD getPeakMaximum();
-
-	@Override
-	IScanVSD getPeakScan(int retentionTime);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/AbstractChromatogramPeakWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/AbstractChromatogramPeakWSD.java
@@ -13,6 +13,7 @@
 package org.eclipse.chemclipse.wsd.model.core;
 
 import org.eclipse.chemclipse.model.core.IChromatogram;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.exceptions.PeakException;
 
 public abstract class AbstractChromatogramPeakWSD extends AbstractPeakWSD implements IChromatogramPeakWSD {
@@ -79,12 +80,14 @@ public abstract class AbstractChromatogramPeakWSD extends AbstractPeakWSD implem
 		/*
 		 * Extracted is the unknown and genuine the reference scan.
 		 */
-		IScanWSD peakScan = getPeakModel().getPeakMaximum();
-		IScanWSD genuineScanWSD = chromatogram.getScan(getScanMax());
-		if(genuineScanWSD != null) {
-			int numberOfSignals = genuineScanWSD.getNumberOfScanSignals();
-			if(numberOfSignals != 0) {
-				purity = peakScan.getNumberOfScanSignals() / (float)numberOfSignals;
+		IScan peakScan = getPeakModel().getPeakMaximum();
+		if(peakScan instanceof IScanWSD peakScanWSD) {
+			IScanWSD genuineScanWSD = chromatogram.getScan(getScanMax());
+			if(genuineScanWSD != null) {
+				int numberOfSignals = genuineScanWSD.getNumberOfScanSignals();
+				if(numberOfSignals != 0) {
+					purity = peakScanWSD.getNumberOfScanSignals() / (float)numberOfSignals;
+				}
 			}
 		}
 		return purity;

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/AbstractPeakModelWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/AbstractPeakModelWSD.java
@@ -25,16 +25,4 @@ public abstract class AbstractPeakModelWSD extends PeakModel implements IPeakMod
 
 		super(peakMaximum, peakIntensityValues, startBackgroundAbundance, stopBackgroundAbundance);
 	}
-
-	@Override
-	public IScanWSD getPeakMaximum() {
-
-		return (IScanWSD)super.getPeakMaximum();
-	}
-
-	@Override
-	public IScanWSD getPeakScan(int retentionTime) {
-
-		return (IScanWSD)super.getPeakScan(retentionTime);
-	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/IPeakModelWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/IPeakModelWSD.java
@@ -15,10 +15,4 @@ package org.eclipse.chemclipse.wsd.model.core;
 import org.eclipse.chemclipse.model.core.IPeakModel;
 
 public interface IPeakModelWSD extends IPeakModel {
-
-	@Override
-	IScanWSD getPeakMaximum();
-
-	@Override
-	IScanWSD getPeakScan(int retentionTime);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1001.java
@@ -31,6 +31,7 @@ import org.eclipse.chemclipse.csd.model.core.IPeakModelCSD;
 import org.eclipse.chemclipse.csd.model.core.IScanCSD;
 import org.eclipse.chemclipse.model.baseline.IBaselineModel;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.settings.Format;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -210,7 +211,7 @@ public class ChromatogramWriter_1001 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanCSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(scan.getRetentionIndex()); // Retention Index
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1002.java
@@ -31,6 +31,7 @@ import org.eclipse.chemclipse.csd.model.core.IPeakModelCSD;
 import org.eclipse.chemclipse.csd.model.core.IScanCSD;
 import org.eclipse.chemclipse.model.baseline.IBaselineModel;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.settings.Format;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -209,7 +210,7 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanCSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(scan.getRetentionIndex()); // Retention Index
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1003.java
@@ -31,6 +31,7 @@ import org.eclipse.chemclipse.csd.model.core.IPeakModelCSD;
 import org.eclipse.chemclipse.csd.model.core.IScanCSD;
 import org.eclipse.chemclipse.model.baseline.IBaselineModel;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.settings.Format;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -211,7 +212,7 @@ public class ChromatogramWriter_1003 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanCSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(scan.getRetentionIndex()); // Retention Index
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1004.java
@@ -31,6 +31,7 @@ import org.eclipse.chemclipse.csd.model.core.IPeakModelCSD;
 import org.eclipse.chemclipse.csd.model.core.IScanCSD;
 import org.eclipse.chemclipse.model.baseline.IBaselineModel;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.settings.Format;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -213,7 +214,7 @@ public class ChromatogramWriter_1004 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanCSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(scan.getRetentionIndex()); // Retention Index
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1005.java
@@ -32,6 +32,7 @@ import org.eclipse.chemclipse.csd.model.core.IScanCSD;
 import org.eclipse.chemclipse.model.baseline.IBaselineModel;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IMethod;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.settings.Format;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -242,7 +243,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanCSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(scan.getRetentionIndex()); // Retention Index
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1006.java
@@ -33,6 +33,7 @@ import org.eclipse.chemclipse.csd.model.core.IScanCSD;
 import org.eclipse.chemclipse.model.baseline.IBaselineModel;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IMethod;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.support.model.SeparationColumnType;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.internal.support.RetentionIndexTypeSupport;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.preferences.PreferenceSupplier;
@@ -258,7 +259,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanCSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal
 		dataOutputStream.writeInt(scan.getRetentionTimeColumn1());

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1007.java
@@ -33,6 +33,7 @@ import org.eclipse.chemclipse.csd.model.core.IScanCSD;
 import org.eclipse.chemclipse.model.baseline.IBaselineModel;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IMethod;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.support.model.SeparationColumnType;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.internal.support.RetentionIndexTypeSupport;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.preferences.PreferenceSupplier;
@@ -258,7 +259,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanCSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal
 		dataOutputStream.writeInt(scan.getRetentionTimeColumn1());

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1100.java
@@ -34,6 +34,7 @@ import org.eclipse.chemclipse.csd.model.core.IScanCSD;
 import org.eclipse.chemclipse.model.baseline.IBaselineModel;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IMethod;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.quantitation.IInternalStandard;
 import org.eclipse.chemclipse.support.model.SeparationColumnType;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.internal.support.RetentionIndexTypeSupport;
@@ -270,7 +271,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanCSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal
 		dataOutputStream.writeInt(scan.getRetentionTimeColumn1());

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1300.java
@@ -42,6 +42,7 @@ import org.eclipse.chemclipse.model.columns.ISeparationColumnIndices;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IMethod;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.core.ISignal;
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
@@ -321,7 +322,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanCSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeInt(scan.getRelativeRetentionTime());
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
@@ -44,6 +44,7 @@ import org.eclipse.chemclipse.model.columns.ISeparationColumnIndices;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IMethod;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.core.ISignal;
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
@@ -321,7 +322,7 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanCSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeInt(scan.getRelativeRetentionTime());
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
@@ -45,6 +45,7 @@ import org.eclipse.chemclipse.model.columns.ISeparationColumnIndices;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IMethod;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.core.ISignal;
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
@@ -360,7 +361,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanCSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeInt(scan.getRelativeRetentionTime());
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
@@ -45,6 +45,7 @@ import org.eclipse.chemclipse.model.columns.ISeparationColumnIndices;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IMethod;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
@@ -359,7 +360,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanCSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeInt(scan.getRelativeRetentionTime());
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
@@ -44,6 +44,7 @@ import org.eclipse.chemclipse.model.columns.ISeparationColumnIndices;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IMethod;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.quantitation.IInternalStandard;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.ranges.TimeRange;
@@ -351,7 +352,7 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanCSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeInt(scan.getRelativeRetentionTime());
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1502.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1502.java
@@ -44,6 +44,7 @@ import org.eclipse.chemclipse.model.columns.ISeparationColumnIndices;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IMethod;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.quantitation.IInternalStandard;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.ranges.TimeRange;
@@ -347,7 +348,7 @@ public class ChromatogramWriter_1502 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanCSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeInt(scan.getRelativeRetentionTime());
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1300.java
@@ -37,6 +37,7 @@ import org.eclipse.chemclipse.model.columns.ISeparationColumnIndices;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IMethod;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.core.ISignal;
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
@@ -353,7 +354,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanWSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeInt(scan.getRelativeRetentionTime());
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
@@ -39,6 +39,7 @@ import org.eclipse.chemclipse.model.columns.ISeparationColumnIndices;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IMethod;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.core.ISignal;
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
@@ -353,7 +354,7 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanWSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeInt(scan.getRelativeRetentionTime());
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
@@ -40,6 +40,7 @@ import org.eclipse.chemclipse.model.columns.ISeparationColumnIndices;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IMethod;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.core.ISignal;
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
@@ -389,7 +390,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanWSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeInt(scan.getRelativeRetentionTime());
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
@@ -40,6 +40,7 @@ import org.eclipse.chemclipse.model.columns.ISeparationColumnIndices;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IMethod;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
@@ -388,7 +389,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanWSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeInt(scan.getRelativeRetentionTime());
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
@@ -39,6 +39,7 @@ import org.eclipse.chemclipse.model.columns.ISeparationColumnIndices;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IMethod;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.quantitation.IInternalStandard;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.ranges.TimeRange;
@@ -380,7 +381,7 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanWSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeInt(scan.getRelativeRetentionTime());
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1502.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1502.java
@@ -39,6 +39,7 @@ import org.eclipse.chemclipse.model.columns.ISeparationColumnIndices;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
 import org.eclipse.chemclipse.model.core.IMethod;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.quantitation.IInternalStandard;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.ranges.TimeRange;
@@ -379,7 +380,7 @@ public class ChromatogramWriter_1502 extends AbstractChromatogramWriter implemen
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStartRetentionTime())); // Start Background Abundance
 		dataOutputStream.writeFloat(peakModel.getBackgroundAbundance(peakModel.getStopRetentionTime())); // Stop Background Abundance
 
-		IScanWSD scan = peakModel.getPeakMaximum();
+		IScan scan = peakModel.getPeakMaximum();
 		dataOutputStream.writeInt(scan.getRetentionTime()); // Retention Time
 		dataOutputStream.writeInt(scan.getRelativeRetentionTime());
 		dataOutputStream.writeFloat(scan.getTotalSignal()); // Total Signal


### PR DESCRIPTION
Reverts eclipse-chemclipse/chemclipse#2698. Fixes https://github.com/eclipse-chemclipse/chemclipse/issues/2745.