### PR TITLE
Fix ArrayIndexOutOfBoundsException in peak penalty chart.

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPenaltyCalculationUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPenaltyCalculationUI.java
@@ -36,13 +36,12 @@ public class ExtendedPenaltyCalculationUI extends Composite implements IExtended
 	private static final String TOOLTIP_CALCULATION = "calculation details.";
 	private static final String IMAGE_CALCULATION = IApplicationImage.IMAGE_CALCULATE;
 
-	private Button buttonToolbarInfo;
+	private AtomicReference<Button> buttonToolbarInfo = new AtomicReference<>();
 	private AtomicReference<InformationUI> toolbarInfo = new AtomicReference<>();
-	private Button buttonToolbarCalculation;
+	private AtomicReference<Button> buttonToolbarCalculation = new AtomicReference<>();
 	private AtomicReference<PenaltyCalculationUI> toolbarCalculation = new AtomicReference<>();
 	private AtomicReference<PenaltyCalculationChart> chartControl = new AtomicReference<>();
 
-	private final PeakDataSupport peakDataSupport = new PeakDataSupport();
 	private IPeak peak = null;
 
 	public ExtendedPenaltyCalculationUI(Composite parent, int style) {
@@ -84,8 +83,8 @@ public class ExtendedPenaltyCalculationUI extends Composite implements IExtended
 
 	private void initialize() {
 
-		enableToolbar(toolbarInfo, buttonToolbarInfo, IMAGE_INFO, TOOLTIP_INFO, true);
-		enableToolbar(toolbarCalculation, buttonToolbarCalculation, IMAGE_CALCULATION, TOOLTIP_CALCULATION, true);
+		enableToolbar(toolbarInfo, buttonToolbarInfo.get(), IMAGE_INFO, TOOLTIP_INFO, true);
+		enableToolbar(toolbarCalculation, buttonToolbarCalculation.get(), IMAGE_CALCULATION, TOOLTIP_CALCULATION, true);
 		applySettings();
 	}
 
@@ -97,9 +96,19 @@ public class ExtendedPenaltyCalculationUI extends Composite implements IExtended
 		composite.setLayoutData(gridData);
 		composite.setLayout(new GridLayout(3, false));
 
-		buttonToolbarInfo = createButtonToggleToolbar(composite, toolbarInfo, IMAGE_INFO, TOOLTIP_INFO);
-		buttonToolbarCalculation = createButtonToggleToolbar(composite, toolbarCalculation, IMAGE_CALCULATION, TOOLTIP_CALCULATION);
+		createButtonInfo(composite);
+		createButtonCalculation(composite);
 		createButtonSettings(composite);
+	}
+
+	private void createButtonInfo(Composite parent) {
+
+		buttonToolbarInfo.set(createButtonToggleToolbar(parent, toolbarInfo, IMAGE_INFO, TOOLTIP_INFO));
+	}
+
+	private void createButtonCalculation(Composite parent) {
+
+		buttonToolbarCalculation.set(createButtonToggleToolbar(parent, toolbarCalculation, IMAGE_CALCULATION, TOOLTIP_CALCULATION));
 	}
 
 	private void createToolbarInfo(Composite parent) {
@@ -149,6 +158,7 @@ public class ExtendedPenaltyCalculationUI extends Composite implements IExtended
 
 	private void updateLabel() {
 
+		PeakDataSupport peakDataSupport = new PeakDataSupport();
 		toolbarInfo.get().setText(peakDataSupport.getPeakLabel(peak));
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PenaltyCalculationChart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PenaltyCalculationChart.java
@@ -245,7 +245,7 @@ public class PenaltyCalculationChart extends ChromatogramChart {
 		for(double value : series) {
 			seriesAdjusted[index++] = value;
 		}
-		seriesAdjusted[index + 1] = stop;
+		seriesAdjusted[index++] = stop;
 
 		return seriesAdjusted;
 	}


### PR DESCRIPTION
```
!ENTRY org.eclipse.e4.ui.workbench 4 0 2026-05-20 06:44:12.433
!MESSAGE Failed to grant focus to element (org.eclipse.chemclipse.ux.extension.xxd.ui.partdescriptor.penaltyCalculationPartDescriptor)
!STACK 0
org.eclipse.e4.core.di.InjectionException: java.lang.ArrayIndexOutOfBoundsException: Index 53 out of bounds for length 53
	at org.eclipse.e4.core.internal.di.MethodRequestor.execute(MethodRequestor.java:68)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invokeUsingClass(InjectorImpl.java:305)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invokeUsingClass(InjectorImpl.java:312)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invokeUsingClass(InjectorImpl.java:312)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invoke(InjectorImpl.java:231)
	at org.eclipse.e4.core.contexts.ContextInjectionFactory.invoke(ContextInjectionFactory.java:148)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.focusGui(PartRenderingEngine.java:802)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.activate(PartServiceImpl.java:782)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.activate(PartServiceImpl.java:695)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.activate(PartServiceImpl.java:690)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.showPart(PartServiceImpl.java:1269)
	at org.eclipse.chemclipse.ux.extension.ui.support.PartSupport.showPart(PartSupport.java:243)
	at org.eclipse.chemclipse.ux.extension.ui.support.PartSupport.setPartVisibility(PartSupport.java:299)
	at org.eclipse.chemclipse.ux.extension.ui.support.PartSupport.togglePartVisibility(PartSupport.java:202)
	at org.eclipse.chemclipse.ux.extension.ui.support.PartSupport.togglePartVisibility(PartSupport.java:355)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.toolbar.AbstractPartHandler.action(AbstractPartHandler.java:129)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.toolbar.AbstractPartHandler.toggleVisibility(AbstractPartHandler.java:146)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.toolbar.CommandPartHandler.execute(CommandPartHandler.java:26)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.e4.core.internal.di.MethodRequestor.execute(MethodRequestor.java:58)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invokeUsingClass(InjectorImpl.java:305)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invoke(InjectorImpl.java:237)
	at org.eclipse.e4.core.contexts.ContextInjectionFactory.invoke(ContextInjectionFactory.java:174)
	at org.eclipse.e4.core.commands.internal.HandlerServiceHandler.execute(HandlerServiceHandler.java:165)
	at org.eclipse.core.commands.Command.executeWithChecks(Command.java:488)
	at org.eclipse.core.commands.ParameterizedCommand.executeWithChecks(ParameterizedCommand.java:484)
	at org.eclipse.e4.core.commands.internal.HandlerServiceImpl.executeHandler(HandlerServiceImpl.java:204)
	at org.eclipse.e4.ui.workbench.renderers.swt.HandledContributionItem.executeItem(HandledContributionItem.java:446)
	at org.eclipse.e4.ui.workbench.renderers.swt.AbstractContributionItem.handleWidgetSelection(AbstractContributionItem.java:471)
	at org.eclipse.e4.ui.workbench.renderers.swt.AbstractContributionItem.lambda$2(AbstractContributionItem.java:493)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:91)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5845)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1656)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:5060)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4497)
	at org.eclipse.e4.ui.workbench.renderers.swt.AbstractContributionItem.dropdownEvent(AbstractContributionItem.java:447)
	at org.eclipse.e4.ui.workbench.renderers.swt.AbstractContributionItem.handleWidgetSelection(AbstractContributionItem.java:458)
	at org.eclipse.e4.ui.workbench.renderers.swt.AbstractContributionItem.lambda$2(AbstractContributionItem.java:493)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:91)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5845)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1656)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:5060)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4497)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1160)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1051)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:684)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:583)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:173)
	at org.eclipse.chemclipse.rcp.app.ui.internal.support.ApplicationSupportDefault.start(ApplicationSupportDefault.java:26)
	at org.eclipse.chemclipse.rcp.app.ui.Application.start(Application.java:28)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:219)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:149)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:115)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:467)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:298)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:615)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:563)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1415)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1387)
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 53 out of bounds for length 53
	at org.eclipse.chemclipse.ux.extension.xxd.ui.swt.PenaltyCalculationChart.adjust(PenaltyCalculationChart.java:247)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.swt.PenaltyCalculationChart.updatePeak(PenaltyCalculationChart.java:118)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.swt.PenaltyCalculationChart.updateChart(PenaltyCalculationChart.java:96)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.swt.PenaltyCalculationChart.setInput(Unknown Source)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedPenaltyCalculationUI.updatePeak(ExtendedPenaltyCalculationUI.java:167)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedPenaltyCalculationUI.update(ExtendedPenaltyCalculationUI.java:65)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.parts.PenaltyCalculationPart.updateData(PenaltyCalculationPart.java:50)
	at org.eclipse.chemclipse.ux.extension.ui.parts.AbstractUpdater.updateSelection(AbstractUpdater.java:141)
	at org.eclipse.chemclipse.ux.extension.ui.parts.AbstractUpdater.setFocus(AbstractUpdater.java:67)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.e4.core.internal.di.MethodRequestor.execute(MethodRequestor.java:58)
	... 64 more
```