### PR TITLE
Remove createEditorPages methods

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/editors/PlateEditorPCR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/editors/PlateEditorPCR.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Matthias Mailänder - remember save location
@@ -146,7 +146,7 @@ public class PlateEditorPCR implements IChemClipseEditor {
 
 	private void initialize(Composite parent) {
 
-		createEditorPages(parent);
+		extendedPCRPlateUI = new ExtendedPCRPlateUI(parent, SWT.NONE);
 		plate = loadPlate();
 		extendedPCRPlateUI.update(plate);
 	}
@@ -186,16 +186,6 @@ public class PlateEditorPCR implements IChemClipseEditor {
 
 		plateFile = file;
 		return runnable.getPlate();
-	}
-
-	private void createEditorPages(Composite parent) {
-
-		createScanPage(parent);
-	}
-
-	private void createScanPage(Composite parent) {
-
-		extendedPCRPlateUI = new ExtendedPCRPlateUI(parent, SWT.NONE);
 	}
 
 	private void updatePlate() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
@@ -265,7 +265,7 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 	private synchronized void initialize(Composite parent) {
 
 		IChromatogramSelection chromatogramSelection = loadChromatogram();
-		createEditorPages(parent);
+		createChromatogramPage(parent);
 		extendedChromatogramUI.updateChromatogramSelection(chromatogramSelection);
 		processChromatogram(chromatogramSelection);
 		setControl(extendedChromatogramUI);
@@ -449,11 +449,6 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 				throw new NoChromatogramConverterAvailableException();
 			}
 		}
-	}
-
-	private void createEditorPages(Composite parent) {
-
-		createChromatogramPage(parent);
 	}
 
 	private void createChromatogramPage(Composite parent) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ChromatogramEditorTSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ChromatogramEditorTSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -112,7 +112,7 @@ public class ChromatogramEditorTSD implements IChemClipseEditor {
 
 	private void initialize(Composite parent) {
 
-		createEditorPages(parent);
+		chromatogramHeatmapUI = new ChromatogramHeatmapUI(parent, SWT.NONE);
 		IChromatogramTSD chromatogramTSD = loadChromatogram();
 		chromatogramHeatmapUI.setInput(chromatogramTSD);
 	}
@@ -151,8 +151,4 @@ public class ChromatogramEditorTSD implements IChemClipseEditor {
 		return runnable.getChromatogram();
 	}
 
-	private void createEditorPages(Composite parent) {
-
-		chromatogramHeatmapUI = new ChromatogramHeatmapUI(parent, SWT.NONE);
-	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/QuantitationDatabaseEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/QuantitationDatabaseEditor.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -117,14 +117,9 @@ public class QuantitationDatabaseEditor implements IQuantitationDatabaseEditor {
 
 	private void initialize(Composite parent) {
 
-		createEditorPages(parent);
+		createPage(parent);
 		quantitationDatabase = loadQuantitationDatabase();
 		extendedQuantCompoundListUI.update(quantitationDatabase);
-	}
-
-	private void createEditorPages(Composite parent) {
-
-		createPage(parent);
 	}
 
 	private void createPage(Composite parent) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ScanEditorFSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ScanEditorFSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
@@ -132,7 +132,7 @@ public class ScanEditorFSD implements IScanEditorFSD {
 	private void initialize(Composite parent) {
 
 		spectrumFSD = loadScan();
-		createEditorPages(parent);
+		extendedFSDScanUI = new ExtendedFSDScanUI(parent, SWT.NONE);
 		extendedFSDScanUI.update(spectrumFSD);
 	}
 
@@ -178,13 +178,4 @@ public class ScanEditorFSD implements IScanEditorFSD {
 		return runnable.getSpectrumFSD();
 	}
 
-	private void createEditorPages(Composite parent) {
-
-		createScanPage(parent);
-	}
-
-	private void createScanPage(Composite parent) {
-
-		extendedFSDScanUI = new ExtendedFSDScanUI(parent, SWT.NONE);
-	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ScanEditorVSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ScanEditorVSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -132,7 +132,7 @@ public class ScanEditorVSD implements IScanEditorVSD {
 	private void initialize(Composite parent) {
 
 		scanVSD = loadScan();
-		createEditorPages(parent);
+		extendedScanVSDEditorUI = new ExtendedVSDScanUI(parent, SWT.NONE);
 		extendedScanVSDEditorUI.update(scanVSD);
 	}
 
@@ -178,13 +178,4 @@ public class ScanEditorVSD implements IScanEditorVSD {
 		return runnable.getSpectrumVSD();
 	}
 
-	private void createEditorPages(Composite parent) {
-
-		createScanPage(parent);
-	}
-
-	private void createScanPage(Composite parent) {
-
-		extendedScanVSDEditorUI = new ExtendedVSDScanUI(parent, SWT.NONE);
-	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ScanEditorWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ScanEditorWSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -132,7 +132,7 @@ public class ScanEditorWSD implements IScanEditorWSD {
 	private void initialize(Composite parent) {
 
 		spectrumWSD = loadScan();
-		createEditorPages(parent);
+		extendedScanWSDEditorUI = new ExtendedWSDScanUI(parent, SWT.NONE);
 		extendedScanWSDEditorUI.update(spectrumWSD);
 	}
 
@@ -176,15 +176,5 @@ public class ScanEditorWSD implements IScanEditorWSD {
 
 		scanFile = file;
 		return runnable.getSpectrumWSD();
-	}
-
-	private void createEditorPages(Composite parent) {
-
-		createScanPage(parent);
-	}
-
-	private void createScanPage(Composite parent) {
-
-		extendedScanWSDEditorUI = new ExtendedWSDScanUI(parent, SWT.NONE);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/SequenceEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/SequenceEditor.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -99,7 +99,7 @@ public class SequenceEditor {
 
 	private void initialize(Composite parent) {
 
-		createEditorPages(parent);
+		extendedSequenceListUI = new ExtendedSequenceListUI(parent, SWT.NONE);
 		extendedSequenceListUI.update(loadSequence());
 	}
 
@@ -154,13 +154,4 @@ public class SequenceEditor {
 		return sequence;
 	}
 
-	private void createEditorPages(Composite parent) {
-
-		createPage(parent);
-	}
-
-	private void createPage(Composite parent) {
-
-		extendedSequenceListUI = new ExtendedSequenceListUI(parent, SWT.NONE);
-	}
 }


### PR DESCRIPTION
These are remnant from the past when most things were MultiPageEditorPage, now that they are single page these become just useless chaining of method calls to complicate reading and debugging.