### PR TITLE
Do not fail on password protected zips

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.container.supplier.zip/src/org/eclipse/chemclipse/xxd/converter/supplier/zip/io/MagicNumberMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.container.supplier.zip/src/org/eclipse/chemclipse/xxd/converter/supplier/zip/io/MagicNumberMatcher.java
@@ -14,16 +14,38 @@
 package org.eclipse.chemclipse.xxd.converter.supplier.zip.io;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 
 import org.eclipse.chemclipse.converter.core.AbstractMagicNumberMatcher;
 
 public class MagicNumberMatcher extends AbstractMagicNumberMatcher {
 
 	private static final byte[] MAGIC_CODE = new byte[]{(byte)0x50, (byte)0x4B, (byte)0x03, (byte)0x04};
+	private static final int LOCAL_HEADER_SIZE = 8;
+	private static final int GENERAL_PURPOSE_FLAG_OFFSET = 6;
+	private static final int ENCRYPTION_BIT = 0x01;
 
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		return checkFileExtension(file, ".zip") && checkMagicCode(file, MAGIC_CODE);
+		return checkFileExtension(file, ".zip") && checkMagicCode(file, MAGIC_CODE) && !isEncrypted(file);
+	}
+
+	private boolean isEncrypted(File file) {
+
+		try (InputStream inputStream = Files.newInputStream(file.toPath())) {
+			byte[] header = new byte[LOCAL_HEADER_SIZE];
+			if(inputStream.read(header) < LOCAL_HEADER_SIZE) {
+				return false;
+			}
+			/*
+			 * Bit 0 of the general purpose bit flag (offset 6 in the local file header) indicates an encrypted entry.
+			 */
+			return (header[GENERAL_PURPOSE_FLAG_OFFSET] & ENCRYPTION_BIT) != 0;
+		} catch(IOException e) {
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
Prevents errors like:
```
 !ENTRY org.eclipse.chemclipse.container.supplier.zip 2 0 2026-06-16
21:14:44.936
!MESSAGE invalid CEN header (encrypted entry)
!STACK 0
java.util.zip.ZipException: invalid CEN header (encrypted entry)
    at java.base/java.util.zip.ZipFile$Source.zerror(ZipFile.java:1781)
    at java.base/java.util.zip.ZipFile$Source.checkAndAddEntry(ZipFile.java:1216)
    at java.base/java.util.zip.ZipFile$Source.initCEN(ZipFile.java:1720)
    at java.base/java.util.zip.ZipFile$Source.<init>(ZipFile.java:1495)
    at java.base/java.util.zip.ZipFile$Source.get(ZipFile.java:1458)
    at java.base/java.util.zip.ZipFile$CleanableResource.<init>(ZipFile.java:724)
    at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:251)
    at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:180)
    at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:194)
    at org.eclipse.chemclipse.xxd.converter.supplier.zip.io.ZipContainer.hasContainerContents(ZipContainer.java:110)
    at org.eclipse.chemclipse.ux.extension.ui.provider.FileExplorerContentProvider.hasContainerContents(FileExplorerContentProvider.java:155)
    at org.eclipse.chemclipse.ux.extension.ui.provider.FileExplorerContentProvider.hasChildren(FileExplorerContentProvider.java:142)
    at org.eclipse.chemclipse.ux.extension.ui.provider.FileExplorerContentProvider.hasChildren(FileExplorerContentProvider.java:54)
```
when there is password protected zip file in the directory.