### PR TITLE
Reset perspective on e4 model

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/addons/PerspectiveApplicationAddon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/addons/PerspectiveApplicationAddon.java
@@ -20,7 +20,10 @@ import org.eclipse.e4.core.services.events.IEventBroker;
 import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
 import org.eclipse.e4.ui.model.application.ui.advanced.MPerspectiveStack;
+import org.eclipse.e4.ui.workbench.UIEvents;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
 
 import jakarta.annotation.PostConstruct;
 
@@ -55,6 +58,41 @@ public class PerspectiveApplicationAddon {
 		perspectiveStack.setSelectedElement(perspective);
 		if(eventBroker != null) {
 			eventBroker.send(IChemClipseEvents.TOPIC_APPLICATION_SELECT_PERSPECTIVE, perspective.getLabel());
+			scheduleSnapshot(application, modelService, perspectiveStack, eventBroker);
+		}
+	}
+
+	/*
+	 * The perspectives are snapshotted as snippets so that the reset perspective command can clone
+	 * them later. Snapshotting is deferred until the UI has been rendered, because adding snippets
+	 * while the model is still being processed disturbs the initial trim layout.
+	 */
+	private void scheduleSnapshot(MApplication application, EModelService modelService, MPerspectiveStack perspectiveStack, IEventBroker eventBroker) {
+
+		eventBroker.subscribe(UIEvents.UILifeCycle.APP_STARTUP_COMPLETE, new EventHandler() {
+
+			@Override
+			public void handleEvent(Event event) {
+
+				eventBroker.unsubscribe(this);
+				snapshotPerspectives(application, modelService, perspectiveStack);
+			}
+		});
+	}
+
+	private void snapshotPerspectives(MApplication application, EModelService modelService, MPerspectiveStack perspectiveStack) {
+
+		for(MPerspective perspective : perspectiveStack.getChildren()) {
+			String perspectiveId = perspective.getElementId();
+			if(perspectiveId == null || perspectiveId.isEmpty()) {
+				continue;
+			}
+			/*
+			 * The model is rebuilt from the fragments each start and the snapshot is always pristine.
+			 */
+			if(modelService.findSnippet(application, perspectiveId) == null) {
+				modelService.cloneElement(perspective, application);
+			}
 		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/handlers/ResetPerspectiveHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/handlers/ResetPerspectiveHandler.java
@@ -12,19 +12,99 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.rcp.app.ui.handlers;
 
+import java.util.List;
+
+import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.support.events.IChemClipseEvents;
+import org.eclipse.chemclipse.support.events.IPerspectiveAndViewIds;
 import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.core.services.events.IEventBroker;
-import org.eclipse.ui.IWorkbenchPage;
-import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.e4.ui.model.application.MApplication;
+import org.eclipse.e4.ui.model.application.ui.MUIElement;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPerspectiveStack;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPlaceholder;
+import org.eclipse.e4.ui.model.application.ui.basic.MPartSashContainerElement;
+import org.eclipse.e4.ui.model.application.ui.basic.MPartStack;
+import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
+import org.eclipse.e4.ui.workbench.modeling.EModelService;
+import org.eclipse.e4.ui.workbench.modeling.EPartService;
+import org.eclipse.ui.IPageLayout;
 
 public class ResetPerspectiveHandler {
 
-	@Execute
-	public void execute(IEventBroker eventBroker, IWorkbenchWindow workbenchWindow) {
+	private static final Logger logger = Logger.getLogger(ResetPerspectiveHandler.class);
 
-		IWorkbenchPage page = workbenchWindow.getActivePage();
-		page.resetPerspective();
-		eventBroker.post(IChemClipseEvents.TOPIC_APPLICATION_RESET_PERSPECTIVE, page.getPerspective().getLabel());
+	@Execute
+	public void execute(MApplication application, MWindow window, EModelService modelService, EPartService partService, IEventBroker eventBroker) {
+
+		MPerspectiveStack perspectiveStack = (MPerspectiveStack)modelService.find(IPerspectiveAndViewIds.STACK_PERSPECTIVES, application);
+		if(perspectiveStack == null) {
+			return;
+		}
+		MPerspective perspective = perspectiveStack.getSelectedElement();
+		if(perspective == null) {
+			return;
+		}
+		/*
+		 * Remember the live shared editor area, so that it can be reconnected to the reset
+		 * perspective below in order to keep the open editors.
+		 */
+		MUIElement editorArea = null;
+		if(modelService.find(IPageLayout.ID_EDITOR_AREA, perspective) instanceof MPlaceholder placeholder) {
+			editorArea = placeholder.getRef();
+		}
+		modelService.resetPerspectiveModel(perspective, window);
+		MUIElement snippet = modelService.cloneSnippet(application, perspective.getElementId(), window);
+		if(!(snippet instanceof MPerspective resetPerspective)) {
+			logger.warn("No snapshot is available to reset the perspective: " + perspective.getElementId());
+			return;
+		}
+		reconnectEditorArea(modelService, window, resetPerspective, editorArea);
+		modelService.hideLocalPlaceholders(window, resetPerspective);
+		List<MPartSashContainerElement> resetChildren = resetPerspective.getChildren();
+		List<MPartSashContainerElement> perspectiveChildren = perspective.getChildren();
+		int resetCount = resetChildren.size();
+		while(!resetChildren.isEmpty()) {
+			perspectiveChildren.add(resetChildren.remove(0));
+		}
+		while(perspectiveChildren.size() > resetCount) {
+			MUIElement obsoleteChild = perspectiveChildren.get(0);
+			obsoleteChild.setToBeRendered(false);
+			perspectiveChildren.remove(0);
+		}
+		perspective.getTags().clear();
+		perspective.getTags().addAll(resetPerspective.getTags());
+		restoreEditorAreaStackId(modelService, window);
+		partService.requestActivation();
+		eventBroker.post(IChemClipseEvents.TOPIC_APPLICATION_RESET_PERSPECTIVE, perspective.getLabel());
+	}
+
+	/*
+	 * Reconnect the placeholder to the existing area so that the open editors are preserved.
+	 */
+	private void reconnectEditorArea(EModelService modelService, MWindow window, MPerspective resetPerspective, MUIElement editorArea) {
+
+		if(editorArea != null && modelService.find(IPageLayout.ID_EDITOR_AREA, resetPerspective) instanceof MPlaceholder placeholder) {
+			MUIElement createdArea = placeholder.getRef();
+			if(createdArea != editorArea) {
+				placeholder.setRef(editorArea);
+				if(createdArea != null) {
+					window.getSharedElements().remove(createdArea);
+				}
+			}
+		}
+	}
+
+	/*
+	 * Restore shared editor area id so that newly opened editors are still docked into it.
+	 */
+	private void restoreEditorAreaStackId(EModelService modelService, MWindow window) {
+
+		for(MPartStack partStack : modelService.findElements(window, null, MPartStack.class)) {
+			if(partStack.getTags().contains(IPerspectiveAndViewIds.EDITOR_PART_STACK_ID) && !IPerspectiveAndViewIds.EDITOR_PART_STACK_ID.equals(partStack.getElementId())) {
+				partStack.setElementId(IPerspectiveAndViewIds.EDITOR_PART_STACK_ID);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Perspectives are contributed via the e4 model in 2026-06, so the legacy IWorkbenchPage#resetPerspective() can't be used (it will NPE on the missing e3 perspective descriptor). Reset by cloning the snippet stored on startup.
Fixes https://github.com/eclipse-chemclipse/chemclipse/issues/901
