### PR TITLE
Add eager loading and directory expansion user preferences to Data Explorer

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/preferences/PreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/preferences/PreferencePage.java
@@ -38,6 +38,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Uncheck for better performance:", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplierDataExplorer.P_EXPAND_PRECHECK, "Check if folders can be expanded.", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplierDataExplorer.P_EAGER_LOADING, "Remember last location.", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplierDataExplorer.P_FILTER_FILES, "Only show applicable files.", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplierDataExplorer.P_SHOW_ICONS, "Display icons matching the file type.", getFieldEditorParent()));
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/preferences/PreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/preferences/PreferencePage.java
@@ -37,6 +37,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 		addField(new BooleanFieldEditor(PreferenceSupplierDataExplorer.P_OPEN_EDITOR_MULTIPLE_TIMES, "Open Editor Multiple Times", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Uncheck for better performance:", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplierDataExplorer.P_EXPAND_PRECHECK, "Check if folders can be expanded.", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplierDataExplorer.P_FILTER_FILES, "Only show applicable files.", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplierDataExplorer.P_SHOW_ICONS, "Display icons matching the file type.", getFieldEditorParent()));
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/preferences/PreferenceSupplierDataExplorer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/preferences/PreferenceSupplierDataExplorer.java
@@ -21,10 +21,13 @@ public class PreferenceSupplierDataExplorer extends AbstractPreferenceSupplier {
 
 	public static final String P_SELECTED_DRIVE_PATH = "selectedDrivePath";
 	public static final String DEF_SELECTED_DRIVE_PATH = "";
+
 	public static final String P_SELECTED_HOME_PATH = "selectedHomePath";
 	public static final String DEF_SELECTED_HOME_PATH = "";
+
 	public static final String P_SELECTED_WORKSPACE_PATH = "selectedWorkspacePath";
 	public static final String DEF_SELECTED_WORKSPACE_PATH = "";
+
 	public static final String P_SELECTED_USER_LOCATION_PATH = "selectedUserLocationPath";
 	public static final String DEF_SELECTED_USER_LOCATION_PATH = "";
 
@@ -46,6 +49,9 @@ public class PreferenceSupplierDataExplorer extends AbstractPreferenceSupplier {
 	 */
 	public static final String P_EXPAND_PRECHECK = "expandPrecheck";
 	public static final boolean DEF_EXPAND_PRECHECK = true;
+
+	public static final String P_EAGER_LOADING = "eagerLoading";
+	public static final boolean DEF_EAGER_LOADING = true;
 
 	public static final String P_FILTER_FILES = "filterFiles";
 	public static final boolean DEF_FILTER_FILES = true;
@@ -79,6 +85,7 @@ public class PreferenceSupplierDataExplorer extends AbstractPreferenceSupplier {
 		putDefault(P_USER_LOCATIONS_TEMPLATE_FOLDER, DEF_USER_LOCATIONS_TEMPLATE_FOLDER);
 
 		putDefault(P_EXPAND_PRECHECK, DEF_EXPAND_PRECHECK);
+		putDefault(P_EAGER_LOADING, DEF_EAGER_LOADING);
 		putDefault(P_FILTER_FILES, DEF_FILTER_FILES);
 		putDefault(P_SHOW_ICONS, DEF_SHOW_ICONS);
 	}
@@ -167,6 +174,12 @@ public class PreferenceSupplierDataExplorer extends AbstractPreferenceSupplier {
 
 		return INSTANCE().getBoolean(P_EXPAND_PRECHECK);
 	}
+
+	public static boolean eagerLoading() {
+
+		return INSTANCE().getBoolean(P_EAGER_LOADING);
+	}
+
 	public static boolean filterFiles() {
 
 		return INSTANCE().getBoolean(P_FILTER_FILES);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/preferences/PreferenceSupplierDataExplorer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/preferences/PreferenceSupplierDataExplorer.java
@@ -44,6 +44,9 @@ public class PreferenceSupplierDataExplorer extends AbstractPreferenceSupplier {
 	/*
 	 * Performance related workarounds. Set to false for less pretty but faster.
 	 */
+	public static final String P_EXPAND_PRECHECK = "expandPrecheck";
+	public static final boolean DEF_EXPAND_PRECHECK = true;
+
 	public static final String P_FILTER_FILES = "filterFiles";
 	public static final boolean DEF_FILTER_FILES = true;
 
@@ -75,6 +78,7 @@ public class PreferenceSupplierDataExplorer extends AbstractPreferenceSupplier {
 
 		putDefault(P_USER_LOCATIONS_TEMPLATE_FOLDER, DEF_USER_LOCATIONS_TEMPLATE_FOLDER);
 
+		putDefault(P_EXPAND_PRECHECK, DEF_EXPAND_PRECHECK);
 		putDefault(P_FILTER_FILES, DEF_FILTER_FILES);
 		putDefault(P_SHOW_ICONS, DEF_SHOW_ICONS);
 	}
@@ -159,6 +163,10 @@ public class PreferenceSupplierDataExplorer extends AbstractPreferenceSupplier {
 		INSTANCE().set(P_USER_LOCATIONS_TEMPLATE_FOLDER, filterPath);
 	}
 
+	public static boolean expandPrecheck() {
+
+		return INSTANCE().getBoolean(P_EXPAND_PRECHECK);
+	}
 	public static boolean filterFiles() {
 
 		return INSTANCE().getBoolean(P_FILTER_FILES);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/FileExplorerContentProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/FileExplorerContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,14 +13,16 @@
 package org.eclipse.chemclipse.ux.extension.ui.provider;
 
 import java.io.File;
+import java.io.FileFilter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.eclipse.chemclipse.ux.extension.ui.preferences.PreferenceSupplierDataExplorer;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.Viewer;
 
-public class FileExplorerContentProvider implements ITreeContentProvider {
+public class FileExplorerContentProvider implements ITreeContentProvider, FileFilter {
 
 	@Override
 	public Object[] getChildren(Object parentElement) {
@@ -118,9 +120,14 @@ public class FileExplorerContentProvider implements ITreeContentProvider {
 			/*
 			 * Check if the parent file is a chromatogram.
 			 */
-			File[] fileList = parentFile.listFiles();
+			File[] fileList;
+			if(PreferenceSupplierDataExplorer.filterFiles()) {
+				fileList = parentFile.listFiles(FileExplorerContentProvider.this);
+			} else {
+				fileList = parentFile.listFiles();
+			}
 			if(fileList != null) {
-				for(File file : parentFile.listFiles()) {
+				for(File file : fileList) {
 					if(!file.isHidden()) {
 						files.add(file);
 					}
@@ -132,5 +139,11 @@ public class FileExplorerContentProvider implements ITreeContentProvider {
 		} else {
 			return false;
 		}
+	}
+
+	@Override
+	public boolean accept(File file) {
+
+		return !file.isHidden() && !file.getName().startsWith(".") && file.canRead();
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/LazyDataExplorerContentProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/LazyDataExplorerContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2026 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,11 +9,11 @@
  * 
  * Contributors:
  * Philip Wenig - initial API and implementation
+ * Christoph Läubrich - adopt to new API, add caching/access of determined {@link ISupplierFileIdentifier}s
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.ui.provider;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Function;
@@ -21,55 +21,26 @@ import java.util.function.Function;
 import org.eclipse.chemclipse.container.support.FileContainerSupport;
 import org.eclipse.chemclipse.processing.converter.ISupplier;
 import org.eclipse.chemclipse.processing.converter.ISupplierFileIdentifier;
-import org.eclipse.chemclipse.ux.extension.ui.preferences.PreferenceSupplierDataExplorer;
 import org.eclipse.chemclipse.ux.extension.ui.swt.IdentifierCacheSupport;
-import org.eclipse.jface.viewers.Viewer;
 
-public class DataExplorerContentProvider extends FileExplorerContentProvider implements FileFilter {
-
-	private File[] root;
+public class LazyDataExplorerContentProvider extends LazyFileExplorerContentProvider {
 
 	private final Function<File, Map<ISupplierFileIdentifier, Collection<ISupplier>>> supplierFunction;
 
-	public DataExplorerContentProvider(Collection<? extends ISupplierFileIdentifier> supplierFileIdentifierList) {
+	public LazyDataExplorerContentProvider(Collection<? extends ISupplierFileIdentifier> supplierFileIdentifierList) {
 
 		this(IdentifierCacheSupport.createIdentifierCache(supplierFileIdentifierList));
 	}
 
-	public DataExplorerContentProvider(Function<File, Map<ISupplierFileIdentifier, Collection<ISupplier>>> identifier) {
+	public LazyDataExplorerContentProvider(Function<File, Map<ISupplierFileIdentifier, Collection<ISupplier>>> identifier) {
 
 		this.supplierFunction = identifier;
-	}
-
-	@Override
-	public Object[] getChildren(Object parentElement) {
-
-		if(parentElement instanceof File file) {
-			return getFiles(file);
-		}
-		return root;
-	}
-
-	@Override
-	public void dispose() {
-
-		root = null;
-	}
-
-	@Override
-	public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
-
-		root = (File[])newInput;
 	}
 
 	@Override
 	public boolean accept(File file) {
 
 		if(super.accept(file)) {
-			if(PreferenceSupplierDataExplorer.filterFiles()) {
-				return true;
-			}
-
 			if(file.isDirectory()) {
 				return true;
 			} else if(FileContainerSupport.getCache().getFileContentProvider(file) != null) {
@@ -77,7 +48,6 @@ public class DataExplorerContentProvider extends FileExplorerContentProvider imp
 			}
 			return !supplierFunction.apply(file).isEmpty();
 		}
-
 		return false;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/DataExplorerTreeUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/DataExplorerTreeUI.java
@@ -24,8 +24,10 @@ import org.eclipse.chemclipse.processing.converter.ISupplier;
 import org.eclipse.chemclipse.processing.converter.ISupplierFileIdentifier;
 import org.eclipse.chemclipse.ux.extension.ui.l10n.ExtensionMessages;
 import org.eclipse.chemclipse.ux.extension.ui.listener.DataExplorerDragListener;
-import org.eclipse.chemclipse.ux.extension.ui.provider.DataExplorerContentProvider;
+import org.eclipse.chemclipse.ux.extension.ui.preferences.PreferenceSupplierDataExplorer;
 import org.eclipse.chemclipse.ux.extension.ui.provider.DataExplorerLabelProvider;
+import org.eclipse.chemclipse.ux.extension.ui.provider.FileExplorerContentProvider;
+import org.eclipse.chemclipse.ux.extension.ui.provider.LazyDataExplorerContentProvider;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.jface.preference.IPersistentPreferenceStore;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -154,11 +156,14 @@ public class DataExplorerTreeUI {
 	private void createTreeViewer(Composite parent, Function<File, Map<ISupplierFileIdentifier, Collection<ISupplier>>> identifier) {
 
 		TreeViewer treeViewer = new TreeViewer(parent, SWT.MULTI | SWT.VIRTUAL);
-
+		if(PreferenceSupplierDataExplorer.eagerLoading()) {
+			treeViewer.setContentProvider(new FileExplorerContentProvider());
+		} else {
+			treeViewer.setContentProvider(new LazyDataExplorerContentProvider(identifier));
+		}
+		treeViewer.setLabelProvider(new DataExplorerLabelProvider(identifier));
 		treeViewer.setUseHashlookup(true);
 		treeViewer.setExpandPreCheckFilters(PreferenceSupplierDataExplorer.expandPrecheck());
-		treeViewer.setContentProvider(new DataExplorerContentProvider(identifier));
-		treeViewer.setLabelProvider(new DataExplorerLabelProvider(identifier));
 		setInput(treeViewer);
 		treeViewerControl.set(treeViewer);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/DataExplorerTreeUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/DataExplorerTreeUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -156,7 +156,7 @@ public class DataExplorerTreeUI {
 		TreeViewer treeViewer = new TreeViewer(parent, SWT.MULTI | SWT.VIRTUAL);
 
 		treeViewer.setUseHashlookup(true);
-		treeViewer.setExpandPreCheckFilters(true);
+		treeViewer.setExpandPreCheckFilters(PreferenceSupplierDataExplorer.expandPrecheck());
 		treeViewer.setContentProvider(new DataExplorerContentProvider(identifier));
 		treeViewer.setLabelProvider(new DataExplorerLabelProvider(identifier));
 		setInput(treeViewer);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/MultiDataExplorerTreeUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/MultiDataExplorerTreeUI.java
@@ -48,8 +48,8 @@ import org.eclipse.chemclipse.ux.extension.ui.model.DataExplorerTreeSettings;
 import org.eclipse.chemclipse.ux.extension.ui.preferences.PreferencePage;
 import org.eclipse.chemclipse.ux.extension.ui.preferences.PreferencePageUserLocations;
 import org.eclipse.chemclipse.ux.extension.ui.preferences.PreferenceSupplierDataExplorer;
-import org.eclipse.chemclipse.ux.extension.ui.provider.DataExplorerContentProvider;
 import org.eclipse.chemclipse.ux.extension.ui.provider.ISupplierFileEditorSupport;
+import org.eclipse.chemclipse.ux.extension.ui.provider.LazyDataExplorerContentProvider;
 import org.eclipse.chemclipse.ux.extension.ui.provider.LazyFileExplorerContentProvider;
 import org.eclipse.chemclipse.xxd.process.files.SupplierFileIdentifierCache;
 import org.eclipse.jface.action.Action;
@@ -60,6 +60,7 @@ import org.eclipse.jface.preference.IPersistentPreferenceStore;
 import org.eclipse.jface.preference.IPreferencePage;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.viewers.ComboViewer;
+import org.eclipse.jface.viewers.IContentProvider;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
@@ -730,15 +731,15 @@ public class MultiDataExplorerTreeUI extends Composite implements IExtendedPartU
 	private void openOverview(File file, DataExplorerTreeUI dataExplorerTreeUI) {
 
 		if(file != null) {
-			DataExplorerContentProvider contentProvider = (DataExplorerContentProvider)dataExplorerTreeUI.getTreeViewer().getContentProvider();
 			/*
 			 * Update the directories content, until there is
 			 * actual no way to monitor the file system outside
 			 * of the workbench without using operating system
 			 * specific function via e.g. JNI.
 			 */
-			if(file.isDirectory()) {
-				contentProvider.refresh(file);
+			IContentProvider contentProvider = dataExplorerTreeUI.getTreeViewer().getContentProvider();
+			if(file.isDirectory() && contentProvider instanceof LazyDataExplorerContentProvider lazyDataExplorerContentProvider) {
+				lazyDataExplorerContentProvider.refresh(file);
 			}
 
 			Collection<ISupplierFileIdentifier> identifiers = getIdentifierSupplier().apply(file).keySet();


### PR DESCRIPTION
This adds two new settings:
* Check if folders can be expanded. Disable the check to get an I/O performance win as the underlying folder doesn't need to be checked.
* Allow the last location to be remembered by disabling all lazy loading of the file explorer. This may lead to poor performance on slow network drives, but we regain the behavior from before https://github.com/eclipse-chemclipse/chemclipse/pull/2570. I also reused a much simpler implementation. This is now the default and has to be disabled in the existing performance-related settings.

Currently there is a trade-off between performance and features for the Data Explorer, which the users have to decide based on their situation. I also have a hunch that the lazy implementations might make matters worse in some cases or may not be required because the file labeling and filtering are actually the major pain points.