### PR TITLE
Don't remove file extension dots from PCR converters

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter/src/org/eclipse/chemclipse/pcr/converter/support/PlateSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter/src/org/eclipse/chemclipse/pcr/converter/support/PlateSupplier.java
@@ -16,12 +16,4 @@ import org.eclipse.chemclipse.converter.core.AbstractSupplier;
 
 public class PlateSupplier extends AbstractSupplier implements IPlateSupplier {
 
-	@Override
-	public void setFileExtension(final String fileExtension) {
-
-		if(fileExtension != null && !fileExtension.isEmpty()) {
-			String cleanedExtension = fileExtension.startsWith(".") ? fileExtension.substring(1) : fileExtension;
-			super.setFileExtension(cleanedExtension);
-		}
-	}
 }


### PR DESCRIPTION
This partly reverts https://github.com/eclipse-chemclipse/chemclipse/pull/2576.
Fixes https://github.com/eclipse-chemclipse/chemclipse/issues/2802.