### PR TITLE
Use JVM's [Standard]Charset instead of CharsetNIO

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/preferences/PreferenceSupplier.java
@@ -13,10 +13,10 @@
 package org.eclipse.chemclipse.msd.converter.supplier.amdis.preferences;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.eclipse.chemclipse.support.preferences.AbstractPreferenceSupplier;
 import org.eclipse.chemclipse.support.preferences.IPreferenceSupplier;
-import org.eclipse.chemclipse.support.text.CharsetNIO;
 import org.osgi.framework.FrameworkUtil;
 
 public class PreferenceSupplier extends AbstractPreferenceSupplier {
@@ -39,13 +39,13 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static final boolean DEF_PARSE_MOL_INFORMATION = true;
 
 	public static final String P_CHARSET_IMPORT_MSL = "charsetImportMSL";
-	public static final String DEF_CHARSET_IMPORT_MSL = CharsetNIO.US_ASCII.name();
+	public static final String DEF_CHARSET_IMPORT_MSL = StandardCharsets.US_ASCII.name();
 	public static final String P_CHARSET_IMPORT_MSP = "charsetImportMSP";
-	public static final String DEF_CHARSET_IMPORT_MSP = CharsetNIO.US_ASCII.name();
+	public static final String DEF_CHARSET_IMPORT_MSP = StandardCharsets.US_ASCII.name();
 	public static final String P_CHARSET_IMPORT_FIN = "charsetImportFIN";
-	public static final String DEF_CHARSET_IMPORT_FIN = CharsetNIO.US_ASCII.name();
+	public static final String DEF_CHARSET_IMPORT_FIN = StandardCharsets.US_ASCII.name();
 	public static final String P_CHARSET_IMPORT_ELU = "charsetImportELU";
-	public static final String DEF_CHARSET_IMPORT_ELU = CharsetNIO.US_ASCII.name();
+	public static final String DEF_CHARSET_IMPORT_ELU = StandardCharsets.US_ASCII.name();
 
 	public static final String P_PATH_IMPORT = "pathImport";
 	public static final String DEF_PATH_IMPORT = "";
@@ -129,7 +129,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 		return getCharset(P_CHARSET_IMPORT_MSL, DEF_CHARSET_IMPORT_MSL);
 	}
 
-	public static void setCharsetImportMSL(CharsetNIO charsetNIO) {
+	public static void setCharsetImportMSL(Charset charsetNIO) {
 
 		setCharset(P_CHARSET_IMPORT_MSL, charsetNIO);
 	}
@@ -139,7 +139,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 		return getCharset(P_CHARSET_IMPORT_MSP, DEF_CHARSET_IMPORT_MSP);
 	}
 
-	public static void setCharsetImportMSP(CharsetNIO charsetNIO) {
+	public static void setCharsetImportMSP(Charset charsetNIO) {
 
 		setCharset(P_CHARSET_IMPORT_MSP, charsetNIO);
 	}
@@ -149,7 +149,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 		return getCharset(P_CHARSET_IMPORT_FIN, DEF_CHARSET_IMPORT_FIN);
 	}
 
-	public static void setCharsetImportFIN(CharsetNIO charsetNIO) {
+	public static void setCharsetImportFIN(Charset charsetNIO) {
 
 		setCharset(P_CHARSET_IMPORT_FIN, charsetNIO);
 	}
@@ -159,7 +159,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 		return getCharset(P_CHARSET_IMPORT_ELU, DEF_CHARSET_IMPORT_ELU);
 	}
 
-	public static void setCharsetImportELU(CharsetNIO charsetNIO) {
+	public static void setCharsetImportELU(Charset charsetNIO) {
 
 		setCharset(P_CHARSET_IMPORT_ELU, charsetNIO);
 	}
@@ -187,13 +187,13 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	private static Charset getCharset(String key, String def) {
 
 		try {
-			return CharsetNIO.valueOf(INSTANCE().get(key, def)).getCharset();
+			return Charset.forName(INSTANCE().get(key, def));
 		} catch(Exception e) {
-			return CharsetNIO.US_ASCII.getCharset();
+			return StandardCharsets.US_ASCII;
 		}
 	}
 
-	private static void setCharset(String key, CharsetNIO charsetNIO) {
+	private static void setCharset(String key, Charset charsetNIO) {
 
 		INSTANCE().put(key, charsetNIO.name());
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/system/ConverterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/src/org/eclipse/chemclipse/msd/converter/supplier/amdis/system/ConverterSettings.java
@@ -1,19 +1,21 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.converter.supplier.amdis.system;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 import org.eclipse.chemclipse.processing.system.ISystemProcessSettings;
-import org.eclipse.chemclipse.support.text.CharsetNIO;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -22,53 +24,53 @@ public class ConverterSettings implements ISystemProcessSettings {
 
 	@JsonProperty(value = "Charset Import MSL", defaultValue = "US_ASCII")
 	@JsonPropertyDescription(value = "The following charset is used to import the *.msl files.")
-	private CharsetNIO charsetImportMSL = CharsetNIO.US_ASCII;
+	private Charset charsetImportMSL = StandardCharsets.US_ASCII;
 	@JsonProperty(value = "Charset Import MSP", defaultValue = "US_ASCII")
 	@JsonPropertyDescription(value = "The following charset is used to import the *.msp files.")
-	private CharsetNIO charsetImportMSP = CharsetNIO.US_ASCII;
+	private Charset charsetImportMSP = StandardCharsets.US_ASCII;
 	@JsonProperty(value = "Charset Import FIN", defaultValue = "US_ASCII")
 	@JsonPropertyDescription(value = "The following charset is used to import the *.fin files.")
-	private CharsetNIO charsetImportFIN = CharsetNIO.US_ASCII;
+	private Charset charsetImportFIN = StandardCharsets.US_ASCII;
 	@JsonProperty(value = "Charset Import ELU", defaultValue = "US_ASCII")
 	@JsonPropertyDescription(value = "The following charset is used to import the *.elu files.")
-	private CharsetNIO charsetImportELU = CharsetNIO.US_ASCII;
+	private Charset charsetImportELU = StandardCharsets.US_ASCII;
 
-	public CharsetNIO getCharsetImportMSL() {
+	public Charset getCharsetImportMSL() {
 
 		return charsetImportMSL;
 	}
 
-	public void setCharsetImportMSL(CharsetNIO charsetImportMSL) {
+	public void setCharsetImportMSL(Charset charsetImportMSL) {
 
 		this.charsetImportMSL = charsetImportMSL;
 	}
 
-	public CharsetNIO getCharsetImportMSP() {
+	public Charset getCharsetImportMSP() {
 
 		return charsetImportMSP;
 	}
 
-	public void setCharsetImportMSP(CharsetNIO charsetImportMSP) {
+	public void setCharsetImportMSP(Charset charsetImportMSP) {
 
 		this.charsetImportMSP = charsetImportMSP;
 	}
 
-	public CharsetNIO getCharsetImportFIN() {
+	public Charset getCharsetImportFIN() {
 
 		return charsetImportFIN;
 	}
 
-	public void setCharsetImportFIN(CharsetNIO charsetImportFIN) {
+	public void setCharsetImportFIN(Charset charsetImportFIN) {
 
 		this.charsetImportFIN = charsetImportFIN;
 	}
 
-	public CharsetNIO getCharsetImportELU() {
+	public Charset getCharsetImportELU() {
 
 		return charsetImportELU;
 	}
 
-	public void setCharsetImportELU(CharsetNIO charsetImportELU) {
+	public void setCharsetImportELU(Charset charsetImportELU) {
 
 		this.charsetImportELU = charsetImportELU;
 	}


### PR DESCRIPTION
Reduces work as it uses JVM cached charsets, reduces layers of indirection and package coupling and simplifies code.