### PR TITLE
Migrate pdfbox to 3.0.7

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.pdf/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/pdf/io/ReportWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.pdf/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/pdf/io/ReportWriter.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Lablicate GmbH.
+ * Copyright (c) 2024, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
@@ -18,11 +18,13 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.PDPageContentStream.AppendMode;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts.FontName;
 import org.apache.pdfbox.util.Matrix;
 import org.eclipse.chemclipse.chromatogram.xxd.report.supplier.pdf.settings.ReportSettings;
 import org.eclipse.chemclipse.chromatogram.xxd.report.supplier.pdf.support.ValueScaling;
@@ -46,6 +48,7 @@ public class ReportWriter {
 
 	private static final Logger logger = Logger.getLogger(ReportWriter.class);
 	private static final DecimalFormat decimalFormat = new DecimalFormat("0.0E0", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
+	private static final PDType1Font HELVETICA = new PDType1Font(FontName.HELVETICA);
 
 	private static final Unit PAGE_UNIT = Unit.PT;
 	private static final boolean LANDSCAPE = true;
@@ -53,7 +56,7 @@ public class ReportWriter {
 	public void generate(File file, boolean append, IChromatogram chromatogram, ReportSettings reportSettings, IProgressMonitor monitor) throws IOException {
 
 		if(file.exists() && append) {
-			try (PDDocument document = PDDocument.load(file)) {
+			try (PDDocument document = Loader.loadPDF(file)) {
 				addPages(document, file, chromatogram, reportSettings, monitor);
 			}
 		}
@@ -85,11 +88,11 @@ public class ReportWriter {
 
 		try (PDPageContentStream contentStream = new PDPageContentStream(pageUtil.getDocument(), pageUtil.getPage(), AppendMode.APPEND, false, false);) {
 			String name = chromatogram.getDataName().isBlank() ? chromatogram.getFile().getName() : chromatogram.getDataName();
-			float textWidth = pageUtil.calculateTextWidth(PDType1Font.HELVETICA, 12, name);
-			float textHeight = pageUtil.calculateTextHeight(PDType1Font.HELVETICA, 12);
+			float textWidth = pageUtil.calculateTextWidth(HELVETICA, 12, name);
+			float textHeight = pageUtil.calculateTextHeight(HELVETICA, 12);
 			float center = (350 + textWidth) / 2;
 			contentStream.beginText();
-			contentStream.setFont(PDType1Font.HELVETICA, 12);
+			contentStream.setFont(HELVETICA, 12);
 			contentStream.newLineAtOffset(center, 575 - textHeight);
 			contentStream.showText(name);
 			contentStream.endText();
@@ -148,7 +151,7 @@ public class ReportWriter {
 	private void drawAxisLabels(PDPageContentStream contentStream) throws IOException {
 
 		contentStream.beginText();
-		contentStream.setFont(PDType1Font.HELVETICA_BOLD, 12);
+		contentStream.setFont(new PDType1Font(FontName.HELVETICA_BOLD), 12);
 		contentStream.newLineAtOffset(400, 15);
 		contentStream.showText("Time [min]");
 		contentStream.setTextMatrix(Matrix.getRotateInstance(Math.PI / 2, 20, 300));
@@ -158,7 +161,7 @@ public class ReportWriter {
 
 	private void drawXAxisMarkers(PDPageContentStream contentStream, ITotalScanSignals scans) throws IOException {
 
-		contentStream.setFont(PDType1Font.HELVETICA, 8);
+		contentStream.setFont(HELVETICA, 8);
 		double startTime = scans.getFirstTotalScanSignal().getRetentionTime() / IChromatogramOverview.MINUTE_CORRELATION_FACTOR;
 		double stopTime = scans.getLastTotalScanSignal().getRetentionTime() / IChromatogramOverview.MINUTE_CORRELATION_FACTOR;
 		float ticks = Math.round(stopTime - startTime);
@@ -178,7 +181,7 @@ public class ReportWriter {
 
 	private void drawYAxisMarkers(PDPageContentStream contentStream, IChromatogram chromatogram) throws IOException {
 
-		contentStream.setFont(PDType1Font.HELVETICA, 8);
+		contentStream.setFont(HELVETICA, 8);
 		float minY = 50;
 		float maxY = 500;
 		float logMin = (float)Math.log10(chromatogram.getMinSignal());
@@ -202,10 +205,10 @@ public class ReportWriter {
 
 	private void drawPeaks(IChromatogram chromatogram, ValueScaling valueScaling, PageUtil pageUtil) throws IOException {
 
-		float textHeight = pageUtil.calculateTextHeight(PDType1Font.HELVETICA, 8);
+		float textHeight = pageUtil.calculateTextHeight(HELVETICA, 8);
 		try (PDPageContentStream contentStream = new PDPageContentStream(pageUtil.getDocument(), pageUtil.getPage(), AppendMode.APPEND, false, false)) {
 			contentStream.beginText();
-			contentStream.setFont(PDType1Font.HELVETICA, 8);
+			contentStream.setFont(HELVETICA, 8);
 			for(IPeak peak : chromatogram.getPeaks()) {
 				IPeakModel peakModel = peak.getPeakModel();
 				float x = valueScaling.getX(peakModel.getRetentionTimeAtPeakMaximum()) + (textHeight / 2);
@@ -214,7 +217,7 @@ public class ReportWriter {
 				}
 				float y = valueScaling.getY(peakModel.getBackgroundAbundance() + peakModel.getPeakAbundance());
 				String target = TargetSupport.getBestTargetLibraryField(peak);
-				float textWidth = pageUtil.calculateTextWidth(PDType1Font.HELVETICA, 8, target);
+				float textWidth = pageUtil.calculateTextWidth(HELVETICA, 8, target);
 				if(y + textWidth > 500) {
 					y -= textWidth;
 					if(y < 0) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.pdfbox.extensions/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pdfbox.extensions/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: ChemClipse
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.logging;bundle-version="0.8.0",
- org.apache.pdfbox
+ org.apache.pdfbox;bundle-version="3.0.7"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.pdfbox.extensions.core,

--- a/chemclipse/plugins/org.eclipse.chemclipse.pdfbox.extensions/src/org/eclipse/chemclipse/pdfbox/extensions/elements/TextElement.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pdfbox.extensions/src/org/eclipse/chemclipse/pdfbox/extensions/elements/TextElement.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -16,11 +16,12 @@ import java.awt.Color;
 
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts.FontName;
 import org.eclipse.chemclipse.pdfbox.extensions.settings.TextOption;
 
 public class TextElement extends AbstractReferenceElement<TextElement> {
 
-	private PDFont font = PDType1Font.HELVETICA;
+	private PDFont font = new PDType1Font(FontName.HELVETICA);
 	private float fontSize = 12; // pt
 	private Color color = Color.BLACK;
 	private float minHeight = -1;

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -60,25 +60,31 @@
 			<dependency>
 				<groupId>org.apache.pdfbox</groupId>
 				<artifactId>fontbox</artifactId>
-				<version>2.0.36</version>
+				<version>3.0.7</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.pdfbox</groupId>
 				<artifactId>pdfbox</artifactId>
-				<version>2.0.36</version>
+				<version>3.0.7</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.pdfbox</groupId>
 				<artifactId>preflight</artifactId>
-				<version>2.0.36</version>
+				<version>3.0.7</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.pdfbox</groupId>
+				<artifactId>pdfbox-io</artifactId>
+				<version>3.0.7</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.pdfbox</groupId>
 				<artifactId>xmpbox</artifactId>
-				<version>2.0.36</version>
+				<version>3.0.7</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>

--- a/chemclipse/tests/org.eclipse.chemclipse.pdfbox.extensions.fragment.test/src/org/eclipse/chemclipse/pdfbox/extensions/core/PageUtil_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.pdfbox.extensions.fragment.test/src/org/eclipse/chemclipse/pdfbox/extensions/core/PageUtil_3_Test.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -20,6 +20,7 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts.FontName;
 import org.eclipse.chemclipse.pdfbox.extensions.settings.PageBase;
 import org.eclipse.chemclipse.pdfbox.extensions.settings.PageSettings;
 import org.eclipse.chemclipse.pdfbox.extensions.settings.Unit;
@@ -33,7 +34,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 public class PageUtil_3_Test {
 
 	private static final String TEXT = "Hallo Welt!";
-	private static final PDFont FONT_REGULAR = PDType1Font.HELVETICA;
+	private static final PDFont FONT_REGULAR = new PDType1Font(FontName.HELVETICA);
 	private static final float FONT_SIZE_12 = 12.0f;
 
 	private PDDocument document;

--- a/chemclipse/tests/org.eclipse.chemclipse.pdfbox.extensions.fragment.test/src/org/eclipse/chemclipse/pdfbox/extensions/elements/CellElement_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.pdfbox.extensions.fragment.test/src/org/eclipse/chemclipse/pdfbox/extensions/elements/CellElement_1_Test.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.awt.Color;
 
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts.FontName;
 import org.eclipse.chemclipse.pdfbox.extensions.settings.ReferenceX;
 import org.eclipse.chemclipse.pdfbox.extensions.settings.ReferenceY;
 import org.eclipse.chemclipse.pdfbox.extensions.settings.TextOption;
@@ -80,14 +81,14 @@ public class CellElement_1_Test {
 	@Test
 	public void test4() {
 
-		assertEquals(PDType1Font.HELVETICA, element.getFont());
+		assertEquals(FontName.HELVETICA.getName(), element.getFont().getName());
 	}
 
 	@Test
 	public void test4a() {
 
-		element.setFont(PDType1Font.COURIER);
-		assertEquals(PDType1Font.COURIER, element.getFont());
+		element.setFont(new PDType1Font(FontName.COURIER));
+		assertEquals(FontName.COURIER.getName(), element.getFont().getName());
 	}
 
 	@Test

--- a/chemclipse/tests/org.eclipse.chemclipse.pdfbox.extensions.fragment.test/src/org/eclipse/chemclipse/pdfbox/extensions/elements/TextElement_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.pdfbox.extensions.fragment.test/src/org/eclipse/chemclipse/pdfbox/extensions/elements/TextElement_1_Test.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.awt.Color;
 
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts.FontName;
 import org.eclipse.chemclipse.pdfbox.extensions.settings.ReferenceX;
 import org.eclipse.chemclipse.pdfbox.extensions.settings.ReferenceY;
 import org.eclipse.chemclipse.pdfbox.extensions.settings.TextOption;
@@ -75,14 +76,14 @@ public class TextElement_1_Test {
 	@Test
 	public void test4() {
 
-		assertEquals(PDType1Font.HELVETICA, element.getFont());
+		assertEquals(FontName.HELVETICA.getName(), element.getFont().getName());
 	}
 
 	@Test
 	public void test4a() {
 
-		element.setFont(PDType1Font.COURIER);
-		assertEquals(PDType1Font.COURIER, element.getFont());
+		element.setFont(new PDType1Font(FontName.COURIER));
+		assertEquals(FontName.COURIER.getName(), element.getFont().getName());
 	}
 
 	@Test


### PR DESCRIPTION
PDFBox doesn't implement equals in its model classes and there are no more constants so some adjustments to tests are needed.