### PR TITLE
Do not include org.eclipse.osgi.services

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/feature.xml
@@ -113,10 +113,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.osgi.services"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.swt"
          version="0.0.0"/>
 


### PR DESCRIPTION
This bundle is scheduled for removal via
https://github.com/eclipse-equinox/equinox/pull/1309