### PR TITLE
Fix the column index part not updating

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterRetentionIndexSelector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/scan/core/FilterRetentionIndexSelector.java
@@ -31,6 +31,7 @@ import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.identifier.IColumnIndexMarker;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
+import org.eclipse.chemclipse.model.notifier.UpdateNotifier;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.model.support.ColumnIndexSupport;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -51,6 +52,7 @@ public class FilterRetentionIndexSelector extends AbstractChromatogramFilter {
 				processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, "Select Retention Index", "The retention indices have been selected successfully."));
 				processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, "Retention Index selection was successful."));
 				chromatogramSelection.getChromatogram().setDirty(true);
+				UpdateNotifier.update(chromatogramSelection);
 			}
 		}
 		return processingInfo;

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/ColumnIndicesPart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/ColumnIndicesPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.parts;
 
+import java.util.List;
+
+import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedColumnIndicesUI;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
@@ -30,5 +33,38 @@ public class ColumnIndicesPart extends AbstractLibraryInformationPart<ExtendedCo
 	protected ExtendedColumnIndicesUI createControl(Composite parent) {
 
 		return new ExtendedColumnIndicesUI(parent, SWT.NONE);
+	}
+
+	@Override
+	protected boolean updateData(List<Object> objects, String topic) {
+
+		if(objects.size() == 1) {
+			if(isChromatogramEvent(topic)) {
+				getControl().updateInput();
+				return true;
+			} else if(isCloseEvent(topic)) {
+				getControl().setInput(null);
+				unloadData();
+				return false;
+			}
+		}
+
+		return false;
+	}
+
+	@Override
+	protected boolean isUpdateTopic(String topic) {
+
+		return isChromatogramEvent(topic) || isCloseEvent(topic);
+	}
+
+	private boolean isChromatogramEvent(String topic) {
+
+		return IChemClipseEvents.TOPIC_CHROMATOGRAM_XXD_UPDATE_SELECTION.equals(topic);
+	}
+
+	private boolean isCloseEvent(String topic) {
+
+		return IChemClipseEvents.TOPIC_EDITOR_CHROMATOGRAM_CLOSE.equals(topic);
 	}
 }


### PR DESCRIPTION
I went with `TOPIC_CHROMATOGRAM_XXD_UPDATE_SELECTION` here although technically it is an update on each peak/scan target library entries. However that might be too spammy and `FilterRetentionIndexSelector` is a chromatogram filter.