### PR TITLE
Add a file content matcher for NMR .dx files

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/plugin.xml
@@ -126,6 +126,7 @@
             id="org.eclipse.chemclipse.nmr.converter.supplier.jcampdx"
             importConverter="org.eclipse.chemclipse.nmr.converter.supplier.jcampdx.converter.ScanImportConverterNMR"
             importMagicNumberMatcher="org.eclipse.chemclipse.nmr.converter.supplier.jcampdx.io.MagicNumberMatcherNMR"
+            importContentMatcher="org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.io.FileContentMatcherNMR"
             isExportable="false"
             isImportable="true">
       </ScanSupplier>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/nmr/converter/supplier/jcampdx/io/FileContentMatcherNMR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/nmr/converter/supplier/jcampdx/io/FileContentMatcherNMR.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.nmr.converter.supplier.jcampdx.io;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
+import org.eclipse.chemclipse.converter.core.IFileContentMatcher;
+
+public class FileContentMatcherNMR extends AbstractFileContentMatcher implements IFileContentMatcher {
+
+	@Override
+	public boolean checkFileFormat(File file) {
+
+		try (BufferedReader bufferedReader = new BufferedReader(new FileReader(file))) {
+			for(int i = 0; i < 10; i++) {
+				String line = bufferedReader.readLine().trim();
+				if(line.startsWith("##DATA TYPE") && line.contains("NMR Spectrum")) {
+					return true;
+				}
+			}
+		} catch(IOException e) {
+			return false;
+		}
+		return false;
+	}
+}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/BrukerAFFN_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/BrukerAFFN_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.model.core.IComplexSignalMeasurement;
 import org.eclipse.chemclipse.nmr.converter.supplier.jcampdx.converter.ScanImportConverterNMR;
@@ -34,7 +33,7 @@ public class BrukerAFFN_ITest {
 	private IComplexSignalMeasurement<?> complexSignalMeasurement;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File file = new File(TestPathHelper.REAL_SPECTRUM_ASCII_FREE_FORMAT_NUMERIC);
 		ScanImportConverterNMR importConverter = new ScanImportConverterNMR();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Chromatogram_01_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Chromatogram_01_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
@@ -36,7 +35,7 @@ public class Chromatogram_01_ITest {
 	private IChromatogramMSD chromatogram;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File file = new File(TestPathHelper.CHROMATOGRAM_01);
 		ChromatogramImportConverter chromatogramImportConverter = new ChromatogramImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Cinnamon_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Cinnamon_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.xxd.converter.supplier.jcampdx;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.csd.converter.supplier.jcampdx.converter.ChromatogramImportConverter;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
@@ -32,7 +31,7 @@ public class Cinnamon_ITest {
 	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File file = new File(TestPathHelper.CINNAMON);
 		ChromatogramImportConverter chromatogramImportConverter = new ChromatogramImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedDecrease1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedDecrease1_ITest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.converter.ScanImportConverter;
@@ -33,7 +32,7 @@ public class FixedDecrease1_ITest {
 	private ISpectrumVSD spectrumVSD;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File file = new File(TestPathHelper.FIXDEC1);
 		ScanImportConverter importConverter = new ScanImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedIncrease1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedIncrease1_ITest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.converter.ScanImportConverter;
@@ -33,7 +32,7 @@ public class FixedIncrease1_ITest {
 	private ISpectrumVSD spectrumVSD;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File file = new File(TestPathHelper.FIXINC1);
 		ScanImportConverter importConverter = new ScanImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedIncrease2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/FixedIncrease2_ITest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.converter.ScanImportConverter;
@@ -33,7 +32,7 @@ public class FixedIncrease2_ITest {
 	private ISpectrumVSD spectrumVSD;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File file = new File(TestPathHelper.FIXINC2);
 		ScanImportConverter importConverter = new ScanImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Ginger_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Ginger_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.xxd.converter.supplier.jcampdx;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.csd.converter.supplier.jcampdx.converter.ChromatogramImportConverter;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
@@ -32,7 +31,7 @@ public class Ginger_ITest {
 	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File file = new File(TestPathHelper.GINGER);
 		ChromatogramImportConverter chromatogramImportConverter = new ChromatogramImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Grape_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Grape_ITest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.supplier.jcampdx.converter.ScanImportConverter;
@@ -33,7 +32,7 @@ public class Grape_ITest {
 	private ISpectrumWSD spectrumWSD;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File file = new File(TestPathHelper.GRAPE);
 		ScanImportConverter importConverter = new ScanImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Guava_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Guava_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.xxd.converter.supplier.jcampdx;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.csd.converter.supplier.jcampdx.converter.ChromatogramImportConverter;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
@@ -32,7 +31,7 @@ public class Guava_ITest {
 	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File file = new File(TestPathHelper.GUAVA);
 		ChromatogramImportConverter chromatogramImportConverter = new ChromatogramImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_0_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_0_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.database.DatabaseConverter;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
@@ -35,7 +34,7 @@ public class Heptane_0_ITest {
 	private IMassSpectra massSpectra;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File file = new File(TestPathHelper.HEPTANE_0);
 		IProcessingInfo<IMassSpectra> processingInfo = DatabaseConverter.convert(file, new NullProgressMonitor());

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_1_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.database.DatabaseConverter;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
@@ -36,7 +35,7 @@ public class Heptane_1_ITest {
 	private IMassSpectra massSpectra;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex1(SeparationColumnType.NON_POLAR);
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex2(SeparationColumnType.POLAR);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_2_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_2_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.database.DatabaseConverter;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
@@ -36,7 +35,7 @@ public class Heptane_2_ITest {
 	private IMassSpectra massSpectra;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex1(SeparationColumnType.NON_POLAR);
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex2(SeparationColumnType.POLAR);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_3_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_3_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.database.DatabaseConverter;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
@@ -36,7 +35,7 @@ public class Heptane_3_ITest {
 	private IMassSpectra massSpectra;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex1(SeparationColumnType.NON_POLAR);
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex2(SeparationColumnType.POLAR);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_X_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Heptane_X_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.msd.converter.database.DatabaseConverter;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
@@ -36,7 +35,7 @@ public class Heptane_X_ITest {
 	private IMassSpectra massSpectra;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex1(SeparationColumnType.NON_POLAR);
 		PreferenceSupplier.setSeparationColumnTypeRetentionIndex2(SeparationColumnType.POLAR);

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/JCAMPTestPolys_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/JCAMPTestPolys_ITest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.converter.ScanImportConverter;
@@ -33,7 +32,7 @@ public class JCAMPTestPolys_ITest {
 	private ISpectrumVSD spectrumVSD;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File file = new File(TestPathHelper.JTPOLYS);
 		ScanImportConverter importConverter = new ScanImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Lime_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Lime_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.xxd.converter.supplier.jcampdx;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.csd.converter.supplier.jcampdx.converter.ChromatogramImportConverter;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
@@ -32,7 +31,7 @@ public class Lime_ITest {
 	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File file = new File(TestPathHelper.LIME);
 		ChromatogramImportConverter chromatogramImportConverter = new ChromatogramImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/PacDecreasing_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/PacDecreasing_ITest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.converter.supplier.jcampdx.converter.ScanImportConverter;
@@ -33,7 +32,7 @@ public class PacDecreasing_ITest {
 	private ISpectrumVSD spectrumVSD;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File file = new File(TestPathHelper.PACDEC1);
 		ScanImportConverter importConverter = new ScanImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/PassionFruit_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/PassionFruit_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.xxd.converter.supplier.jcampdx;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.csd.converter.supplier.jcampdx.converter.ChromatogramImportConverter;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
@@ -32,7 +31,7 @@ public class PassionFruit_ITest {
 	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File file = new File(TestPathHelper.PASSION_FRUIT);
 		ChromatogramImportConverter chromatogramImportConverter = new ChromatogramImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Pepsi_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Pepsi_ITest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.supplier.jcampdx.converter.ScanImportConverter;
@@ -33,7 +32,7 @@ public class Pepsi_ITest {
 	private ISpectrumWSD spectrumWSD;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File file = new File(TestPathHelper.PEPSI);
 		ScanImportConverter importConverter = new ScanImportConverter();

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Piment_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/src/org/eclipse/chemclipse/xxd/converter/supplier/jcampdx/Piment_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.xxd.converter.supplier.jcampdx;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.chemclipse.csd.converter.supplier.jcampdx.converter.ChromatogramImportConverter;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
@@ -32,7 +31,7 @@ public class Piment_ITest {
 	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public void setUp() throws IOException {
+	public void setUp() {
 
 		File file = new File(TestPathHelper.PIMENT);
 		ChromatogramImportConverter chromatogramImportConverter = new ChromatogramImportConverter();


### PR DESCRIPTION
The main problem is actually a proprietary ZIP-based vendor format sharing the same extension.