### PR TITLE
Update target platform to Apache HTTP components 5

### DIFF
--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -24,8 +24,8 @@
 	<unit id="org.apache.commons.commons-compress"/>
 	<unit id="org.apache.commons.commons-io"/>
 	<unit id="org.apache.commons.lang3"/>
-	<unit id="org.apache.httpcomponents.httpclient"/>
-	<unit id="org.apache.httpcomponents.httpcore"/>
+	<unit id="org.apache.httpcomponents.client5.httpclient5"/>
+	<unit id="org.apache.httpcomponents.core5.httpcore5"/>
 	<unit id="org.eclipse.jdt.junit6.runtime"/>
 	<repository location="https://download.eclipse.org/releases/2026-03/"/>
 </location>


### PR DESCRIPTION
Actually I believe we only use version 5 right now.