### PR TITLE
Strengthen TraceRange*EditingSupport

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/TraceRange1DEditingSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/TraceRange1DEditingSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Lablicate GmbH.
+ * Copyright (c) 2024, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -55,13 +55,13 @@ public class TraceRange1DEditingSupport extends EditingSupport {
 
 		if(element instanceof TraceRange1D traceRange) {
 			switch(column) {
-				case TraceRange2DLabelProvider.NAME:
+				case TraceRange1DLabelProvider.NAME:
 					return traceRange.getName();
-				case TraceRange2DLabelProvider.TRACES:
+				case TraceRange1DLabelProvider.TRACES:
 					return traceRange.getTraces();
 			}
 		}
-		return false;
+		return "";
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/TraceRange2DEditingSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/TraceRange2DEditingSupport.java
@@ -78,7 +78,7 @@ public class TraceRange2DEditingSupport extends EditingSupport {
 					return getComboIndexType(traceRange.getSecondDimensionHint(), secondDimensionValues);
 			}
 		}
-		return false;
+		return "";
 	}
 
 	@Override


### PR DESCRIPTION
As TextCellEditor is used in these returning false can lead to assertion errors (similar case to
https://github.com/eclipse-chemclipse/chemclipse/pull/2928 ) . Also not mix two different label providers in same *EditingSupport.