### PR TITLE
Fix NPE if the molecule structure is null for some reasons.

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedMoleculeUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedMoleculeUI.java
@@ -479,11 +479,14 @@ public class ExtendedMoleculeUI extends Composite implements IExtendedPartUI {
 
 	private void setTextMolecule() {
 
+		String content = "";
 		if(libraryInformation != null) {
-			textMolecule.get().setText(libraryInformation.getMoleculeStructure());
-		} else {
-			textMolecule.get().setText("");
+			String moleculeStructure = libraryInformation.getMoleculeStructure();
+			if(moleculeStructure != null) {
+				content = moleculeStructure;
+			}
 		}
+		textMolecule.get().setText(content);
 	}
 
 	private void setTextInput() {


### PR DESCRIPTION
```
java.lang.IllegalArgumentException: Argument cannot be null
	at org.eclipse.swt.SWT.error(SWT.java:4931)
	at org.eclipse.swt.SWT.error(SWT.java:4865)
	at org.eclipse.swt.SWT.error(SWT.java:4836)
	at org.eclipse.swt.widgets.Widget.error(Widget.java:598)
	at org.eclipse.swt.widgets.Text.setText(Text.java:2666)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedMoleculeUI.setTextMolecule(ExtendedMoleculeUI.java:483)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedMoleculeUI.updateWidgets(ExtendedMoleculeUI.java:476)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedMoleculeUI.updateContent(ExtendedMoleculeUI.java:469)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedMoleculeUI.setInput(ExtendedMoleculeUI.java:100)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.parts.MoleculePart.updateData(MoleculePart.java:66)
	at org.eclipse.chemclipse.ux.extension.ui.parts.AbstractUpdater.updateSelection(AbstractUpdater.java:141)
	at org.eclipse.chemclipse.ux.extension.ui.parts.AbstractUpdater.lambda$0(AbstractUpdater.java:36)
	at org.eclipse.chemclipse.ux.extension.ui.support.DataUpdateSupport.fireUpdate(DataUpdateSupport.java:242)
	at org.eclipse.chemclipse.ux.extension.ui.support.DataUpdateSupport.updateObjects(DataUpdateSupport.java:213)
	at org.eclipse.chemclipse.ux.extension.ui.support.DataUpdateSupport.update(DataUpdateSupport.java:178)
	at org.eclipse.chemclipse.ux.extension.ui.support.DataUpdateSupport.lambda$0(DataUpdateSupport.java:167)
	at org.eclipse.e4.ui.services.internal.events.UIEventHandler.handleEvent(UIEventHandler.java:36)
	at org.eclipse.equinox.internal.event.EventHandlerWrapper.handleEvent(EventHandlerWrapper.java:206)
	at org.eclipse.equinox.internal.event.EventHandlerTracker.dispatchEvent(EventHandlerTracker.java:201)
	at org.eclipse.equinox.internal.event.EventHandlerTracker.dispatchEvent(EventHandlerTracker.java:1)
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)
	at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:151)
	at org.eclipse.equinox.internal.event.EventAdminImpl.dispatchEvent(EventAdminImpl.java:132)
	at org.eclipse.equinox.internal.event.EventAdminImpl.sendEvent(EventAdminImpl.java:73)
	at org.eclipse.equinox.internal.event.EventComponent.sendEvent(EventComponent.java:48)
	at org.eclipse.e4.ui.services.internal.events.EventBroker.send(EventBroker.java:55)
	at org.eclipse.chemclipse.model.notifier.UpdateNotifier.update(UpdateNotifier.java:56)
	at org.eclipse.chemclipse.ux.extension.msd.ui.swt.MassSpectrumLibraryUI.lambda$1(MassSpectrumLibraryUI.java:342)
	at org.eclipse.jface.viewers.Viewer$1.run(Viewer.java:151)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.jface.util.SafeRunnable.run(SafeRunnable.java:169)
	at org.eclipse.jface.viewers.Viewer.fireSelectionChanged(Viewer.java:148)
	at org.eclipse.jface.viewers.StructuredViewer.updateSelection(StructuredViewer.java:2132)
	at org.eclipse.jface.viewers.ColumnViewer.updateSelection(ColumnViewer.java:1044)
	at org.eclipse.jface.viewers.StructuredViewer.handleSelect(StructuredViewer.java:1173)
	at org.eclipse.jface.viewers.StructuredViewer$4.widgetSelected(StructuredViewer.java:1202)
	at org.eclipse.jface.util.OpenStrategy.fireSelectionEvent(OpenStrategy.java:262)
	at org.eclipse.jface.util.OpenStrategy$1.handleEvent(OpenStrategy.java:420)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:91)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5845)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1656)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:5060)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4497)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1160)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1051)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:684)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:583)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:173)
	at org.eclipse.chemclipse.rcp.app.ui.internal.support.ApplicationSupportDefault.start(ApplicationSupportDefault.java:26)
	at org.eclipse.chemclipse.rcp.app.ui.Application.start(Application.java:28)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:219)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:149)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:115)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:467)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:298)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:615)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:563)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1415)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1387)

```