### PR TITLE
Avoid a followup error when the chromatogram (selection) is null

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -375,6 +375,9 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 
 	public synchronized void updateChromatogramSelection(IChromatogramSelection chromatogramSelection) {
 
+		if(chromatogramSelection == null) {
+			return;
+		}
 		toolbarReferencesControl.get().update(chromatogramSelection, this::setChromatogramSelectionInternal);
 		setChromatogramSelectionInternal(chromatogramSelection);
 		chromatogramBaselinesControl.get().update(chromatogramSelection.getChromatogram());


### PR DESCRIPTION
Close https://github.com/eclipse-chemclipse/chemclipse/issues/2774