### PR TITLE
Fix delete targets not updating properly

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeleteTargetsFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/src/org/eclipse/chemclipse/xxd/filter/peaks/DeleteTargetsFilter.java
@@ -61,6 +61,7 @@ public class DeleteTargetsFilter extends AbstractPeakFilter<DeleteTargetsFilterS
 			TargetsFilter.filter(peak, configuration);
 			subMonitor.worked(1);
 		}
+		updateChromatogramSelection(chromatogramSelection);
 	}
 
 	@Override
@@ -69,5 +70,11 @@ public class DeleteTargetsFilter extends AbstractPeakFilter<DeleteTargetsFilterS
 		List<String> legacyIDs = new ArrayList<>();
 		legacyIDs.add("PeakFilter:filter:processor:class:org.eclipse.chemclipse.xxd.model.filter.peaks.DeleteTargetsFilter");
 		return legacyIDs;
+	}
+
+	private void updateChromatogramSelection(IChromatogramSelection chromatogramSelection) {
+
+		chromatogramSelection.update(true);
+		chromatogramSelection.getChromatogram().setDirty(true);
 	}
 }


### PR DESCRIPTION
the peak/scan list and the chromatogram editor * to show that the data was modified.