### PR TITLE
Unify PCR file name extension

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/plugin.xml
@@ -6,7 +6,7 @@
       <PlateSupplier
             description="Exports PCR Plate Data"
             exportConverter="org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.core.PCRExportConverter"
-            fileExtension="csv"
+            fileExtension=".csv"
             fileName=""
             filterName="Tabular Plate Report (*.csv)"
             id="org.eclipse.chemclipse.pcr.report.supplier.tabular.csv"

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/plugin.xml
@@ -6,7 +6,7 @@
       <PlateSupplier
             description="Exports PCR Plate Data to Excel"
             exportConverter="org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.core.PCRExportConverter"
-            fileExtension="xlsx"
+            fileExtension=".xlsx"
             fileName=""
             filterName="Tabular Plate Report (*.xlsx)"
             id="org.eclipse.chemclipse.pcr.report.supplier.tabular.excel"

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.txt/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.txt/plugin.xml
@@ -6,7 +6,7 @@
       <PlateSupplier
             description="Exports PCR Plate Data"
             exportConverter="org.eclipse.chemclipse.pcr.report.supplier.txt.core.PCRExportConverter"
-            fileExtension="txt"
+            fileExtension=".txt"
             fileName=""
             filterName="PCR Plate Report (*.txt)"
             id="org.eclipse.chemclipse.pcr.report.supplier.txt"

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/charts/ChartPCR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/src/org/eclipse/chemclipse/ux/extension/pcr/ui/charts/ChartPCR.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Locale;
 
 import org.eclipse.chemclipse.converter.core.IConverterSupport;
+import org.eclipse.chemclipse.converter.support.FileExtensionCompiler;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.pcr.converter.core.PlateConverterPCR;
 import org.eclipse.chemclipse.pcr.converter.support.IPlateConverterSupport;
@@ -163,8 +164,9 @@ public class ChartPCR extends LineChart {
 					}
 					FileDialog fileDialog = new FileDialog(shell, SWT.SAVE);
 					fileDialog.setText(ExtensionMessages.pcrExport);
-					fileDialog.setFileName(plate.getName() + "." + supplier.getFileExtension()); //$NON-NLS-1$
-					fileDialog.setFilterExtensions("*" + supplier.getFileExtension()); //$NON-NLS-1$
+					fileDialog.setFileName(plate.getName());
+					FileExtensionCompiler fileExtensionCompiler = new FileExtensionCompiler(supplier.getFileExtension(), false);
+					fileDialog.setFilterExtensions(fileExtensionCompiler.getCompiledFileExtension());
 					fileDialog.setFilterNames(supplier.getFilterName());
 					String pathname = fileDialog.open();
 					if(pathname != null) {


### PR DESCRIPTION
I now use the same code paths to determine for both Save as via the menu toolbar https://github.com/eclipse-chemclipse/chemclipse/blob/409879808df21d821d0fb262ae331ac7b5ed2311/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/IConverterSupport.java#L46-L47 and the right-click menu inside the chart so the fighting between them can stop. This is a followup to #2808.