### PR TITLE
Use EasyMock from Orbit

### DIFF
--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -53,16 +53,7 @@
 		<unit id="org.apache.poi.ooxml"/>
 		<unit id="org.apache.poi.ooxml.schemas"/>
 		<unit id="org.apache.xmlbeans"/>
-	</location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>org.easymock</groupId>
-				<artifactId>easymock</artifactId>
-				<version>5.6.0</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
+		<unit id="org.easymock"/>
 	</location>
 	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="org.apache.pdfbox" missingManifest="generate" type="Maven">
 		<dependencies>


### PR DESCRIPTION
https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-03/ ships the same version we fetch from Maven Central. It shouldn't matter as we don't expose it to https://download.eclipse.org/chemclipse/integration/develop/repository/plugins/ anyway.