### PR TITLE
Fix error opening editor on Java 25

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
@@ -322,23 +322,25 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 	}
 
 	private void processChromatogram(IChromatogramSelection chromatogramSelection) {
+		String loadProcessMethodPath = preferenceStore.getString(PreferenceSupplier.P_CHROMATOGRAM_LOAD_PROCESS_METHOD);
+		if(!loadProcessMethodPath.trim().isEmpty()) {
+			File file = new File(loadProcessMethodPath);
+			if(file.exists() && chromatogramSelection != null) {
+				try {
+					ProgressMonitorDialog dialog = new ProgressMonitorDialog(shell);
+					dialog.run(false, false, monitor -> {
 
-		File file = new File(preferenceStore.getString(PreferenceSupplier.P_CHROMATOGRAM_LOAD_PROCESS_METHOD));
-		if(file.exists() && chromatogramSelection != null) {
-			try {
-				ProgressMonitorDialog dialog = new ProgressMonitorDialog(shell);
-				dialog.run(false, false, monitor -> {
-
-					IProcessMethod processMethod = Adapters.adapt(file, IProcessMethod.class);
-					if(processMethod != null) {
-						AbstractProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, new ProcessingInfo<>(), processSupplierContext), IChromatogramSelectionProcessSupplier.createConsumer(chromatogramSelection));
-					}
-				});
-			} catch(InvocationTargetException e) {
-				logger.warn(e);
-			} catch(InterruptedException e) {
-				logger.warn(e);
-				Thread.currentThread().interrupt();
+						IProcessMethod processMethod = Adapters.adapt(file, IProcessMethod.class);
+						if(processMethod != null) {
+							AbstractProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, new ProcessingInfo<>(), processSupplierContext), IChromatogramSelectionProcessSupplier.createConsumer(chromatogramSelection));
+						}
+					});
+				} catch(InvocationTargetException e) {
+					logger.warn(e);
+				} catch(InterruptedException e) {
+					logger.warn(e);
+					Thread.currentThread().interrupt();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
On Java 25 due to https://bugs.openjdk.org/browse/JDK-8024695 aka `new File("")` returns true,
causes Error log like:
!ENTRY org.eclipse.chemclipse.converter 4 0 2026-03-30 12:50:17.619 !MESSAGE  (No such file or directory)
!STACK 0
java.io.FileNotFoundException:  (No such file or directory)
	at java.base/java.io.FileInputStream.open0(Native Method)
	at java.base/java.io.FileInputStream.open(FileInputStream.java:185)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:139)
	at org.eclipse.chemclipse.xxd.converter.supplier.ocx.internal.methods.IMethodReader.convert(IMethodReader.java:40)
	at org.eclipse.chemclipse.xxd.converter.supplier.ocx.methods.MethodImportConverter.convert(MethodImportConverter.java:52)
	at org.eclipse.chemclipse.converter.methods.MethodConverter.convert(MethodConverter.java:93)
	at org.eclipse.chemclipse.converter.methods.MethodConverter.convert(MethodConverter.java:77)
	at org.eclipse.chemclipse.converter.adapters.MethodAdapterFactory.convertFile(MethodAdapterFactory.java:55)
	at org.eclipse.chemclipse.converter.adapters.MethodAdapterFactory.getAdapter(MethodAdapterFactory.java:47)
	at org.eclipse.core.internal.runtime.AdapterManager.lambda$13(AdapterManager.java:312)