### PR TITLE
Allow file identifier to match against a database folder

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/settings/IdentifierSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/settings/IdentifierSettings.java
@@ -28,6 +28,7 @@ import org.eclipse.chemclipse.support.settings.FileSettingProperty;
 import org.eclipse.chemclipse.support.settings.FileSettingProperty.DialogType;
 import org.eclipse.chemclipse.support.settings.FloatSettingsProperty;
 import org.eclipse.chemclipse.support.settings.IntSettingsProperty;
+import org.eclipse.chemclipse.support.util.FileListUtil;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -54,9 +55,9 @@ public class IdentifierSettings extends AbstractIdentifierSettingsMSD implements
 	@FloatSettingsProperty(minValue = IIdentifierSettings.MIN_LIMIT_MATCH_FACTOR, maxValue = IIdentifierSettings.MAX_LIMIT_MATCH_FACTOR)
 	private float limitMatchFactor = IIdentifierSettings.DEF_LIMIT_MATCH_FACTOR;
 
-	@JsonProperty(value = "Library File", defaultValue = "")
-	@JsonPropertyDescription("Select the library file.")
-	@FileSettingProperty(dialogType = DialogType.OPEN_DIALOG, extensionNames = {"AMDIS (*.msl)"}, validExtensions = {"*.msl;*.MSL"}, onlyDirectory = false, allowEmpty = false)
+	@JsonProperty(value = "Library File or Folder", defaultValue = "")
+	@JsonPropertyDescription("Select the library file or folder containing them.")
+	@FileSettingProperty(dialogType = DialogType.OPEN_DIALOG, onlyDirectory = false, allowEmpty = false)
 	private File libraryFile;
 
 	@JsonProperty(value = "Mass Spectrum Comparator", defaultValue = DEFAULT_COMPARATOR_ID)
@@ -138,6 +139,9 @@ public class IdentifierSettings extends AbstractIdentifierSettingsMSD implements
 	public String getMassSpectraFiles() {
 
 		if(libraryFile != null) {
+			if(libraryFile.isDirectory()) {
+				return FileListUtil.getAllContainingFilesAbsolutePath(libraryFile);
+			}
 			return libraryFile.getAbsolutePath();
 		} else {
 			return massSpectraFiles;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/settings/MassSpectrumLibraryIdentifierSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/settings/MassSpectrumLibraryIdentifierSettings.java
@@ -14,7 +14,6 @@
 package org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.settings;
 
 import java.io.File;
-import java.util.StringJoiner;
 
 import org.eclipse.chemclipse.msd.identifier.settings.AbstractMassSpectrumIdentifierSettings;
 import org.eclipse.chemclipse.support.settings.DoubleSettingsProperty;
@@ -30,8 +29,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 public class MassSpectrumLibraryIdentifierSettings extends AbstractMassSpectrumIdentifierSettings implements ILibraryIdentifierSettings {
 
-	@JsonProperty(value = "Library File", defaultValue = "")
-	@JsonPropertyDescription("Select the library file.")
+	@JsonProperty(value = "Library File or Folder", defaultValue = "")
+	@JsonPropertyDescription("Select the library file or folder containing them.")
 	@FileSettingProperty(dialogType = DialogType.OPEN_DIALOG, onlyDirectory = false, allowEmpty = false)
 	private File libraryFile;
 
@@ -65,26 +64,12 @@ public class MassSpectrumLibraryIdentifierSettings extends AbstractMassSpectrumI
 
 		if(libraryFile != null) {
 			if(libraryFile.isDirectory()) {
-				return getAllContainingFilesAbsolutePath(libraryFile);
+				return FileListUtil.getAllContainingFilesAbsolutePath(libraryFile);
 			}
 			return libraryFile.getAbsolutePath();
 		} else {
 			return massSpectraFiles;
 		}
-	}
-
-	private static String getAllContainingFilesAbsolutePath(File directory) {
-
-		StringJoiner joiner = new StringJoiner(FileListUtil.SEPARATOR_TOKEN);
-		File[] files = directory.listFiles();
-		if(files != null) {
-			for(File file : files) {
-				if(file.isFile()) {
-					joiner.add(file.getAbsolutePath());
-				}
-			}
-		}
-		return joiner.toString();
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/settings/PeakIdentifierSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/src/org/eclipse/chemclipse/chromatogram/xxd/identifier/supplier/file/settings/PeakIdentifierSettings.java
@@ -22,6 +22,7 @@ import org.eclipse.chemclipse.support.settings.FileSettingProperty;
 import org.eclipse.chemclipse.support.settings.FileSettingProperty.DialogType;
 import org.eclipse.chemclipse.support.settings.FloatSettingsProperty;
 import org.eclipse.chemclipse.support.settings.IntSettingsProperty;
+import org.eclipse.chemclipse.support.util.FileListUtil;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -30,9 +31,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 @GeneratedIdentifierSettings
 public class PeakIdentifierSettings extends AbstractPeakIdentifierSettingsMSD implements IFileIdentifierSettings {
 
-	@JsonProperty(value = "Library File", defaultValue = "")
-	@JsonPropertyDescription("Select the library file.")
-	@FileSettingProperty(dialogType = DialogType.OPEN_DIALOG, extensionNames = {"AMDIS (*.msl)", "NIST (*.msp)"}, validExtensions = {"*.msl;*.MSL", "*.msp;*.MSP"}, onlyDirectory = false, allowEmpty = false)
+	@JsonProperty(value = "Library File or Folder", defaultValue = "")
+	@JsonPropertyDescription("Select the library file or folder containing them.")
+	@FileSettingProperty(dialogType = DialogType.OPEN_DIALOG, onlyDirectory = false, allowEmpty = false)
 	private File libraryFile;
 
 	@JsonProperty(value = "Pre-Optimization", defaultValue = "false")
@@ -64,6 +65,9 @@ public class PeakIdentifierSettings extends AbstractPeakIdentifierSettingsMSD im
 	public String getMassSpectraFiles() {
 
 		if(libraryFile != null) {
+			if(libraryFile.isDirectory()) {
+				return FileListUtil.getAllContainingFilesAbsolutePath(libraryFile);
+			}
 			return libraryFile.getAbsolutePath();
 		} else {
 			return massSpectraFiles;

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/FileListUtil.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/util/FileListUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.StringJoiner;
 
 public class FileListUtil {
 
@@ -74,5 +75,19 @@ public class FileListUtil {
 			}
 		}
 		return files;
+	}
+
+	public static String getAllContainingFilesAbsolutePath(File directory) {
+
+		StringJoiner joiner = new StringJoiner(SEPARATOR_TOKEN);
+		File[] files = directory.listFiles();
+		if(files != null) {
+			for(File file : files) {
+				if(file.isFile()) {
+					joiner.add(file.getAbsolutePath());
+				}
+			}
+		}
+		return joiner.toString();
 	}
 }


### PR DESCRIPTION
The idea is not new. I added this in https://github.com/eclipse-chemclipse/chemclipse/pull/2121 for MALDI because the databases are spread across files (sometimes one MSP per file) and I rely on downstream converters in @OpenChrom, so I can't just hardcode file extensions.

I am adding this now also for chromatogram peak identification because we lost the one-click query all databases functionality when removing system settings. The benefit is that I don't change the settings API, as the same field is reused. Just point it to your folder containing your MSL/MSP databases, and you can query them all in one go as before. Save the settings and don't ask again to make it truly one click.