### PR TITLE
Various javadoc fixes

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.converter/src/org/eclipse/chemclipse/chromatogram/alignment/converter/retentionindices/IRetentionIndicesConverterSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.converter/src/org/eclipse/chemclipse/chromatogram/alignment/converter/retentionindices/IRetentionIndicesConverterSupport.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -25,9 +25,6 @@ public interface IRetentionIndicesConverterSupport {
 	 * The filter extension are the specific retention indices file extensions.
 	 * AMDIS has for example an filter extension (.cal) which represents a
 	 * retention indices file.
-	 * 
-	 * @return String[]
-	 * @throws NoRetentionIndicesConverterAvailableException
 	 */
 	String[] getFilterExtensions() throws NoRetentionIndicesConverterAvailableException;
 
@@ -37,9 +34,6 @@ public interface IRetentionIndicesConverterSupport {
 	 * The filter names are the specific retention indices file names to be
 	 * displayed for example in the SWT FileDialog. AMDIS has for example an
 	 * filter name "AMDIS RI Calibration Data (.cal)".
-	 * 
-	 * @return String[]
-	 * @throws NoRetentionIndicesConverterAvailableException
 	 */
 	String[] getFilterNames() throws NoRetentionIndicesConverterAvailableException;
 
@@ -48,10 +42,6 @@ public interface IRetentionIndicesConverterSupport {
 	 * The id of the selected filter is used to determine which converter should
 	 * be used to import or export the retention indices.<br/>
 	 * Be aware of that the first index is 0. It is a 0-based index.
-	 * 
-	 * @param index
-	 * @return String
-	 * @throws NoRetentionIndicesConverterAvailableException
 	 */
 	String getConverterId(int index) throws NoRetentionIndicesConverterAvailableException;
 
@@ -59,10 +49,6 @@ public interface IRetentionIndicesConverterSupport {
 	 * Returns an ArrayList with all available converter ids for the given file.<br/>
 	 * If the file ends with "*.cal" all converter ids which can convert files
 	 * ending with "*.cal" will be returned.<br/>
-	 * 
-	 * @param retentionIndices
-	 * @return List<String>
-	 * @throws NoRetentionIndicesConverterAvailableException
 	 */
 	List<String> getAvailableConverterIds(File retentionIndices) throws NoRetentionIndicesConverterAvailableException;
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.converter/src/org/eclipse/chemclipse/chromatogram/alignment/converter/retentionindices/RetentionIndicesConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.converter/src/org/eclipse/chemclipse/chromatogram/alignment/converter/retentionindices/RetentionIndicesConverter.java
@@ -6,14 +6,13 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.alignment.converter.retentionindices;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -68,14 +67,6 @@ public class RetentionIndicesConverter {
 	 * If a failure in the file could be detected an exception will be thrown.<br/>
 	 * For example that the file is not readable or the file is not existent.<br/>
 	 * If the converter was not able to convert the file, null will be returned.
-	 * 
-	 * @param retentionIndices
-	 * @param converterId
-	 * @return {@link IChromatogram}
-	 * @throws FileNotFoundException
-	 * @throws FileIsNotReadableException
-	 * @throws FileIsEmptyException
-	 * @throws IOException
 	 */
 	public static IRetentionIndices convert(final File retentionIndices, final String converterId) throws FileIsNotReadableException, FileIsEmptyException, IOException {
 
@@ -96,12 +87,6 @@ public class RetentionIndicesConverter {
 	 * which retention index converter to use.<br/>
 	 * This method will test all suitable converters.<br/>
 	 * If no converter was able to read the file, null will be returned.
-	 * 
-	 * @param file
-	 * @throws FileNotFoundException
-	 * @throws FileIsNotReadableException
-	 * @throws FileIsEmptyException
-	 * @return {@link IChromatogram}
 	 */
 	public static IRetentionIndices convert(final File file) throws FileIsNotReadableException, FileIsEmptyException {
 
@@ -177,14 +162,6 @@ public class RetentionIndicesConverter {
 
 	/**
 	 * Returns the written file or null if something has gone wrong.
-	 * 
-	 * @param file
-	 * @param retentionIndices
-	 * @param converterId
-	 * @return File
-	 * @throws FileNotFoundException
-	 * @throws FileIsNotWriteableException
-	 * @throws IOException
 	 */
 	public static File convert(final File file, final IRetentionIndices retentionIndices, final String converterId) throws FileIsNotWriteableException, IOException {
 
@@ -203,9 +180,6 @@ public class RetentionIndicesConverter {
 	/**
 	 * Returns an IRetentionIndicesImportConverter instance or null if none is
 	 * available.
-	 * 
-	 * @param converterId
-	 * @return IChromatogramImportConverter
 	 */
 	private static IRetentionIndicesImportConverter getRetentionIndicesImportConverter(final String converterId) {
 
@@ -225,9 +199,6 @@ public class RetentionIndicesConverter {
 	/**
 	 * Returns an IRetentionIndicesExportConverter instance or null if none is
 	 * available.
-	 * 
-	 * @param converterId
-	 * @return IRetentionIndicesExportConverter
 	 */
 	private static IRetentionIndicesExportConverter getRetentionIndicesExportConverter(final String converterId) {
 
@@ -247,9 +218,6 @@ public class RetentionIndicesConverter {
 	/**
 	 * Returns an IRetentionIndicesImportConverter or
 	 * IRetentionIndicesExportConverter instance or null if none is available.
-	 * 
-	 * @param converterId
-	 * @return IConfigurationElement
 	 */
 	private static IConfigurationElement getConfigurationElement(final String converterId) {
 
@@ -272,8 +240,6 @@ public class RetentionIndicesConverter {
 	 * about all valid and registered chromatogram converters.<br/>
 	 * It can be used to get more information about the registered converters
 	 * such like filter names, file extensions.
-	 * 
-	 * @return RetentionIndicesConverterSupport
 	 */
 	public static RetentionIndicesConverterSupport getRetentionIndicesConverterSupport() {
 
@@ -309,11 +275,9 @@ public class RetentionIndicesConverter {
 
 	/**
 	 * This method return true if the input string contains a not allowed
-	 * character like \/:*?"<>| It returns true if the input string is a valid
+	 * character like \/:*?"&lt;&gt;| It returns true if the input string is a valid
 	 * string and false if not.<br/>
 	 * If the input string is null it returns false.
-	 * 
-	 * @return boolean
 	 */
 	protected static boolean isValid(final String input) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.model/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndex.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.model/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndex.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -55,7 +55,7 @@ public class RetentionIndex implements IRetentionIndex, Comparable<IRetentionInd
 
 	/**
 	 * Checks the retention time to min and max values and sets it if valid.
-	 * 
+	 *
 	 * @param retentionTime
 	 */
 	// @edu.umd.cs.findbugs.annotations.SuppressWarnings("INT_VACUOUS_COMPARISON")
@@ -83,7 +83,7 @@ public class RetentionIndex implements IRetentionIndex, Comparable<IRetentionInd
 
 	/**
 	 * Checks the index to min and max values and sets it if valid.
-	 * 
+	 *
 	 * @param index
 	 */
 	private void setCheckedIndex(final float index) {
@@ -107,8 +107,8 @@ public class RetentionIndex implements IRetentionIndex, Comparable<IRetentionInd
 
 	/**
 	 * Compares the index of two retention index entries. Returns the following
-	 * values: a.compareTo(b) 0 a == b : 2000 == 2000 -1 a < b : 1000 < 2000 +1
-	 * a > b : 3000 > 2000
+	 * values: a.compareTo(b) 0 a == b : 2000 == 2000 -1 a &lt; b : 1000 &lt; 2000 +1
+	 * a &gt; b : 3000 &gt; 2000
 	 */
 	@Override
 	public int compareTo(final IRetentionIndex other) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/core/chromatogram/ChromatogramCalculator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/core/chromatogram/ChromatogramCalculator.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -52,11 +52,6 @@ public class ChromatogramCalculator {
 	 * mechanism.<br/>
 	 * You could think of filters that for example remove background
 	 * automatically or mean normalize the chromatogram.
-	 * 
-	 * @param chromatogramSelection
-	 * @param chromatogramCalculatorSettings
-	 * @param filterId
-	 * @return {@link IChromatogramCalculatorProcessingInfo}
 	 */
 	public static IProcessingInfo<?> applyCalculator(IChromatogramSelection chromatogramSelection, IChromatogramCalculatorSettings chromatogramCalculatorSettings, String filterId, IProgressMonitor monitor) {
 
@@ -124,7 +119,7 @@ public class ChromatogramCalculator {
 	/**
 	 * Returns an {@link IChromatogramCalculator} instance or null if none is
 	 * available.
-	 * 
+	 *
 	 * @param calculatorId
 	 * @return IConfigurationElement
 	 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/core/chromatogram/IChromatogramCalculator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/core/chromatogram/IChromatogramCalculator.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -32,20 +32,11 @@ public interface IChromatogramCalculator {
 	 * calculator settings.<br/>
 	 * Return an {@link IChromatogramCalculatorProcessingInfo} instance.<br/>
 	 * If there is no monitor instance, use a {@link NullProgressMonitor}.
-	 * 
-	 * @param chromatogramSelection
-	 * @param chromatogramCalculatorSettings
-	 * @param monitor
-	 * @return {@link IProcessingInfo}
 	 */
 	IProcessingInfo<?> applyCalculator(IChromatogramSelection chromatogramSelection, IChromatogramCalculatorSettings chromatogramCalculatorSettings, IProgressMonitor monitor);
 
 	/**
 	 * Validates the selection and settings and returns a process info instance.
-	 * 
-	 * @param chromatogramSelection
-	 * @param chromatogramCalculatorSettings
-	 * @return {@link IProcessingInfo}
 	 */
 	IProcessingInfo<?> validate(IChromatogramSelection chromatogramSelection, IChromatogramCalculatorSettings chromatogramCalculatorSettings);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/core/chromatogram/IChromatogramCalculatorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/core/chromatogram/IChromatogramCalculatorSupport.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -23,36 +23,22 @@ public interface IChromatogramCalculatorSupport {
 	 * The id of the selected filter is used to determine which filter should be
 	 * used to calculate the integration results of the chromatogram.<br/>
 	 * Be aware of that the first index is 0. It is a 0-based index.
-	 * 
-	 * @param index
-	 * @return String
-	 * @throws NoChromatogramCalculatorSupplierAvailableException
 	 */
 	String getCalculatorId(int index) throws NoChromatogramCalculatorSupplierAvailableException;
 
 	/**
 	 * Returns an IChromatogramFilterSupplier object.<br/>
 	 * The object stores some additional supplier information.
-	 * 
-	 * @param calculatorId
-	 * @return {@link IChromatogramCalculatorSupplier}
-	 * @throws NoChromatogramCalculatorSupplierAvailableException
 	 */
 	IChromatogramCalculatorSupplier getCalculatorSupplier(String calculatorId) throws NoChromatogramCalculatorSupplierAvailableException;
 
 	/**
 	 * Returns an ArrayList with all available chromatogram calculator supplier ids.<br/>
-	 * 
-	 * @return List<String>
-	 * @throws NoChromatogramCalculatorSupplierAvailableException
 	 */
 	List<String> getAvailableCalculatorIds() throws NoChromatogramCalculatorSupplierAvailableException;
 
 	/**
 	 * Returns the list of available chromatogram calculator names.
-	 * 
-	 * @return String[]
-	 * @throws NoChromatogramCalculatorSupplierAvailableException
 	 */
 	String[] getCalculatorNames() throws NoChromatogramCalculatorSupplierAvailableException;
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/core/noise/INoiseCalculatorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/core/noise/INoiseCalculatorSupport.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -24,36 +24,22 @@ public interface INoiseCalculatorSupport {
 	 * The id of the selected filter is used to determine which calculator should
 	 * be used to set the baseline of the chromatogram.<br/>
 	 * Be aware of that the first index is 0. It is a 0-based index.
-	 * 
-	 * @param index
-	 * @return String
-	 * @throws NoNoiseCalculatorAvailableException
 	 */
 	String getCalculatorId(int index) throws NoNoiseCalculatorAvailableException;
 
 	/**
 	 * Returns an INoiseCalculatorSupplier object.<br/>
 	 * The object stores some additional supplier information.
-	 * 
-	 * @param detectorId
-	 * @return {@link INoiseCalculatorSupplier}
-	 * @throws NoNoiseCalculatorAvailableException
 	 */
 	INoiseCalculatorSupplier getCalculatorSupplier(String detectorId) throws NoNoiseCalculatorAvailableException;
 
 	/**
 	 * Returns an ArrayList with all available noise calculator ids.<br/>
-	 * 
-	 * @return List<String>
-	 * @throws NoNoiseCalculatorAvailableException
 	 */
 	List<String> getAvailableCalculatorIds() throws NoNoiseCalculatorAvailableException;
 
 	/**
 	 * Returns the list of available noise calculator names.
-	 * 
-	 * @return String[]
-	 * @throws NoNoiseCalculatorAvailableException
 	 */
 	String[] getCalculatorNames() throws NoNoiseCalculatorAvailableException;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/baseline/IBaselineSegment.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/baseline/IBaselineSegment.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -23,36 +23,28 @@ public interface IBaselineSegment {
 	int getStartRetentionTime();
 
 	/**
-	 * The start retention time must be >= 0 and must be =< stopRetentionTime.
-	 * 
-	 * @param startRetentionTime
+	 * The start retention time must be &gt;= 0 and must be =&lt; stopRetentionTime.
 	 */
 	void setStartRetentionTime(int startRetentionTime);
 
 	float getStartBackgroundAbundance();
 
 	/**
-	 * The start background abundance time must be >= 0.
-	 * 
-	 * @param startBackgroundAbundance
+	 * The start background abundance time must be &gt;= 0.
 	 */
 	void setStartBackgroundAbundance(float startBackgroundAbundance);
 
 	int getStopRetentionTime();
 
 	/**
-	 * The stop retention time must be >= 0 and must be >= startRetentionTime.
-	 * 
-	 * @param stopRetentionTime
+	 * The stop retention time must be &gt;= 0 and must be &gt;= startRetentionTime.
 	 */
 	void setStopRetentionTime(int stopRetentionTime);
 
 	float getStopBackgroundAbundance();
 
 	/**
-	 * The stop background abundance time must be >= 0.
-	 * 
-	 * @param stopBackgroundAbundance
+	 * The stop background abundance time must be &gt;= 0.
 	 */
 	void setStopBackgroundAbundance(float stopBackgroundAbundance);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeakModel.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractPeakModel.java
@@ -68,12 +68,7 @@ public abstract class AbstractPeakModel extends AbstractPeakModelStrict {
 	 * The peak maximum should contain absolute abundance values for the given
 	 * peak. The background should not be considered in the peak maximum. So the
 	 * peak maximum represents the pure maybe deconvoluted mass spectrum for the
-	 * actual peak.<br/>
-	 *
-	 * @param peakMaximum
-	 * @param peakIntensityValues
-	 * @param startBackgroundAbundance
-	 * @param stopBackgroundAbundance
+	 * actual peak.
 	 */
 	protected AbstractPeakModel(IScan peakMaximum, IPeakIntensityValues peakIntensityValues, float startBackgroundAbundance, float stopBackgroundAbundance, boolean strictModel) throws PeakException {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IPeakIntensityValues.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/IPeakIntensityValues.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -101,7 +101,7 @@ public interface IPeakIntensityValues extends IPeakIntensityValuesStrict {
 	 * It means that the entry - defined by its retention time key - will be
 	 * returned which is equal or lower to the given retention time key.<br/>
 	 * Only valid entries will be returned if the following condition is true:
-	 * "retentionTime &gt;= getStartRetentionTime() && retentionTime &lt;= getStopRetentionTime()"
+	 * "retentionTime &gt;= getStartRetentionTime() &amp;&amp; retentionTime &lt;= getStopRetentionTime()"
 	 * , if it is not true, null will be returned.<br/>
 	 * If there is no entry available, null will be returned.
 	 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/filter/IMeasurementFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/filter/IMeasurementFilter.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Christoph Läubrich - initial API and implementation
  *******************************************************************************/
@@ -24,7 +24,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 /**
  * A {@link Filter} Extension interface for filters that can work on {@link IMeasurement}s.
  * This is part of the Chemclipse FilterFramework, to make the Filter available simply register it with the OSGi Servicefactory under the {@link Filter} interface, implementors are encouraged to also register each filter under all sub(filter) interface.
- * 
+ *
  * @author Christoph Läubrich
  *
  * @param <ConfigType>
@@ -34,7 +34,7 @@ public interface IMeasurementFilter<ConfigType> extends Filter<ConfigType> {
 	/**
 	 * Filters the given Collection of {@link IMeasurement}s with this filter and returns the result.
 	 * The resulting Collection could either be the same or a new collection, might have more or less items
-	 * 
+	 *
 	 * @param configuration
 	 *            the configuration to apply or <code>null</code> if no special configuration is desired
 	 * @param resultTransformer
@@ -45,13 +45,13 @@ public interface IMeasurementFilter<ConfigType> extends Filter<ConfigType> {
 	 *            a {@link IProgressMonitor} to report progress of the filtering or <code>null</code> if no progress is desired
 	 * @return the result of the processing or <code>null</code> if processing was canceled
 	 * @throws IllegalArgumentException
-	 *             if the given {@link IMeasurement}s are incompatible with this filter ({@link #acceptsIMeasurements(IMeasurement)} returns <code>false</code>)
+	 *             if the given {@link IMeasurement}s are incompatible with this filter ({@link #acceptsIMeasurements(Collection)} returns <code>false</code>)
 	 */
 	<ResultType> ResultType filterIMeasurements(Collection<? extends IMeasurement> filterItems, ConfigType configuration, Function<? super Collection<? extends IMeasurement>, ResultType> resultTransformer, IMessageConsumer messageConsumer, IProgressMonitor monitor) throws IllegalArgumentException;
 
 	/**
 	 * Checks if the given {@link IMeasurement} is compatible with this filter, that means that this filter can be applied without throwing an {@link IllegalArgumentException}
-	 * 
+	 *
 	 * @param items
 	 *            the {@link IMeasurement} to check
 	 * @return <code>true</code> if this {@link IMeasurement} can be applied, <code>false</code> otherwise
@@ -60,10 +60,10 @@ public interface IMeasurementFilter<ConfigType> extends Filter<ConfigType> {
 
 	/**
 	 * Creates a new configuration that is specially suited for the given {@link IMeasurement} types
-	 * 
+	 *
 	 * @return a new configuration for this items or the default config if items is empty or no suitable configuration can be created
 	 * @throws IllegalArgumentException
-	 *             if the given {@link IMeasurement}s are incompatible with this filter ({@link #acceptsIMeasurements(IMeasurement)} returns <code>false</code>)
+	 *             if the given {@link IMeasurement}s are incompatible with this filter ({@link #acceptsIMeasurements(Collection)} returns <code>false</code>)
 	 */
 	default ConfigType createConfiguration(Collection<? extends IMeasurement> items) throws IllegalArgumentException {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/ranges/TimeRange.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/ranges/TimeRange.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -53,7 +53,7 @@ public class TimeRange {
 	/**
 	 * Start / Stop in milliseconds.
 	 * Auto-correction of start/stop if performed.
-	 * 
+	 *
 	 * @param start
 	 * @param stop
 	 */
@@ -71,7 +71,7 @@ public class TimeRange {
 	/**
 	 * Start / Maximum / Stop in milliseconds.
 	 * Auto-correction of start/maximum/stop if performed.
-	 * 
+	 *
 	 * @param start
 	 * @param maximum
 	 * @param stop
@@ -131,8 +131,8 @@ public class TimeRange {
 
 	/**
 	 * Updates the start time.
-	 * The start time must be <= stop time, otherwise no update is performed.
-	 * 
+	 * The start time must be &lt;= stop time, otherwise no update is performed.
+	 *
 	 * @param start
 	 */
 	public void updateStart(int start) {
@@ -150,14 +150,12 @@ public class TimeRange {
 	 */
 	public void updateMaximum() {
 
-		this.maximum = (int)calculateCenter(start, stop);
+		this.maximum = calculateCenter(start, stop);
 	}
 
 	/**
 	 * Updates the maximum time.
-	 * The maximum time must be >= start time and <= stop time, otherwise no update is performed.
-	 * 
-	 * @param maximum
+	 * The maximum time must be &gt;= start time and &lt;= stop time, otherwise no update is performed.
 	 */
 	public void updateMaximum(int maximum) {
 
@@ -168,9 +166,7 @@ public class TimeRange {
 
 	/**
 	 * Updates the stop time.
-	 * The stop time must be >= start time, otherwise no update is performed.
-	 * 
-	 * @param stop
+	 * The stop time must be &gt;= start time, otherwise no update is performed.
 	 */
 	public void updateStop(int stop) {
 
@@ -236,18 +232,23 @@ public class TimeRange {
 	@Override
 	public boolean equals(Object obj) {
 
-		if(this == obj)
+		if(this == obj) {
 			return true;
-		if(obj == null)
+		}
+		if(obj == null) {
 			return false;
-		if(getClass() != obj.getClass())
+		}
+		if(getClass() != obj.getClass()) {
 			return false;
+		}
 		TimeRange other = (TimeRange)obj;
 		if(identifier == null) {
-			if(other.identifier != null)
+			if(other.identifier != null) {
 				return false;
-		} else if(!identifier.equals(other.identifier))
+			}
+		} else if(!identifier.equals(other.identifier)) {
 			return false;
+		}
 		return true;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/services/IDatabaseResolverService.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/services/IDatabaseResolverService.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -22,8 +22,6 @@ public interface IDatabaseResolverService {
 
 	/**
 	 * Tries to resolve the database name by UUID.
-	 * 
-	 * @param UUID
 	 */
 	String resolve(String uuid);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/signals/ITotalScanSignals.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/signals/ITotalScanSignals.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - add method to get values in a given range
@@ -26,34 +26,24 @@ public interface ITotalScanSignals extends Iterable<Integer> {
 
 	/**
 	 * Returns the chromatogram where these signals derive from.
-	 * 
-	 * @return {@link IChromatogram}
 	 */
 	IChromatogram getChromatogram();
 
 	/**
 	 * Adds an {@link ITotalScanSignal} instance at the end of the stored
 	 * signals.
-	 * 
-	 * @param totalScanSignal
 	 */
 	void add(ITotalScanSignal totalScanSignal);
 
 	/**
 	 * Returns an {@link ITotalScanSignal} object.<br/>
 	 * If no object is available, null will be returned.
-	 * 
-	 * @param scan
-	 * @return ITotalIonSignal
 	 */
 	ITotalScanSignal getTotalScanSignal(int scan);
 
 	/**
 	 * Returns the next scan relative to the given scan.<br/>
 	 * If no scan is available, null will be returned.
-	 * 
-	 * @param scan
-	 * @return ITotalIonSignal
 	 */
 	default ITotalScanSignal getNextTotalScanSignal(int scan) {
 
@@ -63,9 +53,6 @@ public interface ITotalScanSignals extends Iterable<Integer> {
 	/**
 	 * Returns the previous scan relative to the given scan.<br/>
 	 * If no scan is available, null will be returned.
-	 * 
-	 * @param scan
-	 * @return IPoint
 	 */
 	default ITotalScanSignal getPreviousTotalScanSignal(int scan) {
 
@@ -73,7 +60,7 @@ public interface ITotalScanSignals extends Iterable<Integer> {
 	}
 
 	/**
-	 * 
+	 *
 	 * @return first signal with index start scan if signals is empty return null
 	 */
 	default ITotalScanSignal getFirstTotalScanSignal() {
@@ -82,7 +69,7 @@ public interface ITotalScanSignals extends Iterable<Integer> {
 	}
 
 	/**
-	 * 
+	 *
 	 * @return first signal with index stop scan if signals is empty return null
 	 */
 	default ITotalScanSignal getLastTotalScanSignal() {
@@ -94,29 +81,21 @@ public interface ITotalScanSignals extends Iterable<Integer> {
 
 	/**
 	 * Returns the size.
-	 * 
-	 * @return int
 	 */
 	int size();
 
 	/**
 	 * Returns the start scan number.
-	 * 
-	 * @return int
 	 */
 	int getStartScan();
 
 	/**
 	 * Returns the stop scan number.
-	 * 
-	 * @return int
 	 */
 	int getStopScan();
 
 	/**
 	 * Returns the highest total signal from the stored total ion signals.
-	 * 
-	 * @return float
 	 */
 	default float getMaxSignal() {
 
@@ -132,8 +111,6 @@ public interface ITotalScanSignals extends Iterable<Integer> {
 
 	/**
 	 * Returns the lowest total signal from the stored total ion signals.
-	 * 
-	 * @return float
 	 */
 	default float getMinSignal() {
 
@@ -149,8 +126,6 @@ public interface ITotalScanSignals extends Iterable<Integer> {
 
 	/**
 	 * Makes a deep copy of the actual total ion signals list.
-	 * 
-	 * @return ITotalIonSignals
 	 */
 	ITotalScanSignals makeDeepCopy();
 
@@ -158,22 +133,16 @@ public interface ITotalScanSignals extends Iterable<Integer> {
 	 * Returns a list of the stored total ion signals. The list is a copy.
 	 * Remove or add total ion signals with the appropriate methods of this
 	 * interface.
-	 * 
-	 * @return List<ITotalIonSignal>
 	 */
 	List<ITotalScanSignal> getTotalScanSignals();
 
 	/**
 	 * Returns a list of the stored total ion signals. The list is unmodifiable.
-	 * 
-	 * @return List<ITotalIonSignal>
 	 */
 	List<ITotalScanSignal> getTotalScanSignalList();
 
 	/**
 	 * Returns the highest total ion signal.
-	 * 
-	 * @return {@link ITotalScanSignal}
 	 */
 	default ITotalScanSignal getMaxTotalScanSignal() {
 
@@ -182,8 +151,6 @@ public interface ITotalScanSignals extends Iterable<Integer> {
 
 	/**
 	 * Returns the lowest total ion signal.
-	 * 
-	 * @return {@link ITotalScanSignal}
 	 */
 	default ITotalScanSignal getMinTotalScanSignal() {
 
@@ -227,8 +194,6 @@ public interface ITotalScanSignals extends Iterable<Integer> {
 
 	/**
 	 * Returns all total ion signals as an float array.
-	 * 
-	 * @return float[]
 	 */
 	default float[] getValues() {
 
@@ -241,7 +206,7 @@ public interface ITotalScanSignals extends Iterable<Integer> {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param range
 	 * @return all values in the given range as array
 	 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/IRetentionTimeRange.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/IRetentionTimeRange.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - add contentEquals / containsRetentionTime / javadoc
@@ -27,7 +27,7 @@ public interface IRetentionTimeRange {
 
 	/**
 	 * Compares this objects content to the other objects content, the default implementation compares {@link #getStartRetentionTime()}, {@link #getStopRetentionTime()}
-	 * this method is different to {@link #equals(Object)} that it does compares for user visible properties to be equal in contrast to objects identity and it allows to compare different instance type, this also means that it is not required that
+	 * this method is different to {@link java.lang.Object#equals(Object)} that it does compares for user visible properties to be equal in contrast to objects identity and it allows to compare different instance type, this also means that it is not required that
 	 * Object1.contentEquals(Object2} == Object2.contentEquals(Object1}
 	 */
 	default boolean contentEquals(IRetentionTimeRange other) {
@@ -43,11 +43,11 @@ public interface IRetentionTimeRange {
 
 	/**
 	 * Check if the given retention time is contained within this range
-	 * 
+	 *
 	 * @param retentionTime
 	 *            the retention time (in milliseconds) to check
 	 * @return <code>true</code> if retention time is within bounds, <code>false</code> otherwise
-	 * 
+	 *
 	 */
 	default boolean containsRetentionTime(int retentionTime) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/IScanRange.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/IScanRange.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - add contains method
@@ -22,21 +22,21 @@ public interface IScanRange {
 
 	/**
 	 * Returns the start scan number.
-	 * 
+	 *
 	 * @return int
 	 */
 	int getStartScan();
 
 	/**
 	 * Returns the stop scan number.
-	 * 
+	 *
 	 * @return int
 	 */
 	int getStopScan();
 
 	/**
 	 * Returns the width of the scan range.
-	 * 
+	 *
 	 * @return int
 	 */
 	default int getWidth() {
@@ -51,9 +51,9 @@ public interface IScanRange {
 
 	/**
 	 * Compares this objects content to the other objects content, the default implementation compares {@link #getStartScan()}, {@link #getStopScan()}
-	 * this method is different to {@link #equals(Object)} that it does compares for user visible properties to be equal in contrast to objects identity and it allows to compare different instance type, this also means that it is not required that
+	 * this method is different to {@link java.lang.Object#equals(Object)} that it does compares for user visible properties to be equal in contrast to objects identity and it allows to compare different instance type, this also means that it is not required that
 	 * Object1.contentEquals(Object2} == Object2.contentEquals(Object1}
-	 * 
+	 *
 	 * @param other
 	 * @return
 	 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/ScanRange.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/ScanRange.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -19,12 +19,9 @@ public class ScanRange implements IScanRange {
 
 	/**
 	 * Creates a new ScanRange object. There are some limitations:<br/>
-	 * The startScan may not be <= 1 and > MAX_SCAN. In such a case it will be
-	 * set to MIN_SCAN. The stopScan should be <= MAX_SCAN and > 0 otherwise it
+	 * The startScan may not be &lt;= 1 and &gt; MAX_SCAN. In such a case it will be
+	 * set to MIN_SCAN. The stopScan should be &lt;= MAX_SCAN and &gt; 0 otherwise it
 	 * will be set to MAX_SCAN.
-	 * 
-	 * @param startScan
-	 * @param stopScan
 	 */
 	public ScanRange(int startScan, int stopScan) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/SegmentValidatorClassic.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/SegmentValidatorClassic.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - add Method that accept float[]s
@@ -23,9 +23,9 @@ public class SegmentValidatorClassic implements ISegmentValidator {
 	 * E.g.: If the segment has 13 scans. There must
 	 * be at least 6 crossings for the segment to be accepted.<br/>
 	 * length =
-	 * 13 - 1 => 12<br/>
+	 * 13 - 1 =&gt; 12<br/>
 	 * length / 2 = 6<br/>
-	 * With crossings <= 6 there must
+	 * With crossings &lt;= 6 there must
 	 * be at least 7 crossings.
 	 */
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIon.java
@@ -131,13 +131,15 @@ public abstract class AbstractIon implements IIon {
 	/**
 	 * Returns the given ion as an value rounded to the given precision.
 	 * E.g.:
-	 * ion = 28.78749204
-	 * precision 1 => 28.8
-	 * precision 2 => 28.79
-	 * precision 3 => 28.787
-	 * precision 4 => 28.7875
-	 * precision 5 => 28.78749
-	 * precision 6 => 28.787492
+	 * <ul>
+	 * <li>ion = 28.78749204</li>
+	 * <li>precision 1 =&gt; 28.8</li>
+	 * <li>precision 2 =&gt; 28.79</li>
+	 * <li>precision 3 =&gt; 28.787</li>
+	 * <li>precision 4 =&gt; 28.7875</li>
+	 * <li>precision 5 =&gt; 28.78749</li>
+	 * <li>precision 6 =&gt; 28.787492</li>
+	 * </ul>
 	 *
 	 * The precision of 6 is the maximum. If the precious is outward of
 	 * this bounds it will set to 1.
@@ -205,8 +207,8 @@ public abstract class AbstractIon implements IIon {
 
 	/**
 	 * Compares the mass/charge ration of two ions. Returns the
-	 * following values: a.compareTo(b) 0 a == b : 28 == 28 -1 a < b : 18 < 28
-	 * +1 a > b : 28 > 18
+	 * following values: a.compareTo(b) 0 a == b : 28 == 28 -1 a &lt; b : 18 &lt; 28
+	 * +1 a &gt; b : 28 &gt; 18
 	 */
 	@Override
 	public int compareTo(IIon other) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractPeakIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractPeakIon.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -42,12 +42,6 @@ public abstract class AbstractPeakIon extends AbstractIon implements IPeakIon {
 	 * A factor of 0.0f mean 0%, a factor of 1.0f means 100%.<br/>
 	 * 100% means, that this ions belongs surely to the corresponding
 	 * mass spectrum.
-	 * 
-	 * @param ion
-	 * @param abundance
-	 * @param uncertaintyFactor
-	 * @throws AbundanceLimitExceededException
-	 * @throws IonLimitExceededException
 	 */
 	protected AbstractPeakIon(double ion, float abundance, float uncertaintyFactor) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractPeakMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractPeakMassSpectrum.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -32,9 +32,9 @@ public abstract class AbstractPeakMassSpectrum extends AbstractRegularMassSpectr
 	/**
 	 * Creates a new instance of a peak mass spectrum shifted to the given
 	 * intensity relative to the intensity of peakMassSpectrum. The given
-	 * intensity must be intensity >= 0 and intensity <=
+	 * intensity must be intensity &gt;= 0 and intensity &lt;=
 	 * IPeakIntensityValues.MAX_INTENSITY.
-	 * 
+	 *
 	 * @param peakMassSpectrum
 	 * @param intensity
 	 */
@@ -78,13 +78,10 @@ public abstract class AbstractPeakMassSpectrum extends AbstractRegularMassSpectr
 	 * percentageIntensity of 125.0f will be provided, the total intensity of
 	 * the returned peak mass spectrum will be 45600.<br/>
 	 * Some examples:<br/>
-	 * 97.2% actual: 6514141.6f -> 100% : 6701791.77f<br/>
-	 * 100% actual: 6514141.6f -> 100% : 6514141.6f<br/>
-	 * 120% actual: 6514141.6f -> 100% : 5428451.333f<br/>
-	 * 50% actual: 6514141.6f -> 100% : 13028283.2f<br/>
-	 * 
-	 * @param massSpectrum
-	 * @param actualPercentageIntensity
+	 * 97.2% actual: 6514141.6f -&gt; 100% : 6701791.77f<br/>
+	 * 100% actual: 6514141.6f -&gt; 100% : 6514141.6f<br/>
+	 * 120% actual: 6514141.6f -&gt; 100% : 5428451.333f<br/>
+	 * 50% actual: 6514141.6f -&gt; 100% : 13028283.2f<br/>
 	 */
 	protected AbstractPeakMassSpectrum(IScanMSD massSpectrum, float actualPercentageIntensity) throws IllegalArgumentException {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IChromatogramMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IChromatogramMSD.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -33,19 +33,12 @@ public interface IChromatogramMSD extends IChromatogram, IChromatogramPeaksMSD {
 	 * You can test the retrieved mass spectrum with "instanceof" if it is a
 	 * kind of ISupplierMassSpectrum. If no scan is available, null will be
 	 * returned.
-	 * 
-	 * @param scan
-	 * @param excludedIons
-	 * @return IScanMSD
 	 */
 	IScanMSD getScan(int scan, IMarkedIons excludedIons);
 
 	/**
 	 * Returns a supplier scan mass spectrum or null, if no supplier
 	 * scan mass spectrum is stored.
-	 * 
-	 * @param scan
-	 * @return {@link IScanMSD}
 	 */
 	@Override
 	IScanMSD getScan(int scan);
@@ -55,8 +48,6 @@ public interface IChromatogramMSD extends IChromatogram, IChromatogramPeaksMSD {
 	 * If a chromatogram contains for example 100 scans. These 100 scans contain
 	 * each 300 ions, then a value of 100 * 300 = 30000 will be
 	 * returned.
-	 * 
-	 * @return int
 	 */
 	int getNumberOfScanIons();
 
@@ -72,55 +63,40 @@ public interface IChromatogramMSD extends IChromatogram, IChromatogramPeaksMSD {
 	 * This represents approximately the threshold value of the mass
 	 * spectrometer.<br/>
 	 * If no scans are stored, 0 will be returned.
-	 * 
-	 * @return float
 	 */
 	float getMinIonAbundance();
 
 	/**
 	 * Returns the maximal available ion abundance signal.<br/>
 	 * If no scans are stored, 0 will be returned.
-	 * 
-	 * @return float
 	 */
 	float getMaxIonAbundance();
 
 	/**
 	 * Returns the lowest start ion (ion).<br/>
 	 * Returns 0 if no scan is stored.
-	 * 
-	 * @return double
 	 */
 	double getStartIon();
 
 	/**
 	 * Returns the highest stop ion (ion).<br/>
 	 * Returns 0 if no scan is stored.
-	 * 
-	 * @return double
 	 */
 	double getStopIon();
 
 	/**
 	 * Returns the ion transition settings.
 	 * Used e.g. by triple quadrupol experiments.
-	 * 
-	 * @return {@link IIonTransitionSettings
-	 * 
 	 */
 	IIonTransitionSettings getIonTransitionSettings();
 
 	/**
 	 * Set the combined mass spectrum of the chromatogram.
-	 * 
-	 * @param scanMSD
 	 */
 	void setCombinedMassSpectrum(IScanMSD scanMSD);
 
 	/**
 	 * The combined mass spectrum is a summary of the scans/peaks of the chromatogram.
-	 * 
-	 * @return {@link IScanMSD}
 	 */
 	IScanMSD getCombinedMassSpectrum();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IIonProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IIonProvider.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Dr. Alexander Kerner - initial API and implementation
  *******************************************************************************/
@@ -18,16 +18,12 @@ public interface IIonProvider {
 
 	/**
 	 * Returns the ion list.
-	 * 
-	 * @return List<Iion> - ion list
 	 */
 	List<IIon> getIons();
 
 	/**
 	 * Returns the number of stored ions.<br/>
 	 * If no ions are stored, 0 will be returned.
-	 * 
-	 * @return int
 	 */
 	int getNumberOfIons();
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IIonTransitionSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IIonTransitionSettings.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -20,16 +20,6 @@ public interface IIonTransitionSettings {
 	/**
 	 * Returns the ion transition. If it doesn't exists, a the element and the group will be created.
 	 * Keep in mind that the transition group index is 0 based.
-	 * 
-	 * @param filter1FirstIon
-	 * @param filter1LastIon
-	 * @param filter3FirstIon
-	 * @param filter3LastIon
-	 * @param collisionEnergy
-	 * @param filter1Resolution
-	 * @param filter3Resolution
-	 * @param transitionGroup
-	 * @return {@link IIonTransition}
 	 */
 	IIonTransition getIonTransition(double filter1FirstIon, double filter1LastIon, double filter3FirstIon, double filter3LastIon, double collisionEnergy, double filter1Resolution, double filter3Resolution, int transitionGroup);
 
@@ -38,54 +28,33 @@ public interface IIonTransitionSettings {
 	/**
 	 * Returns the ion transition. If it doesn't exists, a the element and the group will be created.
 	 * Keep in mind that the transition group index is 0 based.
-	 * 
-	 * @param filter1Ion
-	 * @param filter3Ion
-	 * @param collisionEnergy
-	 * @param filter1Resolution
-	 * @param filter3Resolution
-	 * @param transitionGroup
-	 * @return {@link IIonTransition}
 	 */
 	IIonTransition getIonTransition(double filter1Ion, double filter3Ion, double collisionEnergy, double filter1Resolution, double filter3Resolution, int transitionGroup);
 
 	/**
 	 * Returns a new ion transition if an ion transition with the given compound name doesn't exist yet.
-	 * 
-	 * @param ionTransition
-	 * @param compoundName
-	 * @return {@link IIonTransition}
 	 */
 	IIonTransition getIonTransition(IIonTransition ionTransition, String compoundName);
 
 	/**
 	 * The index is 0 based.
 	 * The method may return null.
-	 * 
-	 * @param index
-	 * @return {@link IIonTransitionGroup}
 	 */
 	IIonTransitionGroup get(int index);
 
 	/**
 	 * Do not remove elements from the list.
 	 * It will not affect the original list.
-	 * 
-	 * @return
 	 */
 	List<IIonTransitionGroup> getIonTransitionGroups();
 
 	/**
 	 * Size of transition groups.
-	 * 
-	 * @return
 	 */
 	int size();
 
 	/**
 	 * Returns a set of all ion transitions.
-	 * 
-	 * @return Set<IIonTransition>
 	 */
 	Set<IIonTransition> getIonTransitions();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IMassSpectra.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IMassSpectra.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Alexander Kerner - implementation
@@ -26,8 +26,6 @@ public interface IMassSpectra extends IUpdateListener {
 
 	/**
 	 * Adds the mass spectrum to the end of the list.
-	 * 
-	 * @param massSpectrum
 	 */
 	void addMassSpectrum(IScanMSD massSpectrum);
 
@@ -35,8 +33,6 @@ public interface IMassSpectra extends IUpdateListener {
 
 	/**
 	 * Removes the mass spectrum from the list.
-	 * 
-	 * @param massSpectrum
 	 */
 	void removeMassSpectrum(IScanMSD massSpectrum);
 
@@ -44,72 +40,51 @@ public interface IMassSpectra extends IUpdateListener {
 	 * Returns the mass spectrum with the given number.<br/>
 	 * Be aware, the index is 1 based and not 0 based like in a normal list.<br/>
 	 * If no mass spectrum is available, null will be returned.
-	 * 
-	 * @param i
-	 * @return IMassSpectrum
 	 */
 	IScanMSD getMassSpectrum(int i);
 
 	/**
 	 * Returns a list of stored mass spectra.
-	 * 
-	 * @return List<IMassSpectrum>
 	 */
 	List<IScanMSD> getList();
 
 	/**
 	 * Returns true if the list is empty.
-	 * 
-	 * @return boolean
 	 */
 	boolean isEmpty();
 
 	/**
 	 * Returns the number of stored mass spectra.
-	 * 
-	 * @return int
 	 */
 	int size();
 
 	/**
 	 * Returns the converter id.
-	 * 
-	 * @return String
 	 */
 	String getConverterId();
 
 	/**
 	 * Sets the converter id.
-	 * 
-	 * @param converterId
 	 */
 	void setConverterId(String converterId);
 
 	/**
 	 * Returns the name.
-	 * 
-	 * @return String
 	 */
 	String getName();
 
 	/**
 	 * Sets the name.
-	 * 
-	 * @param name
 	 */
 	void setName(String name);
 
 	/**
 	 * Use the update listener to react to updates.
-	 * 
-	 * @param updateListener
 	 */
 	void addUpdateListener(IUpdateListener updateListener);
 
 	/**
 	 * Remove the specified update listener.
-	 * 
-	 * @param updateListener
 	 */
 	void removeUpdateListener(IUpdateListener updateListener);
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IScanMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IScanMSD.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Alexander Kerner - implementation
@@ -53,7 +53,7 @@ import org.eclipse.chemclipse.msd.model.xic.IExtractedIonSignal;
  * [AMDISLibraryMassSpectrum]<br/>
  * [PeakSubstanceLibraryMassSpectrum]<br/>
  * [...]<br/>
- * 
+ *
  * @author Philip Wenig
  * @author Alexander Kerner
  * @see AbstractChromatogramMSD
@@ -65,7 +65,7 @@ public interface IScanMSD extends IScan, IMassSpectrumCloneable, IMassSpectrumNo
 	 * All ions which are stored in excludedIons will not be
 	 * considered.<br/>
 	 * If no ions are stored, 0 will be returned.
-	 * 
+	 *
 	 * @return float - total ion current
 	 */
 	float getTotalSignal(IMarkedIons excludedIons);
@@ -73,14 +73,14 @@ public interface IScanMSD extends IScan, IMassSpectrumCloneable, IMassSpectrumNo
 	/**
 	 * Returns an IExtractedIonSignal object.<br/>
 	 * The lowest and highest ion borders will be calculated dynamically.
-	 * 
+	 *
 	 * @return IExtractedIonSignal
 	 */
 	IExtractedIonSignal getExtractedIonSignal();
 
 	/**
 	 * Returns an IExtractedIonSignal object with the given scan range.
-	 * 
+	 *
 	 * @return IExtractedIonSignal
 	 */
 	IExtractedIonSignal getExtractedIonSignal(double startIon, double stopIon);
@@ -89,7 +89,7 @@ public interface IScanMSD extends IScan, IMassSpectrumCloneable, IMassSpectrumNo
 	 * Returns the base peak. The base peak is the peak with the highest
 	 * abundance.<br/>
 	 * If no ions are stored, 0 will be returned.
-	 * 
+	 *
 	 * @return float BasePeak
 	 */
 	double getBasePeak();
@@ -97,7 +97,7 @@ public interface IScanMSD extends IScan, IMassSpectrumCloneable, IMassSpectrumNo
 	/**
 	 * Returns the abundance of the base peak.<br/>
 	 * If no ions are stored, 0 will be returned.
-	 * 
+	 *
 	 * @return float BasePeakAbundance
 	 */
 	float getBasePeakAbundance();
@@ -105,7 +105,7 @@ public interface IScanMSD extends IScan, IMassSpectrumCloneable, IMassSpectrumNo
 	/**
 	 * Returns the lowest ion ion of the mass spectrum.<br/>
 	 * If no ions are stored, the ImmutableZeroIon will be returned.
-	 * 
+	 *
 	 * @return IIon
 	 */
 	IIon getLowestIon();
@@ -131,7 +131,7 @@ public interface IScanMSD extends IScan, IMassSpectrumCloneable, IMassSpectrumNo
 	/**
 	 * Returns the lowest and the highest ion (ion) of the actual scan.<br/>
 	 * If no ions are stored, null will be returned.
-	 * 
+	 *
 	 * @return {@link IIonBounds}
 	 */
 	IIonBounds getIonBounds();
@@ -278,7 +278,7 @@ public interface IScanMSD extends IScan, IMassSpectrumCloneable, IMassSpectrumNo
 	IScanMSD getOptimizedMassSpectrum();
 
 	/**
-	 * Returns whether this is a SIM (<= 10 m/z values) or SCAN measurement.
+	 * Returns whether this is a SIM (&lt;= 10 m/z values) or SCAN measurement.
 	 */
 	boolean isMeasurementSIM();
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/PeakMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/PeakMassSpectrum.java
@@ -34,11 +34,8 @@ public class PeakMassSpectrum extends AbstractPeakMassSpectrum {
 	/**
 	 * Creates a new instance of a peak mass spectrum shifted to the given
 	 * intensity relative to the intensity of peakMassSpectrum. The given
-	 * intensity must be intensity >= 0 and intensity <=
+	 * intensity must be intensity &gt;= 0 and intensity &lt;=
 	 * IPeakIntensityValues.MAX_INTENSITY.
-	 *
-	 * @param peakMassSpectrum
-	 * @param intensity
 	 */
 	public PeakMassSpectrum(IPeakMassSpectrum peakMassSpectrum, float intensity) throws IllegalArgumentException {
 
@@ -71,13 +68,10 @@ public class PeakMassSpectrum extends AbstractPeakMassSpectrum {
 	 * percentageIntensity of 125.0f will be provided, the total intensity of
 	 * the returned peak mass spectrum will be 45600.<br/>
 	 * Some examples:<br/>
-	 * 97.2% actual: 6514141.6f -> 100% : 6701791.77f<br/>
-	 * 100% actual: 6514141.6f -> 100% : 6514141.6f<br/>
-	 * 120% actual: 6514141.6f -> 100% : 5428451.333f<br/>
-	 * 50% actual: 6514141.6f -> 100% : 13028283.2f<br/>
-	 *
-	 * @param massSpectrum
-	 * @param actualPercentageIntensity
+	 * 97.2% actual: 6514141.6f -&gt; 100% : 6701791.77f<br/>
+	 * 100% actual: 6514141.6f -&gt; 100% : 6514141.6f<br/>
+	 * 120% actual: 6514141.6f -&gt; 100% : 5428451.333f<br/>
+	 * 50% actual: 6514141.6f -&gt; 100% : 13028283.2f<br/>
 	 */
 	public PeakMassSpectrum(IScanMSD massSpectrum, float actualPercentageIntensity) throws IllegalArgumentException {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/ScanMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/ScanMSD.java
@@ -47,7 +47,7 @@ public class ScanMSD extends AbstractScanMSD {
 	/**
 	 * Creates a new instance of {@code ScanMSD} by creating a
 	 * shallow copy of provided {@code templateScan}.
-	 * </p>
+	 * <br>
 	 * To create a deep copy, use {@link #makeDeepCopy()}.
 	 *
 	 * @param templateScan

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/splash/SplashFactory.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/splash/SplashFactory.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
@@ -23,9 +23,9 @@ import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.implementation.Ion;
 
 /**
- * @see Wohlgemuth, G, et al. SPLASH, a Hashed Identifier for Mass Spectra.
+ * Reference: Wohlgemuth, G, et al. SPLASH, a Hashed Identifier for Mass Spectra.
  *      Nature Biotechnology 34, 1099-101 (2016).
- *      <a href="https://doi.org/10.1038/nbt.3689">https://doi.org/10.1038/nbt.3689</a>
+ * @see <a href="https://doi.org/10.1038/nbt.3689">https://doi.org/10.1038/nbt.3689</a>
  */
 public class SplashFactory {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/util/ChromatogramMSDs.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/util/ChromatogramMSDs.java
@@ -1,18 +1,19 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Dr. Alexander Kerner - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.model.util;
 
 import org.eclipse.chemclipse.model.core.IIntegrationEntry;
+import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
@@ -20,7 +21,7 @@ import org.eclipse.chemclipse.msd.model.implementation.ChromatogramPeakMSD;
 
 /**
  * Utility class for {@link IChromatogramMSD} related stuff.
- * 
+ *
  * @author Alexander Kerner
  *
  */
@@ -28,19 +29,18 @@ public class ChromatogramMSDs {
 
 	/**
 	 * Convenience method to add a {@link IPeakMSD} to an {@link IChromatogramMSD}.
-	 * </p>
+	 * <br>
 	 * Internally a {@link IChromatogramPeakMSD} is created, added to given chromatogram and finally returned.
 	 * <br>
 	 * {@link IIntegrationEntry integration entries} and {@link IIdentificationTarget peak targets} are copied from given peak.
-	 * </p>
-	 * 
+	 *
 	 * @param chromatogram
 	 *            {@link IChromatogramMSD} to which given peak should be added
 	 * @param peak
 	 *            {@link IPeakMSD} peak to add to given chromatogram
-	 * 
+	 *
 	 * @return {@link IChromatogramPeakMSD} which was created and added to given {@link IChromatogramMSD}
-	 * 
+	 *
 	 * @see IPeakMSD
 	 * @see IChromatogramMSD
 	 * @see IChromatogramPeakMSD

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/util/ILibraryInformations.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/util/ILibraryInformations.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Dr. Alexander Kerner - initial API and implementation
  * Philip Wenig - identification target comparator
@@ -26,7 +26,7 @@ import org.eclipse.chemclipse.support.comparator.SortOrder;
 
 /**
  * Utility class for {@link ILibraryInformation} related stuff.
- * 
+ *
  * @author Alexander Kerner
  *
  */
@@ -36,7 +36,7 @@ public class ILibraryInformations {
 
 	/**
 	 * Same as {@link #selectLibraryInformation(Collection, Comparator)}, using {@link #DEFAULT_TARGET_COMPARATOR}.
-	 * 
+	 *
 	 * @param targets
 	 *            {@link IIdentificationTarget peak targets} from which one {@link ILibraryInformation} should be selected
 	 * @return the selected {@link ILibraryInformation}
@@ -48,9 +48,9 @@ public class ILibraryInformations {
 
 	/**
 	 * From a collection of {@link IIdentificationTarget peak targets} the best one is selected and it's {@link ILibraryInformation} is returned.
-	 * </p>
+	 * <br>
 	 * <i>Best one</i> is defined by given {@link Comparator} and means efficiently <i>lowest one</i>.
-	 * 
+	 *
 	 * @param targets
 	 *            {@link IIdentificationTarget peak targets} from which one {@link ILibraryInformation} should be selected
 	 * @param comparator

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/ExtractedIonSignalsModifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/ExtractedIonSignalsModifier.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -46,7 +46,7 @@ public class ExtractedIonSignalsModifier {
 	 * See
 	 * "An integrated method for spectrum extraction and compound identification from gas chromatography/mass spectrometry data "
 	 * , S.E. Stein, 1999
-	 * 
+	 *
 	 * @throws AnalysisSupportException
 	 */
 	public static IIonUniquenessValues calculateIonUniqueness(IExtractedIonSignals extractedIonSignals) throws AnalysisSupportException {
@@ -76,10 +76,6 @@ public class ExtractedIonSignalsModifier {
 	 * This method adjusts threshold transitions in the given {@link IExtractedIonSignals} instance. See
 	 * "An integrated method for spectrum extraction and compound identification from gas chromatography/mass spectrometry data "
 	 * , S.E. Stein, 1999
-	 * 
-	 * @param extractedIonSignals
-	 * @throws AnalysisSupportException
-	 * @throws NoExtractedIonSignalStoredException
 	 */
 	public static void adjustThresholdTransitions(IExtractedIonSignals extractedIonSignals) throws AnalysisSupportException {
 
@@ -175,7 +171,7 @@ public class ExtractedIonSignalsModifier {
 
 	/**
 	 * Adjusts the ion values.
-	 * 
+	 *
 	 * @param analysisSegment
 	 * @param ion
 	 * @param preSetThresholdAbundanceValue
@@ -203,7 +199,7 @@ public class ExtractedIonSignalsModifier {
 
 	/**
 	 * Sets all zero abundance values to the new abundance.
-	 * 
+	 *
 	 * @param analysisSegment
 	 * @param excludedIons
 	 * @param ion
@@ -234,7 +230,7 @@ public class ExtractedIonSignalsModifier {
 	/**
 	 * Calculates the amount of transitions where the abundance of a certain
 	 * ion falls tos zero.
-	 * 
+	 *
 	 * @param startScan
 	 * @param stopScan
 	 * @param extractedIonSignals
@@ -292,7 +288,7 @@ public class ExtractedIonSignalsModifier {
 
 	/**
 	 * Determines whether the signal is zero or not.
-	 * 
+	 *
 	 * @return boolean
 	 * @throws NoExtractedIonSignalStoredException
 	 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/IonRange.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/IonRange.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -23,12 +23,9 @@ public class IonRange implements IIonRange {
 
 	/**
 	 * Creates a new IonRange object. There are some limitations:<br/>
-	 * The startIon may not be <= 0 and > MAX_Ion. In such a case it
-	 * will be set to MIN_Ion. The stopIon should be <= MAX_Ion and > 0
+	 * The startIon may not be &lt;= 0 and &gt; MAX_Ion. In such a case it
+	 * will be set to MIN_Ion. The stopIon should be &lt;= MAX_Ion and &gt; 0
 	 * otherwise it will be set to MAX_Ion.
-	 * 
-	 * @param startIon
-	 * @param stopIon
 	 */
 	public IonRange(int startIon, int stopIon) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/ProcessorFactory.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/ProcessorFactory.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Christoph Läubrich - initial API and implementation
  *******************************************************************************/
@@ -19,7 +19,7 @@ import java.util.function.BiPredicate;
 
 /**
  * A ProcessorFactory service allows access to all currently known {@link Filter} in the system
- * 
+ *
  * @author Christoph Läubrich
  *
  */
@@ -27,11 +27,11 @@ public interface ProcessorFactory {
 
 	/**
 	 * Returns all processors know to this ProcessorFactory that match the given processorType and acceptor (if given)
-	 * 
+	 *
 	 * @param processorType
-	 *            the subtype of the {@link Processor} to fetch
+	 *            the subtype of the {@link org.eclipse.chemclipse.processing.Processor} to fetch
 	 * @param acceptor
-	 *            an acceptor function that can narrow the result or <code>null</code> if all {@link Processor}s should be returned
+	 *            an acceptor function that can narrow the result or <code>null</code> if all {@link org.eclipse.chemclipse.processing.Processor}s should be returned
 	 * @return the filters that are matched
 	 */
 	<T extends Processor<?>> Collection<T> getProcessors(Class<T> processorType, BiPredicate<? super T, Map<String, ?>> acceptor);

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/IProcessEntry.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/IProcessEntry.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - make unmodifiable except the Settings
@@ -24,20 +24,20 @@ import org.eclipse.chemclipse.processing.supplier.IProcessorPreferences;
 public interface IProcessEntry extends IProcessEntryContainer {
 
 	/**
-	 * 
+	 *
 	 * @return the {@link IProcessSupplier} id this {@link IProcessEntry} referees to
 	 */
 	String getProcessorId();
 
 	/**
-	 * 
+	 *
 	 * @return the name of this {@link IProcessEntry}, most likely the name of the {@link IProcessSupplier}
 	 */
 	@Override
 	String getName();
 
 	/**
-	 * 
+	 *
 	 * @return the description of this {@link IProcessEntry}, most likely the description of the {@link IProcessSupplier}
 	 */
 	@Override
@@ -69,13 +69,13 @@ public interface IProcessEntry extends IProcessEntryContainer {
 	void deleteProfile(String profile);
 
 	/**
-	 * 
+	 *
 	 * @return the current settings of the {@link IProcessEntry} might be <code>null</code>
 	 */
 	String getSettings();
 
 	/**
-	 * 
+	 *
 	 * @return the current settings of the {@link IProcessEntry} might be <code>null</code>
 	 */
 	String getSettings(String profile);
@@ -87,14 +87,14 @@ public interface IProcessEntry extends IProcessEntryContainer {
 	Map<String, String> getSettingsMap();
 
 	/**
-	 * 
+	 *
 	 * @return the {@link DataCategory}s this {@link IProcessEntry} applies to, most likely equals to the {@link DataCategory}s of the {@link IProcessSupplier}
 	 */
 	Set<DataCategory> getDataCategories();
 
 	/**
 	 * Set the settings for this entry
-	 * 
+	 *
 	 * @throws IllegalArgumentException
 	 *             if the entry is readonly
 	 */
@@ -125,7 +125,7 @@ public interface IProcessEntry extends IProcessEntryContainer {
 
 	/**
 	 * Compares this entry content to the other entries content, the default implementation compares {@link #getName()}, {@link #getDescription()}, {@link #getSettings()}, {@link #isReadOnly()} {@link #getProcessorId()},
-	 * this method is different to {@link #equals(Object)} that it does compares for user visible properties to be equal in contrast to objects identity and it allows to compare differnt instance type, this also means that it is not required that
+	 * this method is different to {@link java.lang.Object#equals(Object)} that it does compares for user visible properties to be equal in contrast to objects identity and it allows to compare different instance type, this also means that it is not required that
 	 * Object1.contentEquals(Object2} == Object2.contentEquals(Object1}
 	 */
 	default boolean contentEquals(IProcessEntry other) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/IProcessEntryContainer.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/IProcessEntryContainer.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Christoph Läubrich - initial API and implementation
  * Philip Wenig - support instruments
@@ -30,7 +30,7 @@ public interface IProcessEntryContainer extends Iterable<IProcessEntry> {
 	int DEFAULT_RESUME_INDEX = 0; // Process all items.
 
 	/**
-	 * 
+	 *
 	 * @return an informative name describing the container
 	 */
 	String getName();
@@ -65,7 +65,7 @@ public interface IProcessEntryContainer extends Iterable<IProcessEntry> {
 	/**
 	 * This flag defines if the process method supports the resume operation.
 	 * Both resume and profile selection will be checked.
-	 * 
+	 *
 	 * This option needs to be activated on purpose.
 	 */
 	boolean isSupportResume();
@@ -85,8 +85,8 @@ public interface IProcessEntryContainer extends Iterable<IProcessEntry> {
 	 * <li>if any entry is not contentEquals to the other one <code>false</code> is returned</li>
 	 * <li>if any of the iterator return more elements than the other <code>false</code> is returned
 	 * </ol>
-	 * 
-	 * this method is different to {@link #equals(Object)} that it does compares for user visible properties to be equal in contrast to objects identity and it allows to compare different instance type, this also means that it is not required that
+	 *
+	 * this method is different to {@link java.lang.Object#equals(Object)} that it does compares for user visible properties to be equal in contrast to objects identity and it allows to compare different instance type, this also means that it is not required that
 	 * Object1.contentEquals(Object2} == Object2.contentEquals(Object1}
 	 */
 	default boolean entriesEquals(IProcessEntryContainer other) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/IProcessMethod.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/src/org/eclipse/chemclipse/processing/methods/IProcessMethod.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - enhance method definition, add readonly support
@@ -23,14 +23,14 @@ import org.eclipse.chemclipse.support.model.SeparationColumnType;
 public interface IProcessMethod extends IProcessEntryContainer {
 
 	/**
-	 * 
+	 *
 	 * @return returns the methods UUID to identify the method across file-systems
 	 */
 	String getUUID();
 
 	/**
 	 * The name is used to display a label to the user
-	 * 
+	 *
 	 * @return the human readable label/name
 	 */
 	@Override
@@ -38,27 +38,27 @@ public interface IProcessMethod extends IProcessEntryContainer {
 
 	/**
 	 * The category is used to group similar methods
-	 * 
+	 *
 	 * @return the category
 	 */
 	String getCategory();
 
 	/**
 	 * Returns the map to track the column type for specific profiles.
-	 * 
+	 *
 	 * @return {@link Map}
 	 */
 	Map<String, SeparationColumnType> getProfileColumnsMap();
 
 	/**
 	 * The operator is the person who has created / currently manages this method
-	 * 
+	 *
 	 * @return the operator of the method
 	 */
 	String getOperator();
 
 	/**
-	 * 
+	 *
 	 * @return the human readable description of this method
 	 */
 	@Override
@@ -66,13 +66,13 @@ public interface IProcessMethod extends IProcessEntryContainer {
 
 	/**
 	 * a method marked as final is one that is approved or otherwise locked for further modifications and will stay constant over time
-	 * 
+	 *
 	 * @return <code>true</code> if this is a final method or <code>false</code> otherwise
 	 */
 	boolean isFinal();
 
 	/**
-	 * 
+	 *
 	 * @return the underlying sourcefile or <code>null</code> if this file is not file-based
 	 */
 	default File getSourceFile() {
@@ -82,14 +82,14 @@ public interface IProcessMethod extends IProcessEntryContainer {
 
 	/**
 	 * a method might be defined in the context of valid types e.g. for Chromatography (MSD, WSD, CSD) or NMR
-	 * 
+	 *
 	 * @return the {@link DataCategory}s that are valid for this methods context
 	 */
 	Set<DataCategory> getDataCategories();
 
 	/**
 	 * Each {@link IProcessMethod} can carry a set of metadata pairs to store user metadata
-	 * 
+	 *
 	 * @return a map of key/value pairs of the metadata
 	 */
 	Map<String, String> getMetaData();
@@ -102,11 +102,11 @@ public interface IProcessMethod extends IProcessEntryContainer {
 	 * {@link #getOperator()},
 	 * {@link #isFinal()}
 	 * and all contained {@link IProcessEntry}s
-	 * this method is different to {@link #equals(Object)} that it does compares for user visible properties to be equal in contrast to objects identity and it allows to compare different instance type, this also means that it is not required that
+	 * this method is different to {@link java.lang.Object#equals(Object)} that it does compares for user visible properties to be equal in contrast to objects identity and it allows to compare different instance type, this also means that it is not required that
 	 * Object1.contentEquals(Object2} == Object2.contentEquals(Object1},
-	 * 
+	 *
 	 * {@link #getDataCategories()} are not compared because that does not contribute to the content but is only a hint
-	 * 
+	 *
 	 * @param other
 	 * @return
 	 */

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/preferences/IPreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/preferences/IPreferenceSupplier.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -30,13 +30,17 @@ public interface IPreferenceSupplier {
 
 	/**
 	 * Returns the scope context, e.g.:
+	 * {@snippet :
 	 * InstanceScope.INSTANCE
+	 * }
 	 */
 	IScopeContext getScopeContext();
 
 	/**
 	 * Returns the preference node, e.g.:
+	 * {@snippet :
 	 * Activator.getContext().getBundle().getSymbolicName();
+	 * }
 	 */
 	String getPreferenceNode();
 
@@ -53,21 +57,23 @@ public interface IPreferenceSupplier {
 	/**
 	 * Returns a map of default values
 	 * that can be used to initialize the values for the preference page.
-	 * 
+	 * {@snippet :
 	 * public static final String P_VERSION = "version";
 	 * public static final String DEF_VERSION = "1.0.0.0";
-	 * 
-	 * Map<String, String> defaultValues = new HashMap<String, String>();
+	 *
+	 * Map&lt;String, String&gt; defaultValues = new HashMap&lt;&gt;();
 	 * defaultValues.put(P_VERSION, DEF_VERSION);
+	 * }
 	 */
 	Map<String, String> getDefaultValues();
 
 	/**
 	 * Returns the eclipse preferences instance.
 	 * Use the preferences as follows:
-	 * 
+	 * {@snippet :
 	 * IEclipsePreferences preferences = SCOPE_CONTEXT.getNode(PREFERENCE_NODE);
 	 * String myPreference = preferences.get(P_STRING , DEF_STRING);
+	 * }
 	 */
 	IEclipsePreferences getPreferences();
 


### PR DESCRIPTION
* Escape special characters
* Remove useless tags that sometimes even used special characters
* Remove leftover throws tags
* etc.