### PR TITLE
Reduce redundant super interfaces

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/settings/PeakIdentifierSettingsCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/src/org/eclipse/chemclipse/chromatogram/csd/identifier/settings/PeakIdentifierSettingsCSD.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.csd.identifier.settings;
 
-public class PeakIdentifierSettingsCSD extends AbstractPeakIdentifierSettingsCSD implements IPeakIdentifierSettingsCSD {
+public class PeakIdentifierSettingsCSD extends AbstractPeakIdentifierSettingsCSD {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/settings/ChromatogramFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/settings/ChromatogramFilterSettings.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.filter.settings;
 
-public class ChromatogramFilterSettings extends AbstractChromatogramFilterSettings implements IChromatogramFilterSettings {
+public class ChromatogramFilterSettings extends AbstractChromatogramFilterSettings {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/result/WncClassifierResult.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/result/WncClassifierResult.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Lablicate GmbH.
+ * Copyright (c) 2011, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -14,10 +14,9 @@ package org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.result;
 
 import org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.model.TargetTraces;
 import org.eclipse.chemclipse.chromatogram.xxd.classifier.result.AbstractChromatogramClassifierResult;
-import org.eclipse.chemclipse.chromatogram.xxd.classifier.result.IChromatogramClassifierResult;
 import org.eclipse.chemclipse.chromatogram.xxd.classifier.result.ResultStatus;
 
-public class WncClassifierResult extends AbstractChromatogramClassifierResult implements IChromatogramClassifierResult {
+public class WncClassifierResult extends AbstractChromatogramClassifierResult {
 
 	private TargetTraces targetTraces;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/AbstractDistanceComparator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/AbstractDistanceComparator.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Matthias Mailänder - abstract
@@ -24,12 +24,11 @@ import org.eclipse.chemclipse.model.identifier.ComparisonResult;
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.MatchConstraints;
 import org.eclipse.chemclipse.msd.identifier.comparison.AbstractMassSpectrumComparator;
-import org.eclipse.chemclipse.msd.identifier.comparison.IMassSpectrumComparator;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.xic.IExtractedIonSignal;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 
-public abstract class AbstractDistanceComparator extends AbstractMassSpectrumComparator implements IMassSpectrumComparator {
+public abstract class AbstractDistanceComparator extends AbstractMassSpectrumComparator {
 
 	abstract DistanceMeasure getDistanceMeasure();
 
@@ -60,7 +59,7 @@ public abstract class AbstractDistanceComparator extends AbstractMassSpectrumCom
 	 * Calculates the distance of both mass spectra.
 	 * 0 : best match
 	 * 1 : no match
-	 * 
+	 *
 	 * @param unknownSignal
 	 * @param referenceSignal
 	 * @param distanceMeasure

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CovarianceComparator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance/src/org/eclipse/chemclipse/chromatogram/msd/comparison/supplier/distance/comparator/CovarianceComparator.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Lablicate GmbH.
+ * Copyright (c) 2024, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
@@ -14,9 +14,8 @@ package org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.com
 
 import org.apache.commons.math3.ml.distance.DistanceMeasure;
 import org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.internal.CovarianceDistance;
-import org.eclipse.chemclipse.msd.identifier.comparison.IMassSpectrumComparator;
 
-public class CovarianceComparator extends AbstractDistanceComparator implements IMassSpectrumComparator {
+public class CovarianceComparator extends AbstractDistanceComparator {
 
 	@Override
 	DistanceMeasure getDistanceMeasure() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/settings/PeakIdentifierSettingsWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/settings/PeakIdentifierSettingsWSD.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.wsd.identifier.settings;
 
-public class PeakIdentifierSettingsWSD extends AbstractPeakIdentifierSettingsWSD implements IPeakIdentifierSettingsWSD {
+public class PeakIdentifierSettingsWSD extends AbstractPeakIdentifierSettingsWSD {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/core/ChromatogramExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/core/ChromatogramExportConverter.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -20,13 +20,12 @@ import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.io
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.settings.IndexExportSettings;
 import org.eclipse.chemclipse.converter.chromatogram.AbstractChromatogramExportConverter;
-import org.eclipse.chemclipse.converter.chromatogram.IChromatogramExportConverter;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class ChromatogramExportConverter extends AbstractChromatogramExportConverter implements IChromatogramExportConverter {
+public class ChromatogramExportConverter extends AbstractChromatogramExportConverter {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramExportConverter.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/settings/ChromatogramCalculatorSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/settings/ChromatogramCalculatorSettings.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.calculator.settings;
 
-public class ChromatogramCalculatorSettings extends AbstractChromatogramCalculatorSettings implements IChromatogramCalculatorSettings {
+public class ChromatogramCalculatorSettings extends AbstractChromatogramCalculatorSettings {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/baselinesubtract/core/BaselineFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/baselinesubtract/core/BaselineFilter.java
@@ -1,19 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.core;
 
 import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.AbstractChromatogramFilter;
-import org.eclipse.chemclipse.chromatogram.filter.core.chromatogram.IChromatogramFilter;
 import org.eclipse.chemclipse.chromatogram.filter.result.IChromatogramFilterResult;
 import org.eclipse.chemclipse.chromatogram.filter.settings.IChromatogramFilterSettings;
 import org.eclipse.chemclipse.model.baseline.IBaselineModel;
@@ -24,7 +23,7 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class BaselineFilter extends AbstractChromatogramFilter implements IChromatogramFilter {
+public class BaselineFilter extends AbstractChromatogramFilter {
 
 	@Override
 	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/ChromatogramIntegrationResult.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/ChromatogramIntegrationResult.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -14,7 +14,7 @@ package org.eclipse.chemclipse.chromatogram.xxd.integrator.result;
 
 import org.eclipse.chemclipse.msd.model.core.IIon;
 
-public class ChromatogramIntegrationResult extends AbstractChromatogramIntegrationResult implements IChromatogramIntegrationResult {
+public class ChromatogramIntegrationResult extends AbstractChromatogramIntegrationResult {
 
 	public ChromatogramIntegrationResult(double ion, double chromatogramArea, double backgroundArea) {
 
@@ -23,7 +23,7 @@ public class ChromatogramIntegrationResult extends AbstractChromatogramIntegrati
 
 	/**
 	 * Set the TIC result.
-	 * 
+	 *
 	 * @param chromatogramArea
 	 * @param backgroundArea
 	 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/ChromatogramIntegrationResults.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/ChromatogramIntegrationResults.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.integrator.result;
 
-public class ChromatogramIntegrationResults extends AbstractChromatogramIntegrationResults implements IChromatogramIntegrationResults {
+public class ChromatogramIntegrationResults extends AbstractChromatogramIntegrationResults {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/CombinedIntegrationResult.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/CombinedIntegrationResult.java
@@ -1,18 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.integrator.result;
 
-public class CombinedIntegrationResult extends AbstractCombinedIntegrationResult implements ICombinedIntegrationResult {
+public class CombinedIntegrationResult extends AbstractCombinedIntegrationResult {
 
 	public CombinedIntegrationResult(IChromatogramIntegrationResults chromatogramIntegrationResults, IPeakIntegrationResults peakIntegrationResults) {
 		super(chromatogramIntegrationResults, peakIntegrationResults);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/PeakIntegrationResult.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/PeakIntegrationResult.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.integrator.result;
 
-public class PeakIntegrationResult extends AbstractPeakIntegrationResult implements IPeakIntegrationResult {
+public class PeakIntegrationResult extends AbstractPeakIntegrationResult {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/PeakIntegrationResults.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/PeakIntegrationResults.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.integrator.result;
 
-public class PeakIntegrationResults extends AbstractPeakIntegrationResults implements IPeakIntegrationResults {
+public class PeakIntegrationResults extends AbstractPeakIntegrationResults {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse/src/org/eclipse/chemclipse/chromatogram/xxd/quantitation/supplier/chemclipse/core/PeakQuantifierISTD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse/src/org/eclipse/chemclipse/chromatogram/xxd/quantitation/supplier/chemclipse/core/PeakQuantifierISTD.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.xxd.quantitation.core.AbstractPeakQuantifier;
-import org.eclipse.chemclipse.chromatogram.xxd.quantitation.core.IPeakQuantifier;
 import org.eclipse.chemclipse.chromatogram.xxd.quantitation.settings.IPeakQuantifierSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse.internal.core.PeakQuantitationCalculatorISTD;
 import org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse.preferences.PreferenceSupplier;
@@ -26,7 +25,7 @@ import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class PeakQuantifierISTD extends AbstractPeakQuantifier implements IPeakQuantifier {
+public class PeakQuantifierISTD extends AbstractPeakQuantifier {
 
 	private PeakQuantitationCalculatorISTD calculatorISTD = new PeakQuantitationCalculatorISTD();
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/src/org/eclipse/chemclipse/chromatogram/xxd/report/core/ChromatogramReportSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/src/org/eclipse/chemclipse/chromatogram/xxd/report/core/ChromatogramReportSupplier.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.report.core;
 
-public class ChromatogramReportSupplier extends AbstractChromatogramReportSupplier implements IChromatogramReportSupplier {
+public class ChromatogramReportSupplier extends AbstractChromatogramReportSupplier {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/src/org/eclipse/chemclipse/chromatogram/xxd/report/core/ChromatogramReportSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/src/org/eclipse/chemclipse/chromatogram/xxd/report/core/ChromatogramReportSupport.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.report.core;
 
-public class ChromatogramReportSupport extends AbstractChromatogramReportSupport implements IChromatogramReportSupportSetter {
+public class ChromatogramReportSupport extends AbstractChromatogramReportSupport {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.xy/src/org/eclipse/chemclipse/csd/converter/supplier/xy/core/ChromatogramExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.xy/src/org/eclipse/chemclipse/csd/converter/supplier/xy/core/ChromatogramExportConverter.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.util.List;
 
 import org.eclipse.chemclipse.converter.chromatogram.AbstractChromatogramExportConverter;
-import org.eclipse.chemclipse.converter.chromatogram.IChromatogramExportConverter;
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
 import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.csd.converter.io.IChromatogramCSDWriter;
@@ -29,7 +28,7 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.osgi.util.NLS;
 
-public class ChromatogramExportConverter extends AbstractChromatogramExportConverter implements IChromatogramExportConverter {
+public class ChromatogramExportConverter extends AbstractChromatogramExportConverter {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramExportConverter.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter/src/org/eclipse/chemclipse/csd/converter/chromatogram/ChromatogramConverterCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter/src/org/eclipse/chemclipse/csd/converter/chromatogram/ChromatogramConverterCSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Alexander Kerner - Generics
@@ -23,7 +23,7 @@ import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class ChromatogramConverterCSD extends AbstractChromatogramConverter<IChromatogramPeakCSD, IChromatogramCSD> implements IChromatogramConverter<IChromatogramPeakCSD, IChromatogramCSD> {
+public class ChromatogramConverterCSD extends AbstractChromatogramConverter<IChromatogramPeakCSD, IChromatogramCSD> {
 
 	private static IChromatogramConverter<IChromatogramPeakCSD, IChromatogramCSD> instance = null;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/implementation/ChromatogramCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/implementation/ChromatogramCSD.java
@@ -1,21 +1,20 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.csd.model.implementation;
 
 import org.eclipse.chemclipse.csd.model.core.AbstractChromatogramCSD;
-import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 
-public class ChromatogramCSD extends AbstractChromatogramCSD implements IChromatogramCSD {
+public class ChromatogramCSD extends AbstractChromatogramCSD {
 
 	private static final long serialVersionUID = -5133287349482286074L;
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/implementation/ChromatogramPeakCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/implementation/ChromatogramPeakCSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -14,11 +14,10 @@ package org.eclipse.chemclipse.csd.model.implementation;
 
 import org.eclipse.chemclipse.csd.model.core.AbstractChromatogramPeakCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
-import org.eclipse.chemclipse.csd.model.core.IChromatogramPeakCSD;
 import org.eclipse.chemclipse.csd.model.core.IPeakModelCSD;
 import org.eclipse.chemclipse.model.exceptions.PeakException;
 
-public class ChromatogramPeakCSD extends AbstractChromatogramPeakCSD implements IChromatogramPeakCSD {
+public class ChromatogramPeakCSD extends AbstractChromatogramPeakCSD {
 
 	public ChromatogramPeakCSD(IPeakModelCSD peakModel, IChromatogramCSD chromatogram) throws IllegalArgumentException, PeakException {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/implementation/PeakCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/implementation/PeakCSD.java
@@ -1,22 +1,21 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 Lablicate GmbH.
+ * Copyright (c) 2022, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.csd.model.implementation;
 
 import org.eclipse.chemclipse.csd.model.core.AbstractPeakCSD;
-import org.eclipse.chemclipse.csd.model.core.IPeakCSD;
 import org.eclipse.chemclipse.csd.model.core.IPeakModelCSD;
 
-public class PeakCSD extends AbstractPeakCSD implements IPeakCSD {
+public class PeakCSD extends AbstractPeakCSD {
 
 	public PeakCSD(IPeakModelCSD peakModel, String modelDescription) throws IllegalArgumentException {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/implementation/PeakModelCSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/src/org/eclipse/chemclipse/csd/model/implementation/PeakModelCSD.java
@@ -6,19 +6,18 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.csd.model.implementation;
 
 import org.eclipse.chemclipse.csd.model.core.AbstractPeakModelCSD;
-import org.eclipse.chemclipse.csd.model.core.IPeakModelCSD;
 import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.exceptions.PeakException;
 
-public class PeakModelCSD extends AbstractPeakModelCSD implements IPeakModelCSD {
+public class PeakModelCSD extends AbstractPeakModelCSD {
 
 	private static final long serialVersionUID = 9110628073033467778L;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.fsd.converter/src/org/eclipse/chemclipse/fsd/converter/chromatogram/ChromatogramConverterFSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.fsd.converter/src/org/eclipse/chemclipse/fsd/converter/chromatogram/ChromatogramConverterFSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
@@ -20,7 +20,7 @@ import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class ChromatogramConverterFSD extends AbstractChromatogramConverter<IChromatogramPeakFSD, IChromatogramFSD> implements IChromatogramConverter<IChromatogramPeakFSD, IChromatogramFSD> {
+public class ChromatogramConverterFSD extends AbstractChromatogramConverter<IChromatogramPeakFSD, IChromatogramFSD> {
 
 	private static IChromatogramConverter<IChromatogramPeakFSD, IChromatogramFSD> instance = null;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.fsd.model/src/org/eclipse/chemclipse/fsd/model/core/implementation/ScanFSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.fsd.model/src/org/eclipse/chemclipse/fsd/model/core/implementation/ScanFSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
@@ -14,7 +14,7 @@ package org.eclipse.chemclipse.fsd.model.core.implementation;
 
 import org.eclipse.chemclipse.fsd.model.core.IScanFSD;
 
-public class ScanFSD extends AbstractScanFSD implements IScanFSD {
+public class ScanFSD extends AbstractScanFSD {
 
 	/**
 	 * Renew the serialVersionUID any time you have changed some fields or

--- a/chemclipse/plugins/org.eclipse.chemclipse.fsd.model/src/org/eclipse/chemclipse/fsd/model/core/implementation/ScanSignalFSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.fsd.model/src/org/eclipse/chemclipse/fsd/model/core/implementation/ScanSignalFSD.java
@@ -1,20 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.fsd.model.core.implementation;
 
-import org.eclipse.chemclipse.fsd.model.core.IScanSignalFSD;
-
-public class ScanSignalFSD extends AbstractScanSignalFSD implements IScanSignalFSD {
+public class ScanSignalFSD extends AbstractScanSignalFSD {
 
 	private static final long serialVersionUID = -3273447342785680772L;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractMeasurement.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractMeasurement.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - improve serializable support
@@ -21,7 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-public abstract class AbstractMeasurement extends AbstractMeasurementInfo implements IMeasurement, IMeasurementInfo {
+public abstract class AbstractMeasurement extends AbstractMeasurementInfo implements IMeasurement {
 
 	private static final long serialVersionUID = 3213312019738373785L;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeakIntensityValues.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeakIntensityValues.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -24,7 +24,7 @@ import java.util.TreeMap;
 import org.eclipse.chemclipse.model.exceptions.PeakException;
 import org.eclipse.chemclipse.numeric.equations.LinearEquation;
 
-public abstract class AbstractPeakIntensityValues extends AbstractPeakIntensityValuesStrict implements IPeakIntensityValues {
+public abstract class AbstractPeakIntensityValues extends AbstractPeakIntensityValuesStrict {
 
 	private static final long serialVersionUID = 8193494258780090715L;
 
@@ -49,7 +49,7 @@ public abstract class AbstractPeakIntensityValues extends AbstractPeakIntensityV
 	 * Prefer to use the normal constructor.
 	 * If this constructor is used, please use the normalize() method,
 	 * after setting all intensity values.
-	 * 
+	 *
 	 * @param maxIntensity
 	 */
 	public AbstractPeakIntensityValues(float maxIntensity) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeakModel.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeakModel.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -24,7 +24,7 @@ import org.eclipse.chemclipse.numeric.core.Point;
 import org.eclipse.chemclipse.numeric.equations.Equations;
 import org.eclipse.chemclipse.numeric.equations.LinearEquation;
 
-public abstract class AbstractPeakModel extends AbstractPeakModelStrict implements IPeakModel {
+public abstract class AbstractPeakModel extends AbstractPeakModelStrict {
 
 	/**
 	 * Renew the UUID on change.
@@ -69,7 +69,7 @@ public abstract class AbstractPeakModel extends AbstractPeakModelStrict implemen
 	 * peak. The background should not be considered in the peak maximum. So the
 	 * peak maximum represents the pure maybe deconvoluted mass spectrum for the
 	 * actual peak.<br/>
-	 * 
+	 *
 	 * @param peakMaximum
 	 * @param peakIntensityValues
 	 * @param startBackgroundAbundance
@@ -324,7 +324,7 @@ public abstract class AbstractPeakModel extends AbstractPeakModelStrict implemen
 	 * beginning to the end.<br/>
 	 * If the gradient angle (alpha) is positive, the baseline decreases from
 	 * the beginning to the end.
-	 * 
+	 *
 	 * @return double
 	 */
 	private double calculateGradientAngle() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IChromatogram.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IChromatogram.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - allow chromatogram to be marked as dirty, support for analysis segments
@@ -26,13 +26,12 @@ import org.eclipse.chemclipse.model.support.IScanRange;
 import org.eclipse.chemclipse.model.targets.ITargetDisplaySettings;
 import org.eclipse.chemclipse.model.updates.IUpdater;
 import org.eclipse.chemclipse.support.history.ISupplierEditHistory;
-import org.eclipse.core.runtime.IAdaptable;
 
 /**
  * A chromatogram consists of several scans. This is the detector
  * independent part of it.
  */
-public interface IChromatogram extends SegmentedMeasurement, IMeasurement, IChromatogramOverview, IAdaptable, IChromatogramPeaks, ISupplierEditHistory, IChromatogramBaseline, IUpdater, IChromatogramIntegrationSupport, IChromatogramProcessorSupport, ITargetSupplier, ITargetDisplaySettings {
+public interface IChromatogram extends SegmentedMeasurement, IChromatogramOverview, IChromatogramPeaks, ISupplierEditHistory, IChromatogramBaseline, IUpdater, IChromatogramIntegrationSupport, IChromatogramProcessorSupport, ITargetSupplier, ITargetDisplaySettings {
 
 	String DEFAULT_CHROMATOGRAM_NAME = "Chromatogram";
 	int MIN_SCANDELAY = 0;

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IMeasurement.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IMeasurement.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - add default file / dirty methods
@@ -14,11 +14,10 @@
 package org.eclipse.chemclipse.model.core;
 
 import java.io.File;
-import java.io.Serializable;
 
 import org.eclipse.core.runtime.IAdaptable;
 
-public interface IMeasurement extends IMeasurementInfo, IMeasurementResultSupport, Serializable, IAdaptable {
+public interface IMeasurement extends IMeasurementInfo, IMeasurementResultSupport, IAdaptable {
 
 	/**
 	 * Measurements might adapt to different other specialized objects
@@ -30,7 +29,7 @@ public interface IMeasurement extends IMeasurementInfo, IMeasurementResultSuppor
 	}
 
 	/**
-	 * 
+	 *
 	 * @return the file this measurement was loaded from or <code>null</code> if no file could be determined
 	 */
 	default File getFile() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/ChromatogramComparisonResult.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/ChromatogramComparisonResult.java
@@ -1,18 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.model.identifier;
 
-public class ChromatogramComparisonResult extends AbstractChromatogramComparisonResult implements IChromatogramComparisonResult {
+public class ChromatogramComparisonResult extends AbstractChromatogramComparisonResult {
 
 	/**
 	 * Renew the UUID on change.

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/ChromatogramIdentificationResult.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/ChromatogramIdentificationResult.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.model.identifier;
 
-public class ChromatogramIdentificationResult extends AbstractChromatogramIdentificationResult implements IChromatogramIdentificationResult {
+public class ChromatogramIdentificationResult extends AbstractChromatogramIdentificationResult {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/ChromatogramIdentificationResults.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/ChromatogramIdentificationResults.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.model.identifier;
 
-public class ChromatogramIdentificationResults extends AbstractChromatogramIdentificationResults implements IChromatogramIdentificationResults {
+public class ChromatogramIdentificationResults extends AbstractChromatogramIdentificationResults {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/ChromatogramLibraryInformation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/ChromatogramLibraryInformation.java
@@ -1,18 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.model.identifier;
 
-public class ChromatogramLibraryInformation extends AbstractChromatogramLibraryInformation implements IChromatogramLibraryInformation {
+public class ChromatogramLibraryInformation extends AbstractChromatogramLibraryInformation {
 
 	/**
 	 * Renew the UUID on change.

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/PeakComparisonResult.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/PeakComparisonResult.java
@@ -1,19 +1,19 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Alexander Kerner - implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.model.identifier;
 
-public class PeakComparisonResult extends AbstractPeakComparisonResult implements IPeakComparisonResult {
+public class PeakComparisonResult extends AbstractPeakComparisonResult {
 
 	/**
 	 * Renew the UUID on change.

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/PeakIdentificationResults.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/PeakIdentificationResults.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.model.identifier;
 
-public class PeakIdentificationResults extends AbstractPeakIdentificationResults implements IPeakIdentificationResults {
+public class PeakIdentificationResults extends AbstractPeakIdentificationResults {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/PeakLibraryInformation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/PeakLibraryInformation.java
@@ -1,18 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.model.identifier;
 
-public class PeakLibraryInformation extends AbstractPeakLibraryInformation implements IPeakLibraryInformation {
+public class PeakLibraryInformation extends AbstractPeakLibraryInformation {
 
 	private static final long serialVersionUID = -3906203071580913298L;
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/peak/PeakIdentifierSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/peak/PeakIdentifierSettings.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.model.identifier.peak;
 
-public class PeakIdentifierSettings extends AbstractPeakIdentifierSettings implements IPeakIdentifierSettings {
+public class PeakIdentifierSettings extends AbstractPeakIdentifierSettings {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/implementation/Chromatogram.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/implementation/Chromatogram.java
@@ -1,26 +1,25 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.model.implementation;
 
 import org.eclipse.chemclipse.model.core.AbstractChromatogram;
-import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.INoiseCalculator;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 
 /**
  * Chromatogram shall be used only for testing purposes.
  */
-public class Chromatogram extends AbstractChromatogram implements IChromatogram {
+public class Chromatogram extends AbstractChromatogram {
 
 	private static final long serialVersionUID = -8477205385713705933L;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/implementation/MeasurementResult.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/implementation/MeasurementResult.java
@@ -1,21 +1,20 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.model.implementation;
 
 import org.eclipse.chemclipse.model.core.AbstractMeasurementResult;
-import org.eclipse.chemclipse.model.core.IMeasurementResult;
 
-public class MeasurementResult extends AbstractMeasurementResult<Object> implements IMeasurementResult<Object> {
+public class MeasurementResult extends AbstractMeasurementResult<Object> {
 
 	private static final long serialVersionUID = -8311848081084150204L;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/implementation/Peak.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/implementation/Peak.java
@@ -1,22 +1,21 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.model.implementation;
 
 import org.eclipse.chemclipse.model.core.AbstractPeak;
-import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IPeakModel;
 
-public class Peak extends AbstractPeak implements IPeak {
+public class Peak extends AbstractPeak {
 
 	private IPeakModel peakModel;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/implementation/PeakIntensityValues.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/implementation/PeakIntensityValues.java
@@ -1,21 +1,20 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.model.implementation;
 
 import org.eclipse.chemclipse.model.core.AbstractPeakIntensityValues;
-import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
 
-public class PeakIntensityValues extends AbstractPeakIntensityValues implements IPeakIntensityValues {
+public class PeakIntensityValues extends AbstractPeakIntensityValues {
 
 	private static final long serialVersionUID = 8596503209176077779L;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/implementation/PeakModel.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/implementation/PeakModel.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -14,11 +14,10 @@ package org.eclipse.chemclipse.model.implementation;
 
 import org.eclipse.chemclipse.model.core.AbstractPeakModel;
 import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
-import org.eclipse.chemclipse.model.core.IPeakModel;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.exceptions.PeakException;
 
-public class PeakModel extends AbstractPeakModel implements IPeakModel {
+public class PeakModel extends AbstractPeakModel {
 
 	private static final long serialVersionUID = -5942483159915658483L;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/implementation/Scan.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/implementation/Scan.java
@@ -1,21 +1,20 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.model.implementation;
 
 import org.eclipse.chemclipse.model.core.AbstractScan;
-import org.eclipse.chemclipse.model.core.IScan;
 
-public class Scan extends AbstractScan implements IScan {
+public class Scan extends AbstractScan {
 
 	/**
 	 * Renew the serialVersionUID any time you have changed some fields or

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/selection/ChromatogramSelection.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/selection/ChromatogramSelection.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Alexander Kerner - Generics
@@ -25,7 +25,7 @@ import org.eclipse.chemclipse.model.exceptions.ChromatogramIsNullException;
  * by a mass selective, a flame ionization or another detector.
  *
  */
-public class ChromatogramSelection extends AbstractChromatogramSelection implements IChromatogramSelection {
+public class ChromatogramSelection extends AbstractChromatogramSelection {
 
 	public ChromatogramSelection(IChromatogram chromatogram, boolean fireUpdate) throws ChromatogramIsNullException {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak/src/org/eclipse/chemclipse/msd/classifier/supplier/molpeak/settings/PeakIdentifierSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak/src/org/eclipse/chemclipse/msd/classifier/supplier/molpeak/settings/PeakIdentifierSettings.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Dr. Lorenz Gerber - initial API and implementation
  * Philip Wenig - initial API and implementation
@@ -15,5 +15,5 @@ package org.eclipse.chemclipse.msd.classifier.supplier.molpeak.settings;
 
 import org.eclipse.chemclipse.chromatogram.msd.identifier.settings.IPeakIdentifierSettingsMSD;
 
-public class PeakIdentifierSettings extends AbstractBasePeakSettings implements IPeakIdentifierSettingsMSD, IBasePeakSettings {
+public class PeakIdentifierSettings extends AbstractBasePeakSettings implements IPeakIdentifierSettingsMSD {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/io/MSPReader.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -34,7 +34,6 @@ import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
-import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.misc.CompoundInformation;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.misc.ConverterCID;
 import org.eclipse.chemclipse.msd.converter.supplier.amdis.converter.misc.ConverterMOL;
@@ -49,7 +48,7 @@ import org.eclipse.chemclipse.msd.model.implementation.Ion;
 import org.eclipse.chemclipse.msd.model.implementation.MassSpectra;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class MSPReader extends AbstractMassSpectraReader implements IMassSpectraReader {
+public class MSPReader extends AbstractMassSpectraReader {
 
 	private static final Logger logger = Logger.getLogger(MSPReader.class);
 	private static final String CONVERTER_ID = "org.eclipse.chemclipse.msd.converter.supplier.amdis.massspectrum.msp";
@@ -126,7 +125,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 
 	/**
 	 * Returns an indexed map of mass spectral data so it can be sorted afterward.
-	 * 
+	 *
 	 * @throws IOException
 	 */
 	private ConcurrentHashMap<Integer, String> getMassSpectraData(File file) throws IOException {
@@ -167,7 +166,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 	/**
 	 * Adds the content from the StringBuilder to the mass spectra data list, if
 	 * the length is > 0.
-	 * 
+	 *
 	 * @param builder
 	 * @param massSpectraData
 	 */
@@ -182,7 +181,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 
 	/**
 	 * Adds parsed mass spectra to the massSpectra object.
-	 * 
+	 *
 	 * @param massSpectra
 	 * @param massSpectraData
 	 * @param monitor
@@ -234,7 +233,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 
 	/**
 	 * Detect a mass spectrum and add it to the given mass spectra.
-	 * 
+	 *
 	 * @param massSpectra
 	 * @param massSpectrumData
 	 */
@@ -339,7 +338,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 	/**
 	 * Extracts all ion from the given mass spectrum data and stores
 	 * them in the given mass spectrum.
-	 * 
+	 *
 	 * @param massSpectrum
 	 * @param massSpectrumData
 	 */
@@ -375,7 +374,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 	/**
 	 * Extracts the content from the given mass spectrum string defined by the
 	 * given pattern.
-	 * 
+	 *
 	 * @param massSpectrumData
 	 * @return String
 	 */
@@ -391,7 +390,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 
 	/**
 	 * Extracts the synonyms from the mass spectrum.
-	 * 
+	 *
 	 * @param massSpectrumData
 	 * @param pattern
 	 * @return {@link Set}
@@ -410,7 +409,7 @@ public class MSPReader extends AbstractMassSpectraReader implements IMassSpectra
 	/**
 	 * Extracts the content from the given mass spectrum string defined by the
 	 * given pattern.
-	 * 
+	 *
 	 * @param massSpectrumData
 	 * @return int
 	 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.cml/src/org/eclipse/chemclipse/msd/converter/supplier/cml/converter/DatabaseFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.cml/src/org/eclipse/chemclipse/msd/converter/supplier/cml/converter/DatabaseFileContentMatcher.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Lablicate GmbH.
+ * Copyright (c) 2024, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
@@ -20,9 +20,8 @@ import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
-import org.eclipse.chemclipse.converter.core.IFileContentMatcher;
 
-public class DatabaseFileContentMatcher extends AbstractFileContentMatcher implements IFileContentMatcher {
+public class DatabaseFileContentMatcher extends AbstractFileContentMatcher {
 
 	@Override
 	public boolean checkFileFormat(File file) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.excel/src/org/eclipse/chemclipse/msd/converter/supplier/excel/io/ChromatogramReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.excel/src/org/eclipse/chemclipse/msd/converter/supplier/excel/io/ChromatogramReader.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Lablicate GmbH.
+ * Copyright (c) 2011, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -18,7 +18,6 @@ import java.io.IOException;
 import org.apache.poi.ss.formula.eval.NotImplementedException;
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.msd.converter.io.AbstractChromatogramMSDReader;
-import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
@@ -26,7 +25,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * This class is responsible to read a Excel Chromatogram from its binary
  * file.
  */
-public class ChromatogramReader extends AbstractChromatogramMSDReader implements IChromatogramMSDReader {
+public class ChromatogramReader extends AbstractChromatogramMSDReader {
 
 	public ChromatogramReader() {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramFileContentMatcher.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Matthias Mailänder - auto detection for chromatography files
@@ -19,13 +19,12 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
-import org.eclipse.chemclipse.converter.core.IFileContentMatcher;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.io.ReaderVersion105;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
-public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher implements IFileContentMatcher {
+public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher {
 
 	@Override
 	public boolean checkFileFormat(File file) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion104.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion104.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
@@ -21,7 +21,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
-import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.v104.model.AcqDescType;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.v104.model.AcqDescType.PrecursorList;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.v104.model.AcqSettingsType.AcqInstrument;
@@ -56,7 +55,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 
-public class ChromatogramReaderVersion104 extends AbstractChromatogramReader implements IChromatogramMSDReader {
+public class ChromatogramReaderVersion104 extends AbstractChromatogramReader {
 
 	public static final String VERSION = "1.04";
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion105.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion105.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
@@ -21,7 +21,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
-import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.v105.model.AdminType;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.v105.model.CvParamType;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.v105.model.DataProcessingType;
@@ -57,7 +56,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 
-public class ChromatogramReaderVersion105 extends AbstractChromatogramReader implements IChromatogramMSDReader {
+public class ChromatogramReaderVersion105 extends AbstractChromatogramReader {
 
 	public static final String VERSION = "1.05";
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/io/AbstractChromatogramReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/io/AbstractChromatogramReader.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
@@ -31,14 +31,13 @@ import javax.xml.stream.events.XMLEvent;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.msd.converter.io.AbstractChromatogramMSDReader;
-import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorScan;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public abstract class AbstractChromatogramReader extends AbstractChromatogramMSDReader implements IChromatogramMSDReader {
+public abstract class AbstractChromatogramReader extends AbstractChromatogramMSDReader {
 
 	private static final Logger logger = Logger.getLogger(AbstractChromatogramReader.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/io/ChromatogramReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/io/ChromatogramReader.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Matthias Mailänder - functional reader for specification version 1.05
@@ -26,7 +26,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.io.Chromato
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class ChromatogramReader extends AbstractChromatogramMSDReader implements IChromatogramMSDReader {
+public class ChromatogramReader extends AbstractChromatogramMSDReader {
 
 	public static IChromatogramMSDReader getReader(final File file) throws IOException {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramExportConverter.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -16,7 +16,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.chemclipse.converter.chromatogram.AbstractChromatogramExportConverter;
-import org.eclipse.chemclipse.converter.chromatogram.IChromatogramExportConverter;
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
 import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
@@ -28,7 +27,7 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.osgi.util.NLS;
 
-public class ChromatogramExportConverter extends AbstractChromatogramExportConverter implements IChromatogramExportConverter {
+public class ChromatogramExportConverter extends AbstractChromatogramExportConverter {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramExportConverter.class);
 	private static final String DESCRIPTION = "mzML Chromatogram Export Converter";

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramFileContentMatcher.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Matthias Mailänder - auto detection for chromatography files
@@ -21,9 +21,8 @@ import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
-import org.eclipse.chemclipse.converter.core.IFileContentMatcher;
 
-public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher implements IFileContentMatcher {
+public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher {
 
 	@Override
 	public boolean checkFileFormat(File file) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/io/ChromatogramReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/io/ChromatogramReader.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Matthias Mailänder - functional reader for specification version 1.10
@@ -28,7 +28,7 @@ import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.XmlReader10;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.XmlReader110;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class ChromatogramReader extends AbstractChromatogramMSDReader implements IChromatogramMSDReader {
+public class ChromatogramReader extends AbstractChromatogramMSDReader {
 
 	public static IChromatogramMSDReader getReader(final File file) throws IOException {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramFileContentMatcher.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Matthias Mailänder - auto detection for chromatography files
@@ -19,12 +19,11 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
-import org.eclipse.chemclipse.converter.core.IFileContentMatcher;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.AbstractReader;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 
-public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher implements IFileContentMatcher {
+public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher {
 
 	@Override
 	public boolean checkFileFormat(File file) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/AbstractChromatogramReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/AbstractChromatogramReader.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -31,7 +31,6 @@ import javax.xml.stream.events.XMLEvent;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.msd.converter.io.AbstractChromatogramMSDReader;
-import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorChromatogram;
@@ -40,7 +39,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public abstract class AbstractChromatogramReader extends AbstractChromatogramMSDReader implements IChromatogramMSDReader {
+public abstract class AbstractChromatogramReader extends AbstractChromatogramMSDReader {
 
 	private static final Logger logger = Logger.getLogger(AbstractChromatogramReader.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion20.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion20.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -22,7 +22,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v20.model.DataProcessing;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v20.model.MsInstrument;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v20.model.MsRun;
@@ -51,7 +50,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 
-public class ChromatogramReaderVersion20 extends AbstractChromatogramReader implements IChromatogramMSDReader {
+public class ChromatogramReaderVersion20 extends AbstractChromatogramReader {
 
 	public static final String VERSION = "mzXML_2.0";
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion21.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion21.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -22,7 +22,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.DataProcessing;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.MsInstrument;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v21.model.MsRun;
@@ -51,7 +50,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 
-public class ChromatogramReaderVersion21 extends AbstractChromatogramReader implements IChromatogramMSDReader {
+public class ChromatogramReaderVersion21 extends AbstractChromatogramReader {
 
 	public static final String VERSION = "mzXML_2.1";
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion22.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -22,7 +22,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.DataProcessing;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.MsInstrument;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v22.model.MsRun;
@@ -51,7 +50,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 
-public class ChromatogramReaderVersion22 extends AbstractChromatogramReader implements IChromatogramMSDReader {
+public class ChromatogramReaderVersion22 extends AbstractChromatogramReader {
 
 	public static final String VERSION = "mzXML_2.2";
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion30.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion30.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -23,7 +23,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v30.model.DataProcessing;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v30.model.MsInstrument;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v30.model.MsRun;
@@ -52,7 +51,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 
-public class ChromatogramReaderVersion30 extends AbstractChromatogramReader implements IChromatogramMSDReader {
+public class ChromatogramReaderVersion30 extends AbstractChromatogramReader {
 
 	public static final String VERSION = "mzXML_3.0";
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion31.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion31.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -23,7 +23,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v31.model.DataProcessing;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v31.model.MsInstrument;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v31.model.MsRun;
@@ -52,7 +51,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 
-public class ChromatogramReaderVersion31 extends AbstractChromatogramReader implements IChromatogramMSDReader {
+public class ChromatogramReaderVersion31 extends AbstractChromatogramReader {
 
 	public static final String VERSION = "mzXML_3.1";
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion32.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion32.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -24,7 +24,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v32.model.DataProcessing;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v32.model.MsInstrument;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.v32.model.MsRun;
@@ -54,7 +53,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 
-public class ChromatogramReaderVersion32 extends AbstractChromatogramReader implements IChromatogramMSDReader {
+public class ChromatogramReaderVersion32 extends AbstractChromatogramReader {
 
 	public static final String VERSION = "mzXML_3.2";
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/io/ChromatogramReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/io/ChromatogramReader.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Dr. Alexander Kerner - implementation
@@ -30,7 +30,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.Chromatog
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class ChromatogramReader extends AbstractChromatogramMSDReader implements IChromatogramMSDReader {
+public class ChromatogramReader extends AbstractChromatogramMSDReader {
 
 	public static IChromatogramMSDReader getReader(final File file) throws IOException {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/src/org/eclipse/chemclipse/msd/converter/supplier/sirius/converter/SiriusExportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/src/org/eclipse/chemclipse/msd/converter/supplier/sirius/converter/SiriusExportConverter.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
@@ -15,13 +15,12 @@ package org.eclipse.chemclipse.msd.converter.supplier.sirius.converter;
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.converter.database.AbstractDatabaseExportConverter;
-import org.eclipse.chemclipse.msd.converter.database.IDatabaseExportConverter;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class SiriusExportConverter extends AbstractDatabaseExportConverter implements IDatabaseExportConverter {
+public class SiriusExportConverter extends AbstractDatabaseExportConverter {
 
 	@Override
 	public IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/chromatogram/ChromatogramConverterMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/src/org/eclipse/chemclipse/msd/converter/chromatogram/ChromatogramConverterMSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Alexander Kerner - Generics
@@ -39,7 +39,7 @@ import org.eclipse.chemclipse.processing.DataCategory;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public final class ChromatogramConverterMSD extends AbstractChromatogramConverter<IChromatogramPeakMSD, IChromatogramMSD> implements IChromatogramConverter<IChromatogramPeakMSD, IChromatogramMSD> {
+public final class ChromatogramConverterMSD extends AbstractChromatogramConverter<IChromatogramPeakMSD, IChromatogramMSD> {
 
 	private static IChromatogramConverter<IChromatogramPeakMSD, IChromatogramMSD> instance = null;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/ChromatogramMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/ChromatogramMSD.java
@@ -1,24 +1,23 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.implementation;
 
 import org.eclipse.chemclipse.msd.model.core.AbstractChromatogramMSD;
-import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 
 /**
  * If a new chromatogram type should be implemented, extend the abstract class {@link AbstractChromatogramMSD} and not this class.
  */
-public final class ChromatogramMSD extends AbstractChromatogramMSD implements IChromatogramMSD {
+public final class ChromatogramMSD extends AbstractChromatogramMSD {
 
 	private static final long serialVersionUID = -1949972436584767646L;
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/ChromatogramPeakMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/ChromatogramPeakMSD.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -15,10 +15,9 @@ package org.eclipse.chemclipse.msd.model.implementation;
 import org.eclipse.chemclipse.model.exceptions.PeakException;
 import org.eclipse.chemclipse.msd.model.core.AbstractChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
-import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 
-public class ChromatogramPeakMSD extends AbstractChromatogramPeakMSD implements IChromatogramPeakMSD {
+public class ChromatogramPeakMSD extends AbstractChromatogramPeakMSD {
 
 	public ChromatogramPeakMSD(IPeakModelMSD peakModel, IChromatogramMSD chromatogram) throws PeakException {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/CombinedMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/CombinedMassSpectrum.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -17,7 +17,7 @@ import org.eclipse.chemclipse.msd.model.core.ICombinedMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 
-public class CombinedMassSpectrum extends AbstractCombinedMassSpectrum implements ICombinedMassSpectrum {
+public class CombinedMassSpectrum extends AbstractCombinedMassSpectrum {
 
 	private static final long serialVersionUID = 7845524326973176571L;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/PeakIdentificationResult.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/PeakIdentificationResult.java
@@ -1,19 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.implementation;
 
 import org.eclipse.chemclipse.model.identifier.AbstractPeakIdentificationResult;
-import org.eclipse.chemclipse.model.identifier.IPeakIdentificationResult;
 
-public class PeakIdentificationResult extends AbstractPeakIdentificationResult implements IPeakIdentificationResult {
+public class PeakIdentificationResult extends AbstractPeakIdentificationResult {
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/PeakIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/PeakIon.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -14,9 +14,8 @@ package org.eclipse.chemclipse.msd.model.implementation;
 
 import org.eclipse.chemclipse.msd.model.core.AbstractPeakIon;
 import org.eclipse.chemclipse.msd.model.core.IIon;
-import org.eclipse.chemclipse.msd.model.core.IPeakIon;
 
-public class PeakIon extends AbstractPeakIon implements IPeakIon {
+public class PeakIon extends AbstractPeakIon {
 
 	/**
 	 * Renew the serialVersionUID any time you have changed some fields or

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/PeakMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/PeakMSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -16,7 +16,7 @@ import org.eclipse.chemclipse.msd.model.core.AbstractPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 
-public class PeakMSD extends AbstractPeakMSD implements IPeakMSD {
+public class PeakMSD extends AbstractPeakMSD {
 
 	public PeakMSD(IPeakModelMSD peakModel, String modelDescription) throws IllegalArgumentException {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/PeakMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/PeakMassSpectrum.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -18,7 +18,7 @@ import org.eclipse.chemclipse.msd.model.core.IPeakIon;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 
-public class PeakMassSpectrum extends AbstractPeakMassSpectrum implements IPeakMassSpectrum {
+public class PeakMassSpectrum extends AbstractPeakMassSpectrum {
 
 	/**
 	 * Renew the serialVersionUID any time you have changed some fields or
@@ -36,7 +36,7 @@ public class PeakMassSpectrum extends AbstractPeakMassSpectrum implements IPeakM
 	 * intensity relative to the intensity of peakMassSpectrum. The given
 	 * intensity must be intensity >= 0 and intensity <=
 	 * IPeakIntensityValues.MAX_INTENSITY.
-	 * 
+	 *
 	 * @param peakMassSpectrum
 	 * @param intensity
 	 */
@@ -48,7 +48,7 @@ public class PeakMassSpectrum extends AbstractPeakMassSpectrum implements IPeakM
 	/**
 	 * Creates a new instance of a peak mass spectrum shifted to the given
 	 * intensity relative to the intensity of peakMassSpectrum.
-	 * 
+	 *
 	 * @param massSpectrum
 	 */
 	public PeakMassSpectrum(IScanMSD massSpectrum) throws IllegalArgumentException {
@@ -75,7 +75,7 @@ public class PeakMassSpectrum extends AbstractPeakMassSpectrum implements IPeakM
 	 * 100% actual: 6514141.6f -> 100% : 6514141.6f<br/>
 	 * 120% actual: 6514141.6f -> 100% : 5428451.333f<br/>
 	 * 50% actual: 6514141.6f -> 100% : 13028283.2f<br/>
-	 * 
+	 *
 	 * @param massSpectrum
 	 * @param actualPercentageIntensity
 	 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/PeakModelMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/PeakModelMSD.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - add delegate constructor
@@ -17,9 +17,8 @@ import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
 import org.eclipse.chemclipse.model.exceptions.PeakException;
 import org.eclipse.chemclipse.msd.model.core.AbstractPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
-import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 
-public class PeakModelMSD extends AbstractPeakModelMSD implements IPeakModelMSD {
+public class PeakModelMSD extends AbstractPeakModelMSD {
 
 	/**
 	 * Renew the UUID on change.

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/ScanMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/ScanMSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Alexander Kerner - implementation
@@ -22,11 +22,11 @@ import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 
 /**
  * If a new mass spectrum type should be implemented, extend the abstract class {@link AbstractScanMSD} and not this class.
- * 
+ *
  * @author Philip Wenig
  * @author Alexander Kerner
  */
-public class ScanMSD extends AbstractScanMSD implements IScanMSD {
+public class ScanMSD extends AbstractScanMSD {
 
 	/**
 	 * Renew the serialVersionUID any time you have changed some fields or
@@ -49,7 +49,7 @@ public class ScanMSD extends AbstractScanMSD implements IScanMSD {
 	 * shallow copy of provided {@code templateScan}.
 	 * </p>
 	 * To create a deep copy, use {@link #makeDeepCopy()}.
-	 * 
+	 *
 	 * @param templateScan
 	 *            {@link IScanMSD scan} that is used as a template
 	 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/src/org/eclipse/chemclipse/swt/ui/marker/RetentionIndexMarker.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/src/org/eclipse/chemclipse/swt/ui/marker/RetentionIndexMarker.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -26,7 +26,6 @@ import org.eclipse.swtchart.LineStyle;
 import org.eclipse.swtchart.Range;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.marker.AbstractBaseChartPaintListener;
-import org.eclipse.swtchart.extensions.marker.IBaseChartPaintListener;
 import org.eclipse.swtchart.extensions.model.ElementLine;
 import org.eclipse.swtchart.extensions.model.ElementRectangle;
 import org.eclipse.swtchart.extensions.model.ICustomSeries;
@@ -36,7 +35,7 @@ import org.eclipse.swtchart.extensions.support.ElementSupport;
 import org.eclipse.swtchart.extensions.support.PointPrimary;
 import org.eclipse.swtchart.extensions.support.RectanglePrimary;
 
-public class RetentionIndexMarker extends AbstractBaseChartPaintListener implements IBaseChartPaintListener {
+public class RetentionIndexMarker extends AbstractBaseChartPaintListener {
 
 	private boolean showIdentifier = false;
 	private boolean showLabelTop = true;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/internal/provider/UpdateMenuEntry.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/internal/provider/UpdateMenuEntry.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -21,9 +21,8 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtchart.extensions.core.ScrollableChart;
 import org.eclipse.swtchart.extensions.menu.AbstractChartMenuEntry;
-import org.eclipse.swtchart.extensions.menu.IChartMenuEntry;
 
-public class UpdateMenuEntry extends AbstractChartMenuEntry implements IChartMenuEntry {
+public class UpdateMenuEntry extends AbstractChartMenuEntry {
 
 	@Override
 	public String getCategory() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/editors/ProcessorSupplierMenuEntry.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/editors/ProcessorSupplierMenuEntry.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Christoph Läubrich - initial API and implementation
  * Philip Wenig - support process method resume option
@@ -28,9 +28,8 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtchart.extensions.core.ScrollableChart;
 import org.eclipse.swtchart.extensions.menu.AbstractChartMenuEntry;
-import org.eclipse.swtchart.extensions.menu.IChartMenuEntry;
 
-public class ProcessorSupplierMenuEntry<T> extends AbstractChartMenuEntry implements IChartMenuEntry {
+public class ProcessorSupplierMenuEntry<T> extends AbstractChartMenuEntry {
 
 	private final IProcessSupplier<T> processorSupplier;
 	private final BiConsumer<IProcessSupplier<T>, IProcessSupplierContext> executionConsumer;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/editors/ScanToSecondsConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/editors/ScanToSecondsConverter.java
@@ -1,21 +1,20 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.internal.editors;
 
 import org.eclipse.swtchart.extensions.core.AbstractAxisScaleConverter;
-import org.eclipse.swtchart.extensions.core.IAxisScaleConverter;
 
-public class ScanToSecondsConverter extends AbstractAxisScaleConverter implements IAxisScaleConverter {
+public class ScanToSecondsConverter extends AbstractAxisScaleConverter {
 
 	/*
 	 * NMR

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/listener/PeakTracesOffsetListener.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/listener/PeakTracesOffsetListener.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -16,9 +16,8 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.marker.AbstractBaseChartPaintListener;
-import org.eclipse.swtchart.extensions.marker.IBaseChartPaintListener;
 
-public class PeakTracesOffsetListener extends AbstractBaseChartPaintListener implements IBaseChartPaintListener {
+public class PeakTracesOffsetListener extends AbstractBaseChartPaintListener {
 
 	private int offsetRetentionTime = 0;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/listener/PenaltyMarkerListener.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/listener/PenaltyMarkerListener.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 Lablicate GmbH.
+ * Copyright (c) 2022, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -22,9 +22,8 @@ import org.eclipse.swtchart.IAxis;
 import org.eclipse.swtchart.Range;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.marker.AbstractBaseChartPaintListener;
-import org.eclipse.swtchart.extensions.marker.IBaseChartPaintListener;
 
-public class PenaltyMarkerListener extends AbstractBaseChartPaintListener implements IBaseChartPaintListener {
+public class PenaltyMarkerListener extends AbstractBaseChartPaintListener {
 
 	private int retentionTime = 0;
 	private String labelTop = "";

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangeMarker.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangeMarker.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -32,9 +32,8 @@ import org.eclipse.swtchart.IPlotArea;
 import org.eclipse.swtchart.Range;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.marker.AbstractBaseChartPaintListener;
-import org.eclipse.swtchart.extensions.marker.IBaseChartPaintListener;
 
-public class TimeRangeMarker extends AbstractBaseChartPaintListener implements IBaseChartPaintListener {
+public class TimeRangeMarker extends AbstractBaseChartPaintListener {
 
 	private static final int INVISIBLE = -1;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangePointsMarker.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangePointsMarker.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Lorenz Gerber - add draw line for y selection
@@ -25,9 +25,8 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swtchart.IAxis;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.marker.AbstractBaseChartPaintListener;
-import org.eclipse.swtchart.extensions.marker.IBaseChartPaintListener;
 
-public class TimeRangePointsMarker extends AbstractBaseChartPaintListener implements IBaseChartPaintListener {
+public class TimeRangePointsMarker extends AbstractBaseChartPaintListener {
 
 	private List<Point> pointSelection = new ArrayList<>();
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedColumnIndicesUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedColumnIndicesUI.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -17,7 +17,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
 import org.eclipse.chemclipse.swt.ui.components.SearchSupportUI;
-import org.eclipse.chemclipse.ux.extension.ui.swt.IExtendedPartUI;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
@@ -26,7 +25,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
 
-public class ExtendedColumnIndicesUI extends LibraryInformationComposite implements IExtendedPartUI {
+public class ExtendedColumnIndicesUI extends LibraryInformationComposite {
 
 	private AtomicReference<Button> buttonToolbarSearchControl = new AtomicReference<>();
 	private AtomicReference<SearchSupportUI> toolbarSearch = new AtomicReference<>();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSynonymsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedSynonymsUI.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -21,7 +21,6 @@ import org.eclipse.chemclipse.support.ui.swt.ExtendedTableViewer;
 import org.eclipse.chemclipse.support.ui.swt.ITableSettings;
 import org.eclipse.chemclipse.swt.ui.components.SearchSupportUI;
 import org.eclipse.chemclipse.swt.ui.notifier.UpdateNotifierUI;
-import org.eclipse.chemclipse.ux.extension.ui.swt.IExtendedPartUI;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePage;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
@@ -31,7 +30,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
 
-public class ExtendedSynonymsUI extends LibraryInformationComposite implements IExtendedPartUI {
+public class ExtendedSynonymsUI extends LibraryInformationComposite {
 
 	private Button buttonToolbarSearch;
 	private AtomicReference<SearchSupportUI> toolbarSearch = new AtomicReference<>();

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/implementation/ChromatogramPeakVSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/implementation/ChromatogramPeakVSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -14,11 +14,10 @@ package org.eclipse.chemclipse.vsd.model.implementation;
 
 import org.eclipse.chemclipse.model.exceptions.PeakException;
 import org.eclipse.chemclipse.vsd.model.core.AbstractChromatogramPeakVSD;
-import org.eclipse.chemclipse.vsd.model.core.IChromatogramPeakVSD;
 import org.eclipse.chemclipse.vsd.model.core.IChromatogramVSD;
 import org.eclipse.chemclipse.vsd.model.core.IPeakModelVSD;
 
-public class ChromatogramPeakVSD extends AbstractChromatogramPeakVSD implements IChromatogramPeakVSD {
+public class ChromatogramPeakVSD extends AbstractChromatogramPeakVSD {
 
 	public ChromatogramPeakVSD(IPeakModelVSD peakModel, IChromatogramVSD chromatogram, String modelDescription) throws IllegalArgumentException, PeakException {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/implementation/ChromatogramVSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/implementation/ChromatogramVSD.java
@@ -1,21 +1,20 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.vsd.model.implementation;
 
 import org.eclipse.chemclipse.vsd.model.core.AbstractChromatogramVSD;
-import org.eclipse.chemclipse.vsd.model.core.IChromatogramVSD;
 
-public class ChromatogramVSD extends AbstractChromatogramVSD implements IChromatogramVSD {
+public class ChromatogramVSD extends AbstractChromatogramVSD {
 
 	private static final long serialVersionUID = 7864606541571028587L;
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/implementation/PeakVSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/implementation/PeakVSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -16,7 +16,7 @@ import org.eclipse.chemclipse.vsd.model.core.AbstractPeakVSD;
 import org.eclipse.chemclipse.vsd.model.core.IPeakModelVSD;
 import org.eclipse.chemclipse.vsd.model.core.IPeakVSD;
 
-public class PeakVSD extends AbstractPeakVSD implements IPeakVSD {
+public class PeakVSD extends AbstractPeakVSD {
 
 	public PeakVSD(IPeakModelVSD peakModel, String modelDescription) throws IllegalArgumentException {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.mzml/src/org/eclipse/chemclipse/wsd/converter/supplier/mzml/converter/io/ChromatogramReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.mzml/src/org/eclipse/chemclipse/wsd/converter/supplier/mzml/converter/io/ChromatogramReader.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Lorenz Gerber - adjust failed parsing behaviour
@@ -26,7 +26,7 @@ import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.XmlReader110;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class ChromatogramReader extends AbstractChromatogramWSDReader implements IChromatogramWSDReader {
+public class ChromatogramReader extends AbstractChromatogramWSDReader {
 
 	public static IChromatogramWSDReader getReader(final File file) throws IOException {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/src/org/eclipse/chemclipse/wsd/converter/chromatogram/ChromatogramConverterWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/src/org/eclipse/chemclipse/wsd/converter/chromatogram/ChromatogramConverterWSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Alexander Kerner - Generics
@@ -22,7 +22,7 @@ import org.eclipse.chemclipse.wsd.model.core.IChromatogramPeakWSD;
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class ChromatogramConverterWSD extends AbstractChromatogramConverter<IChromatogramPeakWSD, IChromatogramWSD> implements IChromatogramConverter<IChromatogramPeakWSD, IChromatogramWSD> {
+public class ChromatogramConverterWSD extends AbstractChromatogramConverter<IChromatogramPeakWSD, IChromatogramWSD> {
 
 	private static IChromatogramConverter<IChromatogramPeakWSD, IChromatogramWSD> instance = null;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/implementation/ChromatogramPeakWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/implementation/ChromatogramPeakWSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -14,11 +14,10 @@ package org.eclipse.chemclipse.wsd.model.core.implementation;
 
 import org.eclipse.chemclipse.model.exceptions.PeakException;
 import org.eclipse.chemclipse.wsd.model.core.AbstractChromatogramPeakWSD;
-import org.eclipse.chemclipse.wsd.model.core.IChromatogramPeakWSD;
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
 import org.eclipse.chemclipse.wsd.model.core.IPeakModelWSD;
 
-public class ChromatogramPeakWSD extends AbstractChromatogramPeakWSD implements IChromatogramPeakWSD {
+public class ChromatogramPeakWSD extends AbstractChromatogramPeakWSD {
 
 	public ChromatogramPeakWSD(IPeakModelWSD peakModel, IChromatogramWSD chromatogram, String modelDescription) throws IllegalArgumentException, PeakException {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/implementation/ChromatogramWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/implementation/ChromatogramWSD.java
@@ -1,21 +1,20 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.wsd.model.core.implementation;
 
 import org.eclipse.chemclipse.wsd.model.core.AbstractChromatogramWSD;
-import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
 
-public class ChromatogramWSD extends AbstractChromatogramWSD implements IChromatogramWSD {
+public class ChromatogramWSD extends AbstractChromatogramWSD {
 
 	private static final long serialVersionUID = -1188292397556877608L;
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/implementation/PeakModelWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/implementation/PeakModelWSD.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -16,9 +16,8 @@ import org.eclipse.chemclipse.model.core.IPeakIntensityValues;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.exceptions.PeakException;
 import org.eclipse.chemclipse.wsd.model.core.AbstractPeakModelWSD;
-import org.eclipse.chemclipse.wsd.model.core.IPeakModelWSD;
 
-public class PeakModelWSD extends AbstractPeakModelWSD implements IPeakModelWSD {
+public class PeakModelWSD extends AbstractPeakModelWSD {
 
 	private static final long serialVersionUID = -7038661392283961955L;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/implementation/PeakWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/implementation/PeakWSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -14,9 +14,8 @@ package org.eclipse.chemclipse.wsd.model.core.implementation;
 
 import org.eclipse.chemclipse.wsd.model.core.AbstractPeakWSD;
 import org.eclipse.chemclipse.wsd.model.core.IPeakModelWSD;
-import org.eclipse.chemclipse.wsd.model.core.IPeakWSD;
 
-public class PeakWSD extends AbstractPeakWSD implements IPeakWSD {
+public class PeakWSD extends AbstractPeakWSD {
 
 	public PeakWSD(IPeakModelWSD peakModel, String modelDescription) throws IllegalArgumentException {
 		super(peakModel, modelDescription);

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/implementation/ScanSignalWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/implementation/ScanSignalWSD.java
@@ -1,21 +1,20 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.wsd.model.core.implementation;
 
 import org.eclipse.chemclipse.wsd.model.core.AbstractScanSignalWSD;
-import org.eclipse.chemclipse.wsd.model.core.IScanSignalWSD;
 
-public class ScanSignalWSD extends AbstractScanSignalWSD implements IScanSignalWSD {
+public class ScanSignalWSD extends AbstractScanSignalWSD {
 
 	private static final long serialVersionUID = 7188703805929591517L;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/implementation/ScanWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/implementation/ScanWSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -15,7 +15,7 @@ package org.eclipse.chemclipse.wsd.model.core.implementation;
 import org.eclipse.chemclipse.wsd.model.core.AbstractScanWSD;
 import org.eclipse.chemclipse.wsd.model.core.IScanWSD;
 
-public class ScanWSD extends AbstractScanWSD implements IScanWSD {
+public class ScanWSD extends AbstractScanWSD {
 
 	/**
 	 * Renew the serialVersionUID any time you have changed some fields or

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/implementation/SignalWSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/core/implementation/SignalWSD.java
@@ -1,20 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Lablicate GmbH.
+ * Copyright (c) 2024, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.wsd.model.core.implementation;
 
-import org.eclipse.chemclipse.wsd.model.core.ISignalWSD;
-
-public class SignalWSD extends AbstractSignalWSD implements ISignalWSD, Comparable<ISignalWSD> {
+public class SignalWSD extends AbstractSignalWSD {
 
 	private static final long serialVersionUID = -6878875442146282898L;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/heatmap/ChromatogramImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/heatmap/ChromatogramImportConverter.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -15,14 +15,13 @@ package org.eclipse.chemclipse.xxd.converter.supplier.csv.heatmap;
 import java.io.File;
 
 import org.eclipse.chemclipse.converter.chromatogram.AbstractChromatogramImportConverter;
-import org.eclipse.chemclipse.converter.chromatogram.IChromatogramImportConverter;
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class ChromatogramImportConverter extends AbstractChromatogramImportConverter<IChromatogramMSD> implements IChromatogramImportConverter<IChromatogramMSD> {
+public class ChromatogramImportConverter extends AbstractChromatogramImportConverter<IChromatogramMSD> {
 
 	private static final String DESCRIPTION = "CSV Heatmap Result Import Converter";
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/core/ChromatogramReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/core/ChromatogramReader.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Lablicate GmbH.
+ * Copyright (c) 2011, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -28,7 +28,6 @@ import org.apache.commons.csv.CSVRecord;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.msd.converter.io.AbstractChromatogramMSDReader;
-import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -38,7 +37,7 @@ import org.eclipse.chemclipse.xxd.converter.supplier.csv.model.VendorScan;
 import org.eclipse.chemclipse.xxd.converter.supplier.csv.preferences.PreferenceSupplier;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class ChromatogramReader extends AbstractChromatogramMSDReader implements IChromatogramMSDReader {
+public class ChromatogramReader extends AbstractChromatogramMSDReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/heatmap/ChromatogramReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/heatmap/ChromatogramReader.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -17,11 +17,10 @@ import java.io.IOException;
 
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.msd.converter.io.AbstractChromatogramMSDReader;
-import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class ChromatogramReader extends AbstractChromatogramMSDReader implements IChromatogramMSDReader {
+public class ChromatogramReader extends AbstractChromatogramMSDReader {
 
 	@Override
 	public IChromatogramOverview readOverview(File file, IProgressMonitor monitor) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/nmr/converter/supplier/jcampdx/converter/ScanImportConverterNMR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/nmr/converter/supplier/jcampdx/converter/ScanImportConverterNMR.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
@@ -19,14 +19,13 @@ import java.util.Collections;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IComplexSignalMeasurement;
 import org.eclipse.chemclipse.nmr.converter.core.AbstractScanImportConverter;
-import org.eclipse.chemclipse.nmr.converter.core.IScanImportConverter;
 import org.eclipse.chemclipse.nmr.converter.supplier.jcampdx.io.ScanReaderNMR;
 import org.eclipse.chemclipse.nmr.model.core.ISpectrumNMR;
 import org.eclipse.chemclipse.nmr.model.core.SpectrumNMR;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
-public class ScanImportConverterNMR extends AbstractScanImportConverter implements IScanImportConverter {
+public class ScanImportConverterNMR extends AbstractScanImportConverter {
 
 	private static final Logger logger = Logger.getLogger(ScanImportConverterNMR.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/AbstractChromatogramReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/AbstractChromatogramReader.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -21,14 +21,13 @@ import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
 import org.eclipse.chemclipse.csd.converter.io.AbstractChromatogramCSDReader;
-import org.eclipse.chemclipse.csd.converter.io.IChromatogramCSDReader;
 
-public abstract class AbstractChromatogramReader extends AbstractChromatogramCSDReader implements IChromatogramCSDReader {
+public abstract class AbstractChromatogramReader extends AbstractChromatogramCSDReader {
 
 	/**
 	 * Object = ZipFile or ZipInputStream
 	 * May return null;
-	 * 
+	 *
 	 * @param object
 	 * @param entryName
 	 * @return {@link DataInputStream}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0701.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0701.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -41,7 +41,6 @@ import org.eclipse.chemclipse.model.implementation.IdentificationTarget;
 import org.eclipse.chemclipse.model.implementation.IntegrationEntry;
 import org.eclipse.chemclipse.model.implementation.PeakIntensityValues;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
@@ -70,7 +69,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_0701 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_0701 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_0701.class);
 
@@ -456,7 +455,7 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader implemen
 	/**
 	 * Legacy.
 	 * Convert between Enum and short value.
-	 * 
+	 *
 	 * @param massSpectrometer
 	 * @return
 	 */
@@ -475,7 +474,7 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader implemen
 	/**
 	 * Legacy.
 	 * Convert between Enum and short value.
-	 * 
+	 *
 	 * @param massSpectrometer
 	 * @return
 	 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0801.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0801.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -44,7 +44,6 @@ import org.eclipse.chemclipse.model.implementation.PeakIntensityValues;
 import org.eclipse.chemclipse.model.implementation.QuantitationEntry;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
@@ -72,7 +71,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_0801 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_0801 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_0801.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0802.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0802.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -44,7 +44,6 @@ import org.eclipse.chemclipse.model.implementation.PeakIntensityValues;
 import org.eclipse.chemclipse.model.implementation.QuantitationEntry;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
@@ -74,7 +73,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_0802 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_0802.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0803.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0803.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -45,7 +45,6 @@ import org.eclipse.chemclipse.model.implementation.PeakIntensityValues;
 import org.eclipse.chemclipse.model.implementation.QuantitationEntry;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
@@ -77,7 +76,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_0803 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_0803.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0901.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0901.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -45,7 +45,6 @@ import org.eclipse.chemclipse.model.implementation.PeakIntensityValues;
 import org.eclipse.chemclipse.model.implementation.QuantitationEntry;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
@@ -77,7 +76,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_0901 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_0901.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0902.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0902.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -47,7 +47,6 @@ import org.eclipse.chemclipse.model.implementation.PeakIntensityValues;
 import org.eclipse.chemclipse.model.implementation.QuantitationEntry;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
@@ -79,7 +78,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_0902 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_0902.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0903.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0903.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -47,7 +47,6 @@ import org.eclipse.chemclipse.model.implementation.PeakIntensityValues;
 import org.eclipse.chemclipse.model.implementation.QuantitationEntry;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
@@ -79,7 +78,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_0903 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_0903.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1001.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -47,7 +47,6 @@ import org.eclipse.chemclipse.model.implementation.PeakIntensityValues;
 import org.eclipse.chemclipse.model.implementation.QuantitationEntry;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
@@ -79,7 +78,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_1001 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_1001.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1002.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -51,7 +51,6 @@ import org.eclipse.chemclipse.model.implementation.PeakIntensityValues;
 import org.eclipse.chemclipse.model.implementation.QuantitationEntry;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
@@ -84,7 +83,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_1002 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_1002.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1003.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -51,7 +51,6 @@ import org.eclipse.chemclipse.model.implementation.PeakIntensityValues;
 import org.eclipse.chemclipse.model.implementation.QuantitationEntry;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
@@ -89,7 +88,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_1003 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_1003.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1004.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -51,7 +51,6 @@ import org.eclipse.chemclipse.model.implementation.PeakIntensityValues;
 import org.eclipse.chemclipse.model.implementation.QuantitationEntry;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
@@ -90,7 +89,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_1004 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_1004.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -52,7 +52,6 @@ import org.eclipse.chemclipse.model.implementation.PeakIntensityValues;
 import org.eclipse.chemclipse.model.implementation.QuantitationEntry;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
@@ -91,7 +90,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_1005 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_1005.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -51,7 +51,6 @@ import org.eclipse.chemclipse.model.implementation.PeakIntensityValues;
 import org.eclipse.chemclipse.model.implementation.QuantitationEntry;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
@@ -91,7 +90,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_1006 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_1006.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -51,7 +51,6 @@ import org.eclipse.chemclipse.model.implementation.PeakIntensityValues;
 import org.eclipse.chemclipse.model.implementation.QuantitationEntry;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
@@ -91,7 +90,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_1007 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_1007.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -54,7 +54,6 @@ import org.eclipse.chemclipse.model.quantitation.IInternalStandard;
 import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.quantitation.InternalStandard;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
@@ -95,7 +94,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_1100 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_1100.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -62,7 +62,6 @@ import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.quantitation.InternalStandard;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.ChromatogramReaderMSD;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
@@ -105,7 +104,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_1300 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_1300 extends AbstractChromatogramReader {
 
 	private static final String CLASSIFIER_DELIMITER = " ";
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_1300.class);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -63,7 +63,6 @@ import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.model.quantitation.InternalStandard;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.ChromatogramReaderMSD;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
@@ -106,7 +105,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_1301 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_1301 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_1301.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -67,7 +67,6 @@ import org.eclipse.chemclipse.model.support.ChromatogramSupport;
 import org.eclipse.chemclipse.model.targets.ITargetDisplaySettings;
 import org.eclipse.chemclipse.model.targets.LibraryField;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.ChromatogramReaderMSD;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
@@ -110,7 +109,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_1400 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_1400 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_1400.class);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1500.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -67,7 +67,6 @@ import org.eclipse.chemclipse.model.support.ChromatogramSupport;
 import org.eclipse.chemclipse.model.targets.ITargetDisplaySettings;
 import org.eclipse.chemclipse.model.targets.LibraryField;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.ChromatogramReaderMSD;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
@@ -110,7 +109,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_1500 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_1500 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_1500.class);
 	private IReaderProxy readerProxy = new ReaderProxy_1500();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1501.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1501.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -48,7 +48,6 @@ import org.eclipse.chemclipse.model.quantitation.InternalStandard;
 import org.eclipse.chemclipse.model.quantitation.QuantitationFlag;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.ChromatogramReaderMSD;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
@@ -93,7 +92,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_1501 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_1501 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_1501.class);
 	private ReaderIO_1501 reader1501 = new ReaderIO_1501();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1502.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1502.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -48,7 +48,6 @@ import org.eclipse.chemclipse.model.quantitation.InternalStandard;
 import org.eclipse.chemclipse.model.quantitation.QuantitationFlag;
 import org.eclipse.chemclipse.model.support.ChromatogramSupport;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.ChromatogramReaderMSD;
-import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
@@ -93,7 +92,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
  * Methods are copied to ensure that file formats are kept readable even if they contain errors.
  * This is suitable but I know, it's not the best way to achieve long term support for older formats.
  */
-public class ChromatogramReader_1502 extends AbstractChromatogramReader implements IChromatogramMSDZipReader {
+public class ChromatogramReader_1502 extends AbstractChromatogramReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramReader_1502.class);
 	private ReaderIO_1502 reader = new ReaderIO_1502();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/AbstractChromatogramReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/AbstractChromatogramReader.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Michael Chang.
+ * Copyright (c) 2015, 2026 Michael Chang.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Michael Chang - initial API and implementation
  *******************************************************************************/
@@ -21,14 +21,13 @@ import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
 import org.eclipse.chemclipse.wsd.converter.io.AbstractChromatogramWSDReader;
-import org.eclipse.chemclipse.wsd.converter.io.IChromatogramWSDReader;
 
-public abstract class AbstractChromatogramReader extends AbstractChromatogramWSDReader implements IChromatogramWSDReader {
+public abstract class AbstractChromatogramReader extends AbstractChromatogramWSDReader {
 
 	/**
 	 * Object = ZipFile or ZipInputStream
 	 * May return null;
-	 * 
+	 *
 	 * @param object
 	 * @param entryName
 	 * @return {@link DataInputStream}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/FoldChangeLimits.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/FoldChangeLimits.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Lorenz Gerber- initial API and implementation
  *******************************************************************************/
@@ -24,9 +24,8 @@ import org.eclipse.swtchart.IPlotArea;
 import org.eclipse.swtchart.Range;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.marker.AbstractBaseChartPaintListener;
-import org.eclipse.swtchart.extensions.marker.IBaseChartPaintListener;
 
-public class FoldChangeLimits extends AbstractBaseChartPaintListener implements IBaseChartPaintListener {
+public class FoldChangeLimits extends AbstractBaseChartPaintListener {
 
 	private static final int INVISIBLE = -1;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/VariableLinePlotHighlights.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/VariableLinePlotHighlights.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Lorenz Gerber- initial API and implementation
  *******************************************************************************/
@@ -20,9 +20,8 @@ import org.eclipse.swtchart.Chart;
 import org.eclipse.swtchart.Range;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.marker.AbstractBaseChartPaintListener;
-import org.eclipse.swtchart.extensions.marker.IBaseChartPaintListener;
 
-public class VariableLinePlotHighlights extends AbstractBaseChartPaintListener implements IBaseChartPaintListener {
+public class VariableLinePlotHighlights extends AbstractBaseChartPaintListener {
 
 	private int[] highlightedIndices;
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/ChromatogramIntegrationResult.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/ChromatogramIntegrationResult.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -15,7 +15,7 @@ package org.eclipse.chemclipse.chromatogram.xxd.integrator.result;
 /**
  * THIS IS A TEST CLASS! DO NOT USE EXCEPT FOR TESTS!
  */
-public class ChromatogramIntegrationResult extends AbstractChromatogramIntegrationResult implements IChromatogramIntegrationResult {
+public class ChromatogramIntegrationResult extends AbstractChromatogramIntegrationResult {
 
 	public ChromatogramIntegrationResult(double ion, double chromatogramArea, double backgroundArea) {
 

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/ChromatogramIntegrationResults.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/ChromatogramIntegrationResults.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Lablicate GmbH.
+ * Copyright (c) 2011, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -15,5 +15,5 @@ package org.eclipse.chemclipse.chromatogram.xxd.integrator.result;
 /**
  * THIS IS A TEST CLASS! DO NOT USE EXCEPT FOR TESTS!
  */
-public class ChromatogramIntegrationResults extends AbstractChromatogramIntegrationResults implements IChromatogramIntegrationResults {
+public class ChromatogramIntegrationResults extends AbstractChromatogramIntegrationResults {
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/PeakIntegrationResult.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/PeakIntegrationResult.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -15,5 +15,5 @@ package org.eclipse.chemclipse.chromatogram.xxd.integrator.result;
 /**
  * THIS IS A TEST CLASS! DO NOT USE EXCEPT FOR TESTS!
  */
-public class PeakIntegrationResult extends AbstractPeakIntegrationResult implements IPeakIntegrationResult {
+public class PeakIntegrationResult extends AbstractPeakIntegrationResult {
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/PeakIntegrationResults.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.fragment.test/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/PeakIntegrationResults.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -15,5 +15,5 @@ package org.eclipse.chemclipse.chromatogram.xxd.integrator.result;
 /**
  * THIS IS A TEST CLASS! DO NOT USE EXCEPT FOR TESTS!
  */
-public class PeakIntegrationResults extends AbstractPeakIntegrationResults implements IPeakIntegrationResults {
+public class PeakIntegrationResults extends AbstractPeakIntegrationResults {
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/io/support/ArrayReaderTestImplementation.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/io/support/ArrayReaderTestImplementation.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -15,7 +15,7 @@ package org.eclipse.chemclipse.converter.io.support;
 import java.io.File;
 import java.io.IOException;
 
-public class ArrayReaderTestImplementation extends AbstractArrayReader implements IArrayReader {
+public class ArrayReaderTestImplementation extends AbstractArrayReader {
 
 	public ArrayReaderTestImplementation(byte[] data) {
 

--- a/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/io/support/ArrayWriterTestImplementation.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/src/org/eclipse/chemclipse/converter/io/support/ArrayWriterTestImplementation.java
@@ -1,18 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.converter.io.support;
 
-public class ArrayWriterTestImplementation extends AbstractArrayWriter implements IArrayWriter {
+public class ArrayWriterTestImplementation extends AbstractArrayWriter {
 
 	public ArrayWriterTestImplementation(byte[] data) {
 		super(data);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/src/org/eclipse/chemclipse/msd/converter/chromatogram/TestChromatogramImportConverter.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/src/org/eclipse/chemclipse/msd/converter/chromatogram/TestChromatogramImportConverter.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.msd.converter.chromatogram;
 import java.io.File;
 
 import org.eclipse.chemclipse.converter.chromatogram.AbstractChromatogramImportConverter;
-import org.eclipse.chemclipse.converter.chromatogram.IChromatogramImportConverter;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -26,7 +25,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * THIS CLASS IS NOT SUITED FOR PRODUCTIVE USE!<br/>
  * IT IS AN TESTCLASS!
  */
-public class TestChromatogramImportConverter extends AbstractChromatogramImportConverter<IChromatogram> implements IChromatogramImportConverter<IChromatogram> {
+public class TestChromatogramImportConverter extends AbstractChromatogramImportConverter<IChromatogram> {
 
 	@Override
 	public IProcessingInfo<IChromatogram> convert(File chromatogram, IProgressMonitor monitor) {


### PR DESCRIPTION
Already covered by some other extends/implements thus not needed. Yet, they cause tools (e.g. Type Hierarchy view) to show more complicated hierarchies than needed.