### PR TITLE
Allow null IScanMSD in updateData

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/ComparisonScanChartPart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/ComparisonScanChartPart.java
@@ -10,6 +10,7 @@
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - execute updates in own eventqueue, optimize display of target spectrum
+ * Lorenz Gerber - allow null IScanMSD in updateData
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.parts;
 
@@ -82,12 +83,10 @@ public class ComparisonScanChartPart extends AbstractPart<ExtendedComparisonScan
 						}
 					}
 				} else if(isScanReferenceComparisonEvent(topic)) {
-					if(object instanceof Object[] values) {
-						Object object1 = values[0];
-						Object object2 = values[1];
-						if(object1 instanceof IScanMSD unknownMassSpectrum && object2 instanceof IScanMSD referenceMassSpectrum) {
-							getControl().update(unknownMassSpectrum, referenceMassSpectrum);
-						}
+					if(object instanceof Object[] values && values.length >= 2) {
+						IScanMSD unknownMassSpectrum = values[0] instanceof IScanMSD s ? s : null;
+						IScanMSD referenceMassSpectrum = values[1] instanceof IScanMSD s ? s : null;
+						getControl().update(unknownMassSpectrum, referenceMassSpectrum);
 					}
 				}
 			}


### PR DESCRIPTION
The TOPIC_SCAN_REFERENCE_UPDATE_COMPARISON handler in updateData() used && pattern-matching, requiring both objects to be non-null IScanMSD before calling getControl().update(). Since ExtendedComparisonScanUI.update() already handles null for either argument via copyScan() and the updateChart() null check, the all-or-nothing guard in the event handler was unnecessarily strict. The fix lets partial data through to the method that was already designed to handle it.