### PR TITLE
Disable AMDIS autoloader by default

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/supplier/amdiscalri/preferences/PreferenceSupplier.java
@@ -96,7 +96,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	 * Chromatogram converter post processing
 	 */
 	public static final String P_PARSE_AMDIS_RETENTION_INDEX_DATA = "parseAMDISRetentionIndexData";
-	public static final boolean DEF_PARSE_AMDIS_RETENTION_INDEX_DATA = true;
+	public static final boolean DEF_PARSE_AMDIS_RETENTION_INDEX_DATA = false;
 	public static final String P_USE_AMDIS_CHROMATOGRAM_NAME = "useAMDISChromatogramName";
 	public static final boolean DEF_USE_AMDIS_CHROMATOGRAM_NAME = false;
 	public static final String P_AMDIS_DEFAULT_NAME = "AMDISDefaultName";


### PR DESCRIPTION
This is a follow-up to https://github.com/eclipse-chemclipse/chemclipse/pull/2842/. I assume most people don't need this. It saves an additional I/O operation for each chromatogram load. You can still flip this back on again in preferences.