### PR TITLE
Stop needlessly pass progress monitor

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/noise/stein/core/NoiseCalculator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/noise/stein/core/NoiseCalculator.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - refactor to use noise segments for calculations
@@ -79,7 +79,7 @@ public class NoiseCalculator extends AbstractNoiseCalculator {
 	public List<INoiseSegment> getNoiseSegments(IChromatogram chromatogram, IProgressMonitor monitor) {
 
 		if(chromatogram instanceof IChromatogramMSD) {
-			return getNoiseSegments(chromatogram, IIon.TIC_ION, monitor);
+			return getNoiseSegments(chromatogram, IIon.TIC_ION);
 		} else if(chromatogram != null) {
 			ChromatogramSegmentation segmentation = chromatogram.getMeasurementResult(ChromatogramSegmentation.class);
 			if(segmentation != null) {
@@ -114,7 +114,7 @@ public class NoiseCalculator extends AbstractNoiseCalculator {
 	/**
 	 * See S.E. Stein:
 	 * "An Integrated Method for Spectrum Extraction and Compound Identification from Gas Chromatography/Mass Spectrometry Data"
-	 * 
+	 *
 	 * @param IChromatogram
 	 */
 	private float calculateNoiseFactor(IChromatogram chromatogram) {
@@ -150,9 +150,9 @@ public class NoiseCalculator extends AbstractNoiseCalculator {
 
 	/**
 	 * Calculates the noise factor for the given segment if the segment is valid.
-	 * 
+	 *
 	 * @param baseSegment
-	 * 
+	 *
 	 * @param values
 	 * @return
 	 */
@@ -170,7 +170,7 @@ public class NoiseCalculator extends AbstractNoiseCalculator {
 		}
 	}
 
-	private List<INoiseSegment> getNoiseSegments(IChromatogram chromatogram, double ion, IProgressMonitor monitor) {
+	private List<INoiseSegment> getNoiseSegments(IChromatogram chromatogram, double ion) {
 
 		if(chromatogram instanceof IChromatogramMSD chromatogramMSD) {
 			ChromatogramSegmentation segmentation = chromatogram.getMeasurementResult(ChromatogramSegmentation.class);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterBufferIdentifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterBufferIdentifier.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -69,7 +69,7 @@ public class FilterBufferIdentifier extends AbstractChromatogramFilter {
 				bufferTargets(chromatogram, startScan, stopScan, monitor);
 				break;
 			case RESTORE_TARGERTS:
-				restoreTargets(chromatogram, retentionTimeStart, retentionTimeStop, monitor);
+				restoreTargets(chromatogram, retentionTimeStart, retentionTimeStop);
 				break;
 			case CLEAR_BUFFER:
 				clearBuffer(chromatogram);
@@ -108,7 +108,7 @@ public class FilterBufferIdentifier extends AbstractChromatogramFilter {
 		}
 	}
 
-	private void restoreTargets(IChromatogram chromatogram, int retentionTimeStart, int retentionTimeStop, IProgressMonitor monitor) {
+	private void restoreTargets(IChromatogram chromatogram, int retentionTimeStart, int retentionTimeStop) {
 
 		IMeasurementResult<?> measurementResult = chromatogram.getMeasurementResult(BufferedScanTargets.IDENTIFIER);
 		if(measurementResult != null) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterRemover.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterRemover.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -40,7 +40,7 @@ public class FilterRemover extends AbstractChromatogramFilter {
 		if(!processingInfo.hasErrorMessages()) {
 			if(chromatogramFilterSettings instanceof FilterSettingsRemover settings) {
 				ScanRemoverPattern scanRemoverPattern = new ScanRemoverPattern(settings.getScanRemoverPattern());
-				applyScanRemoverFilter(chromatogramSelection, scanRemoverPattern, monitor);
+				applyScanRemoverFilter(chromatogramSelection, scanRemoverPattern);
 				processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, "Scan Remover", "Scans have been removed successfully."));
 				processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, "Scans have been removed successfully."));
 				chromatogramSelection.getChromatogram().setDirty(true);
@@ -52,11 +52,11 @@ public class FilterRemover extends AbstractChromatogramFilter {
 	/**
 	 * Removes the given ions stored in the excludedIons
 	 * instance from the chromatogram selection.
-	 * 
+	 *
 	 * @param chromatogramSelection
 	 * @throws FilterException
 	 */
-	private void applyScanRemoverFilter(IChromatogramSelection chromatogramSelection, ScanRemoverPattern scanRemoverPattern, IProgressMonitor monitor) {
+	private void applyScanRemoverFilter(IChromatogramSelection chromatogramSelection, ScanRemoverPattern scanRemoverPattern) {
 
 		if(chromatogramSelection != null && scanRemoverPattern != null) {
 			/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterScanClipper.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterScanClipper.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -41,7 +41,7 @@ public class FilterScanClipper extends AbstractChromatogramFilter {
 				/*
 				 * Run
 				 */
-				applyScanClipperFilter(chromatogramSelection, settings.getScanNumberPattern(), monitor);
+				applyScanClipperFilter(chromatogramSelection, settings.getScanNumberPattern());
 				/*
 				 * Result
 				 */
@@ -55,7 +55,7 @@ public class FilterScanClipper extends AbstractChromatogramFilter {
 		return processingInfo;
 	}
 
-	private void applyScanClipperFilter(IChromatogramSelection chromatogramSelection, String scanNumberPattern, IProgressMonitor monitor) {
+	private void applyScanClipperFilter(IChromatogramSelection chromatogramSelection, String scanNumberPattern) {
 
 		if(chromatogramSelection != null && scanNumberPattern != null) {
 			/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterScanDensity.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterScanDensity.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -43,12 +43,12 @@ public class FilterScanDensity extends AbstractChromatogramFilter {
 		if(!processingInfo.hasErrorMessages()) {
 			if(chromatogramFilterSettings instanceof FilterSettingsScanDensity settings) {
 				if(chromatogramSelection != null) {
-					applyScanDensityFilter(chromatogramSelection, settings, monitor);
+					applyScanDensityFilter(chromatogramSelection, settings);
 					if(settings.isProcessReferencedChromatograms()) {
 						IChromatogram chromatogram = chromatogramSelection.getChromatogram();
 						for(IChromatogram chromatogramReference : chromatogram.getReferencedChromatograms()) {
 							ChromatogramSelection chromatogramSelectionReference = new ChromatogramSelection(chromatogramReference);
-							applyScanDensityFilter(chromatogramSelectionReference, settings, monitor);
+							applyScanDensityFilter(chromatogramSelectionReference, settings);
 						}
 					}
 					processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, "Scan Density", "The chromatogram has been modified to reach the target scan density."));
@@ -60,7 +60,7 @@ public class FilterScanDensity extends AbstractChromatogramFilter {
 		return processingInfo;
 	}
 
-	private void applyScanDensityFilter(IChromatogramSelection chromatogramSelection, FilterSettingsScanDensity settings, IProgressMonitor monitor) {
+	private void applyScanDensityFilter(IChromatogramSelection chromatogramSelection, FilterSettingsScanDensity settings) {
 
 		int scanIntervalTarget = Math.round(1000.0f / settings.getScansPerSecond());
 		if(scanIntervalTarget > 0) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterScanMerger.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterScanMerger.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -52,7 +52,7 @@ public class FilterScanMerger extends AbstractChromatogramFilter {
 		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
 			if(chromatogramFilterSettings instanceof FilterSettingsScanMerger settings) {
-				applyScanMergerFilter(chromatogramSelection, settings, monitor);
+				applyScanMergerFilter(chromatogramSelection, settings);
 				processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, "Scan Merger", MESSAGE));
 				processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, MESSAGE));
 				chromatogramSelection.getChromatogram().setDirty(true);
@@ -61,7 +61,7 @@ public class FilterScanMerger extends AbstractChromatogramFilter {
 		return processingInfo;
 	}
 
-	private void applyScanMergerFilter(IChromatogramSelection chromatogramSelection, FilterSettingsScanMerger settings, IProgressMonitor monitor) {
+	private void applyScanMergerFilter(IChromatogramSelection chromatogramSelection, FilterSettingsScanMerger settings) {
 
 		if(chromatogramSelection != null) {
 			/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/supplier/trapezoid/internal/support/ChromatogramIntegratorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/supplier/trapezoid/internal/support/ChromatogramIntegratorSupport.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Lablicate GmbH.
+ * Copyright (c) 2011, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -47,7 +47,7 @@ public class ChromatogramIntegratorSupport {
 		 */
 		double scaleFactor = chromatogramIntegrationSettings.getScaleFactor();
 		List<IIntegrationEntry> chromatogramIntegrationEntries = calculateChromatogramIntegrationEntry(chromatogramSelection, scaleFactor, monitor);
-		List<IIntegrationEntry> backgroundIntegrationEntries = calculateBackgroundIntegrationEntry(chromatogramSelection, scaleFactor, monitor);
+		List<IIntegrationEntry> backgroundIntegrationEntries = calculateBackgroundIntegrationEntry(chromatogramSelection, scaleFactor);
 		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
 		chromatogram.setIntegratedArea(chromatogramIntegrationEntries, backgroundIntegrationEntries, INTEGRATOR_DESCRIPTION);
 		/*
@@ -63,7 +63,7 @@ public class ChromatogramIntegratorSupport {
 
 	/**
 	 * May return null.
-	 * 
+	 *
 	 * @param chromatogramSelection
 	 * @param monitor
 	 * @return
@@ -90,7 +90,7 @@ public class ChromatogramIntegratorSupport {
 		return chromatogramIntegrationEntries;
 	}
 
-	private List<IIntegrationEntry> calculateBackgroundIntegrationEntry(IChromatogramSelection chromatogramSelection, double scaleFactor, IProgressMonitor monitor) {
+	private List<IIntegrationEntry> calculateBackgroundIntegrationEntry(IChromatogramSelection chromatogramSelection, double scaleFactor) {
 
 		List<IIntegrationEntry> backgroundIntegrationEntries = new ArrayList<>();
 		BackgroundIntegrator backgroundIntegrator = new BackgroundIntegrator();

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/io/JobReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/io/JobReader.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -49,9 +49,9 @@ public class JobReader {
 
 		try {
 			readHeader(file, batchProcessJob);
-			readDataTypeEntries(file, batchProcessJob, monitor);
+			readDataTypeEntries(file, batchProcessJob);
 			readChromatogramInputEntries(file, batchProcessJob, monitor);
-			readChromatogramProcessEntries(file, processMethod, monitor);
+			readChromatogramProcessEntries(file, processMethod);
 		} catch(XMLStreamException e) {
 			throw new IOException(e);
 		}
@@ -61,7 +61,7 @@ public class JobReader {
 
 	/**
 	 * Reads the header information.
-	 * 
+	 *
 	 * @throws IOException
 	 */
 	private void readHeader(File file, BatchProcessJob batchProcessJob) throws XMLStreamException, IOException {
@@ -104,7 +104,7 @@ public class JobReader {
 		}
 	}
 
-	private void readDataTypeEntries(File file, BatchProcessJob batchProcessJob, IProgressMonitor monitor) throws XMLStreamException, IOException {
+	private void readDataTypeEntries(File file, BatchProcessJob batchProcessJob) throws XMLStreamException, IOException {
 
 		DataType dataType;
 		XMLEvent event;
@@ -144,7 +144,7 @@ public class JobReader {
 
 	/**
 	 * Read the chromatogram input entries.
-	 * 
+	 *
 	 * @param file
 	 * @param batchProcessJob
 	 * @param monitor
@@ -185,7 +185,7 @@ public class JobReader {
 		bufferedInputStream.close();
 	}
 
-	private void readChromatogramProcessEntries(File file, ProcessMethod method, IProgressMonitor monitor) throws XMLStreamException, IOException {
+	private void readChromatogramProcessEntries(File file, ProcessMethod method) throws XMLStreamException, IOException {
 
 		XMLEvent event;
 		Attribute attribute;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/io/JobWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/io/JobWriter.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2025 Lablicate GmbH.
+ * Copyright (c) 2010, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -77,7 +77,7 @@ public class JobWriter {
 
 	/**
 	 * Writes the comment.
-	 * 
+	 *
 	 * @param eventWriter
 	 * @param eventFactory
 	 * @throws XMLStreamException
@@ -93,7 +93,7 @@ public class JobWriter {
 
 	/**
 	 * Writes the header.
-	 * 
+	 *
 	 * @param eventWriter
 	 * @param eventFactory
 	 * @param batchProcessJob
@@ -132,7 +132,7 @@ public class JobWriter {
 
 	/**
 	 * Writes the chromatogram input entries.
-	 * 
+	 *
 	 * @param eventWriter
 	 * @param eventFactory
 	 * @param inputEntries
@@ -176,7 +176,7 @@ public class JobWriter {
 
 	/**
 	 * Writes the chromatogram input entry.
-	 * 
+	 *
 	 * @param eventWriter
 	 * @param eventFactory
 	 * @param inputEntry
@@ -203,7 +203,7 @@ public class JobWriter {
 
 	/**
 	 * Writes the chromatogram process entries.
-	 * 
+	 *
 	 * @param eventWriter
 	 * @param eventFactory
 	 * @param processEntries
@@ -223,7 +223,7 @@ public class JobWriter {
 
 	/**
 	 * Writes the chromatogram process entry.
-	 * 
+	 *
 	 * @param eventWriter
 	 * @param eventFactory
 	 * @param processEntry

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/io/ReportWriter1.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/io/ReportWriter1.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -78,13 +78,13 @@ public class ReportWriter1 {
 			printWriter.println("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
 
 			for(IChromatogram chromatogram : chromatograms) {
-				printHeader(printWriter, chromatogram, monitor);
+				printHeader(printWriter, chromatogram);
 				reportChromatogram(printWriter, chromatogram, monitor);
 			}
 		}
 	}
 
-	private void printHeader(PrintWriter printWriter, IChromatogramOverview chromatogramOverview, IProgressMonitor monitor) {
+	private void printHeader(PrintWriter printWriter, IChromatogramOverview chromatogramOverview) {
 
 		printHeaderLine(printWriter, "Name", chromatogramOverview.getName());
 		printHeaderLine(printWriter, "Data Name", chromatogramOverview.getDataName());
@@ -129,7 +129,7 @@ public class ReportWriter1 {
 
 	/**
 	 * The report chromatogram is responsible how to print each section.
-	 * 
+	 *
 	 * @param printWriter
 	 * @param chromatogram
 	 * @param monitor
@@ -153,42 +153,42 @@ public class ReportWriter1 {
 		printWriter.println("");
 		printWriter.println("PEAK LIST OVERVIEW");
 		printWriter.println(HORIZONTAL_RULE);
-		reportPeaksOverview(printWriter, peaks, "Peaks are not available.", monitor);
+		reportPeaksOverview(printWriter, peaks, "Peaks are not available.");
 		printWriter.println("");
 		printWriter.println("");
 		printWriter.println("PEAK INTEGRATION RESULTS");
 		printWriter.println(HORIZONTAL_RULE);
-		reportPeakIntegrationResults(printWriter, peaks, "Peak integration results are not available.", monitor);
+		reportPeakIntegrationResults(printWriter, peaks, "Peak integration results are not available.");
 		printWriter.println("");
 		printWriter.println("");
 		printWriter.println("SCAN IDENTIFICATION RESULTS");
 		printWriter.println(HORIZONTAL_RULE);
-		reportScanIdentificationResults(printWriter, chromatogram, "Scan identification results are not available.", monitor);
+		reportScanIdentificationResults(printWriter, chromatogram, "Scan identification results are not available.");
 		printWriter.println("");
 		printWriter.println("");
 		printWriter.println("PEAK IDENTIFICATION RESULTS");
 		printWriter.println(HORIZONTAL_RULE);
-		reportPeakIdentificationResults(printWriter, peaks, "Peak identification results are not available.", monitor);
+		reportPeakIdentificationResults(printWriter, peaks, "Peak identification results are not available.");
 		printWriter.println("");
 		printWriter.println("");
 		printWriter.println("BACKGROUND INTEGRATION RESULTS");
 		printWriter.println(HORIZONTAL_RULE);
-		reportIntegrationResults(printWriter, chromatogram.getBackgroundIntegrationEntries(), "Background integration results are not available.", monitor);
+		reportIntegrationResults(printWriter, chromatogram.getBackgroundIntegrationEntries(), "Background integration results are not available.");
 		printWriter.println("");
 		printWriter.println("");
 		printWriter.println("CHROMATOGRAM INTEGRATION RESULTS");
 		printWriter.println(HORIZONTAL_RULE);
-		reportIntegrationResults(printWriter, chromatogram.getChromatogramIntegrationEntries(), "Chromatogram integration results are not available.", monitor);
+		reportIntegrationResults(printWriter, chromatogram.getChromatogramIntegrationEntries(), "Chromatogram integration results are not available.");
 		printWriter.println("");
 		printWriter.println("");
 		printWriter.println("CHROMATOGRAM IDENTIFICATION RESULTS");
 		printWriter.println(HORIZONTAL_RULE);
-		reportChromatogramIdentificationResults(printWriter, chromatogram, "Chromatogram identification results are not available.", monitor);
+		reportChromatogramIdentificationResults(printWriter, chromatogram, "Chromatogram identification results are not available.");
 		printWriter.println("");
 		printWriter.println("");
 		printWriter.println("PEAK QUANTITATION RESULTS");
 		printWriter.println(HORIZONTAL_RULE);
-		reportPeakQuantitationResults(printWriter, peaks, "Peak quantitation results are not available.", monitor);
+		reportPeakQuantitationResults(printWriter, peaks, "Peak quantitation results are not available.");
 		printWriter.println("");
 		printWriter.println("");
 		printWriter.println("PEAK QUANTITATION SUMMARY");
@@ -211,16 +211,16 @@ public class ReportWriter1 {
 		}
 	}
 
-	private void reportPeaksOverview(PrintWriter printWriter, List<IPeak> peaks, String messageNoResults, IProgressMonitor monitor) {
+	private void reportPeaksOverview(PrintWriter printWriter, List<IPeak> peaks, String messageNoResults) {
 
 		if(!peaks.isEmpty()) {
-			printPeaksOverview(printWriter, peaks, monitor);
+			printPeaksOverview(printWriter, peaks);
 		} else {
 			printWriter.println(messageNoResults);
 		}
 	}
 
-	private void printPeaksOverview(PrintWriter printWriter, List<IPeak> peaks, IProgressMonitor monitor) {
+	private void printPeaksOverview(PrintWriter printWriter, List<IPeak> peaks) {
 
 		/*
 		 * Headline
@@ -347,16 +347,16 @@ public class ReportWriter1 {
 		return builder.toString();
 	}
 
-	private void reportPeakIntegrationResults(PrintWriter printWriter, List<IPeak> peaks, String messageNoResults, IProgressMonitor monitor) {
+	private void reportPeakIntegrationResults(PrintWriter printWriter, List<IPeak> peaks, String messageNoResults) {
 
 		if(!peaks.isEmpty()) {
-			printPeakIntegrationResults(printWriter, peaks, monitor);
+			printPeakIntegrationResults(printWriter, peaks);
 		} else {
 			printWriter.println(messageNoResults);
 		}
 	}
 
-	private void printPeakIntegrationResults(PrintWriter printWriter, List<IPeak> peaks, IProgressMonitor monitor) {
+	private void printPeakIntegrationResults(PrintWriter printWriter, List<IPeak> peaks) {
 
 		/*
 		 * Headline
@@ -397,16 +397,16 @@ public class ReportWriter1 {
 		}
 	}
 
-	private void reportPeakIdentificationResults(PrintWriter printWriter, List<IPeak> peaks, String messageNoResults, IProgressMonitor monitor) {
+	private void reportPeakIdentificationResults(PrintWriter printWriter, List<IPeak> peaks, String messageNoResults) {
 
 		if(!peaks.isEmpty()) {
-			printPeakIdentificationResults(printWriter, peaks, monitor);
+			printPeakIdentificationResults(printWriter, peaks);
 		} else {
 			printWriter.println(messageNoResults);
 		}
 	}
 
-	private void printPeakIdentificationResults(PrintWriter printWriter, List<IPeak> peaks, IProgressMonitor monitor) {
+	private void printPeakIdentificationResults(PrintWriter printWriter, List<IPeak> peaks) {
 
 		/*
 		 * Headline
@@ -426,7 +426,7 @@ public class ReportWriter1 {
 		}
 	}
 
-	private void reportScanIdentificationResults(PrintWriter printWriter, IChromatogram chromatogram, String messageNoResults, IProgressMonitor monitor) {
+	private void reportScanIdentificationResults(PrintWriter printWriter, IChromatogram chromatogram, String messageNoResults) {
 
 		if(scanTargetsAvailable(chromatogram)) {
 			/*
@@ -461,7 +461,7 @@ public class ReportWriter1 {
 		return false;
 	}
 
-	private void reportChromatogramIdentificationResults(PrintWriter printWriter, IChromatogram chromatogram, String messageNoResults, IProgressMonitor monitor) {
+	private void reportChromatogramIdentificationResults(PrintWriter printWriter, IChromatogram chromatogram, String messageNoResults) {
 
 		/*
 		 * Get the targets
@@ -514,7 +514,7 @@ public class ReportWriter1 {
 
 	/**
 	 * Prefix could be null if not needed.
-	 * 
+	 *
 	 * @param printWriter
 	 * @param targets
 	 * @param prefix
@@ -529,7 +529,7 @@ public class ReportWriter1 {
 			ILibraryInformation libraryInformation = identificationTarget.getLibraryInformation();
 			IComparisonResult comparisonResult = identificationTarget.getComparisonResult();
 			/*
-			 * 
+			 *
 			 */
 			if(prefix != null) {
 				printWriter.print("[" + prefix + "]");
@@ -564,7 +564,7 @@ public class ReportWriter1 {
 		}
 	}
 
-	private void reportIntegrationResults(PrintWriter printWriter, List<IIntegrationEntry> integrationEntries, String messageNoResults, IProgressMonitor monitor) {
+	private void reportIntegrationResults(PrintWriter printWriter, List<IIntegrationEntry> integrationEntries, String messageNoResults) {
 
 		if(!integrationEntries.isEmpty()) {
 			printIntegrationEntries(printWriter, integrationEntries);
@@ -601,16 +601,16 @@ public class ReportWriter1 {
 		}
 	}
 
-	private void reportPeakQuantitationResults(PrintWriter printWriter, List<IPeak> peaks, String messageNoResults, IProgressMonitor monitor) {
+	private void reportPeakQuantitationResults(PrintWriter printWriter, List<IPeak> peaks, String messageNoResults) {
 
 		if(!peaks.isEmpty()) {
-			printPeakQuantitationResults(printWriter, peaks, monitor);
+			printPeakQuantitationResults(printWriter, peaks);
 		} else {
 			printWriter.println(messageNoResults);
 		}
 	}
 
-	private void printPeakQuantitationResults(PrintWriter printWriter, List<IPeak> peaks, IProgressMonitor monitor) {
+	private void printPeakQuantitationResults(PrintWriter printWriter, List<IPeak> peaks) {
 
 		/*
 		 * Headline

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.arw/src/org/eclipse/chemclipse/csd/converter/supplier/arw/io/ChromatogramReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.arw/src/org/eclipse/chemclipse/csd/converter/supplier/arw/io/ChromatogramReader.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -38,16 +38,16 @@ public class ChromatogramReader extends AbstractChromatogramCSDReader {
 	@Override
 	public IChromatogramCSD read(File file, IProgressMonitor monitor) throws IOException {
 
-		return readChromatogram(file, monitor);
+		return readChromatogram(file);
 	}
 
 	@Override
 	public IChromatogramOverview readOverview(File file, IProgressMonitor monitor) throws IOException {
 
-		return readChromatogram(file, monitor);
+		return readChromatogram(file);
 	}
 
-	private IChromatogramCSD readChromatogram(File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramCSD readChromatogram(File file) throws IOException {
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
 		chromatogram.setFile(file);
@@ -73,12 +73,12 @@ public class ChromatogramReader extends AbstractChromatogramCSDReader {
 		/*
 		 * Set scan delay and interval
 		 */
-		calculateScanIntervalAndDelay(chromatogram, monitor);
+		calculateScanIntervalAndDelay(chromatogram);
 
 		return chromatogram;
 	}
 
-	private void calculateScanIntervalAndDelay(IChromatogramCSD chromatogram, IProgressMonitor monitor) {
+	private void calculateScanIntervalAndDelay(IChromatogramCSD chromatogram) {
 
 		ChromatogramSupport.calculateScanIntervalAndDelay(chromatogram);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.xy/src/org/eclipse/chemclipse/csd/converter/supplier/xy/io/ChromatogramReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.xy/src/org/eclipse/chemclipse/csd/converter/supplier/xy/io/ChromatogramReader.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -44,16 +44,16 @@ public class ChromatogramReader extends AbstractChromatogramCSDReader {
 	@Override
 	public IChromatogramCSD read(File file, IProgressMonitor monitor) throws IOException {
 
-		return readChromatogram(file, monitor);
+		return readChromatogram(file);
 	}
 
 	@Override
 	public IChromatogramOverview readOverview(File file, IProgressMonitor monitor) throws IOException {
 
-		return readChromatogram(file, monitor);
+		return readChromatogram(file);
 	}
 
-	private IChromatogramCSD readChromatogram(File file, IProgressMonitor monitor) {
+	private IChromatogramCSD readChromatogram(File file) {
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
 		chromatogram.setFile(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumWriterVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumWriterVersion22.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
@@ -66,10 +66,10 @@ public class MassSpectrumWriterVersion22 implements IMassSpectraWriter {
 	@Override
 	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
 
-		writeMassSpectra(file, massSpectra, monitor);
+		writeMassSpectra(file, massSpectra);
 	}
 
-	private void writeMassSpectra(File file, IMassSpectra massSpectra, IProgressMonitor monitor) {
+	private void writeMassSpectra(File file, IMassSpectra massSpectra) {
 
 		for(int i = 1; i <= massSpectra.size(); i++) {
 			IScanMSD massSpectrum = massSpectra.getMassSpectrum(i);

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.arw/src/org/eclipse/chemclipse/wsd/converter/supplier/arw/io/ChromatogramReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.arw/src/org/eclipse/chemclipse/wsd/converter/supplier/arw/io/ChromatogramReader.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Lorenz Gerber - adjust failed parsing behaviour
@@ -44,16 +44,16 @@ public class ChromatogramReader extends AbstractChromatogramWSDReader {
 	@Override
 	public IChromatogramWSD read(File file, IProgressMonitor monitor) throws IOException {
 
-		return readChromatogram(file, monitor);
+		return readChromatogram(file);
 	}
 
 	@Override
 	public IChromatogramOverview readOverview(File file, IProgressMonitor monitor) throws IOException {
 
-		return readChromatogram(file, monitor);
+		return readChromatogram(file);
 	}
 
-	private IChromatogramWSD readChromatogram(File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramWSD readChromatogram(File file) throws IOException {
 
 		/*
 		 * It's a simple text format:

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/core/ChromatogramWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/src/org/eclipse/chemclipse/xxd/converter/supplier/csv/io/core/ChromatogramWriter.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Lablicate GmbH.
+ * Copyright (c) 2011, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -61,13 +61,13 @@ public class ChromatogramWriter extends AbstractChromatogramWriter {
 		/*
 		 * Master / References
 		 */
-		writeChromatogramByType(file, chromatogram, monitor);
+		writeChromatogramByType(file, chromatogram);
 		if(PreferenceSupplier.isExportReferences()) {
-			writeChromatogramReferencesOnDemand(file, chromatogram, monitor);
+			writeChromatogramReferencesOnDemand(file, chromatogram);
 		}
 	}
 
-	private void writeChromatogramReferencesOnDemand(File file, IChromatogram chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramReferencesOnDemand(File file, IChromatogram chromatogram) throws IOException {
 
 		if(PreferenceSupplier.isExportReferences()) {
 			/*
@@ -87,26 +87,26 @@ public class ChromatogramWriter extends AbstractChromatogramWriter {
 				builder.append(i);
 				builder.append(FILE_EXTENSION);
 				File fileReference = new File(builder.toString());
-				writeChromatogramByType(fileReference, chromatogramReference, monitor);
+				writeChromatogramByType(fileReference, chromatogramReference);
 				i++;
 			}
 		}
 	}
 
-	private void writeChromatogramByType(File file, IChromatogram chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramByType(File file, IChromatogram chromatogram) throws IOException {
 
 		if(chromatogram instanceof IChromatogramCSD chromatogramCSD) {
-			writeChromatogram(file, chromatogramCSD, monitor);
+			writeChromatogram(file, chromatogramCSD);
 		} else if(chromatogram instanceof IChromatogramMSD chromatogramMSD) {
-			writeChromatogram(file, chromatogramMSD, monitor);
+			writeChromatogram(file, chromatogramMSD);
 		} else if(chromatogram instanceof IChromatogramWSD chromatogramWSD) {
-			writeChromatogram(file, chromatogramWSD, monitor);
+			writeChromatogram(file, chromatogramWSD);
 		} else if(chromatogram instanceof IChromatogramVSD chromatogramISD) {
-			writeChromatogram(file, chromatogramISD, monitor);
+			writeChromatogram(file, chromatogramISD);
 		}
 	}
 
-	private void writeChromatogram(File file, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogram(File file, IChromatogramCSD chromatogram) throws IOException {
 
 		try (CSVPrinter csvPrinter = new CSVPrinter(new FileWriter(file), CSVFormat.EXCEL)) {
 			writeTIC(csvPrinter, chromatogram);
@@ -115,7 +115,7 @@ public class ChromatogramWriter extends AbstractChromatogramWriter {
 		}
 	}
 
-	private void writeChromatogram(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogram(File file, IChromatogramMSD chromatogram) throws IOException {
 
 		try (CSVPrinter csvPrinter = new CSVPrinter(new FileWriter(file), CSVFormat.EXCEL)) {
 			if(PreferenceSupplier.isExportUseTic()) {
@@ -136,7 +136,7 @@ public class ChromatogramWriter extends AbstractChromatogramWriter {
 		}
 	}
 
-	private void writeChromatogram(File file, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogram(File file, IChromatogramWSD chromatogram) throws IOException {
 
 		try (CSVPrinter csvPrinter = new CSVPrinter(new FileWriter(file), CSVFormat.EXCEL)) {
 			if(PreferenceSupplier.isExportUseTic()) {
@@ -157,7 +157,7 @@ public class ChromatogramWriter extends AbstractChromatogramWriter {
 		}
 	}
 
-	private void writeChromatogram(File file, IChromatogramVSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogram(File file, IChromatogramVSD chromatogram) throws IOException {
 
 		try (CSVPrinter csvPrinter = new CSVPrinter(new FileWriter(file), CSVFormat.EXCEL)) {
 			writeTIC(csvPrinter, chromatogram);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/io/ChromatogramReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/io/ChromatogramReader.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -74,7 +74,7 @@ public class ChromatogramReader extends AbstractChromatogramMSDReader {
 	public IChromatogramMSD read(File file, IProgressMonitor monitor) throws IOException {
 
 		if(isValidFileFormat(file)) {
-			return readChromatogram(file, monitor);
+			return readChromatogram(file);
 		}
 
 		return null;
@@ -84,13 +84,13 @@ public class ChromatogramReader extends AbstractChromatogramMSDReader {
 	public IChromatogramOverview readOverview(File file, IProgressMonitor monitor) throws IOException {
 
 		if(isValidFileFormat(file)) {
-			return readChromatogramOverview(file, monitor);
+			return readChromatogramOverview(file);
 		}
 
 		return null;
 	}
 
-	private IChromatogramMSD readChromatogram(File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readChromatogram(File file) throws IOException {
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
 		try (BufferedReader bufferedReader = new BufferedReader(new FileReader(file))) {
@@ -258,7 +258,7 @@ public class ChromatogramReader extends AbstractChromatogramMSDReader {
 		return new IdentificationTarget(libraryInformation, comparisonResult);
 	}
 
-	private IChromatogramMSD readChromatogramOverview(File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readChromatogramOverview(File file) throws IOException {
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
 		try (BufferedReader bufferedReader = new BufferedReader(new FileReader(file))) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/io/ChromatogramWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/src/org/eclipse/chemclipse/msd/converter/supplier/jcampdx/io/ChromatogramWriter.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -31,14 +31,14 @@ public class ChromatogramWriter extends AbstractChromatogramMSDWriter {
 
 		PrintWriter printWriter = new PrintWriter(file);
 
-		writeHeader(chromatogram, printWriter, monitor);
+		writeHeader(chromatogram, printWriter);
 		writeScans(chromatogram, printWriter, monitor);
 
 		printWriter.flush();
 		printWriter.close();
 	}
 
-	private void writeHeader(IChromatogramMSD chromatogram, PrintWriter printWriter, IProgressMonitor monitor) {
+	private void writeHeader(IChromatogramMSD chromatogram, PrintWriter printWriter) {
 
 		printWriter.println("##TITLE= ");
 		printWriter.println("##JCAMP-DX= ");

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1001.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -59,7 +59,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader implemen
 		IChromatogramCSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -71,7 +71,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader implemen
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readFromZipFile(zipFile, "", file, monitor);
+				chromatogramOverview = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogramOverview;
@@ -80,18 +80,18 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader implemen
 	@Override
 	public IChromatogramCSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramCSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramCSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramCSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
 	/*
@@ -100,7 +100,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader implemen
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramCSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramCSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 		if(object instanceof ZipFile) {
@@ -122,16 +122,16 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader implemen
 		 * Read the chromatographic information.
 		 */
 		chromatogram = new VendorChromatogram();
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_FID), closeStream, chromatogram, monitor);
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_FID), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_FID), closeStream, chromatogram, monitor);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_FID), closeStream, chromatogram);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_FID), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_FID), closeStream, chromatogram);
 
-		setAdditionalInformation(file, chromatogram, monitor);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		/*
 		 * Scans
@@ -152,7 +152,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		/*
 		 * Get the Baseline
@@ -190,12 +190,12 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -206,7 +206,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private IChromatogramPeakCSD readPeak(DataInputStream dataInputStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakCSD readPeak(DataInputStream dataInputStream, IChromatogramCSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		String detectorDescription = readString(dataInputStream); // Detector Description
 		String integratorDescription = readString(dataInputStream); // Integrator Description
@@ -247,7 +247,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader implemen
 		return peak;
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramCSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramCSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1002.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -59,7 +59,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader implemen
 		IChromatogramCSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -71,7 +71,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader implemen
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readFromZipFile(zipFile, "", file, monitor);
+				chromatogramOverview = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogramOverview;
@@ -80,18 +80,18 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader implemen
 	@Override
 	public IChromatogramCSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramCSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramCSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramCSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
 	/*
@@ -100,7 +100,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader implemen
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramCSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramCSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 		if(object instanceof ZipFile) {
@@ -122,16 +122,16 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader implemen
 		 * Read the chromatographic information.
 		 */
 		chromatogram = new VendorChromatogram();
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_FID), closeStream, chromatogram, monitor);
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_FID), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_FID), closeStream, chromatogram, monitor);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_FID), closeStream, chromatogram);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_FID), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_FID), closeStream, chromatogram);
 
-		setAdditionalInformation(file, chromatogram, monitor);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		/*
 		 * Scans
@@ -151,7 +151,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		/*
 		 * Get the Baseline
@@ -189,12 +189,12 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -205,7 +205,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private IChromatogramPeakCSD readPeak(DataInputStream dataInputStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakCSD readPeak(DataInputStream dataInputStream, IChromatogramCSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		String detectorDescription = readString(dataInputStream); // Detector Description
 		String integratorDescription = readString(dataInputStream); // Integrator Description
@@ -246,7 +246,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader implemen
 		return peak;
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramCSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramCSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1003.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -59,7 +59,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader implemen
 		IChromatogramCSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -71,7 +71,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader implemen
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readFromZipFile(zipFile, "", file, monitor);
+				chromatogramOverview = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogramOverview;
@@ -80,18 +80,18 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader implemen
 	@Override
 	public IChromatogramCSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramCSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramCSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramCSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
 	/*
@@ -100,7 +100,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader implemen
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramCSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramCSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 		if(object instanceof ZipFile) {
@@ -122,16 +122,16 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader implemen
 		 * Read the chromatographic information.
 		 */
 		chromatogram = new VendorChromatogram();
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_FID), closeStream, chromatogram, monitor);
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_FID), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_FID), closeStream, chromatogram, monitor);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_FID), closeStream, chromatogram);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_FID), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_FID), closeStream, chromatogram);
 
-		setAdditionalInformation(file, chromatogram, monitor);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; scan++) {
@@ -148,7 +148,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt(); // Number of Scans
 		List<IBaselineElement> baselineElements = new ArrayList<>();
@@ -183,12 +183,12 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -200,7 +200,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private IChromatogramPeakCSD readPeak(DataInputStream dataInputStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakCSD readPeak(DataInputStream dataInputStream, IChromatogramCSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		String detectorDescription = readString(dataInputStream); // Detector Description
 		String integratorDescription = readString(dataInputStream); // Integrator Description
@@ -241,7 +241,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader implemen
 		return peak;
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramCSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramCSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1004.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -59,7 +59,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader implemen
 		IChromatogramCSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -71,7 +71,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader implemen
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readFromZipFile(zipFile, "", file, monitor);
+				chromatogramOverview = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogramOverview;
@@ -80,18 +80,18 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader implemen
 	@Override
 	public IChromatogramCSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramCSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramCSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramCSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
 	/*
@@ -100,7 +100,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader implemen
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramCSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramCSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 		if(object instanceof ZipFile) {
@@ -122,16 +122,16 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader implemen
 		 * Read the chromatographic information.
 		 */
 		chromatogram = new VendorChromatogram();
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_FID), closeStream, chromatogram, monitor);
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_FID), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_FID), closeStream, chromatogram, monitor);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_FID), closeStream, chromatogram);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_FID), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_FID), closeStream, chromatogram);
 
-		setAdditionalInformation(file, chromatogram, monitor);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; scan++) {
@@ -153,7 +153,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt(); // Number of Scans
 		List<IBaselineElement> baselineElements = new ArrayList<>();
@@ -188,12 +188,12 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -204,7 +204,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private IChromatogramPeakCSD readPeak(DataInputStream dataInputStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakCSD readPeak(DataInputStream dataInputStream, IChromatogramCSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		String detectorDescription = readString(dataInputStream); // Detector Description
 		String integratorDescription = readString(dataInputStream); // Integrator Description
@@ -250,7 +250,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader implemen
 		return peak;
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramCSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramCSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -60,7 +60,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 		IChromatogramCSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -72,7 +72,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readFromZipFile(zipFile, "", file, monitor);
+				chromatogramOverview = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogramOverview;
@@ -81,18 +81,18 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 	@Override
 	public IChromatogramCSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramCSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramCSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramCSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
 	/*
@@ -101,7 +101,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramCSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramCSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 		if(object instanceof ZipFile) {
@@ -123,17 +123,17 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 		 * Read the chromatographic information.
 		 */
 		chromatogram = new VendorChromatogram();
-		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_FID), closeStream, chromatogram, monitor);
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_FID), closeStream, chromatogram, monitor);
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_FID), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_FID), closeStream, chromatogram, monitor);
+		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_FID), closeStream, chromatogram);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_FID), closeStream, chromatogram);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_FID), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_FID), closeStream, chromatogram);
 
-		setAdditionalInformation(file, chromatogram, monitor);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		IMethod method = chromatogram.getMethod();
 
@@ -149,7 +149,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 		dataInputStream.close();
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; scan++) {
@@ -171,7 +171,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt(); // Number of Scans
 		List<IBaselineElement> baselineElements = new ArrayList<>();
@@ -206,12 +206,12 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -222,7 +222,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private IChromatogramPeakCSD readPeak(DataInputStream dataInputStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakCSD readPeak(DataInputStream dataInputStream, IChromatogramCSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		String detectorDescription = readString(dataInputStream); // Detector Description
 		String integratorDescription = readString(dataInputStream); // Integrator Description
@@ -268,7 +268,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 		return peak;
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramCSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramCSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -62,7 +62,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 		IChromatogramCSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -74,7 +74,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readFromZipFile(zipFile, "", file, monitor);
+				chromatogramOverview = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogramOverview;
@@ -83,18 +83,18 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 	@Override
 	public IChromatogramCSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramCSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramCSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramCSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
 	/*
@@ -103,7 +103,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramCSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramCSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 		if(object instanceof ZipFile) {
@@ -125,17 +125,17 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 		 * Read the chromatographic information.
 		 */
 		chromatogram = new VendorChromatogram();
-		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_FID), closeStream, chromatogram, monitor);
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_FID), closeStream, chromatogram, monitor);
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_FID), chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_FID), closeStream, chromatogram, monitor);
+		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_FID), closeStream, chromatogram);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_FID), closeStream, chromatogram);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_FID), chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_FID), closeStream, chromatogram);
 
-		setAdditionalInformation(file, chromatogram, monitor);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		IMethod method = chromatogram.getMethod();
 
@@ -153,7 +153,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; scan++) {
@@ -188,7 +188,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt(); // Number of Scans
 		List<IBaselineElement> baselineElements = new ArrayList<>();
@@ -221,12 +221,12 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 		dataInputStream.close();
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -238,7 +238,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private IChromatogramPeakCSD readPeak(DataInputStream dataInputStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakCSD readPeak(DataInputStream dataInputStream, IChromatogramCSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		String detectorDescription = readString(dataInputStream); // Detector Description
 		String quantifierDescription = readString(dataInputStream);
@@ -300,7 +300,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 		return peak;
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramCSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramCSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -62,7 +62,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 		IChromatogramCSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -74,7 +74,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readFromZipFile(zipFile, "", file, monitor);
+				chromatogramOverview = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogramOverview;
@@ -83,18 +83,18 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 	@Override
 	public IChromatogramCSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramCSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramCSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramCSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
 	/*
@@ -103,7 +103,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramCSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramCSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 		if(object instanceof ZipFile) {
@@ -125,17 +125,17 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 		 * Read the chromatographic information.
 		 */
 		chromatogram = new VendorChromatogram();
-		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_FID), closeStream, chromatogram, monitor);
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_FID), closeStream, chromatogram, monitor);
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_FID), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_FID), closeStream, chromatogram, monitor);
+		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_FID), closeStream, chromatogram);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_FID), closeStream, chromatogram);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_FID), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_FID), closeStream, chromatogram);
 
-		setAdditionalInformation(file, chromatogram, monitor);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		IMethod method = chromatogram.getMethod();
 
@@ -153,7 +153,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; scan++) {
@@ -188,7 +188,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt(); // Number of Scans
 		List<IBaselineElement> baselineElements = new ArrayList<>();
@@ -223,12 +223,12 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -239,7 +239,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private IChromatogramPeakCSD readPeak(DataInputStream dataInputStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakCSD readPeak(DataInputStream dataInputStream, IChromatogramCSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		String detectorDescription = readString(dataInputStream); // Detector Description
 		String quantifierDescription = readString(dataInputStream);
@@ -301,7 +301,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 		return peak;
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramCSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramCSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -131,16 +131,16 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 			 */
 			chromatogram = new VendorChromatogram();
 			subMonitor.worked(20);
-			readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_FID), closeStream, chromatogram, monitor);
+			readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_FID), closeStream, chromatogram);
 			subMonitor.worked(20);
-			readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_FID), closeStream, chromatogram, monitor);
+			readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_FID), closeStream, chromatogram);
 			subMonitor.worked(20);
-			readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_FID), closeStream, chromatogram, monitor);
+			readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_FID), closeStream, chromatogram);
 			subMonitor.worked(20);
-			readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_FID), closeStream, chromatogram, monitor);
+			readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_FID), closeStream, chromatogram);
 			subMonitor.worked(20);
 
-			setAdditionalInformation(file, chromatogram, monitor);
+			setAdditionalInformation(file, chromatogram);
 		} finally {
 			SubMonitor.done(subMonitor);
 		}
@@ -148,7 +148,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 		return chromatogram;
 	}
 
-	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		IMethod method = chromatogram.getMethod();
 
@@ -166,7 +166,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		/*
 		 * Scans
@@ -203,7 +203,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		/*
 		 * Get the Baseline
@@ -241,12 +241,12 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramCSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakCSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -258,7 +258,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private IChromatogramPeakCSD readPeak(DataInputStream dataInputStream, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakCSD readPeak(DataInputStream dataInputStream, IChromatogramCSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		String detectorDescription = readString(dataInputStream); // Detector Description
 		String quantifierDescription = readString(dataInputStream);
@@ -323,7 +323,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 		return peak;
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramCSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramCSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -592,11 +592,11 @@ public class ChromatogramReader_1300 extends AbstractChromatogramReader implemen
 				dataInputStream.close();
 			}
 
-			parseChromatogram(object, dataType, directory, chromatogram, closeStream, monitor);
+			parseChromatogram(object, dataType, directory, chromatogram, monitor);
 		}
 	}
 
-	private void parseChromatogram(Object object, String dataType, String directoryPrefix, IChromatogramCSD chromatogram, boolean closeStream, IProgressMonitor monitor) throws IOException {
+	private void parseChromatogram(Object object, String dataType, String directoryPrefix, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
 
 		String directory = directoryPrefix + Format.DIR_CHROMATOGRAM_REFERENCE + Format.DIR_SEPARATOR;
 		if(object instanceof ZipFile zipFile) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1002.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -67,7 +67,7 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
 
 		writeVersion(zipOutputStream, directoryPrefix);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
 	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
@@ -88,7 +88,7 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramCSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -94,17 +94,17 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 		/*
 		 * Referenced Chromatograms
 		 */
 		List<IChromatogram> referencedChromatograms = chromatogram.getReferencedChromatograms();
-		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
+		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms);
 		writeReferencedChromatograms(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -543,7 +543,7 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms) throws IOException {
 
 		ZipEntry zipEntryType = new ZipEntry(directoryPrefix + Format.FILE_REFERENCE_INFO);
 		zipOutputStream.putNextEntry(zipEntryType);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -97,7 +97,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 		/*
 		 * Referenced Chromatograms
@@ -107,7 +107,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 		writeReferencedChromatograms(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -96,17 +96,17 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 		/*
 		 * Referenced Chromatograms
 		 */
 		List<IChromatogram> referencedChromatograms = chromatogram.getReferencedChromatograms();
-		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
+		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms);
 		writeReferencedChromatograms(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -612,7 +612,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms) throws IOException {
 
 		ZipEntry zipEntryType = new ZipEntry(directoryPrefix + Format.FILE_REFERENCE_INFO);
 		zipOutputStream.putNextEntry(zipEntryType);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/csd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -95,7 +95,7 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramCSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 		/*
 		 * Referenced Chromatograms
@@ -105,7 +105,7 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 		writeReferencedChromatograms(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0701.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0701.java
@@ -79,7 +79,7 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader {
 		IChromatogramMSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -91,7 +91,7 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -100,18 +100,18 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader {
 	@Override
 	public IChromatogramMSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramMSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
 	/*
@@ -120,7 +120,7 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader {
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 
@@ -140,29 +140,29 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader {
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
 
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS), closeStream, chromatogram, monitor);
-		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA), closeStream, chromatogram, monitor);
-		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION), closeStream, chromatogram, monitor);
-		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY), closeStream, chromatogram, monitor);
-		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC), closeStream, chromatogram, monitor);
-		setAdditionalInformation(file, chromatogram, monitor);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS), closeStream, chromatogram);
+		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA), closeStream, chromatogram);
+		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION), closeStream, chromatogram);
+		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY), closeStream, chromatogram);
+		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC), closeStream, chromatogram);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IVendorScan massSpectrum;
 		IVendorIon ion;
@@ -181,14 +181,14 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);
 		ChromatogramSupport.calculateScanIntervalAndDelay(chromatogram);
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		/*
 		 * Scans
@@ -203,12 +203,12 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -220,7 +220,7 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		String detectorDescription = readString(dataInputStream); // Detector Description
 		String integratorDescription = readString(dataInputStream); // Integrator Description
@@ -252,7 +252,7 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader {
 		List<IIntegrationEntry> integrationEntries = readIntegrationEntries(dataInputStream);
 		peak.setIntegratedArea(integrationEntries, integratorDescription);
 
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 
 		return peak;
 	}
@@ -270,7 +270,7 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -302,7 +302,7 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		String integratorDescription = readString(dataInputStream); // Chromatogram Integrator Description
 		List<IIntegrationEntry> chromatogramIntegrationEntries = readIntegrationEntries(dataInputStream);
@@ -316,7 +316,7 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfTargets = dataInputStream.readInt(); // Number of Targets
 		for(int i = 1; i <= numberOfTargets; i++) {
@@ -352,7 +352,7 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		List<IEditInformation> parsedEditInformation = new ArrayList<>();
 		int numberOfEntries = dataInputStream.readInt(); // Number of entries
@@ -380,7 +380,7 @@ public class ChromatogramReader_0701 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong(); // Date
 		String miscInfo = readString(dataInputStream); // Miscellaneous Info

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0801.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0801.java
@@ -81,7 +81,7 @@ public class ChromatogramReader_0801 extends AbstractChromatogramReader {
 		IChromatogramMSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -93,7 +93,7 @@ public class ChromatogramReader_0801 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -102,18 +102,18 @@ public class ChromatogramReader_0801 extends AbstractChromatogramReader {
 	@Override
 	public IChromatogramMSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramMSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
 	/*
@@ -122,7 +122,7 @@ public class ChromatogramReader_0801 extends AbstractChromatogramReader {
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 
@@ -142,29 +142,29 @@ public class ChromatogramReader_0801 extends AbstractChromatogramReader {
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
 
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS), closeStream, chromatogram, monitor);
-		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA), closeStream, chromatogram, monitor);
-		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION), closeStream, chromatogram, monitor);
-		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY), closeStream, chromatogram, monitor);
-		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC), closeStream, chromatogram, monitor);
-		setAdditionalInformation(file, chromatogram, monitor);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS), closeStream, chromatogram);
+		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA), closeStream, chromatogram);
+		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION), closeStream, chromatogram);
+		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY), closeStream, chromatogram);
+		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC), closeStream, chromatogram);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IVendorScan massSpectrum;
 		IVendorIon ion;
@@ -183,14 +183,14 @@ public class ChromatogramReader_0801 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);
 		ChromatogramSupport.calculateScanIntervalAndDelay(chromatogram);
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		/*
 		 * Scans
@@ -205,12 +205,12 @@ public class ChromatogramReader_0801 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -221,7 +221,7 @@ public class ChromatogramReader_0801 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		String detectorDescription = readString(dataInputStream); // Detector Description
 		String integratorDescription = readString(dataInputStream); // Integrator Description
@@ -255,11 +255,11 @@ public class ChromatogramReader_0801 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
@@ -277,7 +277,7 @@ public class ChromatogramReader_0801 extends AbstractChromatogramReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -309,7 +309,7 @@ public class ChromatogramReader_0801 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {
@@ -342,7 +342,7 @@ public class ChromatogramReader_0801 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		String integratorDescription = readString(dataInputStream); // Chromatogram Integrator Description
 		List<IIntegrationEntry> chromatogramIntegrationEntries = readIntegrationEntries(dataInputStream);
@@ -356,7 +356,7 @@ public class ChromatogramReader_0801 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfTargets = dataInputStream.readInt(); // Number of Targets
 		for(int i = 1; i <= numberOfTargets; i++) {
@@ -392,7 +392,7 @@ public class ChromatogramReader_0801 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		List<IEditInformation> parsedEditInformation = new ArrayList<>();
 		int numberOfEntries = dataInputStream.readInt(); // Number of entries
@@ -420,7 +420,7 @@ public class ChromatogramReader_0801 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong(); // Date
 		String miscInfo = readString(dataInputStream); // Miscellaneous Info

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0802.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0802.java
@@ -83,7 +83,7 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 		IChromatogramMSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -95,7 +95,7 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -104,18 +104,18 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 	@Override
 	public IChromatogramMSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramMSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
 	/*
@@ -124,7 +124,7 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 
@@ -144,29 +144,29 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
 
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS), closeStream, chromatogram, monitor);
-		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA), closeStream, chromatogram, monitor);
-		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION), closeStream, chromatogram, monitor);
-		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY), closeStream, chromatogram, monitor);
-		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC), closeStream, chromatogram, monitor);
-		setAdditionalInformation(file, chromatogram, monitor);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS), closeStream, chromatogram);
+		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA), closeStream, chromatogram);
+		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION), closeStream, chromatogram);
+		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY), closeStream, chromatogram);
+		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC), closeStream, chromatogram);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IVendorScan massSpectrum;
 		IVendorIon ion;
@@ -185,14 +185,14 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);
 		ChromatogramSupport.calculateScanIntervalAndDelay(chromatogram);
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 		/*
@@ -209,12 +209,12 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -225,7 +225,7 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 
@@ -261,11 +261,11 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
@@ -283,7 +283,7 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -315,7 +315,7 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {
@@ -348,7 +348,7 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		String integratorDescription = readString(dataInputStream); // Chromatogram Integrator Description
 		List<IIntegrationEntry> chromatogramIntegrationEntries = readIntegrationEntries(dataInputStream);
@@ -362,7 +362,7 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfTargets = dataInputStream.readInt(); // Number of Targets
 		for(int i = 1; i <= numberOfTargets; i++) {
@@ -398,7 +398,7 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		List<IEditInformation> parsedEditInformation = new ArrayList<>();
 		int numberOfEntries = dataInputStream.readInt(); // Number of entries
@@ -426,7 +426,7 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong(); // Date
 		String miscInfo = readString(dataInputStream); // Miscellaneous Info

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0803.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0803.java
@@ -86,7 +86,7 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 		IChromatogramMSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -98,7 +98,7 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -107,18 +107,18 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 	@Override
 	public IChromatogramMSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramMSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
 	/*
@@ -127,7 +127,7 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 
@@ -147,30 +147,30 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
 
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS), closeStream, chromatogram, monitor);
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS), closeStream, chromatogram, monitor);
-		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA), closeStream, chromatogram, monitor);
-		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION), closeStream, chromatogram, monitor);
-		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY), closeStream, chromatogram, monitor);
-		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC), closeStream, chromatogram, monitor);
-		setAdditionalInformation(file, chromatogram, monitor);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS), closeStream, chromatogram);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS), closeStream, chromatogram);
+		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA), closeStream, chromatogram);
+		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION), closeStream, chromatogram);
+		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY), closeStream, chromatogram);
+		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC), closeStream, chromatogram);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IVendorScan massSpectrum;
 		IVendorIon ion;
@@ -189,14 +189,14 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);
 		ChromatogramSupport.calculateScanIntervalAndDelay(chromatogram);
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 		/*
@@ -213,7 +213,7 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		/*
 		 * Get the Baseline
@@ -251,12 +251,12 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -268,7 +268,7 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 
@@ -304,11 +304,11 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
@@ -326,7 +326,7 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -358,7 +358,7 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {
@@ -391,7 +391,7 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		String integratorDescription = readString(dataInputStream); // Chromatogram Integrator Description
 		List<IIntegrationEntry> chromatogramIntegrationEntries = readIntegrationEntries(dataInputStream);
@@ -405,7 +405,7 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfTargets = dataInputStream.readInt(); // Number of Targets
 		for(int i = 1; i <= numberOfTargets; i++) {
@@ -441,7 +441,7 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		List<IEditInformation> parsedEditInformation = new ArrayList<>();
 		int numberOfEntries = dataInputStream.readInt(); // Number of entries
@@ -469,7 +469,7 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong(); // Date
 		String miscInfo = readString(dataInputStream); // Miscellaneous Info

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0901.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0901.java
@@ -86,7 +86,7 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 		IChromatogramMSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -98,7 +98,7 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -107,18 +107,18 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 	@Override
 	public IChromatogramMSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramMSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
 	/*
@@ -127,7 +127,7 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 
@@ -147,30 +147,30 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
 
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS), closeStream, chromatogram, monitor);
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS), closeStream, chromatogram, monitor);
-		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA), closeStream, chromatogram, monitor);
-		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION), closeStream, chromatogram, monitor);
-		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY), closeStream, chromatogram, monitor);
-		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC), closeStream, chromatogram, monitor);
-		setAdditionalInformation(file, chromatogram, monitor);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS), closeStream, chromatogram);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS), closeStream, chromatogram);
+		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA), closeStream, chromatogram);
+		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION), closeStream, chromatogram);
+		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY), closeStream, chromatogram);
+		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC), closeStream, chromatogram);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IVendorScan massSpectrum;
 		IVendorIon ion;
@@ -189,14 +189,14 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);
 		ChromatogramSupport.calculateScanIntervalAndDelay(chromatogram);
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 		/*
@@ -213,7 +213,7 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		/*
 		 * Get the Baseline
@@ -251,12 +251,12 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -268,7 +268,7 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 
@@ -304,11 +304,11 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
@@ -326,7 +326,7 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -362,7 +362,7 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {
@@ -395,7 +395,7 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		String integratorDescription = readString(dataInputStream); // Chromatogram Integrator Description
 		List<IIntegrationEntry> chromatogramIntegrationEntries = readIntegrationEntries(dataInputStream);
@@ -409,7 +409,7 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfTargets = dataInputStream.readInt(); // Number of Targets
 		for(int i = 1; i <= numberOfTargets; i++) {
@@ -449,7 +449,7 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		List<IEditInformation> parsedEditInformation = new ArrayList<>();
 		int numberOfEntries = dataInputStream.readInt(); // Number of entries
@@ -477,7 +477,7 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong(); // Date
 		String miscInfo = readString(dataInputStream); // Miscellaneous Info

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0902.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0902.java
@@ -88,7 +88,7 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 		IChromatogramMSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -100,7 +100,7 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -109,18 +109,18 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 	@Override
 	public IChromatogramMSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramMSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
 	/*
@@ -129,7 +129,7 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 
@@ -149,30 +149,30 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
 
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS), closeStream, chromatogram, monitor);
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS), closeStream, chromatogram, monitor);
-		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA), closeStream, chromatogram, monitor);
-		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION), closeStream, chromatogram, monitor);
-		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY), closeStream, chromatogram, monitor);
-		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC), closeStream, chromatogram, monitor);
-		setAdditionalInformation(file, chromatogram, monitor);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS), closeStream, chromatogram);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS), closeStream, chromatogram);
+		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA), closeStream, chromatogram);
+		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION), closeStream, chromatogram);
+		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY), closeStream, chromatogram);
+		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC), closeStream, chromatogram);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IVendorScan massSpectrum;
 		IVendorIon ion;
@@ -191,14 +191,14 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);
 		ChromatogramSupport.calculateScanIntervalAndDelay(chromatogram);
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 		/*
@@ -214,7 +214,7 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		/*
 		 * Get the Baseline
@@ -252,12 +252,12 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -269,7 +269,7 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 
@@ -305,11 +305,11 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
@@ -327,7 +327,7 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -369,7 +369,7 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {
@@ -402,7 +402,7 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		String integratorDescription = readString(dataInputStream); // Chromatogram Integrator Description
 		List<IIntegrationEntry> chromatogramIntegrationEntries = readIntegrationEntries(dataInputStream);
@@ -416,7 +416,7 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfTargets = dataInputStream.readInt(); // Number of Targets
 		for(int i = 1; i <= numberOfTargets; i++) {
@@ -462,7 +462,7 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		List<IEditInformation> parsedEditInformation = new ArrayList<>();
 		int numberOfEntries = dataInputStream.readInt(); // Number of entries
@@ -490,7 +490,7 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong(); // Date
 		String miscInfo = readString(dataInputStream); // Miscellaneous Info

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0903.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0903.java
@@ -88,7 +88,7 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 		IChromatogramMSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -100,7 +100,7 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -109,18 +109,18 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 	@Override
 	public IChromatogramMSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramMSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
 	/*
@@ -129,7 +129,7 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 
@@ -149,30 +149,30 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
 
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS), closeStream, chromatogram, monitor);
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS), closeStream, chromatogram, monitor);
-		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA), closeStream, chromatogram, monitor);
-		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION), closeStream, chromatogram, monitor);
-		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY), closeStream, chromatogram, monitor);
-		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC), closeStream, chromatogram, monitor);
-		setAdditionalInformation(file, chromatogram, monitor);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS), closeStream, chromatogram);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS), closeStream, chromatogram);
+		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA), closeStream, chromatogram);
+		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION), closeStream, chromatogram);
+		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY), closeStream, chromatogram);
+		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC), closeStream, chromatogram);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IVendorScan massSpectrum;
 		IVendorIon ion;
@@ -191,14 +191,14 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);
 		ChromatogramSupport.calculateScanIntervalAndDelay(chromatogram);
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 		/*
@@ -215,7 +215,7 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		/*
 		 * Get the Baseline
@@ -253,12 +253,12 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -270,7 +270,7 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 
@@ -308,11 +308,11 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
@@ -330,7 +330,7 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -372,7 +372,7 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {
@@ -405,7 +405,7 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		String integratorDescription = readString(dataInputStream); // Chromatogram Integrator Description
 		List<IIntegrationEntry> chromatogramIntegrationEntries = readIntegrationEntries(dataInputStream);
@@ -419,7 +419,7 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfTargets = dataInputStream.readInt(); // Number of Targets
 		for(int i = 1; i <= numberOfTargets; i++) {
@@ -465,7 +465,7 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		List<IEditInformation> parsedEditInformation = new ArrayList<>();
 		int numberOfEntries = dataInputStream.readInt(); // Number of entries
@@ -493,7 +493,7 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong(); // Date
 		String miscInfo = readString(dataInputStream); // Miscellaneous Info

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1001.java
@@ -88,7 +88,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 		IChromatogramMSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -100,7 +100,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -109,18 +109,18 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 	@Override
 	public IChromatogramMSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramMSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
 	/*
@@ -129,7 +129,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 
@@ -149,30 +149,30 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
 
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_MSD), closeStream, chromatogram, monitor);
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_MSD), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_MSD), closeStream, chromatogram, monitor);
-		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA_MSD), closeStream, chromatogram, monitor);
-		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION_MSD), closeStream, chromatogram, monitor);
-		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_MSD), closeStream, chromatogram, monitor);
-		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_MSD), closeStream, chromatogram, monitor);
-		setAdditionalInformation(file, chromatogram, monitor);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_MSD), closeStream, chromatogram);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_MSD), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_MSD), closeStream, chromatogram);
+		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA_MSD), closeStream, chromatogram);
+		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION_MSD), closeStream, chromatogram);
+		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_MSD), closeStream, chromatogram);
+		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_MSD), closeStream, chromatogram);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_MSD);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IVendorScan massSpectrum;
 		IVendorIon ion;
@@ -191,14 +191,14 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);
 		ChromatogramSupport.calculateScanIntervalAndDelay(chromatogram);
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 		/*
@@ -214,7 +214,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		/*
 		 * Get the Baseline
@@ -252,12 +252,12 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -268,7 +268,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 
@@ -306,11 +306,11 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
@@ -328,7 +328,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -370,7 +370,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {
@@ -403,7 +403,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		String integratorDescription = readString(dataInputStream); // Chromatogram Integrator Description
 		List<IIntegrationEntry> chromatogramIntegrationEntries = readIntegrationEntries(dataInputStream);
@@ -417,7 +417,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfTargets = dataInputStream.readInt(); // Number of Targets
 		for(int i = 1; i <= numberOfTargets; i++) {
@@ -463,7 +463,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		List<IEditInformation> parsedEditInformation = new ArrayList<>();
 		int numberOfEntries = dataInputStream.readInt(); // Number of entries
@@ -491,7 +491,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong(); // Date
 		String miscInfo = readString(dataInputStream); // Miscellaneous Info

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1002.java
@@ -93,7 +93,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		IChromatogramMSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -105,7 +105,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -114,18 +114,18 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 	@Override
 	public IChromatogramMSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramMSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
 	/*
@@ -134,7 +134,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramMSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 
@@ -154,30 +154,30 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
 
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_MSD), closeStream, chromatogram, monitor);
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_MSD), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_MSD), closeStream, chromatogram, monitor);
-		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA_MSD), closeStream, chromatogram, monitor);
-		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION_MSD), closeStream, chromatogram, monitor);
-		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_MSD), closeStream, chromatogram, monitor);
-		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_MSD), closeStream, chromatogram, monitor);
-		setAdditionalInformation(file, chromatogram, monitor);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_MSD), closeStream, chromatogram);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_MSD), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_MSD), closeStream, chromatogram);
+		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA_MSD), closeStream, chromatogram);
+		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION_MSD), closeStream, chromatogram);
+		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_MSD), closeStream, chromatogram);
+		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_MSD), closeStream, chromatogram);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_MSD);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IVendorScan massSpectrum;
 		IVendorIon ion;
@@ -196,14 +196,14 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);
 		ChromatogramSupport.calculateScanIntervalAndDelay(chromatogram);
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 		/*
@@ -211,7 +211,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		 */
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; scan++) {
-			IVendorScan massSpectrum = readMassSpectrum(dataInputStream, ionTransitionSettings, monitor);
+			IVendorScan massSpectrum = readMassSpectrum(dataInputStream, ionTransitionSettings);
 			chromatogram.addScan(massSpectrum);
 		}
 		if(closeStream) {
@@ -219,7 +219,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		/*
 		 * Get the Baseline
@@ -256,12 +256,12 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -272,7 +272,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 
@@ -285,7 +285,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		float startBackgroundAbundance = dataInputStream.readFloat(); // Start Background Abundance
 		float stopBackgroundAbundance = dataInputStream.readFloat(); // Stop Background Abundance
 
-		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings, monitor);
+		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings);
 
 		int numberOfRetentionTimes = dataInputStream.readInt(); // Number Retention Times
 		IPeakIntensityValues intensityValues = new PeakIntensityValues(Float.MAX_VALUE);
@@ -310,11 +310,11 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
@@ -332,7 +332,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -374,7 +374,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {
 
 		int numberOfMassSpectrumTargets = dataInputStream.readInt(); // Number Mass Spectrum Targets
 		for(int i = 1; i <= numberOfMassSpectrumTargets; i++) {
@@ -416,7 +416,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {
@@ -449,7 +449,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		String integratorDescription = readString(dataInputStream); // Chromatogram Integrator Description
 		List<IIntegrationEntry> chromatogramIntegrationEntries = readIntegrationEntries(dataInputStream);
@@ -463,7 +463,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfTargets = dataInputStream.readInt(); // Number of Targets
 		for(int i = 1; i <= numberOfTargets; i++) {
@@ -509,7 +509,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		List<IEditInformation> parsedEditInformation = new ArrayList<>();
 		int numberOfEntries = dataInputStream.readInt(); // Number of entries
@@ -537,7 +537,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong(); // Date
 		String miscInfo = readString(dataInputStream); // Miscellaneous Info
@@ -553,7 +553,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IVendorScan readMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private IVendorScan readMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		short massSpectrometer = dataInputStream.readShort(); // Mass Spectrometer
 		short massSpectrumType = dataInputStream.readShort(); // Mass Spectrum Type
@@ -577,12 +577,12 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum, monitor);
+		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 
 		return massSpectrum;
 	}
 
-	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		short massSpectrometer = dataInputStream.readShort(); // Mass Spectrometer
 		short massSpectrumType = dataInputStream.readShort(); // Mass Spectrum Type
@@ -606,7 +606,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum, monitor);
+		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 
 		return massSpectrum;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1003.java
@@ -110,7 +110,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -166,31 +166,31 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		if(useScanProxies) {
 			readScanProxies((ZipFile)object, directoryPrefix, file, chromatogram, monitor);
 		} else {
-			readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_MSD), closeStream, chromatogram, monitor);
+			readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_MSD), closeStream, chromatogram);
 		}
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_MSD), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_MSD), closeStream, chromatogram, monitor);
-		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA_MSD), closeStream, chromatogram, monitor);
-		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION_MSD), closeStream, chromatogram, monitor);
-		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_MSD), closeStream, chromatogram, monitor);
-		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_MSD), closeStream, chromatogram, monitor);
-		setAdditionalInformation(file, chromatogram, monitor);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_MSD), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_MSD), closeStream, chromatogram);
+		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA_MSD), closeStream, chromatogram);
+		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION_MSD), closeStream, chromatogram);
+		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_MSD), closeStream, chromatogram);
+		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_MSD), closeStream, chromatogram);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_MSD);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IVendorScan massSpectrum;
 		IVendorIon ion;
@@ -209,7 +209,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);
@@ -244,7 +244,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		dataInputStream.close();
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 		/*
@@ -263,7 +263,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		/*
 		 * Get the Baseline
@@ -304,12 +304,12 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -321,7 +321,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 
@@ -334,7 +334,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		float startBackgroundAbundance = dataInputStream.readFloat(); // Start Background Abundance
 		float stopBackgroundAbundance = dataInputStream.readFloat(); // Stop Background Abundance
 
-		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings, monitor);
+		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings);
 
 		int numberOfRetentionTimes = dataInputStream.readInt(); // Number Retention Times
 		IPeakIntensityValues intensityValues = new PeakIntensityValues(Float.MAX_VALUE);
@@ -359,11 +359,11 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
@@ -381,7 +381,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -423,7 +423,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {
 
 		int numberOfMassSpectrumTargets = dataInputStream.readInt(); // Number Mass Spectrum Targets
 		for(int i = 1; i <= numberOfMassSpectrumTargets; i++) {
@@ -465,7 +465,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {
@@ -498,7 +498,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		String integratorDescription = readString(dataInputStream); // Chromatogram Integrator Description
 		List<IIntegrationEntry> chromatogramIntegrationEntries = readIntegrationEntries(dataInputStream);
@@ -512,7 +512,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfTargets = dataInputStream.readInt(); // Number of Targets
 		for(int i = 1; i <= numberOfTargets; i++) {
@@ -558,7 +558,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		List<IEditInformation> parsedEditInformation = new ArrayList<>();
 		int numberOfEntries = dataInputStream.readInt(); // Number of entries
@@ -586,7 +586,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong(); // Date
 		String miscInfo = readString(dataInputStream); // Miscellaneous Info
@@ -602,7 +602,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		short massSpectrometer = dataInputStream.readShort(); // Mass Spectrometer
 		short massSpectrumType = dataInputStream.readShort(); // Mass Spectrum Type
@@ -626,7 +626,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum, monitor);
+		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 
 		return massSpectrum;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1004.java
@@ -111,7 +111,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -167,31 +167,31 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		if(useScanProxies) {
 			readScanProxies((ZipFile)object, directoryPrefix, file, chromatogram, monitor);
 		} else {
-			readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_MSD), closeStream, chromatogram, monitor);
+			readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_MSD), closeStream, chromatogram);
 		}
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_MSD), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_MSD), closeStream, chromatogram, monitor);
-		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA_MSD), closeStream, chromatogram, monitor);
-		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION_MSD), closeStream, chromatogram, monitor);
-		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_MSD), closeStream, chromatogram, monitor);
-		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_MSD), closeStream, chromatogram, monitor);
-		setAdditionalInformation(file, chromatogram, monitor);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_MSD), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_MSD), closeStream, chromatogram);
+		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA_MSD), closeStream, chromatogram);
+		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION_MSD), closeStream, chromatogram);
+		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_MSD), closeStream, chromatogram);
+		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_MSD), closeStream, chromatogram);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_MSD);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IVendorScan massSpectrum;
 		IVendorIon ion;
@@ -210,7 +210,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);
@@ -249,7 +249,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		dataInputStream.close();
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 		/*
@@ -268,7 +268,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		/*
 		 * Get the Baseline
@@ -309,12 +309,12 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -326,7 +326,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 
@@ -339,7 +339,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		float startBackgroundAbundance = dataInputStream.readFloat(); // Start Background Abundance
 		float stopBackgroundAbundance = dataInputStream.readFloat(); // Stop Background Abundance
 
-		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings, monitor);
+		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings);
 
 		int numberOfRetentionTimes = dataInputStream.readInt(); // Number Retention Times
 		IPeakIntensityValues intensityValues = new PeakIntensityValues(Float.MAX_VALUE);
@@ -364,18 +364,18 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 		/*
 		 * Optimized Mass Spectrum
 		 */
 		boolean readOptimizedMassSpectrum = dataInputStream.readBoolean();
 		if(readOptimizedMassSpectrum) {
 			IScanMSD optimizedMassSpectrum = new ScanMSD();
-			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings, monitor);
+			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings);
 			peakMaximum.setOptimizedMassSpectrum(optimizedMassSpectrum);
 		}
 
@@ -395,7 +395,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -437,7 +437,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {
 
 		int numberOfMassSpectrumTargets = dataInputStream.readInt(); // Number Mass Spectrum Targets
 		for(int i = 1; i <= numberOfMassSpectrumTargets; i++) {
@@ -479,7 +479,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {
@@ -512,7 +512,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		String integratorDescription = readString(dataInputStream); // Chromatogram Integrator Description
 		List<IIntegrationEntry> chromatogramIntegrationEntries = readIntegrationEntries(dataInputStream);
@@ -526,7 +526,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfTargets = dataInputStream.readInt(); // Number of Targets
 		for(int i = 1; i <= numberOfTargets; i++) {
@@ -572,7 +572,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		List<IEditInformation> parsedEditInformation = new ArrayList<>();
 		int numberOfEntries = dataInputStream.readInt(); // Number of entries
@@ -600,7 +600,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong(); // Date
 		String miscInfo = readString(dataInputStream); // Miscellaneous Info
@@ -616,7 +616,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		short massSpectrometer = dataInputStream.readShort(); // Mass Spectrometer
 		short massSpectrumType = dataInputStream.readShort(); // Mass Spectrum Type
@@ -627,12 +627,12 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		massSpectrum.setMassSpectrumType(getMassSpectrumType(massSpectrumType));
 		massSpectrum.setPrecursorIon(precursorIon);
 
-		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings, monitor);
+		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings);
 
 		return massSpectrum;
 	}
 
-	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		int retentionTime = dataInputStream.readInt();
 		float retentionIndex = dataInputStream.readFloat(); // Retention Index
@@ -654,7 +654,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum, monitor);
+		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
 	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
@@ -112,7 +112,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -165,24 +165,24 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
 
-		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_MSD), closeStream, chromatogram, monitor);
+		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_MSD), closeStream, chromatogram);
 		if(useScanProxies) {
 			readScanProxies((ZipFile)object, directoryPrefix, file, chromatogram, monitor);
 		} else {
-			readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_MSD), closeStream, chromatogram, monitor);
+			readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_MSD), closeStream, chromatogram);
 		}
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_MSD), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_MSD), closeStream, chromatogram, monitor);
-		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA_MSD), closeStream, chromatogram, monitor);
-		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION_MSD), closeStream, chromatogram, monitor);
-		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_MSD), closeStream, chromatogram, monitor);
-		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_MSD), closeStream, chromatogram, monitor);
-		setAdditionalInformation(file, chromatogram, monitor);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_MSD), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_MSD), closeStream, chromatogram);
+		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA_MSD), closeStream, chromatogram);
+		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION_MSD), closeStream, chromatogram);
+		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_MSD), closeStream, chromatogram);
+		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_MSD), closeStream, chromatogram);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IMethod method = chromatogram.getMethod();
 
@@ -200,18 +200,18 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_MSD);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IVendorScan massSpectrum;
 		IVendorIon ion;
@@ -230,7 +230,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);
@@ -269,7 +269,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		dataInputStream.close();
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 
@@ -289,7 +289,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		/*
 		 * Get the Baseline
@@ -330,12 +330,12 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -347,7 +347,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 
@@ -360,7 +360,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		float startBackgroundAbundance = dataInputStream.readFloat(); // Start Background Abundance
 		float stopBackgroundAbundance = dataInputStream.readFloat(); // Stop Background Abundance
 
-		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings, monitor);
+		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings);
 
 		int numberOfRetentionTimes = dataInputStream.readInt(); // Number Retention Times
 		IPeakIntensityValues intensityValues = new PeakIntensityValues(Float.MAX_VALUE);
@@ -385,18 +385,18 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 		/*
 		 * Optimized Mass Spectrum
 		 */
 		boolean readOptimizedMassSpectrum = dataInputStream.readBoolean();
 		if(readOptimizedMassSpectrum) {
 			IScanMSD optimizedMassSpectrum = new ScanMSD();
-			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings, monitor);
+			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings);
 			peakMaximum.setOptimizedMassSpectrum(optimizedMassSpectrum);
 		}
 
@@ -416,7 +416,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -458,7 +458,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {
 
 		int numberOfMassSpectrumTargets = dataInputStream.readInt(); // Number Mass Spectrum Targets
 		for(int i = 1; i <= numberOfMassSpectrumTargets; i++) {
@@ -500,7 +500,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {
@@ -533,7 +533,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		String integratorDescription = readString(dataInputStream); // Chromatogram Integrator Description
 		List<IIntegrationEntry> chromatogramIntegrationEntries = readIntegrationEntries(dataInputStream);
@@ -547,7 +547,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfTargets = dataInputStream.readInt(); // Number of Targets
 		for(int i = 1; i <= numberOfTargets; i++) {
@@ -593,7 +593,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		List<IEditInformation> parsedEditInformation = new ArrayList<>();
 		int numberOfEntries = dataInputStream.readInt(); // Number of entries
@@ -621,7 +621,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong(); // Date
 		String miscInfo = readString(dataInputStream); // Miscellaneous Info
@@ -637,7 +637,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		short massSpectrometer = dataInputStream.readShort(); // Mass Spectrometer
 		short massSpectrumType = dataInputStream.readShort(); // Mass Spectrum Type
@@ -648,12 +648,12 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		massSpectrum.setMassSpectrumType(getMassSpectrumType(massSpectrumType));
 		massSpectrum.setPrecursorIon(precursorIon);
 
-		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings, monitor);
+		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings);
 
 		return massSpectrum;
 	}
 
-	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		int retentionTime = dataInputStream.readInt();
 		float retentionIndex = dataInputStream.readFloat(); // Retention Index
@@ -675,7 +675,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum, monitor);
+		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
 	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
@@ -112,7 +112,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -165,24 +165,24 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
 
-		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_MSD), closeStream, chromatogram, monitor);
+		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_MSD), closeStream, chromatogram);
 		if(useScanProxies) {
 			readScanProxies((ZipFile)object, directoryPrefix, file, chromatogram, monitor);
 		} else {
-			readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_MSD), closeStream, chromatogram, monitor);
+			readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_MSD), closeStream, chromatogram);
 		}
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_MSD), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_MSD), closeStream, chromatogram, monitor);
-		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA_MSD), closeStream, chromatogram, monitor);
-		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION_MSD), closeStream, chromatogram, monitor);
-		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_MSD), closeStream, chromatogram, monitor);
-		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_MSD), closeStream, chromatogram, monitor);
-		setAdditionalInformation(file, chromatogram, monitor);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_MSD), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_MSD), closeStream, chromatogram);
+		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA_MSD), closeStream, chromatogram);
+		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION_MSD), closeStream, chromatogram);
+		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_MSD), closeStream, chromatogram);
+		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_MSD), closeStream, chromatogram);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IMethod method = chromatogram.getMethod();
 
@@ -200,18 +200,18 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_MSD);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IVendorScan massSpectrum;
 		IVendorIon ion;
@@ -230,7 +230,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);
@@ -269,7 +269,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		dataInputStream.close();
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 
@@ -289,7 +289,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		/*
 		 * Get the Baseline
@@ -330,12 +330,12 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -347,7 +347,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 
@@ -362,7 +362,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		float startBackgroundAbundance = dataInputStream.readFloat(); // Start Background Abundance
 		float stopBackgroundAbundance = dataInputStream.readFloat(); // Stop Background Abundance
 
-		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings, monitor);
+		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings);
 
 		int numberOfRetentionTimes = dataInputStream.readInt(); // Number Retention Times
 		IPeakIntensityValues intensityValues = new PeakIntensityValues(Float.MAX_VALUE);
@@ -389,18 +389,18 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 		/*
 		 * Optimized Mass Spectrum
 		 */
 		boolean readOptimizedMassSpectrum = dataInputStream.readBoolean();
 		if(readOptimizedMassSpectrum) {
 			IScanMSD optimizedMassSpectrum = new ScanMSD();
-			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings, monitor);
+			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings);
 			peakMaximum.setOptimizedMassSpectrum(optimizedMassSpectrum);
 		}
 
@@ -420,7 +420,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -484,7 +484,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {
 
 		int numberOfMassSpectrumTargets = dataInputStream.readInt(); // Number Mass Spectrum Targets
 		for(int i = 1; i <= numberOfMassSpectrumTargets; i++) {
@@ -548,7 +548,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {
@@ -581,7 +581,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		String integratorDescription = readString(dataInputStream); // Chromatogram Integrator Description
 		List<IIntegrationEntry> chromatogramIntegrationEntries = readIntegrationEntries(dataInputStream);
@@ -595,7 +595,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfTargets = dataInputStream.readInt(); // Number of Targets
 		for(int i = 1; i <= numberOfTargets; i++) {
@@ -663,7 +663,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		List<IEditInformation> parsedEditInformation = new ArrayList<>();
 		int numberOfEntries = dataInputStream.readInt(); // Number of entries
@@ -691,7 +691,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong(); // Date
 		String miscInfo = readString(dataInputStream); // Miscellaneous Info
@@ -711,7 +711,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		short massSpectrometer = dataInputStream.readShort(); // Mass Spectrometer
 		short massSpectrumType = dataInputStream.readShort(); // Mass Spectrum Type
@@ -722,12 +722,12 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		massSpectrum.setMassSpectrumType(getMassSpectrumType(massSpectrumType));
 		massSpectrum.setPrecursorIon(precursorIon);
 
-		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings, monitor);
+		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings);
 
 		return massSpectrum;
 	}
 
-	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		int retentionTime = dataInputStream.readInt();
 		int retentionTimeColumn1 = dataInputStream.readInt();
@@ -761,7 +761,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum, monitor);
+		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
 	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
@@ -112,7 +112,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -165,24 +165,24 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
 
-		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_MSD), closeStream, chromatogram, monitor);
+		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_MSD), closeStream, chromatogram);
 		if(useScanProxies) {
 			readScanProxies((ZipFile)object, directoryPrefix, file, chromatogram, monitor);
 		} else {
-			readScans(getDataInputStream(object, Format.FILE_SCANS_MSD), closeStream, chromatogram, monitor);
+			readScans(getDataInputStream(object, Format.FILE_SCANS_MSD), closeStream, chromatogram);
 		}
-		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_MSD), closeStream, chromatogram, monitor);
-		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_MSD), closeStream, chromatogram, monitor);
-		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA_MSD), closeStream, chromatogram, monitor);
-		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION_MSD), closeStream, chromatogram, monitor);
-		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_MSD), closeStream, chromatogram, monitor);
-		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_MSD), closeStream, chromatogram, monitor);
-		setAdditionalInformation(file, chromatogram, monitor);
+		readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_MSD), closeStream, chromatogram);
+		readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_MSD), closeStream, chromatogram);
+		readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA_MSD), closeStream, chromatogram);
+		readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION_MSD), closeStream, chromatogram);
+		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_MSD), closeStream, chromatogram);
+		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_MSD), closeStream, chromatogram);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IMethod method = chromatogram.getMethod();
 
@@ -200,19 +200,19 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_MSD);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IVendorScan massSpectrum;
 		IVendorIon ion;
@@ -231,7 +231,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);
@@ -270,7 +270,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		dataInputStream.close();
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 		/*
@@ -289,7 +289,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaseline(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		/*
 		 * Get the Baseline
@@ -330,12 +330,12 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readPeaks(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram, monitor);
+				IChromatogramPeakMSD peak = readPeak(dataInputStream, chromatogram);
 				chromatogram.getPeaks().add(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -347,7 +347,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IChromatogramPeakMSD readPeak(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = chromatogram.getIonTransitionSettings();
 
@@ -362,7 +362,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		float startBackgroundAbundance = dataInputStream.readFloat(); // Start Background Abundance
 		float stopBackgroundAbundance = dataInputStream.readFloat(); // Stop Background Abundance
 
-		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings, monitor);
+		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings);
 
 		int numberOfRetentionTimes = dataInputStream.readInt(); // Number Retention Times
 		IPeakIntensityValues intensityValues = new PeakIntensityValues(Float.MAX_VALUE);
@@ -389,18 +389,18 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 		/*
 		 * Optimized Mass Spectrum
 		 */
 		boolean readOptimizedMassSpectrum = dataInputStream.readBoolean();
 		if(readOptimizedMassSpectrum) {
 			IScanMSD optimizedMassSpectrum = new ScanMSD();
-			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings, monitor);
+			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings);
 			peakMaximum.setOptimizedMassSpectrum(optimizedMassSpectrum);
 		}
 
@@ -420,7 +420,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -479,7 +479,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {
 
 		int numberOfMassSpectrumTargets = dataInputStream.readInt(); // Number Mass Spectrum Targets
 		for(int i = 1; i <= numberOfMassSpectrumTargets; i++) {
@@ -538,7 +538,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {
@@ -571,7 +571,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		String integratorDescription = readString(dataInputStream); // Chromatogram Integrator Description
 		List<IIntegrationEntry> chromatogramIntegrationEntries = readIntegrationEntries(dataInputStream);
@@ -585,7 +585,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readIdentification(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		int numberOfTargets = dataInputStream.readInt(); // Number of Targets
 		for(int i = 1; i <= numberOfTargets; i++) {
@@ -648,7 +648,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		List<IEditInformation> parsedEditInformation = new ArrayList<>();
 		int numberOfEntries = dataInputStream.readInt(); // Number of entries
@@ -676,7 +676,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong(); // Date
 		String miscInfo = readString(dataInputStream); // Miscellaneous Info
@@ -696,7 +696,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		short massSpectrometer = dataInputStream.readShort(); // Mass Spectrometer
 		short massSpectrumType = dataInputStream.readShort(); // Mass Spectrum Type
@@ -707,12 +707,12 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		massSpectrum.setMassSpectrumType(getMassSpectrumType(massSpectrumType));
 		massSpectrum.setPrecursorIon(precursorIon);
 
-		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings, monitor);
+		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings);
 
 		return massSpectrum;
 	}
 
-	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		int retentionTime = dataInputStream.readInt();
 		int retentionTimeColumn1 = dataInputStream.readInt();
@@ -746,7 +746,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum, monitor);
+		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
 	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
@@ -116,7 +116,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -171,7 +171,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 			}
 			subMonitor.worked(10);
 
-			readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_MSD), closeStream, chromatogram, subMonitor.split(10));
+			readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_MSD), closeStream, chromatogram);
 			if(useScanProxies) {
 				readScanProxies((ZipFile)object, directoryPrefix, file, chromatogram, subMonitor.split(10));
 			} else {
@@ -179,11 +179,11 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 			}
 			readBaseline(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_MSD), closeStream, chromatogram, subMonitor.split(10));
 			readPeaks(getDataInputStream(object, directoryPrefix + Format.FILE_PEAKS_MSD), closeStream, chromatogram, subMonitor.split(10));
-			readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA_MSD), closeStream, chromatogram, subMonitor.split(10));
+			readArea(getDataInputStream(object, directoryPrefix + Format.FILE_AREA_MSD), closeStream, chromatogram);
 			readIdentification(getDataInputStream(object, directoryPrefix + Format.FILE_IDENTIFICATION_MSD), closeStream, chromatogram, subMonitor.split(10));
 			readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_MSD), closeStream, chromatogram, subMonitor.split(10));
-			readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_MSD), closeStream, chromatogram, subMonitor.split(10));
-			setAdditionalInformation(file, chromatogram, subMonitor.split(10));
+			readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_MSD), closeStream, chromatogram);
+			setAdditionalInformation(file, chromatogram);
 		} finally {
 			SubMonitor.done(subMonitor);
 		}
@@ -191,7 +191,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 		return chromatogram;
 	}
 
-	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IMethod method = chromatogram.getMethod();
 
@@ -209,19 +209,19 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_MSD);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramMSD chromatogram) throws IOException {
 
 		IVendorScan massSpectrum;
 		IVendorIon ion;
@@ -240,7 +240,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramMSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);
@@ -398,7 +398,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 			float startBackgroundAbundance = dataInputStream.readFloat(); // Start Background Abundance
 			float stopBackgroundAbundance = dataInputStream.readFloat(); // Stop Background Abundance
 
-			IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings, subMonitor.split(10));
+			IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings);
 
 			int numberOfRetentionTimes = dataInputStream.readInt(); // Number Retention Times
 			IPeakIntensityValues intensityValues = new PeakIntensityValues(Float.MAX_VALUE);
@@ -425,18 +425,18 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 			/*
 			 * Identification Results
 			 */
-			readPeakIdentificationTargets(dataInputStream, peak, subMonitor.split(10));
+			readPeakIdentificationTargets(dataInputStream, peak);
 			/*
 			 * Quantitation Results
 			 */
-			readPeakQuantitationEntries(dataInputStream, peak, subMonitor.split(10));
+			readPeakQuantitationEntries(dataInputStream, peak);
 			/*
 			 * Optimized Mass Spectrum
 			 */
 			boolean readOptimizedMassSpectrum = dataInputStream.readBoolean();
 			if(readOptimizedMassSpectrum) {
 				IScanMSD optimizedMassSpectrum = new ScanMSD();
-				readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings, subMonitor.split(10));
+				readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings);
 				peakMaximum.setOptimizedMassSpectrum(optimizedMassSpectrum);
 			}
 
@@ -479,7 +479,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -538,7 +538,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {
 
 		int numberOfMassSpectrumTargets = dataInputStream.readInt(); // Number Mass Spectrum Targets
 		for(int i = 1; i <= numberOfMassSpectrumTargets; i++) {
@@ -597,7 +597,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {
@@ -630,7 +630,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readArea(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		String integratorDescription = readString(dataInputStream); // Chromatogram Integrator Description
 		List<IIntegrationEntry> chromatogramIntegrationEntries = readIntegrationEntries(dataInputStream);
@@ -747,7 +747,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong(); // Date
 		String miscInfo = readString(dataInputStream); // Miscellaneous Info
@@ -767,7 +767,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		short massSpectrometer = dataInputStream.readShort(); // Mass Spectrometer
 		short massSpectrumType = dataInputStream.readShort(); // Mass Spectrum Type
@@ -778,12 +778,12 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 		massSpectrum.setMassSpectrumType(getMassSpectrumType(massSpectrumType));
 		massSpectrum.setPrecursorIon(precursorIon);
 
-		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings, monitor);
+		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings);
 
 		return massSpectrum;
 	}
 
-	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		int retentionTime = dataInputStream.readInt();
 		int retentionTimeColumn1 = dataInputStream.readInt();
@@ -817,7 +817,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 		/*
 		 * Identification Results
 		 */
-		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum, monitor);
+		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
 	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
@@ -127,7 +127,7 @@ public class ChromatogramReader_1301 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -236,7 +236,7 @@ public class ChromatogramReader_1301 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_MSD);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
@@ -131,7 +131,7 @@ public class ChromatogramReader_1400 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -240,7 +240,7 @@ public class ChromatogramReader_1400 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_MSD);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1500.java
@@ -132,7 +132,7 @@ public class ChromatogramReader_1500 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -241,7 +241,7 @@ public class ChromatogramReader_1500 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_MSD);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1501.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1501.java
@@ -116,7 +116,7 @@ public class ChromatogramReader_1501 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -225,7 +225,7 @@ public class ChromatogramReader_1501 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_MSD);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1502.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1502.java
@@ -116,7 +116,7 @@ public class ChromatogramReader_1502 extends AbstractChromatogramReader {
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -225,7 +225,7 @@ public class ChromatogramReader_1502 extends AbstractChromatogramReader {
 		}
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_MSD);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0701.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0701.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -77,12 +77,12 @@ public class ChromatogramWriter_0701 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -100,7 +100,7 @@ public class ChromatogramWriter_0701 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -128,7 +128,7 @@ public class ChromatogramWriter_0701 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		/*
@@ -140,15 +140,15 @@ public class ChromatogramWriter_0701 extends AbstractChromatogramWriter implemen
 		/*
 		 * WRITE THE FILES
 		 */
-		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
-		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -170,7 +170,7 @@ public class ChromatogramWriter_0701 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -191,7 +191,7 @@ public class ChromatogramWriter_0701 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -214,7 +214,7 @@ public class ChromatogramWriter_0701 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -269,7 +269,7 @@ public class ChromatogramWriter_0701 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0801.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0801.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -78,12 +78,12 @@ public class ChromatogramWriter_0801 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -101,7 +101,7 @@ public class ChromatogramWriter_0801 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -129,7 +129,7 @@ public class ChromatogramWriter_0801 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		/*
@@ -141,15 +141,15 @@ public class ChromatogramWriter_0801 extends AbstractChromatogramWriter implemen
 		/*
 		 * WRITE THE FILES
 		 */
-		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
-		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -171,7 +171,7 @@ public class ChromatogramWriter_0801 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -192,7 +192,7 @@ public class ChromatogramWriter_0801 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -215,7 +215,7 @@ public class ChromatogramWriter_0801 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -270,7 +270,7 @@ public class ChromatogramWriter_0801 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0802.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0802.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -79,12 +79,12 @@ public class ChromatogramWriter_0802 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -102,7 +102,7 @@ public class ChromatogramWriter_0802 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -130,7 +130,7 @@ public class ChromatogramWriter_0802 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		/*
@@ -142,15 +142,15 @@ public class ChromatogramWriter_0802 extends AbstractChromatogramWriter implemen
 		/*
 		 * WRITE THE FILES
 		 */
-		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
-		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -172,7 +172,7 @@ public class ChromatogramWriter_0802 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -193,7 +193,7 @@ public class ChromatogramWriter_0802 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -216,7 +216,7 @@ public class ChromatogramWriter_0802 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -271,7 +271,7 @@ public class ChromatogramWriter_0802 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0803.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0803.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -80,12 +80,12 @@ public class ChromatogramWriter_0803 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -103,7 +103,7 @@ public class ChromatogramWriter_0803 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -131,7 +131,7 @@ public class ChromatogramWriter_0803 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		/*
@@ -143,16 +143,16 @@ public class ChromatogramWriter_0803 extends AbstractChromatogramWriter implemen
 		/*
 		 * WRITE THE FILES
 		 */
-		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
-		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -174,7 +174,7 @@ public class ChromatogramWriter_0803 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -200,7 +200,7 @@ public class ChromatogramWriter_0803 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -221,7 +221,7 @@ public class ChromatogramWriter_0803 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -244,7 +244,7 @@ public class ChromatogramWriter_0803 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -299,7 +299,7 @@ public class ChromatogramWriter_0803 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0901.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0901.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -81,12 +81,12 @@ public class ChromatogramWriter_0901 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -104,7 +104,7 @@ public class ChromatogramWriter_0901 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -132,7 +132,7 @@ public class ChromatogramWriter_0901 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		/*
@@ -144,16 +144,16 @@ public class ChromatogramWriter_0901 extends AbstractChromatogramWriter implemen
 		/*
 		 * WRITE THE FILES
 		 */
-		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
-		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -175,7 +175,7 @@ public class ChromatogramWriter_0901 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -201,7 +201,7 @@ public class ChromatogramWriter_0901 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -222,7 +222,7 @@ public class ChromatogramWriter_0901 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -245,7 +245,7 @@ public class ChromatogramWriter_0901 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -300,7 +300,7 @@ public class ChromatogramWriter_0901 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0902.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0902.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -80,12 +80,12 @@ public class ChromatogramWriter_0902 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -103,7 +103,7 @@ public class ChromatogramWriter_0902 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -131,7 +131,7 @@ public class ChromatogramWriter_0902 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		/*
@@ -143,16 +143,16 @@ public class ChromatogramWriter_0902 extends AbstractChromatogramWriter implemen
 		/*
 		 * WRITE THE FILES
 		 */
-		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
-		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -174,7 +174,7 @@ public class ChromatogramWriter_0902 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -200,7 +200,7 @@ public class ChromatogramWriter_0902 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -221,7 +221,7 @@ public class ChromatogramWriter_0902 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -244,7 +244,7 @@ public class ChromatogramWriter_0902 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -299,7 +299,7 @@ public class ChromatogramWriter_0902 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0903.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0903.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -80,12 +80,12 @@ public class ChromatogramWriter_0903 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -103,7 +103,7 @@ public class ChromatogramWriter_0903 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -131,7 +131,7 @@ public class ChromatogramWriter_0903 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		/*
@@ -143,16 +143,16 @@ public class ChromatogramWriter_0903 extends AbstractChromatogramWriter implemen
 		/*
 		 * WRITE THE FILES
 		 */
-		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
-		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -174,7 +174,7 @@ public class ChromatogramWriter_0903 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -200,7 +200,7 @@ public class ChromatogramWriter_0903 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -221,7 +221,7 @@ public class ChromatogramWriter_0903 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -244,7 +244,7 @@ public class ChromatogramWriter_0903 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -299,7 +299,7 @@ public class ChromatogramWriter_0903 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1001.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -80,12 +80,12 @@ public class ChromatogramWriter_1001 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -103,7 +103,7 @@ public class ChromatogramWriter_1001 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -131,7 +131,7 @@ public class ChromatogramWriter_1001 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		/*
@@ -143,16 +143,16 @@ public class ChromatogramWriter_1001 extends AbstractChromatogramWriter implemen
 		/*
 		 * WRITE THE FILES
 		 */
-		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
-		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -174,7 +174,7 @@ public class ChromatogramWriter_1001 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -200,7 +200,7 @@ public class ChromatogramWriter_1001 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -221,7 +221,7 @@ public class ChromatogramWriter_1001 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -244,7 +244,7 @@ public class ChromatogramWriter_1001 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -299,7 +299,7 @@ public class ChromatogramWriter_1001 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1002.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -81,12 +81,12 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -104,7 +104,7 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -132,7 +132,7 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		/*
@@ -144,16 +144,16 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 		/*
 		 * WRITE THE FILES
 		 */
-		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
-		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -175,7 +175,7 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -201,7 +201,7 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -222,7 +222,7 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -245,7 +245,7 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -300,7 +300,7 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1003.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -84,12 +84,12 @@ public class ChromatogramWriter_1003 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -107,7 +107,7 @@ public class ChromatogramWriter_1003 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -135,7 +135,7 @@ public class ChromatogramWriter_1003 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		/*
@@ -147,16 +147,16 @@ public class ChromatogramWriter_1003 extends AbstractChromatogramWriter implemen
 		/*
 		 * WRITE THE FILES
 		 */
-		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
-		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -194,10 +194,10 @@ public class ChromatogramWriter_1003 extends AbstractChromatogramWriter implemen
 		/*
 		 * Scan Proxies
 		 */
-		writeChromatogramScanProxies(zipOutputStream, directoryPrefix, scanProxies, monitor);
+		writeChromatogramScanProxies(zipOutputStream, directoryPrefix, scanProxies);
 	}
 
-	private void writeChromatogramScanProxies(ZipOutputStream zipOutputStream, String directoryPrefix, List<IScanProxy> scanProxies, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScanProxies(ZipOutputStream zipOutputStream, String directoryPrefix, List<IScanProxy> scanProxies) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -222,7 +222,7 @@ public class ChromatogramWriter_1003 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -248,7 +248,7 @@ public class ChromatogramWriter_1003 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -269,7 +269,7 @@ public class ChromatogramWriter_1003 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -292,7 +292,7 @@ public class ChromatogramWriter_1003 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -347,7 +347,7 @@ public class ChromatogramWriter_1003 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1004.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -84,12 +84,12 @@ public class ChromatogramWriter_1004 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -107,7 +107,7 @@ public class ChromatogramWriter_1004 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -135,7 +135,7 @@ public class ChromatogramWriter_1004 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		/*
@@ -147,16 +147,16 @@ public class ChromatogramWriter_1004 extends AbstractChromatogramWriter implemen
 		/*
 		 * WRITE THE FILES
 		 */
-		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
-		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -206,10 +206,10 @@ public class ChromatogramWriter_1004 extends AbstractChromatogramWriter implemen
 		/*
 		 * Scan Proxies
 		 */
-		writeChromatogramScanProxies(zipOutputStream, directoryPrefix, scanProxies, monitor);
+		writeChromatogramScanProxies(zipOutputStream, directoryPrefix, scanProxies);
 	}
 
-	private void writeChromatogramScanProxies(ZipOutputStream zipOutputStream, String directoryPrefix, List<IScanProxy> scanProxies, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScanProxies(ZipOutputStream zipOutputStream, String directoryPrefix, List<IScanProxy> scanProxies) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -236,7 +236,7 @@ public class ChromatogramWriter_1004 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -262,7 +262,7 @@ public class ChromatogramWriter_1004 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -283,7 +283,7 @@ public class ChromatogramWriter_1004 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -306,7 +306,7 @@ public class ChromatogramWriter_1004 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -361,7 +361,7 @@ public class ChromatogramWriter_1004 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1005.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -85,12 +85,12 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -108,7 +108,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -136,7 +136,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		/*
@@ -148,17 +148,17 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		/*
 		 * WRITE THE FILES
 		 */
-		writeChromatogramMethod(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMethod(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
-		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeChromatogramMethod(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMethod(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -183,7 +183,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -233,10 +233,10 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		/*
 		 * Scan Proxies
 		 */
-		writeChromatogramScanProxies(zipOutputStream, directoryPrefix, scanProxies, monitor);
+		writeChromatogramScanProxies(zipOutputStream, directoryPrefix, scanProxies);
 	}
 
-	private void writeChromatogramScanProxies(ZipOutputStream zipOutputStream, String directoryPrefix, List<IScanProxy> scanProxies, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScanProxies(ZipOutputStream zipOutputStream, String directoryPrefix, List<IScanProxy> scanProxies) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -263,7 +263,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -289,7 +289,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -310,7 +310,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -333,7 +333,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -388,7 +388,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1006.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -88,12 +88,12 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -111,7 +111,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -139,7 +139,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		/*
@@ -151,17 +151,17 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		/*
 		 * WRITE THE FILES
 		 */
-		writeChromatogramMethod(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMethod(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
-		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeChromatogramMethod(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMethod(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -186,7 +186,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -236,10 +236,10 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		/*
 		 * Scan Proxies
 		 */
-		writeChromatogramScanProxies(zipOutputStream, directoryPrefix, scanProxies, monitor);
+		writeChromatogramScanProxies(zipOutputStream, directoryPrefix, scanProxies);
 	}
 
-	private void writeChromatogramScanProxies(ZipOutputStream zipOutputStream, String directoryPrefix, List<IScanProxy> scanProxies, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScanProxies(ZipOutputStream zipOutputStream, String directoryPrefix, List<IScanProxy> scanProxies) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -266,7 +266,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -292,7 +292,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -313,7 +313,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -336,7 +336,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -391,7 +391,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1007.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -88,12 +88,12 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -111,7 +111,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -139,7 +139,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		/*
@@ -151,17 +151,17 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		/*
 		 * WRITE THE FILES
 		 */
-		writeChromatogramMethod(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMethod(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
-		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeChromatogramMethod(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMethod(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -186,7 +186,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -236,10 +236,10 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		/*
 		 * Scan Proxies
 		 */
-		writeChromatogramScanProxies(zipOutputStream, directoryPrefix, scanProxies, monitor);
+		writeChromatogramScanProxies(zipOutputStream, directoryPrefix, scanProxies);
 	}
 
-	private void writeChromatogramScanProxies(ZipOutputStream zipOutputStream, String directoryPrefix, List<IScanProxy> scanProxies, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScanProxies(ZipOutputStream zipOutputStream, String directoryPrefix, List<IScanProxy> scanProxies) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -266,7 +266,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -292,7 +292,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -313,7 +313,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -336,7 +336,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -391,7 +391,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1100.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -91,12 +91,12 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -114,7 +114,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -155,25 +155,25 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 			/*
 			 * WRITE THE FILES
 			 */
-			writeChromatogramMethod(zipOutputStream, directoryPrefix, chromatogram, monitor);
+			writeChromatogramMethod(zipOutputStream, directoryPrefix, chromatogram);
 			subMonitor.worked(20);
-			writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-			writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram, monitor);
+			writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+			writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram);
 			subMonitor.worked(20);
-			writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram, monitor);
-			writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram, monitor);
+			writeChromatogramPeaks(zipOutputStream, directoryPrefix, chromatogram);
+			writeChromatogramArea(zipOutputStream, directoryPrefix, chromatogram);
 			subMonitor.worked(20);
-			writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram, monitor);
+			writeChromatogramIdentification(zipOutputStream, directoryPrefix, chromatogram);
 			writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
 			subMonitor.worked(20);
-			writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+			writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 			subMonitor.worked(20);
 		} finally {
 			SubMonitor.done(subMonitor);
 		}
 	}
 
-	private void writeChromatogramMethod(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMethod(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -198,7 +198,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -248,10 +248,10 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		/*
 		 * Scan Proxies
 		 */
-		writeChromatogramScanProxies(zipOutputStream, directoryPrefix, scanProxies, monitor);
+		writeChromatogramScanProxies(zipOutputStream, directoryPrefix, scanProxies);
 	}
 
-	private void writeChromatogramScanProxies(ZipOutputStream zipOutputStream, String directoryPrefix, List<IScanProxy> scanProxies, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScanProxies(ZipOutputStream zipOutputStream, String directoryPrefix, List<IScanProxy> scanProxies) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -278,7 +278,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -304,7 +304,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramPeaks(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -325,7 +325,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramArea(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -348,7 +348,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramIdentification(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -403,7 +403,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1300.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -104,18 +104,18 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 		/*
 		 * Referenced Chromatograms
 		 */
 		List<IChromatogram> referencedChromatograms = chromatogram.getReferencedChromatograms();
-		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
+		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms);
 		writeReferencedChromatograms(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -133,7 +133,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -691,7 +691,7 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms) throws IOException {
 
 		ZipEntry zipEntryType = new ZipEntry(directoryPrefix + Format.FILE_REFERENCE_INFO);
 		zipOutputStream.putNextEntry(zipEntryType);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -104,18 +104,18 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 		/*
 		 * Referenced Chromatograms
 		 */
 		List<IChromatogram> referencedChromatograms = chromatogram.getReferencedChromatograms();
-		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
+		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms);
 		writeReferencedChromatograms(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -133,7 +133,7 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -692,7 +692,7 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms) throws IOException {
 
 		ZipEntry zipEntryType = new ZipEntry(directoryPrefix + Format.FILE_REFERENCE_INFO);
 		zipOutputStream.putNextEntry(zipEntryType);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -107,18 +107,18 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 		/*
 		 * Referenced Chromatograms
 		 */
 		List<IChromatogram> referencedChromatograms = chromatogram.getReferencedChromatograms();
-		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
+		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms);
 		writeReferencedChromatograms(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -136,7 +136,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -798,7 +798,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms) throws IOException {
 
 		ZipEntry zipEntryType = new ZipEntry(directoryPrefix + Format.FILE_REFERENCE_INFO);
 		zipOutputStream.putNextEntry(zipEntryType);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -106,18 +106,18 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 		/*
 		 * Referenced Chromatograms
 		 */
 		List<IChromatogram> referencedChromatograms = chromatogram.getReferencedChromatograms();
-		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
+		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms);
 		writeReferencedChromatograms(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -135,7 +135,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -801,7 +801,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms) throws IOException {
 
 		ZipEntry zipEntryType = new ZipEntry(directoryPrefix + Format.FILE_REFERENCE_INFO);
 		zipOutputStream.putNextEntry(zipEntryType);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -104,18 +104,18 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 		/*
 		 * Referenced Chromatograms
 		 */
 		List<IChromatogram> referencedChromatograms = chromatogram.getReferencedChromatograms();
-		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
+		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms);
 		writeReferencedChromatograms(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -133,7 +133,7 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -722,7 +722,7 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms) throws IOException {
 
 		ZipEntry zipEntryType = new ZipEntry(directoryPrefix + Format.FILE_REFERENCE_INFO);
 		zipOutputStream.putNextEntry(zipEntryType);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1502.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1502.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -104,18 +104,18 @@ public class ChromatogramWriter_1502 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 		/*
 		 * Referenced Chromatograms
 		 */
 		List<IChromatogram> referencedChromatograms = chromatogram.getReferencedChromatograms();
-		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
+		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms);
 		writeReferencedChromatograms(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -133,7 +133,7 @@ public class ChromatogramWriter_1502 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramMSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -719,7 +719,7 @@ public class ChromatogramWriter_1502 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms) throws IOException {
 
 		ZipEntry zipEntryType = new ZipEntry(directoryPrefix + Format.FILE_REFERENCE_INFO);
 		zipOutputStream.putNextEntry(zipEntryType);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0701.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0701.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -65,7 +65,7 @@ public class PeakReader_0701 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo<IPeaksMSD> processingInfo = new ProcessingInfo<>();
 		try {
-			IPeaksMSD peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaksMSD peaks = readPeaksFromZipFile(zipFile);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -73,7 +73,7 @@ public class PeakReader_0701 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile) throws IOException {
 
 		IPeaksMSD peaks = new PeaksMSD();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, Format.FILE_PEAKS);
@@ -81,7 +81,7 @@ public class PeakReader_0701 extends AbstractZipReader implements IPeakReader {
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IPeakMSD peak = readPeak(dataInputStream, monitor);
+				IPeakMSD peak = readPeak(dataInputStream);
 				peaks.addPeak(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -94,7 +94,7 @@ public class PeakReader_0701 extends AbstractZipReader implements IPeakReader {
 		return peaks;
 	}
 
-	private IPeakMSD readPeak(DataInputStream dataInputStream, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IPeakMSD readPeak(DataInputStream dataInputStream) throws IOException, IllegalArgumentException, PeakException {
 
 		String detectorDescription = readString(dataInputStream); // Detector Description
 		String integratorDescription = readString(dataInputStream); // Integrator Description
@@ -126,7 +126,7 @@ public class PeakReader_0701 extends AbstractZipReader implements IPeakReader {
 		List<IIntegrationEntry> integrationEntries = readIntegrationEntries(dataInputStream);
 		peak.setIntegratedArea(integrationEntries, integratorDescription);
 
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 
 		return peak;
 	}
@@ -172,7 +172,7 @@ public class PeakReader_0701 extends AbstractZipReader implements IPeakReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -207,7 +207,7 @@ public class PeakReader_0701 extends AbstractZipReader implements IPeakReader {
 	/**
 	 * Legacy.
 	 * Convert between Enum and short value.
-	 * 
+	 *
 	 * @param massSpectrometer
 	 * @return
 	 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0801.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0801.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -67,7 +67,7 @@ public class PeakReader_0801 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo<IPeaksMSD> processingInfo = new ProcessingInfo<>();
 		try {
-			IPeaksMSD peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaksMSD peaks = readPeaksFromZipFile(zipFile);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -75,7 +75,7 @@ public class PeakReader_0801 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile) throws IOException {
 
 		IPeaksMSD peaks = new PeaksMSD();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, Format.FILE_PEAKS);
@@ -83,7 +83,7 @@ public class PeakReader_0801 extends AbstractZipReader implements IPeakReader {
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IPeakMSD peak = readPeak(dataInputStream, monitor);
+				IPeakMSD peak = readPeak(dataInputStream);
 				peaks.addPeak(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -96,7 +96,7 @@ public class PeakReader_0801 extends AbstractZipReader implements IPeakReader {
 		return peaks;
 	}
 
-	private IPeakMSD readPeak(DataInputStream dataInputStream, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IPeakMSD readPeak(DataInputStream dataInputStream) throws IOException, IllegalArgumentException, PeakException {
 
 		String detectorDescription = readString(dataInputStream); // Detector Description
 		String integratorDescription = readString(dataInputStream); // Integrator Description
@@ -134,7 +134,7 @@ public class PeakReader_0801 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
@@ -210,7 +210,7 @@ public class PeakReader_0801 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0802.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0802.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -70,7 +70,7 @@ public class PeakReader_0802 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo<IPeaksMSD> processingInfo = new ProcessingInfo<>();
 		try {
-			IPeaksMSD peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaksMSD peaks = readPeaksFromZipFile(zipFile);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -78,7 +78,7 @@ public class PeakReader_0802 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile) throws IOException {
 
 		IPeaksMSD peaks = new PeaksMSD();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, Format.FILE_PEAKS);
@@ -86,7 +86,7 @@ public class PeakReader_0802 extends AbstractZipReader implements IPeakReader {
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IPeakMSD peak = readPeak(dataInputStream, monitor);
+				IPeakMSD peak = readPeak(dataInputStream);
 				peaks.addPeak(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -99,7 +99,7 @@ public class PeakReader_0802 extends AbstractZipReader implements IPeakReader {
 		return peaks;
 	}
 
-	private IPeakMSD readPeak(DataInputStream dataInputStream, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IPeakMSD readPeak(DataInputStream dataInputStream) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = new IonTransitionSettings();
 
@@ -135,11 +135,11 @@ public class PeakReader_0802 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
@@ -212,7 +212,7 @@ public class PeakReader_0802 extends AbstractZipReader implements IPeakReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -244,7 +244,7 @@ public class PeakReader_0802 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0803.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0803.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -70,7 +70,7 @@ public class PeakReader_0803 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo<IPeaksMSD> processingInfo = new ProcessingInfo<>();
 		try {
-			IPeaksMSD peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaksMSD peaks = readPeaksFromZipFile(zipFile);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -78,7 +78,7 @@ public class PeakReader_0803 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile) throws IOException {
 
 		IPeaksMSD peaks = new PeaksMSD();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, Format.FILE_PEAKS);
@@ -86,7 +86,7 @@ public class PeakReader_0803 extends AbstractZipReader implements IPeakReader {
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IPeakMSD peak = readPeak(dataInputStream, monitor);
+				IPeakMSD peak = readPeak(dataInputStream);
 				peaks.addPeak(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -99,7 +99,7 @@ public class PeakReader_0803 extends AbstractZipReader implements IPeakReader {
 		return peaks;
 	}
 
-	private IPeakMSD readPeak(DataInputStream dataInputStream, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IPeakMSD readPeak(DataInputStream dataInputStream) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = new IonTransitionSettings();
 
@@ -135,11 +135,11 @@ public class PeakReader_0803 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
@@ -212,7 +212,7 @@ public class PeakReader_0803 extends AbstractZipReader implements IPeakReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -244,7 +244,7 @@ public class PeakReader_0803 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0901.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0901.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -70,7 +70,7 @@ public class PeakReader_0901 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo<IPeaksMSD> processingInfo = new ProcessingInfo<>();
 		try {
-			IPeaksMSD peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaksMSD peaks = readPeaksFromZipFile(zipFile);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -78,7 +78,7 @@ public class PeakReader_0901 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile) throws IOException {
 
 		IPeaksMSD peaks = new PeaksMSD();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, Format.FILE_PEAKS);
@@ -86,7 +86,7 @@ public class PeakReader_0901 extends AbstractZipReader implements IPeakReader {
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IPeakMSD peak = readPeak(dataInputStream, monitor);
+				IPeakMSD peak = readPeak(dataInputStream);
 				peaks.addPeak(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -99,7 +99,7 @@ public class PeakReader_0901 extends AbstractZipReader implements IPeakReader {
 		return peaks;
 	}
 
-	private IPeakMSD readPeak(DataInputStream dataInputStream, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IPeakMSD readPeak(DataInputStream dataInputStream) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = new IonTransitionSettings();
 
@@ -135,11 +135,11 @@ public class PeakReader_0901 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
@@ -212,7 +212,7 @@ public class PeakReader_0901 extends AbstractZipReader implements IPeakReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -248,7 +248,7 @@ public class PeakReader_0901 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0902.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0902.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -72,7 +72,7 @@ public class PeakReader_0902 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo<IPeaksMSD> processingInfo = new ProcessingInfo<>();
 		try {
-			IPeaksMSD peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaksMSD peaks = readPeaksFromZipFile(zipFile);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -80,7 +80,7 @@ public class PeakReader_0902 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile) throws IOException {
 
 		IPeaksMSD peaks = new PeaksMSD();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, Format.FILE_PEAKS);
@@ -88,7 +88,7 @@ public class PeakReader_0902 extends AbstractZipReader implements IPeakReader {
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IPeakMSD peak = readPeak(dataInputStream, monitor);
+				IPeakMSD peak = readPeak(dataInputStream);
 				peaks.addPeak(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -101,7 +101,7 @@ public class PeakReader_0902 extends AbstractZipReader implements IPeakReader {
 		return peaks;
 	}
 
-	private IPeakMSD readPeak(DataInputStream dataInputStream, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IPeakMSD readPeak(DataInputStream dataInputStream) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = new IonTransitionSettings();
 
@@ -137,11 +137,11 @@ public class PeakReader_0902 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
@@ -214,7 +214,7 @@ public class PeakReader_0902 extends AbstractZipReader implements IPeakReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -256,7 +256,7 @@ public class PeakReader_0902 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0903.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0903.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -72,7 +72,7 @@ public class PeakReader_0903 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo<IPeaksMSD> processingInfo = new ProcessingInfo<>();
 		try {
-			IPeaksMSD peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaksMSD peaks = readPeaksFromZipFile(zipFile);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -80,7 +80,7 @@ public class PeakReader_0903 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile) throws IOException {
 
 		IPeaksMSD peaks = new PeaksMSD();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, Format.FILE_PEAKS);
@@ -88,7 +88,7 @@ public class PeakReader_0903 extends AbstractZipReader implements IPeakReader {
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IPeakMSD peak = readPeak(dataInputStream, monitor);
+				IPeakMSD peak = readPeak(dataInputStream);
 				peaks.addPeak(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -101,7 +101,7 @@ public class PeakReader_0903 extends AbstractZipReader implements IPeakReader {
 		return peaks;
 	}
 
-	private IPeakMSD readPeak(DataInputStream dataInputStream, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IPeakMSD readPeak(DataInputStream dataInputStream) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = new IonTransitionSettings();
 
@@ -139,11 +139,11 @@ public class PeakReader_0903 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
@@ -216,7 +216,7 @@ public class PeakReader_0903 extends AbstractZipReader implements IPeakReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -258,7 +258,7 @@ public class PeakReader_0903 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1001.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -72,7 +72,7 @@ public class PeakReader_1001 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo<IPeaksMSD> processingInfo = new ProcessingInfo<>();
 		try {
-			IPeaksMSD peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaksMSD peaks = readPeaksFromZipFile(zipFile);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -80,7 +80,7 @@ public class PeakReader_1001 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile) throws IOException {
 
 		IPeaksMSD peaks = new PeaksMSD();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, Format.FILE_PEAKS_MSD);
@@ -88,7 +88,7 @@ public class PeakReader_1001 extends AbstractZipReader implements IPeakReader {
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IPeakMSD peak = readPeak(dataInputStream, monitor);
+				IPeakMSD peak = readPeak(dataInputStream);
 				peaks.addPeak(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -101,7 +101,7 @@ public class PeakReader_1001 extends AbstractZipReader implements IPeakReader {
 		return peaks;
 	}
 
-	private IPeakMSD readPeak(DataInputStream dataInputStream, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IPeakMSD readPeak(DataInputStream dataInputStream) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = new IonTransitionSettings();
 
@@ -139,11 +139,11 @@ public class PeakReader_1001 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
@@ -216,7 +216,7 @@ public class PeakReader_1001 extends AbstractZipReader implements IPeakReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -258,7 +258,7 @@ public class PeakReader_1001 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1002.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -77,7 +77,7 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo<IPeaksMSD> processingInfo = new ProcessingInfo<>();
 		try {
-			IPeaksMSD peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaksMSD peaks = readPeaksFromZipFile(zipFile);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -85,7 +85,7 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile) throws IOException {
 
 		IPeaksMSD peaks = new PeaksMSD();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, Format.FILE_PEAKS_MSD);
@@ -93,7 +93,7 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IPeakMSD peak = readPeak(dataInputStream, monitor);
+				IPeakMSD peak = readPeak(dataInputStream);
 				peaks.addPeak(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -106,7 +106,7 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 		return peaks;
 	}
 
-	private IPeakMSD readPeak(DataInputStream dataInputStream, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IPeakMSD readPeak(DataInputStream dataInputStream) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = new IonTransitionSettings();
 
@@ -119,7 +119,7 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 		float startBackgroundAbundance = dataInputStream.readFloat(); // Start Background Abundance
 		float stopBackgroundAbundance = dataInputStream.readFloat(); // Stop Background Abundance
 
-		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings, monitor);
+		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings);
 
 		int numberOfRetentionTimes = dataInputStream.readInt(); // Number Retention Times
 		IPeakIntensityValues intensityValues = new PeakIntensityValues(Float.MAX_VALUE);
@@ -144,16 +144,16 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
 
-	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		short massSpectrometer = dataInputStream.readShort(); // Mass Spectrometer
 		short massSpectrumType = dataInputStream.readShort(); // Mass Spectrum Type
@@ -177,12 +177,12 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum, monitor);
+		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 
 		return massSpectrum;
 	}
 
-	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {
 
 		int numberOfMassSpectrumTargets = dataInputStream.readInt(); // Number Mass Spectrum Targets
 		for(int i = 1; i <= numberOfMassSpectrumTargets; i++) {
@@ -268,7 +268,7 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -310,7 +310,7 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1003.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -77,7 +77,7 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo<IPeaksMSD> processingInfo = new ProcessingInfo<>();
 		try {
-			IPeaksMSD peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaksMSD peaks = readPeaksFromZipFile(zipFile);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -85,7 +85,7 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile) throws IOException {
 
 		IPeaksMSD peaks = new PeaksMSD();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, Format.FILE_PEAKS_MSD);
@@ -93,7 +93,7 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IPeakMSD peak = readPeak(dataInputStream, monitor);
+				IPeakMSD peak = readPeak(dataInputStream);
 				peaks.addPeak(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -106,7 +106,7 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 		return peaks;
 	}
 
-	private IPeakMSD readPeak(DataInputStream dataInputStream, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IPeakMSD readPeak(DataInputStream dataInputStream) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = new IonTransitionSettings();
 
@@ -119,7 +119,7 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 		float startBackgroundAbundance = dataInputStream.readFloat(); // Start Background Abundance
 		float stopBackgroundAbundance = dataInputStream.readFloat(); // Stop Background Abundance
 
-		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings, monitor);
+		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings);
 
 		int numberOfRetentionTimes = dataInputStream.readInt(); // Number Retention Times
 		IPeakIntensityValues intensityValues = new PeakIntensityValues(Float.MAX_VALUE);
@@ -144,16 +144,16 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 
 		return peak;
 	}
 
-	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		short massSpectrometer = dataInputStream.readShort(); // Mass Spectrometer
 		short massSpectrumType = dataInputStream.readShort(); // Mass Spectrum Type
@@ -177,12 +177,12 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum, monitor);
+		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 
 		return massSpectrum;
 	}
 
-	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {
 
 		int numberOfMassSpectrumTargets = dataInputStream.readInt(); // Number Mass Spectrum Targets
 		for(int i = 1; i <= numberOfMassSpectrumTargets; i++) {
@@ -268,7 +268,7 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -310,7 +310,7 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1004.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -78,7 +78,7 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo<IPeaksMSD> processingInfo = new ProcessingInfo<>();
 		try {
-			IPeaksMSD peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaksMSD peaks = readPeaksFromZipFile(zipFile);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -86,7 +86,7 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile) throws IOException {
 
 		IPeaksMSD peaks = new PeaksMSD();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, Format.FILE_PEAKS_MSD);
@@ -94,7 +94,7 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IPeakMSD peak = readPeak(dataInputStream, monitor);
+				IPeakMSD peak = readPeak(dataInputStream);
 				peaks.addPeak(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -107,7 +107,7 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 		return peaks;
 	}
 
-	private IPeakMSD readPeak(DataInputStream dataInputStream, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IPeakMSD readPeak(DataInputStream dataInputStream) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = new IonTransitionSettings();
 
@@ -120,7 +120,7 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 		float startBackgroundAbundance = dataInputStream.readFloat(); // Start Background Abundance
 		float stopBackgroundAbundance = dataInputStream.readFloat(); // Stop Background Abundance
 
-		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings, monitor);
+		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings);
 
 		int numberOfRetentionTimes = dataInputStream.readInt(); // Number Retention Times
 		IPeakIntensityValues intensityValues = new PeakIntensityValues(Float.MAX_VALUE);
@@ -145,25 +145,25 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 		/*
 		 * Optimized Mass Spectrum
 		 */
 		boolean readOptimizedMassSpectrum = dataInputStream.readBoolean();
 		if(readOptimizedMassSpectrum) {
 			IScanMSD optimizedMassSpectrum = new ScanMSD();
-			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings, monitor);
+			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings);
 			peakMaximum.setOptimizedMassSpectrum(optimizedMassSpectrum);
 		}
 
 		return peak;
 	}
 
-	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		short massSpectrometer = dataInputStream.readShort(); // Mass Spectrometer
 		short massSpectrumType = dataInputStream.readShort(); // Mass Spectrum Type
@@ -174,12 +174,12 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 		massSpectrum.setMassSpectrumType(getMassSpectrumType(massSpectrumType));
 		massSpectrum.setPrecursorIon(precursorIon);
 
-		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings, monitor);
+		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings);
 
 		return massSpectrum;
 	}
 
-	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		int retentionTime = dataInputStream.readInt();
 		float retentionIndex = dataInputStream.readFloat(); // Retention Index
@@ -201,10 +201,10 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum, monitor);
+		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {
 
 		int numberOfMassSpectrumTargets = dataInputStream.readInt(); // Number Mass Spectrum Targets
 		for(int i = 1; i <= numberOfMassSpectrumTargets; i++) {
@@ -290,7 +290,7 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -332,7 +332,7 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1005.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -78,7 +78,7 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo<IPeaksMSD> processingInfo = new ProcessingInfo<>();
 		try {
-			IPeaksMSD peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaksMSD peaks = readPeaksFromZipFile(zipFile);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -86,7 +86,7 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile) throws IOException {
 
 		IPeaksMSD peaks = new PeaksMSD();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, Format.FILE_PEAKS_MSD);
@@ -94,7 +94,7 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IPeakMSD peak = readPeak(dataInputStream, monitor);
+				IPeakMSD peak = readPeak(dataInputStream);
 				peaks.addPeak(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -107,7 +107,7 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 		return peaks;
 	}
 
-	private IPeakMSD readPeak(DataInputStream dataInputStream, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IPeakMSD readPeak(DataInputStream dataInputStream) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = new IonTransitionSettings();
 
@@ -120,7 +120,7 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 		float startBackgroundAbundance = dataInputStream.readFloat(); // Start Background Abundance
 		float stopBackgroundAbundance = dataInputStream.readFloat(); // Stop Background Abundance
 
-		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings, monitor);
+		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings);
 
 		int numberOfRetentionTimes = dataInputStream.readInt(); // Number Retention Times
 		IPeakIntensityValues intensityValues = new PeakIntensityValues(Float.MAX_VALUE);
@@ -145,25 +145,25 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 		/*
 		 * Optimized Mass Spectrum
 		 */
 		boolean readOptimizedMassSpectrum = dataInputStream.readBoolean();
 		if(readOptimizedMassSpectrum) {
 			IScanMSD optimizedMassSpectrum = new ScanMSD();
-			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings, monitor);
+			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings);
 			peakMaximum.setOptimizedMassSpectrum(optimizedMassSpectrum);
 		}
 
 		return peak;
 	}
 
-	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		short massSpectrometer = dataInputStream.readShort(); // Mass Spectrometer
 		short massSpectrumType = dataInputStream.readShort(); // Mass Spectrum Type
@@ -174,12 +174,12 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 		massSpectrum.setMassSpectrumType(getMassSpectrumType(massSpectrumType));
 		massSpectrum.setPrecursorIon(precursorIon);
 
-		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings, monitor);
+		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings);
 
 		return massSpectrum;
 	}
 
-	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		int retentionTime = dataInputStream.readInt();
 		float retentionIndex = dataInputStream.readFloat(); // Retention Index
@@ -201,10 +201,10 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum, monitor);
+		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {
 
 		int numberOfMassSpectrumTargets = dataInputStream.readInt(); // Number Mass Spectrum Targets
 		for(int i = 1; i <= numberOfMassSpectrumTargets; i++) {
@@ -293,7 +293,7 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -335,7 +335,7 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1006.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -79,7 +79,7 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo<IPeaksMSD> processingInfo = new ProcessingInfo<>();
 		try {
-			IPeaksMSD peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaksMSD peaks = readPeaksFromZipFile(zipFile);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -87,7 +87,7 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile) throws IOException {
 
 		IPeaksMSD peaks = new PeaksMSD();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, Format.FILE_PEAKS_MSD);
@@ -95,7 +95,7 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IPeakMSD peak = readPeak(dataInputStream, monitor);
+				IPeakMSD peak = readPeak(dataInputStream);
 				peaks.addPeak(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -108,7 +108,7 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 		return peaks;
 	}
 
-	private IPeakMSD readPeak(DataInputStream dataInputStream, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IPeakMSD readPeak(DataInputStream dataInputStream) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = new IonTransitionSettings();
 
@@ -123,7 +123,7 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 		float startBackgroundAbundance = dataInputStream.readFloat(); // Start Background Abundance
 		float stopBackgroundAbundance = dataInputStream.readFloat(); // Stop Background Abundance
 
-		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings, monitor);
+		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings);
 
 		int numberOfRetentionTimes = dataInputStream.readInt(); // Number Retention Times
 		IPeakIntensityValues intensityValues = new PeakIntensityValues(Float.MAX_VALUE);
@@ -150,25 +150,25 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 		/*
 		 * Optimized Mass Spectrum
 		 */
 		boolean readOptimizedMassSpectrum = dataInputStream.readBoolean();
 		if(readOptimizedMassSpectrum) {
 			IScanMSD optimizedMassSpectrum = new ScanMSD();
-			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings, monitor);
+			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings);
 			peakMaximum.setOptimizedMassSpectrum(optimizedMassSpectrum);
 		}
 
 		return peak;
 	}
 
-	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		short massSpectrometer = dataInputStream.readShort(); // Mass Spectrometer
 		short massSpectrumType = dataInputStream.readShort(); // Mass Spectrum Type
@@ -179,12 +179,12 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 		massSpectrum.setMassSpectrumType(getMassSpectrumType(massSpectrumType));
 		massSpectrum.setPrecursorIon(precursorIon);
 
-		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings, monitor);
+		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings);
 
 		return massSpectrum;
 	}
 
-	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		int retentionTime = dataInputStream.readInt();
 		int retentionTimeColumn1 = dataInputStream.readInt();
@@ -218,10 +218,10 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum, monitor);
+		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {
 
 		int numberOfMassSpectrumTargets = dataInputStream.readInt(); // Number Mass Spectrum Targets
 		for(int i = 1; i <= numberOfMassSpectrumTargets; i++) {
@@ -332,7 +332,7 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -396,7 +396,7 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1007.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -79,7 +79,7 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 		ZipFile zipFile = new ZipFile(file);
 		IProcessingInfo<IPeaksMSD> processingInfo = new ProcessingInfo<>();
 		try {
-			IPeaksMSD peaks = readPeaksFromZipFile(zipFile, monitor);
+			IPeaksMSD peaks = readPeaksFromZipFile(zipFile);
 			processingInfo.setProcessingResult(peaks);
 		} finally {
 			zipFile.close();
@@ -87,7 +87,7 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 		return processingInfo;
 	}
 
-	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile, IProgressMonitor monitor) throws IOException {
+	private IPeaksMSD readPeaksFromZipFile(ZipFile zipFile) throws IOException {
 
 		IPeaksMSD peaks = new PeaksMSD();
 		DataInputStream dataInputStream = getDataInputStream(zipFile, Format.FILE_PEAKS_MSD);
@@ -95,7 +95,7 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 		int numberOfPeaks = dataInputStream.readInt();
 		for(int i = 1; i <= numberOfPeaks; i++) {
 			try {
-				IPeakMSD peak = readPeak(dataInputStream, monitor);
+				IPeakMSD peak = readPeak(dataInputStream);
 				peaks.addPeak(peak);
 			} catch(PeakException e) {
 				logger.warn(e.getMessage());
@@ -108,7 +108,7 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 		return peaks;
 	}
 
-	private IPeakMSD readPeak(DataInputStream dataInputStream, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IPeakMSD readPeak(DataInputStream dataInputStream) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = new IonTransitionSettings();
 
@@ -123,7 +123,7 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 		float startBackgroundAbundance = dataInputStream.readFloat(); // Start Background Abundance
 		float stopBackgroundAbundance = dataInputStream.readFloat(); // Stop Background Abundance
 
-		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings, monitor);
+		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings);
 
 		int numberOfRetentionTimes = dataInputStream.readInt(); // Number Retention Times
 		IPeakIntensityValues intensityValues = new PeakIntensityValues(Float.MAX_VALUE);
@@ -150,25 +150,25 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 		/*
 		 * Optimized Mass Spectrum
 		 */
 		boolean readOptimizedMassSpectrum = dataInputStream.readBoolean();
 		if(readOptimizedMassSpectrum) {
 			IScanMSD optimizedMassSpectrum = new ScanMSD();
-			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings, monitor);
+			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings);
 			peakMaximum.setOptimizedMassSpectrum(optimizedMassSpectrum);
 		}
 
 		return peak;
 	}
 
-	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		short massSpectrometer = dataInputStream.readShort(); // Mass Spectrometer
 		short massSpectrumType = dataInputStream.readShort(); // Mass Spectrum Type
@@ -179,12 +179,12 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 		massSpectrum.setMassSpectrumType(getMassSpectrumType(massSpectrumType));
 		massSpectrum.setPrecursorIon(precursorIon);
 
-		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings, monitor);
+		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings);
 
 		return massSpectrum;
 	}
 
-	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		int retentionTime = dataInputStream.readInt();
 		int retentionTimeColumn1 = dataInputStream.readInt();
@@ -218,10 +218,10 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum, monitor);
+		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {
 
 		int numberOfMassSpectrumTargets = dataInputStream.readInt(); // Number Mass Spectrum Targets
 		for(int i = 1; i <= numberOfMassSpectrumTargets; i++) {
@@ -327,7 +327,7 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -386,7 +386,7 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1100.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -99,7 +99,7 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 		try {
 			for(int i = 1; i <= numberOfPeaks; i++) {
 				try {
-					IPeakMSD peak = readPeak(dataInputStream, monitor);
+					IPeakMSD peak = readPeak(dataInputStream);
 					peaks.addPeak(peak);
 					subMonitor.worked(1);
 				} catch(PeakException e) {
@@ -116,7 +116,7 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 		return peaks;
 	}
 
-	private IPeakMSD readPeak(DataInputStream dataInputStream, IProgressMonitor monitor) throws IOException, IllegalArgumentException, PeakException {
+	private IPeakMSD readPeak(DataInputStream dataInputStream) throws IOException, IllegalArgumentException, PeakException {
 
 		IIonTransitionSettings ionTransitionSettings = new IonTransitionSettings();
 
@@ -131,7 +131,7 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 		float startBackgroundAbundance = dataInputStream.readFloat(); // Start Background Abundance
 		float stopBackgroundAbundance = dataInputStream.readFloat(); // Stop Background Abundance
 
-		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings, monitor);
+		IPeakMassSpectrum peakMaximum = readPeakMassSpectrum(dataInputStream, ionTransitionSettings);
 
 		int numberOfRetentionTimes = dataInputStream.readInt(); // Number Retention Times
 		IPeakIntensityValues intensityValues = new PeakIntensityValues(Float.MAX_VALUE);
@@ -158,18 +158,18 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readPeakIdentificationTargets(dataInputStream, peak, monitor);
+		readPeakIdentificationTargets(dataInputStream, peak);
 		/*
 		 * Quantitation Results
 		 */
-		readPeakQuantitationEntries(dataInputStream, peak, monitor);
+		readPeakQuantitationEntries(dataInputStream, peak);
 		/*
 		 * Optimized Mass Spectrum
 		 */
 		boolean readOptimizedMassSpectrum = dataInputStream.readBoolean();
 		if(readOptimizedMassSpectrum) {
 			IScanMSD optimizedMassSpectrum = new ScanMSD();
-			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings, monitor);
+			readNormalMassSpectrum(optimizedMassSpectrum, dataInputStream, ionTransitionSettings);
 			peakMaximum.setOptimizedMassSpectrum(optimizedMassSpectrum);
 		}
 
@@ -196,7 +196,7 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 		return internalStandards;
 	}
 
-	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private IPeakMassSpectrum readPeakMassSpectrum(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		short massSpectrometer = dataInputStream.readShort(); // Mass Spectrometer
 		short massSpectrumType = dataInputStream.readShort(); // Mass Spectrum Type
@@ -207,12 +207,12 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 		massSpectrum.setMassSpectrumType(getMassSpectrumType(massSpectrumType));
 		massSpectrum.setPrecursorIon(precursorIon);
 
-		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings, monitor);
+		readNormalMassSpectrum(massSpectrum, dataInputStream, ionTransitionSettings);
 
 		return massSpectrum;
 	}
 
-	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IProgressMonitor monitor) throws IOException {
+	private void readNormalMassSpectrum(IScanMSD massSpectrum, DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
 
 		int retentionTime = dataInputStream.readInt();
 		int retentionTimeColumn1 = dataInputStream.readInt();
@@ -246,10 +246,10 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 		/*
 		 * Identification Results
 		 */
-		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum, monitor);
+		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {
 
 		int numberOfMassSpectrumTargets = dataInputStream.readInt(); // Number Mass Spectrum Targets
 		for(int i = 1; i <= numberOfMassSpectrumTargets; i++) {
@@ -355,7 +355,7 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 		return integrationEntries;
 	}
 
-	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakIdentificationTargets(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfPeakTargets = dataInputStream.readInt(); // Number Peak Targets
 		for(int i = 1; i <= numberOfPeakTargets; i++) {
@@ -414,7 +414,7 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak, IProgressMonitor monitor) throws IOException {
+	private void readPeakQuantitationEntries(DataInputStream dataInputStream, IPeakMSD peak) throws IOException {
 
 		int numberOfQuantitationEntries = dataInputStream.readInt(); // Number Quantitation Entries
 		for(int i = 1; i <= numberOfQuantitationEntries; i++) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -53,7 +53,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 		IChromatogramWSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -65,7 +65,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -74,26 +74,26 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 	@Override
 	public IChromatogramWSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, "", null, monitor);
+		return readZipData(zipInputStream, "", null);
 	}
 
 	@Override
 	public IChromatogramWSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramWSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramWSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, "", file, monitor);
+		return readZipData(zipFile, "", file);
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_WSD);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 
@@ -106,7 +106,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramWSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramWSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 		if(object instanceof ZipFile) {
@@ -128,18 +128,18 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 		 * Read the chromatographic information.
 		 */
 		chromatogram = new VendorChromatogram();
-		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_WSD), closeStream, chromatogram, monitor);
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_WSD), closeStream, chromatogram, monitor);
-		readBaselines(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_WSD), closeStream, chromatogram, monitor);
-		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_WSD), closeStream, chromatogram, monitor);
-		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_WSD), closeStream, chromatogram, monitor);
+		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_WSD), closeStream, chromatogram);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_WSD), closeStream, chromatogram);
+		readBaselines(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_WSD), closeStream, chromatogram);
+		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_WSD), closeStream, chromatogram);
+		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_WSD), closeStream, chromatogram);
 
-		setAdditionalInformation(file, chromatogram, monitor);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; ++scan) {
@@ -172,7 +172,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		IMethod method = chromatogram.getMethod();
 
@@ -190,7 +190,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; ++scan) {
@@ -227,7 +227,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readBaselines(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaselines(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		List<IBaselineElement> baselineElements = new ArrayList<>();
@@ -262,7 +262,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		IEditHistory editHistory = chromatogram.getEditHistory();
 		int numEntries = dataInputStream.readInt();
@@ -280,7 +280,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong();
 		String miscInfo = readString(dataInputStream);
@@ -310,7 +310,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader implemen
 		return isValid;
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramWSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramWSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -55,7 +55,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 		IChromatogramWSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -67,7 +67,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -76,26 +76,26 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 	@Override
 	public IChromatogramWSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramWSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramWSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramWSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_WSD);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 
@@ -108,7 +108,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramWSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramWSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 		if(object instanceof ZipFile) {
@@ -130,18 +130,18 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 		 * Read the chromatographic information.
 		 */
 		chromatogram = new VendorChromatogram();
-		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_WSD), closeStream, chromatogram, monitor);
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_WSD), closeStream, chromatogram, monitor);
-		readBaselines(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_WSD), closeStream, chromatogram, monitor);
-		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_WSD), closeStream, chromatogram, monitor);
-		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_WSD), closeStream, chromatogram, monitor);
+		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_WSD), closeStream, chromatogram);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_WSD), closeStream, chromatogram);
+		readBaselines(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_WSD), closeStream, chromatogram);
+		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_WSD), closeStream, chromatogram);
+		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_WSD), closeStream, chromatogram);
 
-		setAdditionalInformation(file, chromatogram, monitor);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; ++scan) {
@@ -174,7 +174,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		IMethod method = chromatogram.getMethod();
 
@@ -192,7 +192,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; ++scan) {
@@ -241,7 +241,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readBaselines(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaselines(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		List<IBaselineElement> baselineElements = new ArrayList<>();
@@ -276,7 +276,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		IEditHistory editHistory = chromatogram.getEditHistory();
 		int numEntries = dataInputStream.readInt();
@@ -294,7 +294,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong();
 		String miscInfo = readString(dataInputStream);
@@ -328,7 +328,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader implemen
 		return isValid;
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramWSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramWSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -55,7 +55,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 		IChromatogramWSD chromatogram = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogram = readFromZipFile(zipFile, "", file, monitor);
+				chromatogram = readFromZipFile(zipFile, "", file);
 			}
 		}
 		return chromatogram;
@@ -67,7 +67,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -76,26 +76,26 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 	@Override
 	public IChromatogramWSD read(ZipInputStream zipInputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readZipData(zipInputStream, directoryPrefix, null, monitor);
+		return readZipData(zipInputStream, directoryPrefix, null);
 	}
 
 	@Override
 	public IChromatogramWSD read(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
 
-		return readFromZipFile(zipFile, directoryPrefix, null, monitor);
+		return readFromZipFile(zipFile, directoryPrefix, null);
 	}
 
-	private IChromatogramWSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramWSD readFromZipFile(ZipFile zipFile, String directoryPrefix, File file) throws IOException {
 
-		return readZipData(zipFile, directoryPrefix, file, monitor);
+		return readZipData(zipFile, directoryPrefix, file);
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_WSD);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 
@@ -108,7 +108,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 	 * @param file
 	 * @return
 	 */
-	private IChromatogramWSD readZipData(Object object, String directoryPrefix, File file, IProgressMonitor monitor) throws IOException {
+	private IChromatogramWSD readZipData(Object object, String directoryPrefix, File file) throws IOException {
 
 		boolean closeStream;
 		if(object instanceof ZipFile) {
@@ -130,18 +130,18 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 		 * Read the chromatographic information.
 		 */
 		chromatogram = new VendorChromatogram();
-		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_WSD), closeStream, chromatogram, monitor);
-		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_WSD), closeStream, chromatogram, monitor);
-		readBaselines(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_WSD), closeStream, chromatogram, monitor);
-		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_WSD), closeStream, chromatogram, monitor);
-		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_WSD), closeStream, chromatogram, monitor);
+		readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_WSD), closeStream, chromatogram);
+		readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_WSD), closeStream, chromatogram);
+		readBaselines(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_WSD), closeStream, chromatogram);
+		readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_WSD), closeStream, chromatogram);
+		readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_WSD), closeStream, chromatogram);
 
-		setAdditionalInformation(file, chromatogram, monitor);
+		setAdditionalInformation(file, chromatogram);
 
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; ++scan) {
@@ -174,7 +174,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		IMethod method = chromatogram.getMethod();
 
@@ -192,7 +192,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; ++scan) {
@@ -241,7 +241,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readBaselines(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaselines(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		List<IBaselineElement> baselineElements = new ArrayList<>();
@@ -276,7 +276,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		IEditHistory editHistory = chromatogram.getEditHistory();
 		int numEntries = dataInputStream.readInt();
@@ -294,7 +294,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong();
 		String miscInfo = readString(dataInputStream);
@@ -328,7 +328,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader implemen
 		return isValid;
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramWSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramWSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -71,7 +71,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -94,12 +94,12 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 		return readZipData(zipFile, directoryPrefix, file, monitor);
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_WSD);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 
@@ -135,18 +135,18 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 			 * Read the chromatographic information.
 			 */
 			chromatogram = new VendorChromatogram();
-			readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_WSD), closeStream, chromatogram, monitor);
+			readMethod(getDataInputStream(object, directoryPrefix + Format.FILE_SYSTEM_SETTINGS_WSD), closeStream, chromatogram);
 			subMonitor.worked(20);
-			readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_WSD), closeStream, chromatogram, monitor);
+			readScans(getDataInputStream(object, directoryPrefix + Format.FILE_SCANS_WSD), closeStream, chromatogram);
 			subMonitor.worked(20);
-			readBaselines(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_WSD), closeStream, chromatogram, monitor);
+			readBaselines(getDataInputStream(object, directoryPrefix + Format.FILE_BASELINE_WSD), closeStream, chromatogram);
 			subMonitor.worked(20);
-			readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_WSD), closeStream, chromatogram, monitor);
+			readHistory(getDataInputStream(object, directoryPrefix + Format.FILE_HISTORY_WSD), closeStream, chromatogram);
 			subMonitor.worked(20);
-			readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_WSD), closeStream, chromatogram, monitor);
+			readMiscellaneous(getDataInputStream(object, directoryPrefix + Format.FILE_MISC_WSD), closeStream, chromatogram);
 			subMonitor.worked(20);
 
-			setAdditionalInformation(file, chromatogram, monitor);
+			setAdditionalInformation(file, chromatogram);
 		} finally {
 			SubMonitor.done(subMonitor);
 		}
@@ -154,7 +154,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; ++scan) {
@@ -187,7 +187,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMethod(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		IMethod method = chromatogram.getMethod();
 
@@ -205,7 +205,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScans(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; ++scan) {
@@ -254,7 +254,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readBaselines(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readBaselines(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		List<IBaselineElement> baselineElements = new ArrayList<>();
@@ -289,7 +289,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readHistory(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		IEditHistory editHistory = chromatogram.getEditHistory();
 		int numEntries = dataInputStream.readInt();
@@ -307,7 +307,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 		}
 	}
 
-	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readMiscellaneous(DataInputStream dataInputStream, boolean closeStream, IChromatogramWSD chromatogram) throws IOException {
 
 		long time = dataInputStream.readLong();
 		String miscInfo = readString(dataInputStream);
@@ -339,7 +339,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader implemen
 		return isValid;
 	}
 
-	private void setAdditionalInformation(File file, IChromatogramWSD chromatogram, IProgressMonitor monitor) {
+	private void setAdditionalInformation(File file, IChromatogramWSD chromatogram) {
 
 		chromatogram.setConverterId(Format.CONVERTER_ID_CHROMATOGRAM);
 		chromatogram.setFile(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -116,7 +116,7 @@ public class ChromatogramReader_1300 extends AbstractChromatogramReader implemen
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -139,12 +139,12 @@ public class ChromatogramReader_1300 extends AbstractChromatogramReader implemen
 		return readZipData(zipFile, directoryPrefix, file, monitor);
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_WSD);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 
@@ -213,7 +213,7 @@ public class ChromatogramReader_1300 extends AbstractChromatogramReader implemen
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; ++scan) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -121,7 +121,7 @@ public class ChromatogramReader_1400 extends AbstractChromatogramReader implemen
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -144,12 +144,12 @@ public class ChromatogramReader_1400 extends AbstractChromatogramReader implemen
 		return readZipData(zipFile, directoryPrefix, file, monitor);
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_WSD);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 
@@ -218,7 +218,7 @@ public class ChromatogramReader_1400 extends AbstractChromatogramReader implemen
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; ++scan) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1500.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -121,7 +121,7 @@ public class ChromatogramReader_1500 extends AbstractChromatogramReader implemen
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -144,12 +144,12 @@ public class ChromatogramReader_1500 extends AbstractChromatogramReader implemen
 		return readZipData(zipFile, directoryPrefix, file, monitor);
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_WSD);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 
@@ -218,7 +218,7 @@ public class ChromatogramReader_1500 extends AbstractChromatogramReader implemen
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; ++scan) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1501.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1501.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -105,7 +105,7 @@ public class ChromatogramReader_1501 extends AbstractChromatogramReader implemen
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -128,12 +128,12 @@ public class ChromatogramReader_1501 extends AbstractChromatogramReader implemen
 		return readZipData(zipFile, directoryPrefix, file, monitor);
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_WSD);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 
@@ -202,7 +202,7 @@ public class ChromatogramReader_1501 extends AbstractChromatogramReader implemen
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; ++scan) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1502.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramReader_1502.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -105,7 +105,7 @@ public class ChromatogramReader_1502 extends AbstractChromatogramReader implemen
 		IChromatogramOverview chromatogramOverview = null;
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if(isValidFileFormat(zipFile)) {
-				chromatogramOverview = readOverviewFromZipFile(zipFile, "", monitor);
+				chromatogramOverview = readOverviewFromZipFile(zipFile, "");
 			}
 		}
 		return chromatogramOverview;
@@ -128,12 +128,12 @@ public class ChromatogramReader_1502 extends AbstractChromatogramReader implemen
 		return readZipData(zipFile, directoryPrefix, file, monitor);
 	}
 
-	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private IChromatogramOverview readOverviewFromZipFile(ZipFile zipFile, String directoryPrefix) throws IOException {
 
 		DataInputStream dataInputStream = getDataInputStream(zipFile, directoryPrefix + Format.FILE_TIC_WSD);
 
 		IVendorChromatogram chromatogram = new VendorChromatogram();
-		readScansOverview(dataInputStream, chromatogram, monitor);
+		readScansOverview(dataInputStream, chromatogram);
 
 		dataInputStream.close();
 
@@ -202,7 +202,7 @@ public class ChromatogramReader_1502 extends AbstractChromatogramReader implemen
 		return chromatogram;
 	}
 
-	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void readScansOverview(DataInputStream dataInputStream, IChromatogramWSD chromatogram) throws IOException {
 
 		int scans = dataInputStream.readInt();
 		for(int scan = 1; scan <= scans; ++scan) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1005.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Michael Chang - initial API and implementation
  * Philip Wenig - refactor baseline
@@ -61,12 +61,12 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -84,7 +84,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -126,7 +126,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		// the things we want in chromatogram folder rn ==> SCANS, MISC, HISTORY, BASELINE.
 		// others might be added later
@@ -141,14 +141,14 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		/*
 		 * WRITE THE FILES
 		 */
-		writeChromatogramMethod(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMethod(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeChromatogramMethod(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMethod(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -173,7 +173,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -205,7 +205,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -231,7 +231,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramHistory(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramHistory(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -253,7 +253,7 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1006.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -63,12 +63,12 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -86,7 +86,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -128,7 +128,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		// the things we want in chromatogram folder rn ==> SCANS, MISC, HISTORY, BASELINE.
 		// others might be added later
@@ -143,14 +143,14 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		/*
 		 * WRITE THE FILES
 		 */
-		writeChromatogramMethod(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMethod(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeChromatogramMethod(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMethod(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -175,7 +175,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -217,7 +217,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -243,7 +243,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramHistory(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramHistory(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -265,7 +265,7 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1007.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -63,12 +63,12 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -86,7 +86,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -128,7 +128,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		// the things we want in chromatogram folder rn ==> SCANS, MISC, HISTORY, BASELINE.
 		// others might be added later
@@ -143,14 +143,14 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		/*
 		 * WRITE THE FILES
 		 */
-		writeChromatogramMethod(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram, monitor);
-		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeChromatogramMethod(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
+		writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 	}
 
-	private void writeChromatogramMethod(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMethod(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -175,7 +175,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -217,7 +217,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -243,7 +243,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramHistory(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramHistory(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -265,7 +265,7 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1100.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -65,12 +65,12 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -88,7 +88,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -143,22 +143,22 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 			/*
 			 * WRITE THE FILES
 			 */
-			writeChromatogramMethod(zipOutputStream, directoryPrefix, chromatogram, monitor);
+			writeChromatogramMethod(zipOutputStream, directoryPrefix, chromatogram);
 			subMonitor.worked(20);
-			writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram, monitor);
+			writeChromatogramScans(zipOutputStream, directoryPrefix, chromatogram);
 			subMonitor.worked(20);
-			writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram, monitor);
+			writeChromatogramBaseline(zipOutputStream, directoryPrefix, chromatogram);
 			subMonitor.worked(20);
-			writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram, monitor);
+			writeChromatogramHistory(zipOutputStream, directoryPrefix, chromatogram);
 			subMonitor.worked(20);
-			writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram, monitor);
+			writeChromatogramMiscellaneous(zipOutputStream, directoryPrefix, chromatogram);
 			subMonitor.worked(20);
 		} finally {
 			SubMonitor.done(subMonitor);
 		}
 	}
 
-	private void writeChromatogramMethod(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMethod(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -183,7 +183,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramScans(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -225,7 +225,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramBaseline(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -251,7 +251,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramHistory(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramHistory(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -273,7 +273,7 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramMiscellaneous(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -91,18 +91,18 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 		/*
 		 * Referenced Chromatograms
 		 */
 		List<IChromatogram> referencedChromatograms = chromatogram.getReferencedChromatograms();
-		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
+		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms);
 		writeReferencedChromatograms(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -120,7 +120,7 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -575,7 +575,7 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms) throws IOException {
 
 		ZipEntry zipEntryType = new ZipEntry(directoryPrefix + Format.FILE_REFERENCE_INFO);
 		zipOutputStream.putNextEntry(zipEntryType);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -94,18 +94,18 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 		/*
 		 * Referenced Chromatograms
 		 */
 		List<IChromatogram> referencedChromatograms = chromatogram.getReferencedChromatograms();
-		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
+		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms);
 		writeReferencedChromatograms(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -123,7 +123,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -644,7 +644,7 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms) throws IOException {
 
 		ZipEntry zipEntryType = new ZipEntry(directoryPrefix + Format.FILE_REFERENCE_INFO);
 		zipOutputStream.putNextEntry(zipEntryType);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -93,18 +93,18 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 		/*
 		 * Referenced Chromatograms
 		 */
 		List<IChromatogram> referencedChromatograms = chromatogram.getReferencedChromatograms();
-		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
+		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms);
 		writeReferencedChromatograms(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -122,7 +122,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -643,7 +643,7 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms) throws IOException {
 
 		ZipEntry zipEntryType = new ZipEntry(directoryPrefix + Format.FILE_REFERENCE_INFO);
 		zipOutputStream.putNextEntry(zipEntryType);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -92,18 +92,18 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 		/*
 		 * Referenced Chromatograms
 		 */
 		List<IChromatogram> referencedChromatograms = chromatogram.getReferencedChromatograms();
-		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
+		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms);
 		writeReferencedChromatograms(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -121,7 +121,7 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -563,7 +563,7 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms) throws IOException {
 
 		ZipEntry zipEntryType = new ZipEntry(directoryPrefix + Format.FILE_REFERENCE_INFO);
 		zipOutputStream.putNextEntry(zipEntryType);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1502.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/wsd/converter/supplier/ocx/internal/io/ChromatogramWriter_1502.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - adjust to API Changes
@@ -92,18 +92,18 @@ public class ChromatogramWriter_1502 extends AbstractChromatogramWriter implemen
 	@Override
 	public void writeChromatogram(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, directoryPrefix, monitor);
-		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
+		writeVersion(zipOutputStream, directoryPrefix);
+		writeOverviewFolder(zipOutputStream, directoryPrefix, chromatogram);
 		writeChromatogramFolder(zipOutputStream, directoryPrefix, chromatogram, monitor);
 		/*
 		 * Referenced Chromatograms
 		 */
 		List<IChromatogram> referencedChromatograms = chromatogram.getReferencedChromatograms();
-		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
+		writeChromatogramReferenceInfo(zipOutputStream, directoryPrefix, referencedChromatograms);
 		writeReferencedChromatograms(zipOutputStream, directoryPrefix, referencedChromatograms, monitor);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream, String directoryPrefix) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -121,7 +121,7 @@ public class ChromatogramWriter_1502 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram, IProgressMonitor monitor) throws IOException {
+	private void writeOverviewFolder(ZipOutputStream zipOutputStream, String directoryPrefix, IChromatogramWSD chromatogram) throws IOException {
 
 		ZipEntry zipEntry;
 		DataOutputStream dataOutputStream;
@@ -562,7 +562,7 @@ public class ChromatogramWriter_1502 extends AbstractChromatogramWriter implemen
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms, IProgressMonitor monitor) throws IOException {
+	private void writeChromatogramReferenceInfo(ZipOutputStream zipOutputStream, String directoryPrefix, List<IChromatogram> referencedChromatograms) throws IOException {
 
 		ZipEntry zipEntryType = new ZipEntry(directoryPrefix + Format.FILE_REFERENCE_INFO);
 		zipOutputStream.putNextEntry(zipEntryType);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/internal/methods/AbstractMethodWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/internal/methods/AbstractMethodWriter.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Alexander Kerner - API
@@ -56,11 +56,11 @@ public abstract class AbstractMethodWriter implements IMethodWriter {
 
 	public void writeProcessMethod(ZipOutputStream zipOutputStream, IProcessMethod processMethod, IProgressMonitor monitor) throws IOException {
 
-		writeVersion(zipOutputStream, monitor);
-		writeData(zipOutputStream, processMethod, monitor);
+		writeVersion(zipOutputStream);
+		writeData(zipOutputStream, processMethod);
 	}
 
-	private void writeVersion(ZipOutputStream zipOutputStream, IProgressMonitor monitor) throws IOException {
+	private void writeVersion(ZipOutputStream zipOutputStream) throws IOException {
 
 		/*
 		 * Version
@@ -73,7 +73,7 @@ public abstract class AbstractMethodWriter implements IMethodWriter {
 		zipOutputStream.closeEntry();
 	}
 
-	private void writeData(ZipOutputStream zipOutputStream, IProcessMethod processMethod, IProgressMonitor monitor) throws IOException {
+	private void writeData(ZipOutputStream zipOutputStream, IProcessMethod processMethod) throws IOException {
 
 		/*
 		 * Data


### PR DESCRIPTION
Trying to work locally with ecj warning to show unused parameters is practically impossible as there are too many of these.