### PR TITLE
Remove PerspectiveSupport.getActivePerspective

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/workbench/PerspectiveSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/workbench/PerspectiveSupport.java
@@ -53,19 +53,6 @@ public class PerspectiveSupport {
 		}
 	}
 
-	public String getActivePerspective() {
-
-		MPerspective perspective = getActiveMPerspective();
-		if(perspective != null) {
-			String perspectiveName = perspective.getLabel();
-			perspectiveName = perspectiveName.replace("<", "");
-			perspectiveName = perspectiveName.replace(">", "");
-			return perspectiveName;
-		} else {
-			return "";
-		}
-	}
-
 	private MPerspective getActiveMPerspective() {
 
 		List<MPerspectiveStack> perspectiveStacks = eModelService.findElements(mApplication, null, MPerspectiveStack.class);


### PR DESCRIPTION
This method returns String based on perspective label and removing '<' and '>' symnbols. This is error prone and can be lead to different perspectives be misdentified as same one if one relies on this method. It is not used thus it better be removed before someone starts using it.