### PR TITLE
Explain the OCB/M compression better

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx.ui/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/ui/preferences/PreferencePageOCB.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx.ui/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/ui/preferences/PreferencePageOCB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -43,7 +43,7 @@ public class PreferencePageOCB extends FieldEditorPreferencePage implements IWor
 	public void createFieldEditors() {
 
 		addField(new LabelFieldEditor("Save (*.ocb) as version: " + Format.CHROMATOGRAM_VERSION_LATEST, getFieldEditorParent()));
-		addField(new ScaleFieldEditor(PreferenceSupplier.P_CHROMATOGRAM_COMPRESSION_LEVEL, "Compression: none to best", getFieldEditorParent(), PreferenceSupplier.MIN_COMPRESSION_LEVEL, PreferenceSupplier.MAX_COMPRESSION_LEVEL, 1, 1));
+		addField(new ScaleFieldEditor(PreferenceSupplier.P_CHROMATOGRAM_COMPRESSION_LEVEL, "Compression: fast/large to slow/small", getFieldEditorParent(), PreferenceSupplier.MIN_COMPRESSION_LEVEL, PreferenceSupplier.MAX_COMPRESSION_LEVEL, 1, 1));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_CHROMATGRAM_EXPORT_REFERENCES_SEPARATELY, "Export References Separately", getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_CHROMATGRAM_EXPORT_REFERENCES_HEADER_FIELD, "Header Field (Export References)", HeaderField.getOptions(), getFieldEditorParent()));
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx.ui/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/ui/preferences/PreferencePageOCM.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx.ui/src/org/eclipse/chemclipse/xxd/converter/supplier/ocx/ui/preferences/PreferencePageOCM.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -36,10 +36,11 @@ public class PreferencePageOCM extends FieldEditorPreferencePage implements IWor
 	 * GUI blocks needed to manipulate various types of preferences. Each field
 	 * editor knows how to save and restore itself.
 	 */
+	@Override
 	public void createFieldEditors() {
 
 		addField(new LabelFieldEditor("Save (*.ocm) as version: " + Format.METHOD_VERSION_LATEST, getFieldEditorParent()));
-		addField(new SpinnerFieldEditor(PreferenceSupplier.P_METHOD_COMPRESSION_LEVEL, "Compression 0 = off, 9 = best", PreferenceSupplier.MIN_COMPRESSION_LEVEL, PreferenceSupplier.MAX_COMPRESSION_LEVEL, getFieldEditorParent()));
+		addField(new SpinnerFieldEditor(PreferenceSupplier.P_METHOD_COMPRESSION_LEVEL, "Compression: fast/large to slow/small", PreferenceSupplier.MIN_COMPRESSION_LEVEL, PreferenceSupplier.MAX_COMPRESSION_LEVEL, getFieldEditorParent()));
 	}
 
 	/*
@@ -47,6 +48,7 @@ public class PreferencePageOCM extends FieldEditorPreferencePage implements IWor
 	 * @see
 	 * org.eclipse.ui.IWorkbenchPreferencePage#init(org.eclipse.ui.IWorkbench)
 	 */
+	@Override
 	public void init(IWorkbench workbench) {
 
 	}


### PR DESCRIPTION
I added a scale in https://github.com/eclipse-chemclipse/chemclipse/pull/671 and labelled it none to best so everyone sets it to "best" which is the best compression but the slowest write speed. This tries to explain the trade off better.