### PR TITLE
Reduce Platform static access

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.logging/src/org/eclipse/chemclipse/logging/core/Category.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.logging/src/org/eclipse/chemclipse/logging/core/Category.java
@@ -1,19 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.logging.core;
 
 import org.eclipse.core.runtime.ILog;
-import org.eclipse.core.runtime.Platform;
 
 public class Category {
 
@@ -21,7 +20,7 @@ public class Category {
 
 	public Category(final Class<?> clazz) {
 
-		logger = Platform.getLog(clazz);
+		logger = ILog.of(clazz);
 	}
 
 	public void error(final String message) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractChromatogram.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractChromatogram.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - use getScans() everywhere to access the scan datastructure, modcount support, analysis segment support
@@ -44,8 +44,8 @@ import org.eclipse.chemclipse.model.updates.IChromatogramUpdateListener;
 import org.eclipse.chemclipse.support.history.EditHistory;
 import org.eclipse.chemclipse.support.history.IEditHistory;
 import org.eclipse.chemclipse.support.model.SeparationColumnType;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.ISafeRunnable;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.SafeRunner;
 
 public abstract class AbstractChromatogram extends AbstractMeasurementTarget implements IChromatogram {
@@ -546,10 +546,9 @@ public abstract class AbstractChromatogram extends AbstractMeasurementTarget imp
 	}
 
 	@Override
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	public Object getAdapter(Class adapter) {
+	public <T> T getAdapter(Class<T> adapter) {
 
-		return Platform.getAdapterManager().getAdapter(this, adapter);
+		return Adapters.adapt(this, adapter);
 	}
 
 	@Override
@@ -726,7 +725,7 @@ public abstract class AbstractChromatogram extends AbstractMeasurementTarget imp
 	 * Sets the master chromatogram. If null is provided, the link
 	 * to the master chromatogram is removed. This method is
 	 * primarily used when adding or removing reference chromatograms.
-	 * 
+	 *
 	 * @param masterChromatogram
 	 */
 	private void setMasterChromatogram(IChromatogram chromatogram, IChromatogram masterChromatogram) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractScan.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractScan.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Alexander Kerner - implementation
@@ -20,7 +20,7 @@ import java.util.Set;
 
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.support.model.SeparationColumnType;
-import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Adapters;
 
 public abstract class AbstractScan extends AbstractSignal implements IScan {
 
@@ -63,7 +63,7 @@ public abstract class AbstractScan extends AbstractSignal implements IScan {
 	/**
 	 * Creates a new instance of {@code AbstractScan} by creating a
 	 * shallow copy of provided {@code templateScan}.
-	 * 
+	 *
 	 * @param templateScan
 	 *            {@link IScan scan} that is used as a template
 	 */
@@ -304,10 +304,9 @@ public abstract class AbstractScan extends AbstractSignal implements IScan {
 	}
 
 	@Override
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	public Object getAdapter(Class adapter) {
+	public <T> T getAdapter(Class<T> adapter) {
 
-		return Platform.getAdapterManager().getAdapter(this, adapter);
+		return Adapters.adapt(this, adapter);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIon.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Alexander Kerner - implementation
@@ -14,7 +14,7 @@
 package org.eclipse.chemclipse.msd.model.core;
 
 import org.eclipse.chemclipse.model.math.IonRoundMethod;
-import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Adapters;
 
 /**
  * All ions implement the interface Serializable to enable an
@@ -215,10 +215,9 @@ public abstract class AbstractIon implements IIon {
 	}
 
 	@Override
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	public Object getAdapter(Class adapter) {
+	public <T> T getAdapter(Class<T> adapter) {
 
-		return Platform.getAdapterManager().getAdapter(this, adapter);
+		return Adapters.adapt(this, adapter);
 	}
 
 	@Override


### PR DESCRIPTION
* Use Adapters.adapt and generify the getAdapter methods
* Use ILog.of() instead of Platform.getLog()