### PR TITLE
Make PeakScanListEditingSupport not fail assertions

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/PeakScanListEditingSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/PeakScanListEditingSupport.java
@@ -6,44 +6,30 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - add support for name editing, improve classifier support
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider;
 
-import java.text.DecimalFormat;
-
-import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.model.core.IPeak;
-import org.eclipse.chemclipse.model.core.IPeakModel;
-import org.eclipse.chemclipse.model.targets.TargetSupport;
-import org.eclipse.chemclipse.support.text.ValueFormat;
 import org.eclipse.chemclipse.support.ui.swt.ExtendedTableViewer;
 import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.CheckboxCellEditor;
 import org.eclipse.jface.viewers.EditingSupport;
-import org.eclipse.jface.viewers.TextCellEditor;
 
 public class PeakScanListEditingSupport extends EditingSupport {
 
-	private CellEditor cellEditor;
+	private final CellEditor cellEditor;
 	private final ExtendedTableViewer tableViewer;
 	private final String column;
-
-	private DecimalFormat decimalFormat = ValueFormat.getDecimalFormatEnglish("0.000");
-	private DecimalFormat integerFormat = ValueFormat.getDecimalFormatEnglish("0");
 
 	public PeakScanListEditingSupport(ExtendedTableViewer tableViewer, String column) {
 
 		super(tableViewer);
 		this.column = column;
-		if(PeakScanListLabelProvider.ACTIVE_FOR_ANALYSIS.equals(column)) {
-			this.cellEditor = new CheckboxCellEditor(tableViewer.getTable());
-		} else {
-			this.cellEditor = new TextCellEditor(tableViewer.getTable());
-		}
+		this.cellEditor = new CheckboxCellEditor(tableViewer.getTable());
 		this.tableViewer = tableViewer;
 	}
 
@@ -56,49 +42,16 @@ public class PeakScanListEditingSupport extends EditingSupport {
 	@Override
 	protected boolean canEdit(Object element) {
 
-		if(column.equals(PeakScanListLabelProvider.ACTIVE_FOR_ANALYSIS)) {
-			return (element instanceof IPeak);
-		}
-		return tableViewer.isEditEnabled();
+		return element instanceof IPeak && column.equals(PeakScanListLabelProvider.ACTIVE_FOR_ANALYSIS);
 	}
 
 	@Override
 	protected Object getValue(Object element) {
 
-		if(element instanceof IPeak peak) {
-			IPeakModel peakModel = peak.getPeakModel();
-			if(column.equals(PeakScanListLabelProvider.ACTIVE_FOR_ANALYSIS)) {
-				return peak.isActiveForAnalysis();
-			}
-			if(column.equals(PeakScanListLabelProvider.RETENTION_TIME)) {
-				return decimalFormat.format(peakModel.getRetentionTimeAtPeakMaximum() / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
-			}
-			if(column.equals(PeakScanListLabelProvider.RELATIVE_RETENTION_TIME)) {
-				return decimalFormat.format(peakModel.getPeakMaximum().getRelativeRetentionTime() / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
-			}
-			if(column.equals(PeakScanListLabelProvider.RETENTION_INDEX)) {
-				if(org.eclipse.chemclipse.model.preferences.PreferenceSupplier.showRetentionIndexWithoutDecimals()) {
-					return integerFormat.format(peakModel.getPeakMaximum().getRetentionIndex());
-				}
-				return decimalFormat.format(peakModel.getPeakMaximum().getRetentionIndex());
-			}
-			if(column.equals(PeakScanListLabelProvider.AREA_TOTAL)) {
-				if(org.eclipse.chemclipse.model.preferences.PreferenceSupplier.showAreaWithoutDecimals()) {
-					return integerFormat.format(peak.getIntegratedArea());
-				}
-				return decimalFormat.format(peak.getIntegratedArea());
-			}
-			if(column.equals(PeakScanListLabelProvider.START_RETENTION_TIME)) {
-				return decimalFormat.format(peakModel.getStartRetentionTime() / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
-			}
-			if(column.equals(PeakScanListLabelProvider.STOP_RETENTION_TIME)) {
-				return decimalFormat.format(peakModel.getStopRetentionTime() / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
-			}
-			if(column.equals(PeakScanListLabelProvider.BEST_TARGET)) {
-				return TargetSupport.getBestTargetLibraryField(peak);
-			}
+		if(element instanceof IPeak peak && column.equals(PeakScanListLabelProvider.ACTIVE_FOR_ANALYSIS)) {
+			return peak.isActiveForAnalysis();
 		}
-		return false;
+		return Boolean.FALSE;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - update chromatogram selection after delete, allow updating of selection
@@ -128,7 +128,6 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 	private AtomicReference<Button> buttonMerge = new AtomicReference<>();
 	private AtomicReference<Button> buttonDelete = new AtomicReference<>();
 	private AtomicReference<ScanIdentifierUI> scanIdentifierControl = new AtomicReference<>();
-	private AtomicReference<Button> buttonTableEdit = new AtomicReference<>();
 	private AtomicReference<PeakScanListUI> tableViewer = new AtomicReference<>();
 
 	private IChromatogramSelection chromatogramSelection;
@@ -249,7 +248,6 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 		enableToolbar(toolbarSearch, buttonToolbarSearch.get(), IMAGE_SEARCH, TOOLTIP_SEARCH, false);
 		enableToolbar(toolbarInfoBottom, buttonToolbarInfo.get(), IApplicationImage.IMAGE_INFO, TOOLTIP_INFO, true);
 
-		enableEdit(tableViewer, buttonTableEdit.get(), IMAGE_EDIT_ENTRY, false);
 		buttonComparison.get().setEnabled(false);
 		buttonMerge.get().setEnabled(false);
 		buttonDelete.get().setEnabled(false);
@@ -267,7 +265,6 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 
 		createButtonInfo(composite);
 		createButtonSearch(composite);
-		createButtonEdit(composite);
 		createButtonComparison(composite);
 		createButtonMerge(composite);
 		createButtonDelete(composite);
@@ -288,11 +285,6 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 	private void createButtonSearch(Composite parent) {
 
 		buttonToolbarSearch.set(createButtonToggleToolbar(parent, toolbarSearch, IMAGE_SEARCH, TOOLTIP_SEARCH));
-	}
-
-	private void createButtonEdit(Composite parent) {
-
-		buttonTableEdit.set(createButtonToggleEditTable(parent, tableViewer, IMAGE_EDIT_ENTRY));
 	}
 
 	private void createToolbarInfoTop(Composite parent) {
@@ -668,7 +660,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 
 	/**
 	 * May return null.
-	 * 
+	 *
 	 * @return IScan
 	 */
 	private IScan getScan(Object object) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakScanListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakScanListUI.java
@@ -119,7 +119,9 @@ public class PeakScanListUI extends ExtendedTableViewer {
 		for(int i = 0; i < tableViewerColumns.size(); i++) {
 			TableViewerColumn tableViewerColumn = tableViewerColumns.get(i);
 			String label = tableViewerColumn.getColumn().getText();
-			tableViewerColumn.setEditingSupport(new PeakScanListEditingSupport(this, label));
+			if(label.equals(PeakScanListLabelProvider.ACTIVE_FOR_ANALYSIS)) {
+				tableViewerColumn.setEditingSupport(new PeakScanListEditingSupport(this, label));
+			}
 		}
 	}
 


### PR DESCRIPTION
PeakScanListEditingSupport.setValue() handles only ACTIVE_FOR_ANALYSIS checkbox, all the other edits are just ignored.
What's worse columns not handled in getValue() returned false which lead to runtime problems like:
```
org.eclipse.core.runtime.AssertionFailedException: assertion failed:
	at org.eclipse.core.runtime.Assert.isTrue(Assert.java:121)
	at org.eclipse.core.runtime.Assert.isTrue(Assert.java:106)
	at org.eclipse.jface.viewers.TextCellEditor.doSetValue(TextCellEditor.java:225)
	at org.eclipse.jface.viewers.CellEditor.setValue(CellEditor.java:853)
	at org.eclipse.jface.viewers.EditingSupport.initializeCellEditorValue(EditingSupport.java:102)
	at org.eclipse.jface.viewers.ColumnViewerEditor.activateCellEditor(ColumnViewerEditor.java:203)
	at org.eclipse.jface.viewers.ColumnViewerEditor.handleEditorActivationEvent(ColumnViewerEditor.java:433)
	at org.eclipse.jface.viewers.ColumnViewer.triggerEditorActivationEvent(ColumnViewer.java:680)
	at org.eclipse.jface.viewers.ColumnViewer.handleMouseDown(ColumnViewer.java:655)
	at org.eclipse.jface.viewers.ColumnViewer$1.mouseDown(ColumnViewer.java:111)
	at org.eclipse.swt.widgets.TypedListener.handleEvent(TypedListener.java:234)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:91)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5845)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1656)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:5060)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4497)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1160)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1051)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:684)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:583)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:173)
	at org.eclipse.chemclipse.rcp.app.ui.internal.support.ApplicationSupportDefault.start(ApplicationSupportDefault.java:26)
	at org.eclipse.chemclipse.rcp.app.ui.Application.start(Application.java:28)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:219)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:149)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:115)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:467)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:298)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:615)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:563)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1415)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1387)
```