### PR TITLE
Disable error log window focussing on new event

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
@@ -10,6 +10,11 @@
       </fragment>
    </extension>
    <extension
+         point="org.eclipse.ui.startup">
+      <startup
+            class="org.eclipse.chemclipse.ux.extension.xxd.ui.LogViewSettings"></startup>
+   </extension>
+   <extension
          point="org.eclipse.ui.preferencePages">
       <page
             category="org.eclipse.chemclipse.rcp.app.ui.preferences.settingsPreferencePage"

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/LogViewSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/LogViewSettings.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.ux.extension.xxd.ui;
+
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.ui.IStartup;
+import org.osgi.service.prefs.BackingStoreException;
+import org.osgi.service.prefs.Preferences;
+
+public class LogViewSettings implements IStartup {
+
+	private static final Logger logger = Logger.getLogger(LogViewSettings.class);
+
+	@Override
+	public void earlyStartup() {
+
+		Preferences preferences = InstanceScope.INSTANCE.getNode("org.eclipse.ui.views.log");
+		preferences.putBoolean("activate", false);
+		preferences.putBoolean("activateWarn", false);
+		preferences.putBoolean("activateError", false);
+		try {
+			preferences.flush();
+		} catch(BackingStoreException e) {
+			logger.error(e);
+		}
+	}
+}


### PR DESCRIPTION
because it hides the scan chart which is annoying.

<img width="951" height="370" alt="grafik" src="https://github.com/user-attachments/assets/abee107f-9c1e-448b-87cb-e483ca92b57c" />
