### PR TITLE
Simplify calibration file wizard

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/PageCalibrationTable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/PageCalibrationTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,9 +12,12 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui.wizards;
 
+import java.io.File;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
+import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.impl.CalibrationFile;
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.impl.RetentionIndexExtractor;
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.io.StandardsReader;
 import org.eclipse.chemclipse.model.columns.IRetentionIndexEntry;
@@ -35,14 +38,17 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.FileDialog;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
+import org.eclipse.swt.widgets.Text;
 
 public class PageCalibrationTable extends AbstractExtendedWizardPage {
 
 	private RetentionIndexWizardElements wizardElements;
 
-	private Button checkBoxValidateRetentionIndices;
 	private ChromatogramPeakChart chromatogramPeakChart;
 	private ExtendedRetentionIndexListUI extendedRetentionIndexTableViewerUI;
 
@@ -57,7 +63,7 @@ public class PageCalibrationTable extends AbstractExtendedWizardPage {
 	@Override
 	public boolean canFinish() {
 
-		return wizardElements.isRetentionIndexDataValidated();
+		return wizardElements.getExportFilePath() != null;
 	}
 
 	@Override
@@ -90,29 +96,48 @@ public class PageCalibrationTable extends AbstractExtendedWizardPage {
 		composite.setBackgroundMode(SWT.INHERIT_DEFAULT);
 		composite.setLayout(new GridLayout(1, false));
 
-		createCheckBoxField(composite);
 		createChromatogramField(composite);
 		createTableField(composite);
+		createCalibrationFileField(composite);
 
 		validateSelection();
 		setControl(composite);
 	}
 
-	private void createCheckBoxField(Composite composite) {
+	private void createCalibrationFileField(Composite composite) {
 
-		checkBoxValidateRetentionIndices = new Button(composite, SWT.CHECK);
-		checkBoxValidateRetentionIndices.setText("Retention indices are valid.");
-		checkBoxValidateRetentionIndices.setSelection(false);
-		checkBoxValidateRetentionIndices.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		checkBoxValidateRetentionIndices.addSelectionListener(new SelectionAdapter() {
+		Composite parent = new Composite(composite, SWT.NONE);
+		parent.setLayoutData(new GridData(GridData.FILL_BOTH));
+		parent.setLayout(new GridLayout(3, false));
 
-			@Override
-			public void widgetSelected(SelectionEvent e) {
+		Label labelFile = new Label(parent, SWT.NONE);
+		labelFile.setText("Save as:");
 
-				wizardElements.setRetentionIndexDataIsValidated(checkBoxValidateRetentionIndices.getSelection());
-				validateSelection();
+		Text fileText = new Text(parent, SWT.BORDER);
+		fileText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		Button buttonBrowse = new Button(parent, SWT.PUSH);
+		buttonBrowse.setText("Browse...");
+
+		buttonBrowse.addListener(SWT.Selection, e -> {
+			String selected = openFileDialog(getShell());
+			if(selected != null) {
+				fileText.setText(selected);
+				wizardElements.setExportFilePath(new File(selected));
 			}
+			validateSelection();
 		});
+	}
+
+	private String openFileDialog(Shell shell) {
+
+		FileDialog fileDialog = new FileDialog(shell, SWT.SAVE);
+		fileDialog.setOverwrite(true);
+		fileDialog.setText("Retention Index");
+		fileDialog.setFileName("RetentionIndices_" + new Date().getTime() + CalibrationFile.FILTER_EXTENSION);
+		fileDialog.setFilterExtensions(CalibrationFile.FILTER_EXTENSION);
+		fileDialog.setFilterNames(CalibrationFile.FILTER_NAME);
+		return fileDialog.open();
 	}
 
 	private void createChromatogramField(Composite composite) {
@@ -177,8 +202,9 @@ public class PageCalibrationTable extends AbstractExtendedWizardPage {
 	private void validateSelection() {
 
 		String message = null;
-		if(!checkBoxValidateRetentionIndices.getSelection()) {
-			message = "Please verify the data and activate the check box.";
+		File file = wizardElements.getExportFilePath();
+		if(file == null) {
+			message = "Please select a file location.";
 		}
 		/*
 		 * Updates the status

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/RetentionIndexWizardElements.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/RetentionIndexWizardElements.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui.wizards;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,11 +32,10 @@ public class RetentionIndexWizardElements extends ChromatogramWizardElements {
 	private String startIndexName = "";
 	private String stopIndexName = "";
 	private boolean useAlreadyDetectedPeaks = false;
+	private File calibrationFile;
 
 	private IChromatogramSelection chromatogramSelection;
 	private ISeparationColumnIndices separationColumnIndices = new SeparationColumnIndices();
-
-	private boolean retentionIndexDataIsValidated = false;
 
 	public List<String> getSelectedIndices() {
 
@@ -161,13 +161,13 @@ public class RetentionIndexWizardElements extends ChromatogramWizardElements {
 		this.separationColumnIndices = separationColumnIndices;
 	}
 
-	public boolean isRetentionIndexDataValidated() {
+	public File getExportFilePath() {
 
-		return retentionIndexDataIsValidated;
+		return calibrationFile;
 	}
 
-	public void setRetentionIndexDataIsValidated(boolean retentionIndexDataIsValidated) {
+	public void setExportFilePath(File calibrationFile) {
 
-		this.retentionIndexDataIsValidated = retentionIndexDataIsValidated;
+		this.calibrationFile = calibrationFile;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/WizardCreateRetentionIndexFile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/ui/wizards/WizardCreateRetentionIndexFile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,25 +14,28 @@
 package org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui.wizards;
 
 import java.io.File;
-import java.util.Date;
 
+import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.impl.CalibrationFile;
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.io.CalibrationFileWriter;
 import org.eclipse.chemclipse.csd.converter.chromatogram.ChromatogramConverterCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.csd.model.core.selection.IChromatogramSelectionCSD;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
+import org.eclipse.chemclipse.model.types.DataType;
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.selection.IChromatogramSelectionMSD;
-import org.eclipse.chemclipse.support.ui.wizards.AbstractFileWizard;
+import org.eclipse.chemclipse.support.l10n.SupportMessages;
+import org.eclipse.chemclipse.support.ui.wizards.AbstractWizard;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.part.support.SupplierEditorSupport;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.wizard.IWizardPage;
 
-public class WizardCreateRetentionIndexFile extends AbstractFileWizard {
+public class WizardCreateRetentionIndexFile extends AbstractWizard {
 
 	/**
 	 * Preferred size of the wizard.
@@ -42,9 +45,7 @@ public class WizardCreateRetentionIndexFile extends AbstractFileWizard {
 
 	private static final Logger logger = Logger.getLogger(WizardCreateRetentionIndexFile.class);
 
-	private RetentionIndexWizardElements wizardElements = new RetentionIndexWizardElements();
-
-	private static final String CALIBRATION_FILE_EXTENSION = ".cal";
+	private RetentionIndexWizardElements wizardElements;
 
 	private PageCalibrationSettings pageCalibrationSettings;
 	private PagePeakSelection pagePeakSelection;
@@ -53,7 +54,8 @@ public class WizardCreateRetentionIndexFile extends AbstractFileWizard {
 
 	public WizardCreateRetentionIndexFile() {
 
-		super("RetentionIndices_" + new Date().getTime(), CALIBRATION_FILE_EXTENSION);
+		super(new RetentionIndexWizardElements());
+		this.wizardElements = (RetentionIndexWizardElements)getWizardElements();
 	}
 
 	@Override
@@ -107,7 +109,7 @@ public class WizardCreateRetentionIndexFile extends AbstractFileWizard {
 			canFinish = pagePeakAssignment.canFinish();
 		}
 		if(canFinish) {
-			canFinish = wizardElements.isRetentionIndexDataValidated();
+			canFinish = wizardElements.getExportFilePath() != null;
 		}
 		return canFinish;
 	}
@@ -115,15 +117,15 @@ public class WizardCreateRetentionIndexFile extends AbstractFileWizard {
 	@Override
 	public void doFinish(IProgressMonitor monitor) throws CoreException {
 
+		File calibrationFile = wizardElements.getExportFilePath();
+
 		monitor.beginTask("Create Chromatogram Evaluation", IProgressMonitor.UNKNOWN);
-		final IFile file = super.prepareProject(monitor);
 		try {
 			/*
 			 * Calibration File.
 			 */
-			File calibrationFile = file.getLocation().toFile();
-			if(!calibrationFile.getAbsolutePath().endsWith(CALIBRATION_FILE_EXTENSION)) {
-				calibrationFile = new File(calibrationFile.getAbsolutePath() + CALIBRATION_FILE_EXTENSION);
+			if(!calibrationFile.getAbsolutePath().endsWith(CalibrationFile.FILTER_EXTENSION)) {
+				calibrationFile = new File(calibrationFile.getAbsolutePath() + CalibrationFile.FILTER_EXTENSION);
 			}
 			CalibrationFileWriter calibrationFileWriter = new CalibrationFileWriter();
 			calibrationFileWriter.write(calibrationFile, wizardElements.getSeparationColumnIndices());
@@ -132,7 +134,7 @@ public class WizardCreateRetentionIndexFile extends AbstractFileWizard {
 			 * Export the chromatogram.
 			 */
 			String path = calibrationFile.getAbsolutePath();
-			File chromatogramFile = new File(path.substring(0, path.length() - CALIBRATION_FILE_EXTENSION.length()) + VersionConstants.FILE_EXTENSION_CHROMATOGRAM);
+			File chromatogramFile = new File(path.substring(0, path.length() - CalibrationFile.FILTER_EXTENSION.length()) + VersionConstants.FILE_EXTENSION_CHROMATOGRAM);
 			IChromatogramSelection chromatogramSelection = wizardElements.getChromatogramSelection();
 			if(wizardElements.isUseMassSpectrometryData()) {
 				if(chromatogramSelection instanceof IChromatogramSelectionMSD chromatogramSelectionMSD) {
@@ -148,10 +150,15 @@ public class WizardCreateRetentionIndexFile extends AbstractFileWizard {
 		} catch(Exception e) {
 			logger.warn(e);
 		}
-		/*
-		 * Refresh
-		 */
-		super.refreshWorkspace(monitor);
-		super.runOpenEditor(file, monitor);
+		runOpenEditor(calibrationFile, monitor);
+	}
+
+	private void runOpenEditor(File file, IProgressMonitor monitor) {
+
+		monitor.subTask(SupportMessages.taskOpenEditor);
+		SupplierEditorSupport supplierEditorSupport = new SupplierEditorSupport(DataType.CAL, () -> Activator.getDefault().getEclipseContext());
+		if(!supplierEditorSupport.openEditor(file)) {
+			logger.warn("Failed to open editor.");
+		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/wizards/AbstractWizard.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/wizards/AbstractWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -35,7 +35,7 @@ public abstract class AbstractWizard extends Wizard implements IFileWizard {
 	private IWizardElements wizardElements;
 	private Set<IExtendedWizardPage> wizardPages;
 
-	public AbstractWizard(IWizardElements wizardElements) {
+	protected AbstractWizard(IWizardElements wizardElements) {
 
 		super();
 		setNeedsProgressMonitor(true);


### PR DESCRIPTION
This addresses two usability complaints with it:
* You need to create a project first, and by default it hides its location.
* There is a checkbox in the end that has to be ticked for it to finish.

Instead, I make the user choose a path for the calibration file in the end. This is easier to use, and we get rid of IDE dependencies. All the other processors that use `.cal` files are not project-based.