### PR TITLE
Prevent assertion problems in QuantCompoundEditingSupport

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/QuantCompoundEditingSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/QuantCompoundEditingSupport.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Lablicate GmbH.
+ * Copyright (c) 2019, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  *******************************************************************************/
@@ -97,7 +97,9 @@ public class QuantCompoundEditingSupport extends EditingSupport {
 				return Float.toString(compound.getRetentionIndexWindow().getAllowedPositiveDeviation());
 			}
 		}
-		return false;
+
+		//TextCellEditor used for non-explicitly handled columns
+		return "";
 	}
 
 	@Override
@@ -196,8 +198,7 @@ public class QuantCompoundEditingSupport extends EditingSupport {
 
 		if(column.equals(QuantCompoundLabelProvider.CROSS_ZERO) || column.equals(QuantCompoundLabelProvider.USE_TIC)) {
 			this.cellEditor = new CheckboxCellEditor(tableViewer.getTable());
-		}
-		if(column.equals(QuantCompoundLabelProvider.CALIBRATION_METHOD)) {
+		} else if(column.equals(QuantCompoundLabelProvider.CALIBRATION_METHOD)) {
 			this.cellEditor = new ComboBoxCellEditor(tableViewer.getTable(), //
 					CalibrationMethod.getExternalCalibrationOptionsArray(), //
 					SWT.READ_ONLY);


### PR DESCRIPTION
* Defaults to TextCellEditor thus getValue should return "" by default
* setCellEditor had a bug that CROSS_ZERO and USE_TIC had CheckboxCellEditor but due to lacking if it was later overriden by TextCellEditor