### PR TITLE
Fix quick access process methods not asking for resume/profile

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/methods/UserMethodProcessSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/methods/UserMethodProcessSupplier.java
@@ -40,6 +40,11 @@ public final class UserMethodProcessSupplier extends AbstractProcessSupplier<Voi
 		this.processMethod = processMethod;
 	}
 
+	public IProcessMethod getProcessMethod() {
+
+		return processMethod;
+	}
+
 	@Override
 	public Iterator<IProcessEntry> iterator() {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -32,6 +32,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.eclipse.chemclipse.converter.methods.MetaProcessorProcessSupplier;
+import org.eclipse.chemclipse.converter.methods.UserMethodProcessSupplier;
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.csd.model.core.selection.IChromatogramSelectionCSD;
 import org.eclipse.chemclipse.logging.core.Logger;
@@ -718,6 +719,11 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 			 */
 			if(processSupplier instanceof MetaProcessorProcessSupplier metaProcessorProcessSupplier) {
 				IProcessMethod processMethod = metaProcessorProcessSupplier.getProcessMethod();
+				MethodParameters methodParameters = ResumeMethodSupport.selectMethodParameters(shell, processMethod);
+				processMethod.setActiveProfile(methodParameters.getProfile());
+				processMethod.setResumeIndex(methodParameters.getResumeIndex());
+			} else if(processSupplier instanceof UserMethodProcessSupplier userProcessorProcessSupplier) {
+				IProcessMethod processMethod = userProcessorProcessSupplier.getProcessMethod();
 				MethodParameters methodParameters = ResumeMethodSupport.selectMethodParameters(shell, processMethod);
 				processMethod.setActiveProfile(methodParameters.getProfile());
 				processMethod.setResumeIndex(methodParameters.getResumeIndex());


### PR DESCRIPTION
When using the combo box and then pressing ▶️ you get the profile and step chooser dialog once you enable resume via the checkbox in the process method. Putting that same method in the quick access taskbar 💼 and the dialog was not shown. This fixes it.