### PR TITLE
Add confirmation button hotkey to manual peak detector

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/contexts.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/contexts.xml
@@ -9,6 +9,10 @@
       <description>This is the main editor. Right-click on it to choose chemometric operations.</description>
       <topic label="Controls" href="html/controls/chromatogram_editor.html"/>
    </context>
+   <context id="peak_detector" title="Peak Detector">
+   	 <description>Manual peak detection within Data Analysis.</description>
+  	 <topic label="Peak Detector" href="html/controls/peak_detector.html"/>
+   </context>
    <context id="peak_scan_list" title="Peak/Scan List">
    	 <description>The peak/scan list can be used to manage the peaks or scans shown in the current selection.</description>
   	 <topic label="Controls" href="html/controls/peak_scan_list.html"/>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/controls.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/controls.xml
@@ -4,6 +4,8 @@
 <toc label="Controls" link_to="/org.eclipse.chemclipse.rcp.app.ui/toc.xml#controls">
 	<topic label="Chromatogram Editor" href="html/controls/chromatogram_editor.html">
 	</topic>
+	<topic href="html/controls/peak_detector.html" label="Peak Detector">
+	</topic>
 	<topic label="Peak / Scan List" href="html/controls/peak_scan_list.html">
 	</topic>
 	<topic label="Chromatogram Overlay" href="html/controls/chromatogram_overlay.html">

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/html/controls/peak_detector.html
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/html/controls/peak_detector.html
@@ -2,28 +2,33 @@
 
 <h3>Peak Detector</h3>
 <table border="1" cellpadding="10" cellspacing="0" summary="Peak Detector Hotkeys">
+  Use a hotkey (see below) or the toolbar button to set a mode. Confirm the peak with the add button or its hotkey.
   <tr>
     <th>Key</th>
     <th>Description</th>
   </tr>
   <tr>
     <td><kbd>D</kbd></td>
-    <td><b>B</b>: Baseline</td>
+    <td><b>B</b>: Baseline<br/>Use <kbd>CTRL</kbd> and drag with the mouse.</td>
   </tr>
   <tr>
     <td><kbd>B</kbd></td>
-    <td><b>BB</b>: Baseline to Baseline</td>
+    <td><b>BB</b>: Baseline to Baseline<br/>Use left click to define start and stop.</td>
   </tr>
   <tr>
     <td><kbd>V</kbd></td>
-    <td><b>VV</b>: Valley to Valley</td>
+    <td><b>VV</b>: Valley to Valley<br/>Use left click to define start and stop.</td>
   </tr>
   <tr>
     <td><kbd>N</kbd></td>
-    <td><b>BV</b>: Baseline to Valley</td>
+    <td><b>BV</b>: Baseline to Valley<br/>Use left click to define start and stop.</td>
   </tr>
   <tr>
     <td><kbd>C</kbd></td>
-    <td><b>VB</b>: Valley to Baseline</td>
+    <td><b>VB</b>: Valley to Baseline<br/>Use left click to define start and stop.</td>
+  </tr>
+  <tr>
+	<td><kbd>A</kbd></td>
+	<td><b>+</b>: Add the peak.</td>
   </tr>
 </table>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/html/controls/peak_detector.html
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/html/controls/peak_detector.html
@@ -1,0 +1,29 @@
+<h2>Controls</h2>
+
+<h3>Peak Detector</h3>
+<table border="1" cellpadding="10" cellspacing="0" summary="Peak Detector Hotkeys">
+  <tr>
+    <th>Key</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><kbd>D</kbd></td>
+    <td><b>B</b>: Baseline</td>
+  </tr>
+  <tr>
+    <td><kbd>B</kbd></td>
+    <td><b>BB</b>: Baseline to Baseline</td>
+  </tr>
+  <tr>
+    <td><kbd>V</kbd></td>
+    <td><b>VV</b>: Valley to Valley</td>
+  </tr>
+  <tr>
+    <td><kbd>N</kbd></td>
+    <td><b>BV</b>: Baseline to Valley</td>
+  </tr>
+  <tr>
+    <td><kbd>C</kbd></td>
+    <td><b>VB</b>: Valley to Baseline</td>
+  </tr>
+</table>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/help/HelpContext.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/help/HelpContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 Lablicate GmbH.
+ * Copyright (c) 2022, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,6 +23,7 @@ public class HelpContext {
 
 	public static final String CHROMATOGRAM_EDITOR = PREFIX + "chromatogram_editor"; //$NON-NLS-1$
 	public static final String CHROMATOGRAM_OVERLAY = PREFIX + "chromatogram_overlay"; //$NON-NLS-1$
+	public static final String PEAK_DETECTOR = PREFIX + "peak_detector"; //$NON-NLS-1$
 	public static final String PEAK_SCAN_LIST = PREFIX + "peak_scan_list"; //$NON-NLS-1$
 	public static final String TARGETS = PREFIX + "targets"; //$NON-NLS-1$
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakDetectorUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakDetectorUI.java
@@ -106,6 +106,7 @@ public class ExtendedPeakDetectorUI extends Composite implements IExtendedPartUI
 	private static final char KEY_VV = IKeyboardSupport.KEY_CODE_LC_V;
 	private static final char KEY_BV = IKeyboardSupport.KEY_CODE_LC_N;
 	private static final char KEY_VB = IKeyboardSupport.KEY_CODE_LC_C;
+	private static final char KEY_ADD = IKeyboardSupport.KEY_CODE_LC_A;
 	/*
 	 * Detection Box
 	 */
@@ -466,29 +467,37 @@ public class ExtendedPeakDetectorUI extends Composite implements IExtendedPartUI
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 
-				if(peak != null) {
-					IChromatogram chromatogram = chromatogramSelection.getChromatogram();
-					if(chromatogram instanceof IChromatogramMSD chromatogramMSD) {
-						if(peak instanceof IChromatogramPeakMSD peakMSD) {
-							chromatogramMSD.getPeaks().add(peakMSD);
-							peak = null;
-							setDetectionType(DETECTION_TYPE_NONE);
-							updateChromatogramAndPeak();
-							chromatogramSelection.update(true);
-						}
-					} else if(chromatogram instanceof IChromatogramCSD chromatogramCSD) {
-						if(peak instanceof IChromatogramPeakCSD peakCSD) {
-							chromatogramCSD.getPeaks().add(peakCSD);
-							peak = null;
-							setDetectionType(DETECTION_TYPE_NONE);
-							updateChromatogramAndPeak();
-							chromatogramSelection.update(true);
-						}
-					}
-				}
+				addPeak();
 			}
+
 		});
 		return button;
+	}
+
+	private void addPeak() {
+
+		if(peak == null) {
+			return;
+		}
+
+		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+		if(chromatogram instanceof IChromatogramMSD chromatogramMSD) {
+			if(peak instanceof IChromatogramPeakMSD peakMSD) {
+				chromatogramMSD.getPeaks().add(peakMSD);
+				peak = null;
+				setDetectionType(DETECTION_TYPE_NONE);
+				updateChromatogramAndPeak();
+				chromatogramSelection.update(true);
+			}
+		} else if(chromatogram instanceof IChromatogramCSD chromatogramCSD) {
+			if(peak instanceof IChromatogramPeakCSD peakCSD) {
+				chromatogramCSD.getPeaks().add(peakCSD);
+				peak = null;
+				setDetectionType(DETECTION_TYPE_NONE);
+				updateChromatogramAndPeak();
+				chromatogramSelection.update(true);
+			}
+		}
 	}
 
 	private void createSettingsButton(Composite parent) {
@@ -519,6 +528,7 @@ public class ExtendedPeakDetectorUI extends Composite implements IExtendedPartUI
 		chartSettings.addHandledEventProcessor(new KeyPressedEventProcessor(KEY_VB));
 		chartSettings.addHandledEventProcessor(new KeyPressedEventProcessor(SWT.ARROW_LEFT));
 		chartSettings.addHandledEventProcessor(new KeyPressedEventProcessor(SWT.ARROW_RIGHT));
+		chartSettings.addHandledEventProcessor(new KeyPressedEventProcessor(KEY_ADD));
 		chartSettings.addHandledEventProcessor(new MouseDownEventProcessor());
 		chartSettings.addHandledEventProcessor(new MouseMoveEventProcessor());
 		chartSettings.addHandledEventProcessor(new MouseUpEventProcessor());
@@ -622,6 +632,9 @@ public class ExtendedPeakDetectorUI extends Composite implements IExtendedPartUI
 					redrawBoxPeakSelection(true);
 				}
 			}
+		}
+		if(event.keyCode == KEY_ADD) {
+			addPeak();
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakDetectorUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakDetectorUI.java
@@ -42,6 +42,7 @@ import org.eclipse.chemclipse.ux.extension.ui.support.BaselineSelectionPaintList
 import org.eclipse.chemclipse.ux.extension.ui.swt.IExtendedPartUI;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChromatogramChart;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.help.HelpContext;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.listener.BoxSelectionPaintListener;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.support.ManualPeakDetector;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePagePeaks;
@@ -78,6 +79,7 @@ import org.eclipse.swtchart.extensions.events.AbstractHandledEventProcessor;
 import org.eclipse.swtchart.extensions.linecharts.ICompressionSupport;
 import org.eclipse.swtchart.extensions.linecharts.ILineSeriesData;
 import org.eclipse.swtchart.extensions.linecharts.ILineSeriesSettings;
+import org.eclipse.ui.PlatformUI;
 
 import jakarta.inject.Inject;
 
@@ -293,11 +295,11 @@ public class ExtendedPeakDetectorUI extends Composite implements IExtendedPartUI
 
 		super(parent, SWT.NONE);
 		detectionTypeDescriptions = new HashMap<>();
-		detectionTypeDescriptions.put(DETECTION_TYPE_BASELINE, "Modus (Baseline) [Key:" + KEY_BASELINE + "]");
-		detectionTypeDescriptions.put(DETECTION_TYPE_BOX_BB, "Modus (BB) [Key:" + KEY_BB + "]");
-		detectionTypeDescriptions.put(DETECTION_TYPE_BOX_VV, "Modus (VV) [Key:" + KEY_VV + "]");
-		detectionTypeDescriptions.put(DETECTION_TYPE_BOX_BV, "Modus (BV) [Key:" + KEY_BV + "]");
-		detectionTypeDescriptions.put(DETECTION_TYPE_BOX_VB, "Modus (VB) [Key:" + KEY_VB + "]");
+		detectionTypeDescriptions.put(DETECTION_TYPE_BASELINE, "Modus (Baseline)");
+		detectionTypeDescriptions.put(DETECTION_TYPE_BOX_BB, "Modus (BB)");
+		detectionTypeDescriptions.put(DETECTION_TYPE_BOX_VV, "Modus (VV)");
+		detectionTypeDescriptions.put(DETECTION_TYPE_BOX_BV, "Modus (BV)");
+		detectionTypeDescriptions.put(DETECTION_TYPE_BOX_VB, "Modus (VB)");
 		detectionTypeDescriptions.put(DETECTION_TYPE_NONE, "");
 
 		createControl();
@@ -380,6 +382,7 @@ public class ExtendedPeakDetectorUI extends Composite implements IExtendedPartUI
 	private void initialize() {
 
 		enableToolbar(toolbarInfo, buttonToolbarInfo, IMAGE_INFO, TOOLTIP_INFO, true);
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, HelpContext.PEAK_DETECTOR);
 	}
 
 	private void createToolbarMain(Composite parent) {
@@ -387,7 +390,7 @@ public class ExtendedPeakDetectorUI extends Composite implements IExtendedPartUI
 		Composite composite = new Composite(parent, SWT.NONE);
 		GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
 		composite.setLayoutData(gridData);
-		composite.setLayout(new GridLayout(12, false));
+		composite.setLayout(new GridLayout(13, false));
 
 		labelDetectionType = createDetectionTypeLabel(composite);
 		labelDetectionModus = createDetectionModusLabel(composite);
@@ -400,6 +403,7 @@ public class ExtendedPeakDetectorUI extends Composite implements IExtendedPartUI
 		buttonAddPeak = createAddPeakButton(composite);
 		createButtonToggleChartLegend(composite, chartControl, IMAGE_LEGEND);
 		createDetectionTypeButton(composite, DETECTION_TYPE_NONE, IApplicationImage.IMAGE_RESET);
+		createButtonHelp(composite, HelpContext.PEAK_DETECTOR);
 		createSettingsButton(composite);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakDetectorUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakDetectorUI.java
@@ -23,6 +23,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramPeakCSD;
 import org.eclipse.chemclipse.csd.model.core.selection.IChromatogramSelectionCSD;
+import org.eclipse.chemclipse.fsd.model.core.IChromatogramFSD;
+import org.eclipse.chemclipse.fsd.model.core.IChromatogramPeakFSD;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IPeak;
@@ -50,6 +52,8 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferenceSupplier
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.ChromatogramChartSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.ChromatogramDataSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.PeakChartSupport;
+import org.eclipse.chemclipse.vsd.model.core.IChromatogramPeakVSD;
+import org.eclipse.chemclipse.vsd.model.core.IChromatogramVSD;
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramPeakWSD;
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
 import org.eclipse.chemclipse.wsd.model.core.selection.IChromatogramSelectionWSD;
@@ -484,20 +488,29 @@ public class ExtendedPeakDetectorUI extends Composite implements IExtendedPartUI
 		if(chromatogram instanceof IChromatogramMSD chromatogramMSD) {
 			if(peak instanceof IChromatogramPeakMSD peakMSD) {
 				chromatogramMSD.getPeaks().add(peakMSD);
-				peak = null;
-				setDetectionType(DETECTION_TYPE_NONE);
-				updateChromatogramAndPeak();
-				chromatogramSelection.update(true);
 			}
 		} else if(chromatogram instanceof IChromatogramCSD chromatogramCSD) {
 			if(peak instanceof IChromatogramPeakCSD peakCSD) {
 				chromatogramCSD.getPeaks().add(peakCSD);
-				peak = null;
-				setDetectionType(DETECTION_TYPE_NONE);
-				updateChromatogramAndPeak();
-				chromatogramSelection.update(true);
+			}
+		} else if(chromatogram instanceof IChromatogramWSD chromatogramWSD) {
+			if(peak instanceof IChromatogramPeakWSD peakWSD) {
+				chromatogramWSD.getPeaks().add(peakWSD);
+			}
+		} else if(chromatogram instanceof IChromatogramFSD chromatogramFSD) {
+			if(peak instanceof IChromatogramPeakFSD peakFSD) {
+				chromatogramFSD.getPeaks().add(peakFSD);
+			}
+		} else if(chromatogram instanceof IChromatogramVSD chromatogramVSD) {
+			if(peak instanceof IChromatogramPeakVSD peakVSD) {
+				chromatogramVSD.getPeaks().add(peakVSD);
 			}
 		}
+
+		peak = null;
+		setDetectionType(DETECTION_TYPE_NONE);
+		updateChromatogramAndPeak();
+		chromatogramSelection.update(true);
 	}
 
 	private void createSettingsButton(Composite parent) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/core/AbstractChromatogramVSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/core/AbstractChromatogramVSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,8 @@
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.vsd.model.core;
+
+import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.core.noise.NoiseCalculator;
 import org.eclipse.chemclipse.chromatogram.xxd.calculator.preferences.PreferenceSupplier;
@@ -46,4 +48,17 @@ public abstract class AbstractChromatogramVSD extends AbstractChromatogram imple
 		return NoiseCalculator.getNoiseCalculator(id);
 	}
 
+	@SuppressWarnings("unchecked")
+	@Override
+	public List<IChromatogramPeakVSD> getPeaks() {
+
+		return (List<IChromatogramPeakVSD>)super.getPeaks();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public List<IChromatogramPeakVSD> getPeaks(int startRetentionTime, int stopRetentionTime) {
+
+		return (List<IChromatogramPeakVSD>)super.getPeaks(startRetentionTime, stopRetentionTime);
+	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/core/IChromatogramPeaksVSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/core/IChromatogramPeaksVSD.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.vsd.model.core;
+
+import java.util.List;
+
+import org.eclipse.chemclipse.model.core.IChromatogramPeaks;
+import org.eclipse.chemclipse.model.support.IRetentionTimeRange;
+
+public interface IChromatogramPeaksVSD extends IChromatogramPeaks {
+
+	/**
+	 * returns all peaks that are inside the given retention time, that means the retention time is within the start/stop retention time of the peak
+	 * 
+	 * @return a list of peaks at the given retention time, ordered by the start retention time of the peak
+	 */
+	@Override
+	List<IChromatogramPeakVSD> getPeaks(int startRetentionTime, int stopRetentionTime);
+
+	/**
+	 * Returns a list.
+	 * Modification does not change the chromatogram peak list.
+	 */
+	@Override
+	List<IChromatogramPeakVSD> getPeaks();
+
+	/**
+	 * Returns a list.
+	 * Modification does not change the chromatogram peak list.
+	 */
+	@Override
+	default List<IChromatogramPeakVSD> getPeaks(IRetentionTimeRange range) {
+
+		if(range == null) {
+			return getPeaks();
+		}
+		return getPeaks(range.getStartRetentionTime(), range.getStopRetentionTime());
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/core/IChromatogramVSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/src/org/eclipse/chemclipse/vsd/model/core/IChromatogramVSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,5 +14,5 @@ package org.eclipse.chemclipse.vsd.model.core;
 
 import org.eclipse.chemclipse.model.core.IChromatogram;
 
-public interface IChromatogramVSD extends IChromatogram {
+public interface IChromatogramVSD extends IChromatogram, IChromatogramPeaksVSD {
 }


### PR DESCRIPTION
The `Peak Detector` part has a few problems. It is difficult to find and not intuitive to use. I added some documentation to it. The final confirmation step required mouse interaction. Added another hotkey for power users. It was also limited to just MS and FID for some reason. This adds support HPLC-DAD and other detector types.