### PR TITLE
Remove useless methods from PartSupport

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/workbench/PartSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/workbench/PartSupport.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.support.ui.workbench;
 
-import java.util.Collection;
-
 import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.chemclipse.support.events.IPerspectiveAndViewIds;
 import org.eclipse.e4.core.di.annotations.Creatable;
@@ -45,24 +43,6 @@ public class PartSupport {
 	private EPartService ePartService;
 	@Inject
 	private IEventBroker eventBroker;
-
-	public void removeEditorsFromPartStack() {
-
-		MPartStack partStack = (MPartStack)eModelService.find(IPerspectiveAndViewIds.EDITOR_PART_STACK_ID, mApplication);
-		Collection<MPart> parts = ePartService.getParts();
-		for(MPart part : parts) {
-			if(part.getObject() != null) {
-				part.setToBeRendered(false);
-				part.setVisible(false);
-				partStack.getChildren().remove(part);
-			}
-		}
-	}
-
-	public boolean saveDirtyParts() {
-
-		return ePartService.saveAll(true);
-	}
 
 	/**
 	 * Load and show the part.


### PR DESCRIPTION
* saveDirtyParts is just one-liner for ePartService.saveAll(true) so better call EPartService.saveAll than introduce custom context object to call that
* removeEditorsFromPartStack has a big flaw - retrieve all parts, make each of them not to be not rendered and invisible and try to remove it from EDITOR_PART_STACK_ID even if it the view is not part of this stack.

They are not used so safe to remove.