### PR TITLE
Lazy load process methods in Data Analysis

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.converter.ui/src/org/eclipse/chemclipse/converter/ui/preferences/PreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter.ui/src/org/eclipse/chemclipse/converter/ui/preferences/PreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -35,7 +35,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 		addField(new DirectoryFieldEditor(PreferenceSupplier.P_CHROMATOGRAM_EXPORT_FOLDER, "Chromatogram Export Folder", getFieldEditorParent()));
 		addField(new DirectoryFieldEditor(PreferenceSupplier.P_METHOD_EXPLORER_PATH_ROOT_FOLDER, "Methods Folder", getFieldEditorParent()));
-		addField(new StringFieldEditor(PreferenceSupplier.P_SELECTED_METHOD_NAME, "Method Name", getFieldEditorParent()));
+		addField(new StringFieldEditor(PreferenceSupplier.P_SELECTED_METHOD_FILENAME, "Method Name", getFieldEditorParent()));
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/methods/MethodConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/methods/MethodConverter.java
@@ -18,15 +18,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.chemclipse.converter.core.Converter;
 import org.eclipse.chemclipse.converter.core.IFileContentMatcher;
 import org.eclipse.chemclipse.converter.core.IMagicNumberMatcher;
 import org.eclipse.chemclipse.converter.core.NoFileContentMatcher;
-import org.eclipse.chemclipse.converter.exceptions.NoConverterAvailableException;
 import org.eclipse.chemclipse.converter.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.processing.converter.ISupplier;
@@ -34,7 +31,6 @@ import org.eclipse.chemclipse.processing.core.IMessageConsumer;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.chemclipse.processing.methods.IProcessMethod;
-import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionRegistry;
@@ -286,27 +282,13 @@ public class MethodConverter {
 		return fileContentMatcher;
 	}
 
-	public static Collection<IProcessMethod> getUserMethods() {
+	public static File[] getUserMethods() {
 
-		List<IProcessMethod> methodFiles = new ArrayList<>();
 		File directory = getUserMethodDirectory();
 		if(directory.exists() && directory.isDirectory()) {
-			try {
-				String[] extensions = MethodConverter.getMethodConverterSupport().getFilterExtensions();
-				for(File file : directory.listFiles()) {
-					for(String extension : extensions) {
-						if(file.getName().toLowerCase().endsWith(extension.toLowerCase())) {
-							IProcessMethod adapt = Adapters.adapt(file, IProcessMethod.class);
-							if(adapt != null) {
-								methodFiles.add(adapt);
-							}
-						}
-					}
-				}
-			} catch(NoConverterAvailableException e) {
-			}
+			return directory.listFiles();
 		}
-		return methodFiles;
+		return new File[0];
 	}
 
 	public static File getUserMethodDirectory() {
@@ -334,7 +316,7 @@ public class MethodConverter {
 			IProcessMethod processMethod = processingInfo.getProcessingResult();
 			if(processMethod != null) {
 				setUserMethodDirectory(file.getParentFile());
-				PreferenceSupplier.setSelectedMethodName(processMethod.getName());
+				PreferenceSupplier.setSelectedMethodFileName(file.getName());
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/methods/MethodProcessTypeSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/methods/MethodProcessTypeSupplier.java
@@ -34,6 +34,7 @@ import org.eclipse.chemclipse.processing.methods.IProcessMethod;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplier;
 import org.eclipse.chemclipse.processing.supplier.IProcessTypeSupplier;
+import org.eclipse.core.runtime.Adapters;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
@@ -158,10 +159,11 @@ public class MethodProcessTypeSupplier implements IProcessTypeSupplier, BundleTr
 
 		List<IProcessSupplier<?>> processSupplierList = new ArrayList<>();
 
-		Collection<IProcessMethod> userMethods = MethodConverter.getUserMethods();
+		File[] files = MethodConverter.getUserMethods();
 		Set<String> processSupplierIds = new HashSet<>();
 
-		for(IProcessMethod processMethod : userMethods) {
+		for(File file : files) {
+			IProcessMethod processMethod = Adapters.adapt(file, IProcessMethod.class);
 			UserMethodProcessSupplier processSupplier = new UserMethodProcessSupplier(processMethod, this);
 			if(processSupplierIds.contains(processSupplier.getId())) {
 				logger.warn("Duplicate id detected for method: " + processMethod.getName() + " (id: " + processSupplier.getId() + ")");

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/preferences/PreferenceSupplier.java
@@ -22,8 +22,8 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static final String DEF_CHROMATOGRAM_EXPORT_FOLDER = "";
 	public static final String P_METHOD_EXPLORER_PATH_ROOT_FOLDER = "methodExplorerPathRootFolder";
 	public static final String DEF_METHOD_EXPLORER_PATH_ROOT_FOLDER = "";
-	public static final String P_SELECTED_METHOD_NAME = "selectedMethodName";
-	public static final String DEF_SELECTED_METHOD_NAME = "";
+	public static final String P_SELECTED_METHOD_FILENAME = "selectedMethodName";
+	public static final String DEF_SELECTED_METHOD_FILENAME = "";
 
 	public static IPreferenceSupplier INSTANCE() {
 
@@ -41,7 +41,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 
 		putDefault(P_CHROMATOGRAM_EXPORT_FOLDER, DEF_CHROMATOGRAM_EXPORT_FOLDER);
 		putDefault(P_METHOD_EXPLORER_PATH_ROOT_FOLDER, DEF_METHOD_EXPLORER_PATH_ROOT_FOLDER);
-		putDefault(P_SELECTED_METHOD_NAME, DEF_SELECTED_METHOD_NAME);
+		putDefault(P_SELECTED_METHOD_FILENAME, DEF_SELECTED_METHOD_FILENAME);
 	}
 
 	public static String getSettings(String key, String def) {
@@ -54,14 +54,14 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 		return INSTANCE().get(P_CHROMATOGRAM_EXPORT_FOLDER, DEF_CHROMATOGRAM_EXPORT_FOLDER);
 	}
 
-	public static String getSelectedMethodName() {
+	public static String getSelectedMethodFileName() {
 
-		return INSTANCE().get(P_SELECTED_METHOD_NAME, DEF_SELECTED_METHOD_NAME);
+		return INSTANCE().get(P_SELECTED_METHOD_FILENAME, DEF_SELECTED_METHOD_FILENAME);
 	}
 
-	public static void setSelectedMethodName(String methodName) {
+	public static void setSelectedMethodFileName(String methodName) {
 
-		INSTANCE().put(P_SELECTED_METHOD_NAME, methodName);
+		INSTANCE().put(P_SELECTED_METHOD_FILENAME, methodName);
 	}
 
 	public static void setMethodExplorerPathRootFolder(String directory) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/methods/MethodSupportUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/methods/MethodSupportUI.java
@@ -18,7 +18,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.MessageFormat;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -49,6 +48,7 @@ import org.eclipse.chemclipse.ux.extension.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.ui.l10n.ExtensionMessages;
 import org.eclipse.chemclipse.ux.extension.ui.preferences.PreferenceSupplierMethods;
 import org.eclipse.chemclipse.ux.extension.ui.swt.IExtendedPartUI;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.e4.core.services.events.IEventBroker;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -167,8 +167,8 @@ public class MethodSupportUI extends Composite implements IExtendedPartUI {
 			@Override
 			public String getText(Object element) {
 
-				if(element instanceof IProcessMethod processMethod) {
-					return processMethod.getName();
+				if(element instanceof File file) {
+					return file.getName();
 				}
 				return null;
 			}
@@ -184,8 +184,8 @@ public class MethodSupportUI extends Composite implements IExtendedPartUI {
 			public void widgetSelected(SelectionEvent e) {
 
 				Object object = comboViewer.getStructuredSelection().getFirstElement();
-				if(object instanceof IProcessMethod processMethod) {
-					PreferenceSupplier.setSelectedMethodName(processMethod.getName());
+				if(object instanceof File file) {
+					PreferenceSupplier.setSelectedMethodFileName(file.getName());
 				}
 				enableWidgets();
 			}
@@ -231,7 +231,7 @@ public class MethodSupportUI extends Composite implements IExtendedPartUI {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 
-				File file = getFile(getProcessMethod());
+				File file = getFile();
 				if(file != null) {
 					openProcessMethodEditor(file);
 				}
@@ -266,7 +266,7 @@ public class MethodSupportUI extends Composite implements IExtendedPartUI {
 					/*
 					 * Single Method
 					 */
-					File fileSource = getFile(processMethod);
+					File fileSource = getFile();
 					if(fileSource != null && fileSource.exists()) {
 						if(MessageDialog.openQuestion(e.display.getActiveShell(), ExtensionMessages.copyMethod, MessageFormat.format(ExtensionMessages.shallCopyMethod, fileSource.getName()))) {
 							/*
@@ -390,11 +390,11 @@ public class MethodSupportUI extends Composite implements IExtendedPartUI {
 						}
 					}
 
-					File file = getFile(processMethod);
+					File file = getFile();
 					if(file != null && file.exists()) {
 						if(MessageDialog.openQuestion(e.display.getActiveShell(), ExtensionMessages.deleteMethod, MessageFormat.format(ExtensionMessages.shallDeleteMethod, file.getName()))) {
 							file.delete();
-							PreferenceSupplier.setSelectedMethodName("");
+							PreferenceSupplier.setSelectedMethodFileName("");
 							updateInput();
 						}
 						return;
@@ -487,7 +487,7 @@ public class MethodSupportUI extends Composite implements IExtendedPartUI {
 
 			IProcessingInfo<?> processingInfo = MethodConverter.convert(file, processMethod, MethodConverter.DEFAULT_METHOD_CONVERTER_ID, new NullProgressMonitor());
 			if(!processingInfo.hasErrorMessages()) {
-				PreferenceSupplier.setSelectedMethodName(file.getName());
+				PreferenceSupplier.setSelectedMethodFileName(file.getName());
 				if(openEditor) {
 					updateInput();
 					openProcessMethodEditor(file);
@@ -506,13 +506,13 @@ public class MethodSupportUI extends Composite implements IExtendedPartUI {
 			return;
 		}
 
-		List<IProcessMethod> methods = new ArrayList<>(MethodConverter.getUserMethods());
-		if(!methods.isEmpty()) {
+		List<File> files = Arrays.asList(MethodConverter.getUserMethods());
+		if(!files.isEmpty()) {
 			/*
 			 * Sort methods
 			 */
-			Collections.sort(methods, (m1, m2) -> m1.getName().compareToIgnoreCase(m2.getName()));
-			methodsControl.get().setInput(methods);
+			Collections.sort(files, (m1, m2) -> m1.getName().compareToIgnoreCase(m2.getName()));
+			methodsControl.get().setInput(files);
 			if(methodsControl.get().getCombo().getItemCount() > 0) {
 				updateProcessMethodSelection();
 			}
@@ -525,7 +525,7 @@ public class MethodSupportUI extends Composite implements IExtendedPartUI {
 
 	private void updateProcessMethodSelection() {
 
-		String selectedMethodName = PreferenceSupplier.getSelectedMethodName();
+		String selectedMethodName = PreferenceSupplier.getSelectedMethodFileName();
 		Combo combo = methodsControl.get().getCombo();
 
 		exitloop:
@@ -538,7 +538,7 @@ public class MethodSupportUI extends Composite implements IExtendedPartUI {
 
 		if(combo.getSelectionIndex() == -1) {
 			combo.select(0);
-			PreferenceSupplier.setSelectedMethodName(combo.getItem(0));
+			PreferenceSupplier.setSelectedMethodFileName(combo.getItem(0));
 		}
 	}
 
@@ -555,9 +555,9 @@ public class MethodSupportUI extends Composite implements IExtendedPartUI {
 		copyControl.get().setEnabled(true);
 		directoryControl.get().setEnabled(true);
 
-		IProcessMethod processMethod = getProcessMethod();
-		if(processMethod != null) {
-			boolean editable = getFile(processMethod) != null;
+		File file = getFile();
+		if(file != null) {
+			boolean editable = true;
 			editControl.get().setEnabled(editable);
 			copyControl.get().setEnabled(editable);
 			deleteControl.get().setEnabled(editable);
@@ -567,18 +567,19 @@ public class MethodSupportUI extends Composite implements IExtendedPartUI {
 
 	private IProcessMethod getProcessMethod() {
 
-		Object object = methodsControl.get().getStructuredSelection().getFirstElement();
-		if(object instanceof IProcessMethod processMethod) {
-			return processMethod;
+		File file = getFile();
+		if(file != null) {
+			return Adapters.adapt(file, IProcessMethod.class);
 		}
 
 		return null;
 	}
 
-	private File getFile(IProcessMethod processMethod) {
+	private File getFile() {
 
-		if(processMethod != null) {
-			return processMethod.getSourceFile();
+		Object object = methodsControl.get().getStructuredSelection().getFirstElement();
+		if(object instanceof File file) {
+			return file;
 		}
 
 		return null;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/ProcessMethodToolbar.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/ProcessMethodToolbar.java
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.ux.extension.ui.swt;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -316,21 +315,22 @@ public class ProcessMethodToolbar extends ToolBar {
 					menuItem.dispose();
 				}
 
-				Collection<IProcessMethod> userMethods = MethodConverter.getUserMethods();
-				for(IProcessMethod method : userMethods) {
+				File[] userMethods = MethodConverter.getUserMethods();
+				for(File file : userMethods) {
 					MenuItem menuItem = new MenuItem(menu, SWT.NONE);
-					menuItem.setText(method.getName());
+					menuItem.setText(file.getName());
 					menuItem.addSelectionListener(new SelectionAdapter() {
 
 						@Override
 						public void widgetSelected(SelectionEvent e) {
 
+							IProcessMethod method = Adapters.adapt(file, IProcessMethod.class);
 							loadMethodFile(method);
 						}
 					});
 				}
 
-				if(!userMethods.isEmpty()) {
+				if(userMethods.length > 0) {
 					new MenuItem(menu, SWT.SEPARATOR);
 				}
 


### PR DESCRIPTION
Parsing a process method seemed like a cheap operation, but combined with slow network drives, it slows down the whole chromatogram editor noticeably. So instead of parsing all of them initially, we do it only when we have to on execute/edit/copy button press.