### PR TITLE
Totally disable error log window focussing on new event

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/META-INF/MANIFEST.MF
@@ -29,6 +29,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.9.0",
  org.eclipse.chemclipse.support.ui;bundle-version="0.8.0",
  org.eclipse.chemclipse.swt.ui;bundle-version="0.9.0"
 Import-Package: jakarta.annotation;version="2.1.1",
+ org.osgi.service.prefs,
  jakarta.inject;version="2.0.1",
  org.osgi.framework;version="[1.0.0,2.0.0)",
  org.osgi.service.event;version="[1.0.0,2.0.0)"

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/ApplicationWorkbenchWindowAdvisor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/ApplicationWorkbenchWindowAdvisor.java
@@ -12,13 +12,19 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.rcp.app.ui;
 
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.swt.dnd.FileTransfer;
 import org.eclipse.ui.application.IWorkbenchWindowConfigurer;
 import org.eclipse.ui.application.WorkbenchWindowAdvisor;
 import org.eclipse.ui.internal.ide.EditorAreaDropAdapter;
+import org.osgi.service.prefs.BackingStoreException;
+import org.osgi.service.prefs.Preferences;
 
 @SuppressWarnings("restriction")
 public class ApplicationWorkbenchWindowAdvisor extends WorkbenchWindowAdvisor {
+
+	private static final Logger logger = Logger.getLogger(ApplicationWorkbenchWindowAdvisor.class);
 
 	public ApplicationWorkbenchWindowAdvisor(IWorkbenchWindowConfigurer configurer) {
 
@@ -32,6 +38,19 @@ public class ApplicationWorkbenchWindowAdvisor extends WorkbenchWindowAdvisor {
 
 		IWorkbenchWindowConfigurer configurer = getWindowConfigurer();
 		configurer.setShowProgressIndicator(true);
+		disableLogViewFocus();
 	}
 
+	private void disableLogViewFocus() {
+
+		Preferences preferences = InstanceScope.INSTANCE.getNode("org.eclipse.ui.views.log");
+		preferences.putBoolean("activate", false);
+		preferences.putBoolean("activateWarn", false);
+		preferences.putBoolean("activateError", false);
+		try {
+			preferences.flush();
+		} catch(BackingStoreException e) {
+			logger.error(e);
+		}
+	}
 }


### PR DESCRIPTION
LogView uses both Instance (user saved) and is nothing saved Default scopes (new workspace) see
https://github.com/eclipse-platform/eclipse.platform.ui/blob/62c792ecba2353705cfe1d7fd9a96ff603e9040f/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogView.java#L1773 . This makes plugin_customizations have no effect on existing workspaces.
Set the values we want in ApplicationWorkbenchWindowAdvisor .