### PR TITLE
Add support for indexed MzML

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/plugin.xml
@@ -4,6 +4,20 @@
    <extension
          point="org.eclipse.chemclipse.msd.converter.chromatogramSupplier">
       <ChromatogramSupplier
+            description="Reads indexed mzML Chromatograms"
+            fileExtension=".mzML"
+            filterName="indexed mzML Chromatogram (*.mzML)"
+            id="org.eclipse.chemclipse.msd.converter.supplier.mzml.indexed"
+            importContentMatcher="org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.ChromatogramFileContentMatcherIndexed"
+            importConverter="org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.ChromatogramImportConverterIndexed"
+            importMagicNumberMatcher="org.eclipse.chemclipse.xxd.converter.supplier.mzml.converter.MagicNumberMatcher"
+            isExportable="false"
+            isImportable="true">
+      </ChromatogramSupplier>
+   </extension>
+   <extension
+         point="org.eclipse.chemclipse.msd.converter.chromatogramSupplier">
+      <ChromatogramSupplier
             description="Reads mzML Chromatograms"
             exportConverter="org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.ChromatogramExportConverter"
             fileExtension=".mzML"

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramFileContentMatcherIndexed.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramFileContentMatcherIndexed.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
+
+public class ChromatogramFileContentMatcherIndexed extends AbstractFileContentMatcher {
+
+	@Override
+	public boolean checkFileFormat(File file) {
+
+		boolean isValidFormat = false;
+		try (FileReader fileReader = new FileReader(file)) {
+			final char[] charBuffer = new char[256];
+			fileReader.read(charBuffer);
+			final String header = new String(charBuffer);
+			if(header.contains("<indexedmzML")) {
+				isValidFormat = true;
+			}
+		} catch(IOException e) {
+			// fail silently
+		}
+		return isValidFormat;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverterIndexed.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverterIndexed.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.eclipse.chemclipse.converter.chromatogram.AbstractChromatogramImportConverter;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.model.core.IChromatogramOverview;
+import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.io.ChromatogramReaderIndexed;
+import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+public class ChromatogramImportConverterIndexed extends AbstractChromatogramImportConverter<IChromatogramMSD> {
+
+	private static final Logger logger = Logger.getLogger(ChromatogramImportConverterIndexed.class);
+	private static final String DESCRIPTION = "indexed mzML Import Converter";
+	private static final String IMPORT_CHROMATOGRAM = "Import indexed mzML Chromatogram";
+	private static final String IMPORT_CHROMATOGRAM_OVERVIEW = "Import indexed mzML Chromatogram Overview";
+	private static final String ERROR = "Error reading file: ";
+
+	@Override
+	public IProcessingInfo<IChromatogramMSD> convert(File file, IProgressMonitor monitor) {
+
+		IProcessingInfo<IChromatogramMSD> processingInfo = super.validate(file);
+		if(!processingInfo.hasErrorMessages()) {
+			/*
+			 * Read the chromatogram.
+			 */
+			IChromatogramMSDReader reader = new ChromatogramReaderIndexed();
+			monitor.subTask(IMPORT_CHROMATOGRAM);
+			try {
+				IChromatogramMSD chromatogram = reader.read(file, monitor);
+				processingInfo.setProcessingResult(chromatogram);
+			} catch(IOException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, ERROR + file.getAbsolutePath());
+			} catch(InterruptedException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, ERROR + file.getAbsolutePath());
+				Thread.currentThread().interrupt();
+			}
+		}
+		return processingInfo;
+	}
+
+	@Override
+	public IProcessingInfo<IChromatogramOverview> convertOverview(File file, IProgressMonitor monitor) {
+
+		IProcessingInfo<IChromatogramOverview> processingInfo = super.validate(file);
+		if(!processingInfo.hasErrorMessages()) {
+			IChromatogramMSDReader reader = new ChromatogramReaderIndexed();
+			monitor.subTask(IMPORT_CHROMATOGRAM_OVERVIEW);
+			try {
+				IChromatogramOverview chromatogramOverview = reader.readOverview(file, monitor);
+				processingInfo.setProcessingResult(chromatogramOverview);
+			} catch(IOException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, ERROR + file.getAbsolutePath());
+			}
+		}
+		return processingInfo;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/io/ChromatogramReaderIndexed.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/io/ChromatogramReaderIndexed.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.io;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+import org.eclipse.chemclipse.converter.exceptions.UnknownVersionException;
+import org.eclipse.chemclipse.model.core.IChromatogramOverview;
+import org.eclipse.chemclipse.msd.converter.io.AbstractChromatogramMSDReader;
+import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.io.ChromatogramReaderIndexedVersion110;
+import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+public class ChromatogramReaderIndexed extends AbstractChromatogramMSDReader {
+
+	public static IChromatogramMSDReader getReader(final File file) throws IOException {
+
+		IChromatogramMSDReader chromatogramReader = null;
+
+		try (final FileReader fileReader = new FileReader(file)) {
+			final char[] charBuffer = new char[512];
+			fileReader.read(charBuffer);
+			final String header = new String(charBuffer);
+			if(header.contains("1.1.0")) {
+				chromatogramReader = new ChromatogramReaderIndexedVersion110();
+			} else {
+				throw new UnknownVersionException();
+			}
+		}
+		return chromatogramReader;
+	}
+
+	@Override
+	public IChromatogramMSD read(final File file, final IProgressMonitor monitor) throws IOException, InterruptedException {
+
+		final IChromatogramMSDReader chromatogramReader = getReader(file);
+		return chromatogramReader.read(file, monitor);
+	}
+
+	@Override
+	public IChromatogramOverview readOverview(final File file, final IProgressMonitor monitor) throws IOException {
+
+		final IChromatogramMSDReader chromatogramReader = getReader(file);
+		return chromatogramReader.readOverview(file, monitor);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/IVendorScanProxy.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/IVendorScanProxy.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model;
+
+import org.eclipse.chemclipse.msd.model.core.IMassSpectrumProxy;
+
+public interface IVendorScanProxy extends IVendorScan, IMassSpectrumProxy {
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/VendorScanProxy.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/VendorScanProxy.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import javax.xml.stream.FactoryConfigurationError;
+import javax.xml.stream.XMLStreamException;
+
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.io.ChromatogramReaderVersion110;
+import org.eclipse.chemclipse.msd.model.core.AbstractRegularMassSpectrumProxy;
+import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.XmlHelper;
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.SpectrumType;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import jakarta.xml.bind.JAXBException;
+
+public class VendorScanProxy extends AbstractRegularMassSpectrumProxy implements IVendorScanProxy {
+
+	/**
+	 * Renew the serialVersionUID any time you have changed some fields or
+	 * methods.
+	 */
+	private static final long serialVersionUID = -6126982710427047493L;
+
+	private static final Logger logger = Logger.getLogger(VendorScanProxy.class);
+
+	private File file;
+	private long offset;
+	private IVendorChromatogram chromatogram;
+
+	public VendorScanProxy(File file, long offset, IVendorChromatogram chromatogram, IProgressMonitor monitor) {
+
+		super(monitor);
+		this.file = file;
+		this.offset = offset;
+		this.chromatogram = chromatogram;
+	}
+
+	@Override
+	public void importIons(IProgressMonitor monitor) {
+
+		try {
+			SpectrumType mzMLspectrum = XmlHelper.unmarshalElementAtOffset(file, offset, SpectrumType.class);
+			this.setIdentifier(mzMLspectrum.getId());
+			IRegularMassSpectrum massSpectrum = ChromatogramReaderVersion110.readMassSpectrum(mzMLspectrum);
+			this.setMassSpectrumType(massSpectrum.getMassSpectrumType());
+			this.setPolarity(massSpectrum.getPolarity());
+			this.setMassSpectrometer(massSpectrum.getMassSpectrometer());
+			ChromatogramReaderVersion110.readIons(mzMLspectrum, this, chromatogram);
+			ChromatogramReaderVersion110.setRetentionTime(mzMLspectrum, this);
+			ChromatogramReaderVersion110.setTotalIonCurrent(mzMLspectrum, this);
+		} catch(FileNotFoundException e) {
+			logger.error(e);
+		} catch(IOException e) {
+			logger.error(e);
+		} catch(JAXBException e) {
+			logger.error(e);
+		} catch(XMLStreamException e) {
+			logger.error(e);
+		} catch(FactoryConfigurationError e) {
+			logger.error(e);
+		}
+	}
+
+	@Override
+	public IVendorScan makeDeepCopy() throws CloneNotSupportedException {
+
+		IVendorScanProxy massSpectrum = (IVendorScanProxy)super.clone();
+		for(IIon ion : getIons()) {
+			IVendorIon vendorIon = new VendorIon(ion.getIon(), ion.getAbundance());
+			massSpectrum.addIon(vendorIon);
+		}
+		return massSpectrum;
+	}
+
+	@Override
+	protected Object clone() throws CloneNotSupportedException {
+
+		return makeDeepCopy();
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramReaderIndexedVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramReaderIndexedVersion110.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzml.io;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.stream.FactoryConfigurationError;
+import javax.xml.stream.XMLStreamException;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.chemclipse.converter.io.AbstractChromatogramReader;
+import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.model.core.IChromatogramOverview;
+import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorChromatogram;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorScanProxy;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorChromatogram;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorScanProxy;
+import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v110.IndexType;
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v110.IndexedMzML;
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v110.OffsetType;
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.MetadataReader110;
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.XmlHelper;
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.ChromatogramType;
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.MzMLType;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import jakarta.xml.bind.JAXBException;
+
+public class ChromatogramReaderIndexedVersion110 extends AbstractChromatogramReader implements IChromatogramMSDReader {
+
+	private static final Logger logger = Logger.getLogger(ChromatogramReaderIndexedVersion110.class);
+
+	@Override
+	public IChromatogramOverview readOverview(File file, IProgressMonitor monitor) throws IOException {
+
+		IVendorChromatogram chromatogram = null;
+		try {
+			chromatogram = new VendorChromatogram();
+			MzMLType mzML = XmlHelper.parseFiltered(file, MzMLType.class, "mzML", "run");
+			MetadataReader110.readMetadata(mzML, chromatogram);
+
+			IndexedMzML indexedMzML = XmlHelper.parseFiltered(file, IndexedMzML.class, null, "mzML");
+			for(IndexType index : indexedMzML.getIndexList().getIndex()) {
+				if(index.getName().equals("chromatogram")) {
+					readChromatograms(file, index.getOffset(), chromatogram);
+				}
+			}
+		} catch(JAXBException e) {
+			logger.warn(e);
+		} catch(XMLStreamException e) {
+			logger.warn(e);
+		}
+		return chromatogram;
+	}
+
+	@Override
+	public IChromatogramMSD read(File file, IProgressMonitor monitor) throws IOException {
+
+		IVendorChromatogram chromatogram = null;
+		try {
+			chromatogram = new VendorChromatogram();
+			chromatogram.setFile(file);
+			MzMLType mzML = XmlHelper.parseFiltered(file, MzMLType.class, "mzML", "run");
+			MetadataReader110.readMetadata(mzML, chromatogram);
+
+			IndexedMzML indexedMzML = XmlHelper.parseFiltered(file, IndexedMzML.class, null, "mzML");
+			int indexSize = indexedMzML.getIndexList().getCount().intValue();
+			monitor.beginTask(ConverterMessages.importChromatogramOverview, indexSize * 2);
+			for(IndexType index : indexedMzML.getIndexList().getIndex()) {
+				if(index.getName().equals("chromatogram")) {
+					readChromatograms(file, index.getOffset(), chromatogram);
+				}
+				monitor.worked(1);
+			}
+			for(IndexType index : indexedMzML.getIndexList().getIndex()) {
+				if(index.getName().equals("spectrum")) {
+					readSpectra(index.getOffset(), file, monitor, chromatogram);
+				}
+				monitor.worked(1);
+			}
+		} catch(JAXBException e) {
+			logger.warn(e);
+		} catch(XMLStreamException e) {
+			logger.warn(e);
+		}
+		return chromatogram;
+	}
+
+	private void readChromatograms(File file, List<OffsetType> offsets, IVendorChromatogram chromatogram) {
+
+		for(OffsetType offset : offsets) {
+			if(offset.getIdRef().equals("tic") || offset.getIdRef().equals("TIC")) {
+				readTIC(file, offset.getValue(), chromatogram);
+			}
+		}
+	}
+
+	private void readTIC(File file, long offset, IVendorChromatogram chromatogram) {
+
+		try {
+			ChromatogramType mzMLchromatogram = XmlHelper.unmarshalElementAtOffset(file, offset, ChromatogramType.class);
+			chromatogram.setDataName(mzMLchromatogram.getId());
+			Pair<double[], double[]> binaryData = ChromatogramReaderVersion110.readBinaryData(mzMLchromatogram);
+			XmlChromatogramReader.addTotalSignals(binaryData.getValue(), binaryData.getKey(), chromatogram);
+		} catch(FileNotFoundException e) {
+			logger.error(e);
+		} catch(IOException e) {
+			logger.error(e);
+		} catch(JAXBException e) {
+			logger.error(e);
+		} catch(FactoryConfigurationError e) {
+			logger.error(e);
+		} catch(XMLStreamException e) {
+			logger.error(e);
+		}
+	}
+
+	// Replace TIC with scan proxies
+	private void readSpectra(List<OffsetType> offsets, File file, IProgressMonitor monitor, IVendorChromatogram chromatogram) {
+
+		int i = 1;
+		List<IVendorScanProxy> scanProxies = new ArrayList<>();
+		monitor.beginTask(ConverterMessages.importScan, offsets.size());
+		for(OffsetType offset : offsets) {
+			IScanMSD scan = chromatogram.getScan(i);
+			if(scan == null) {
+				// TODO: handle DAD spectra
+				continue;
+			}
+			IVendorScanProxy scanProxy = new VendorScanProxy(file, offset.getValue(), chromatogram, monitor);
+			scanProxy.setTotalSignal(scan.getTotalSignal());
+			scanProxy.setRetentionTime(scan.getRetentionTime());
+			scanProxy.setIdentifier(offset.getIdRef());
+			scanProxies.add(scanProxy);
+			monitor.worked(1);
+			i++;
+		}
+		chromatogram.getScans().clear();
+		for(IVendorScanProxy scanProxy : scanProxies) {
+			chromatogram.addScan(scanProxy);
+		}
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramReaderVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramReaderVersion110.java
@@ -150,7 +150,7 @@ public class ChromatogramReaderVersion110 extends AbstractChromatogramReader imp
 		}
 	}
 
-	private void setRetentionTime(SpectrumType spectrum, IRegularMassSpectrum massSpectrum) {
+	public static void setRetentionTime(SpectrumType spectrum, IRegularMassSpectrum massSpectrum) {
 
 		for(ScanType scanType : spectrum.getScanList().getScan()) {
 			for(CVParamType cvParam : scanType.getCvParam()) {
@@ -158,6 +158,17 @@ public class ChromatogramReaderVersion110 extends AbstractChromatogramReader imp
 					float multiplicator = XmlReader110.getTimeMultiplicator(cvParam);
 					int retentionTime = Math.round(Float.parseFloat(cvParam.getValue()) * multiplicator);
 					massSpectrum.setRetentionTime(retentionTime);
+				}
+			}
+		}
+	}
+
+	public static void setTotalIonCurrent(SpectrumType spectrum, IRegularMassSpectrum massSpectrum) {
+
+		for(ScanType scanType : spectrum.getScanList().getScan()) {
+			for(CVParamType cvParam : scanType.getCvParam()) {
+				if(cvParam.getAccession().equals("MS:1000285") && cvParam.getName().equals("total ion current")) {
+					massSpectrum.adjustTotalSignal(Float.parseFloat(cvParam.getValue()));
 				}
 			}
 		}
@@ -273,7 +284,7 @@ public class ChromatogramReaderVersion110 extends AbstractChromatogramReader imp
 		}
 	}
 
-	private double getSelectedIon(SpectrumType spectrum) {
+	private static double getSelectedIon(SpectrumType spectrum) {
 
 		if(spectrum.getPrecursorList() != null) {
 			for(PrecursorType precursorType : spectrum.getPrecursorList().getPrecursor()) {
@@ -292,7 +303,7 @@ public class ChromatogramReaderVersion110 extends AbstractChromatogramReader imp
 		return 0;
 	}
 
-	private double getSelectedIonPeakIntensity(SpectrumType spectrum) {
+	private static double getSelectedIonPeakIntensity(SpectrumType spectrum) {
 
 		if(spectrum.getPrecursorList() != null) {
 			for(PrecursorType precursorType : spectrum.getPrecursorList().getPrecursor()) {
@@ -311,7 +322,7 @@ public class ChromatogramReaderVersion110 extends AbstractChromatogramReader imp
 		return 0;
 	}
 
-	private double getCollisionEnergy(SpectrumType spectrum) {
+	private static double getCollisionEnergy(SpectrumType spectrum) {
 
 		if(spectrum.getPrecursorList() != null) {
 			for(PrecursorType precursorType : spectrum.getPrecursorList().getPrecursor()) {
@@ -325,7 +336,7 @@ public class ChromatogramReaderVersion110 extends AbstractChromatogramReader imp
 		return 0;
 	}
 
-	private void readIons(SpectrumType spectrum, IRegularMassSpectrum massSpectrum, IVendorChromatogram chromatogram) {
+	public static void readIons(SpectrumType spectrum, IRegularMassSpectrum massSpectrum, IVendorChromatogram chromatogram) {
 
 		double[] intensities = null;
 		double[] mzs = null;
@@ -361,7 +372,7 @@ public class ChromatogramReaderVersion110 extends AbstractChromatogramReader imp
 		}
 	}
 
-	private void setReferencedPolarity(SpectrumType spectrum, IRegularMassSpectrum massSpectrum) {
+	private static void setReferencedPolarity(SpectrumType spectrum, IRegularMassSpectrum massSpectrum) {
 
 		if(spectrum.getReferenceableParamGroupRef() == null) {
 			return;
@@ -374,7 +385,7 @@ public class ChromatogramReaderVersion110 extends AbstractChromatogramReader imp
 		}
 	}
 
-	private IRegularMassSpectrum readMassSpectrum(SpectrumType spectrum) {
+	public static IRegularMassSpectrum readMassSpectrum(SpectrumType spectrum) {
 
 		IRegularMassSpectrum massSpectrum = new RegularMassSpectrum();
 		for(CVParamType cvParam : spectrum.getCvParam()) {
@@ -406,7 +417,7 @@ public class ChromatogramReaderVersion110 extends AbstractChromatogramReader imp
 		return false;
 	}
 
-	private Pair<double[], double[]> readBinaryData(ChromatogramType chromatogramType) {
+	public static Pair<double[], double[]> readBinaryData(ChromatogramType chromatogramType) {
 
 		double[] retentionTimes = null;
 		double[] intensities = null;
@@ -426,7 +437,7 @@ public class ChromatogramReaderVersion110 extends AbstractChromatogramReader imp
 		return new ImmutablePair<>(retentionTimes, intensities);
 	}
 
-	private void setPolarity(CVParamType cvParam, IRegularMassSpectrum massSpectrum) {
+	private static void setPolarity(CVParamType cvParam, IRegularMassSpectrum massSpectrum) {
 
 		if(cvParam.getAccession().equals("MS:1000129") && cvParam.getName().equals("negative scan")) {
 			massSpectrum.setPolarity(Polarity.NEGATIVE);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/META-INF/MANIFEST.MF
@@ -20,6 +20,11 @@ Import-Package: jakarta.xml.bind,
  jakarta.xml.bind.annotation,
  jakarta.xml.bind.annotation.adapters
 Export-Package: org.eclipse.chemclipse.xxd.converter.supplier.mzml.converter,
+ org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v100,
+ org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v110,
+ org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v111,
+ org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v112,
+ org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v113,
  org.eclipse.chemclipse.xxd.converter.supplier.mzml.io,
  org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v10,
  org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v100/IndexedMzML.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v100/IndexedMzML.java
@@ -1,0 +1,205 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v100;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v10.MzMLType;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlIDREF;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlValue;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {"mzML", "indexList", "indexListOffset", "fileChecksum"})
+@XmlRootElement(name = "indexedmzML")
+public class IndexedMzML {
+
+	@XmlElement(required = true)
+	protected MzMLType mzML;
+
+	@XmlElement(required = true)
+	protected IndexedMzML.IndexList indexList;
+
+	@XmlElement(required = true, type = Long.class, nillable = true)
+	protected Long indexListOffset;
+
+	@XmlElement(required = true)
+	protected String fileChecksum;
+
+	public MzMLType getMzML() {
+
+		return mzML;
+	}
+
+	public void setMzML(MzMLType value) {
+
+		this.mzML = value;
+	}
+
+	public IndexedMzML.IndexList getIndexList() {
+
+		return indexList;
+	}
+
+	public void setIndexList(IndexedMzML.IndexList value) {
+
+		this.indexList = value;
+	}
+
+	public Long getIndexListOffset() {
+
+		return indexListOffset;
+	}
+
+	public void setIndexListOffset(Long value) {
+
+		this.indexListOffset = value;
+	}
+
+	public String getFileChecksum() {
+
+		return fileChecksum;
+	}
+
+	public void setFileChecksum(String value) {
+
+		this.fileChecksum = value;
+	}
+
+	@XmlAccessorType(XmlAccessType.FIELD)
+	@XmlType(name = "", propOrder = {"index"})
+	public static class IndexList {
+
+		@XmlElement(required = true)
+		protected List<IndexedMzML.IndexList.Index> index;
+
+		@XmlAttribute(name = "count", required = true)
+		@XmlSchemaType(name = "nonNegativeInteger")
+		protected BigInteger count;
+
+		public List<IndexedMzML.IndexList.Index> getIndex() {
+
+			if(index == null) {
+				index = new ArrayList<>();
+			}
+			return this.index;
+		}
+
+		public BigInteger getCount() {
+
+			return count;
+		}
+
+		public void setCount(BigInteger value) {
+
+			this.count = value;
+		}
+
+		@XmlAccessorType(XmlAccessType.FIELD)
+		@XmlType(name = "", propOrder = {"offset"})
+		public static class Index {
+
+			@XmlElement(required = true)
+			protected List<IndexedMzML.IndexList.Index.Offset> offset;
+
+			@XmlAttribute(name = "name", required = true)
+			protected String name;
+
+			public List<IndexedMzML.IndexList.Index.Offset> getOffset() {
+
+				if(offset == null) {
+					offset = new ArrayList<>();
+				}
+				return this.offset;
+			}
+
+			public String getName() {
+
+				return name;
+			}
+
+			public void setName(String value) {
+
+				this.name = value;
+			}
+
+			@XmlAccessorType(XmlAccessType.FIELD)
+			@XmlType(name = "", propOrder = {"value"})
+			public static class Offset {
+
+				@XmlValue
+				protected long value;
+
+				@XmlAttribute(name = "idRef", required = true)
+				@XmlIDREF
+				@XmlSchemaType(name = "IDREF")
+				protected Object idRef;
+
+				@XmlAttribute(name = "nativeID", required = true)
+				protected String nativeID;
+
+				@XmlAttribute(name = "spotID")
+				protected String spotID;
+
+				public long getValue() {
+
+					return value;
+				}
+
+				public void setValue(long value) {
+
+					this.value = value;
+				}
+
+				public Object getIdRef() {
+
+					return idRef;
+				}
+
+				public void setIdRef(Object value) {
+
+					this.idRef = value;
+				}
+
+				public String getNativeID() {
+
+					return nativeID;
+				}
+
+				public void setNativeID(String value) {
+
+					this.nativeID = value;
+				}
+
+				public String getSpotID() {
+
+					return spotID;
+				}
+
+				public void setSpotID(String value) {
+
+					this.spotID = value;
+				}
+			}
+		}
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v100/package-info.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v100/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+@XmlSchema(namespace = "http://psi.hupo.org/ms/mzml", elementFormDefault = XmlNsForm.QUALIFIED, xmlns = {@XmlNs(namespaceURI = "http://psi.hupo.org/ms/mzml", prefix = "")})
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v100;
+
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v110/IndexListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v110/IndexListType.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v110;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "IndexListType", propOrder = {"index"})
+public class IndexListType {
+
+	@XmlElement(required = true)
+	protected List<IndexType> index;
+
+	@XmlAttribute(name = "count", required = true)
+	@XmlSchemaType(name = "nonNegativeInteger")
+	protected BigInteger count;
+
+	public List<IndexType> getIndex() {
+
+		if(index == null) {
+			index = new ArrayList<>();
+		}
+		return this.index;
+	}
+
+	public BigInteger getCount() {
+
+		return count;
+	}
+
+	public void setCount(BigInteger value) {
+
+		this.count = value;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v110/IndexType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v110/IndexType.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v110;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "IndexType", propOrder = {"offset"})
+public class IndexType {
+
+	@XmlElement(required = true)
+	protected List<OffsetType> offset;
+
+	@XmlAttribute(name = "name", required = true)
+	protected String name;
+
+	public List<OffsetType> getOffset() {
+
+		if(offset == null) {
+			offset = new ArrayList<>();
+		}
+		return this.offset;
+	}
+
+	public String getName() {
+
+		return name;
+	}
+
+	public void setName(String value) {
+
+		this.name = value;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v110/IndexedMzML.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v110/IndexedMzML.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v110;
+
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.MzMLType;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {"mzML", "indexList", "indexListOffset", "fileChecksum"})
+@XmlRootElement(name = "indexedmzML")
+public class IndexedMzML {
+
+	@XmlElement(required = true)
+	protected MzMLType mzML;
+
+	@XmlElement(required = true)
+	protected IndexListType indexList;
+
+	@XmlElement(required = true, type = Long.class, nillable = true)
+	protected Long indexListOffset;
+
+	@XmlElement(required = true)
+	protected String fileChecksum;
+
+	public MzMLType getMzML() {
+
+		return mzML;
+	}
+
+	public void setMzML(MzMLType value) {
+
+		this.mzML = value;
+	}
+
+	public IndexListType getIndexList() {
+
+		return indexList;
+	}
+
+	public void setIndexList(IndexListType value) {
+
+		this.indexList = value;
+	}
+
+	public Long getIndexListOffset() {
+
+		return indexListOffset;
+	}
+
+	public void setIndexListOffset(Long value) {
+
+		this.indexListOffset = value;
+	}
+
+	public String getFileChecksum() {
+
+		return fileChecksum;
+	}
+
+	public void setFileChecksum(String value) {
+
+		this.fileChecksum = value;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v110/OffsetType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v110/OffsetType.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v110;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlValue;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "OffsetType", propOrder = {"value"})
+public class OffsetType {
+
+	@XmlValue
+	protected long value;
+
+	@XmlAttribute(name = "idRef", required = true)
+	protected String idRef;
+
+	@XmlAttribute(name = "spotID")
+	protected String spotID;
+
+	@XmlAttribute(name = "scanTime")
+	protected Double scanTime;
+
+	public long getValue() {
+
+		return value;
+	}
+
+	public void setValue(long value) {
+
+		this.value = value;
+	}
+
+	public String getIdRef() {
+
+		return idRef;
+	}
+
+	public void setIdRef(String value) {
+
+		this.idRef = value;
+	}
+
+	public String getSpotID() {
+
+		return spotID;
+	}
+
+	public void setSpotID(String value) {
+
+		this.spotID = value;
+	}
+
+	public Double getScanTime() {
+
+		return scanTime;
+	}
+
+	public void setScanTime(Double value) {
+
+		this.scanTime = value;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v110/package-info.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v110/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+@XmlSchema(namespace = "http://psi.hupo.org/ms/mzml", elementFormDefault = XmlNsForm.QUALIFIED, xmlns = {@XmlNs(namespaceURI = "http://psi.hupo.org/ms/mzml", prefix = "")})
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v110;
+
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v111/IndexListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v111/IndexListType.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v111;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "IndexListType", propOrder = {"index"})
+public class IndexListType {
+
+	@XmlElement(required = true)
+	protected List<IndexType> index;
+
+	@XmlAttribute(name = "count", required = true)
+	@XmlSchemaType(name = "nonNegativeInteger")
+	protected BigInteger count;
+
+	public List<IndexType> getIndex() {
+
+		if(index == null) {
+			index = new ArrayList<>();
+		}
+		return this.index;
+	}
+
+	public BigInteger getCount() {
+
+		return count;
+	}
+
+	public void setCount(BigInteger value) {
+
+		this.count = value;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v111/IndexType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v111/IndexType.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v111;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "IndexType", propOrder = {"offset"})
+public class IndexType {
+
+	@XmlElement(required = true)
+	protected List<OffsetType> offset;
+
+	@XmlAttribute(name = "name", required = true)
+	protected String name;
+
+	public List<OffsetType> getOffset() {
+
+		if(offset == null) {
+			offset = new ArrayList<>();
+		}
+		return this.offset;
+	}
+
+	public String getName() {
+
+		return name;
+	}
+
+	public void setName(String value) {
+
+		this.name = value;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v111/IndexedMzML.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v111/IndexedMzML.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v111;
+
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.MzMLType;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {"mzML", "indexList", "indexListOffset", "fileChecksum"})
+@XmlRootElement(name = "indexedmzML")
+public class IndexedMzML {
+
+	@XmlElement(required = true)
+	protected MzMLType mzML;
+
+	@XmlElement(required = true)
+	protected IndexListType indexList;
+
+	@XmlElement(required = true, type = Long.class, nillable = true)
+	protected Long indexListOffset;
+
+	@XmlElement(required = true)
+	protected String fileChecksum;
+
+	public MzMLType getMzML() {
+
+		return mzML;
+	}
+
+	public void setMzML(MzMLType value) {
+
+		this.mzML = value;
+	}
+
+	public IndexListType getIndexList() {
+
+		return indexList;
+	}
+
+	public void setIndexList(IndexListType value) {
+
+		this.indexList = value;
+	}
+
+	public Long getIndexListOffset() {
+
+		return indexListOffset;
+	}
+
+	public void setIndexListOffset(Long value) {
+
+		this.indexListOffset = value;
+	}
+
+	public String getFileChecksum() {
+
+		return fileChecksum;
+	}
+
+	public void setFileChecksum(String value) {
+
+		this.fileChecksum = value;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v111/OffsetType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v111/OffsetType.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v111;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlValue;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "OffsetType", propOrder = {"value"})
+public class OffsetType {
+
+	@XmlValue
+	protected long value;
+
+	@XmlAttribute(name = "idRef", required = true)
+	protected String idRef;
+
+	@XmlAttribute(name = "spotID")
+	protected String spotID;
+
+	@XmlAttribute(name = "scanTime")
+	protected Double scanTime;
+
+	public long getValue() {
+
+		return value;
+	}
+
+	public void setValue(long value) {
+
+		this.value = value;
+	}
+
+	public String getIdRef() {
+
+		return idRef;
+	}
+
+	public void setIdRef(String value) {
+
+		this.idRef = value;
+	}
+
+	public String getSpotID() {
+
+		return spotID;
+	}
+
+	public void setSpotID(String value) {
+
+		this.spotID = value;
+	}
+
+	public Double getScanTime() {
+
+		return scanTime;
+	}
+
+	public void setScanTime(Double value) {
+
+		this.scanTime = value;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v111/package-info.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v111/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+@XmlSchema(namespace = "http://psi.hupo.org/ms/mzml", elementFormDefault = XmlNsForm.QUALIFIED, xmlns = {@XmlNs(namespaceURI = "http://psi.hupo.org/ms/mzml", prefix = "")})
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v111;
+
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v112/IndexListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v112/IndexListType.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v112;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "IndexListType", propOrder = {"index"})
+public class IndexListType {
+
+	@XmlElement(required = true)
+	protected List<IndexType> index;
+
+	@XmlAttribute(name = "count", required = true)
+	@XmlSchemaType(name = "nonNegativeInteger")
+	protected BigInteger count;
+
+	public List<IndexType> getIndex() {
+
+		if(index == null) {
+			index = new ArrayList<>();
+		}
+		return this.index;
+	}
+
+	public BigInteger getCount() {
+
+		return count;
+	}
+
+	public void setCount(BigInteger value) {
+
+		this.count = value;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v112/IndexType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v112/IndexType.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v112;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "IndexType", propOrder = {"offset"})
+public class IndexType {
+
+	protected List<OffsetType> offset;
+	@XmlAttribute(name = "name", required = true)
+
+	protected String name;
+
+	public List<OffsetType> getOffset() {
+
+		if(offset == null) {
+			offset = new ArrayList<>();
+		}
+		return this.offset;
+	}
+
+	public String getName() {
+
+		return name;
+	}
+
+	public void setName(String value) {
+
+		this.name = value;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v112/IndexedMzML.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v112/IndexedMzML.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v112;
+
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.MzMLType;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {"mzML", "indexList", "indexListOffset", "fileChecksum"})
+@XmlRootElement(name = "indexedmzML")
+public class IndexedMzML {
+
+	@XmlElement(required = true)
+	protected MzMLType mzML;
+
+	@XmlElement(required = true)
+	protected IndexListType indexList;
+
+	@XmlElement(required = true, type = Long.class, nillable = true)
+	protected Long indexListOffset;
+
+	@XmlElement(required = true)
+	protected String fileChecksum;
+
+	public MzMLType getMzML() {
+
+		return mzML;
+	}
+
+	public void setMzML(MzMLType value) {
+
+		this.mzML = value;
+	}
+
+	public IndexListType getIndexList() {
+
+		return indexList;
+	}
+
+	public void setIndexList(IndexListType value) {
+
+		this.indexList = value;
+	}
+
+	public Long getIndexListOffset() {
+
+		return indexListOffset;
+	}
+
+	public void setIndexListOffset(Long value) {
+
+		this.indexListOffset = value;
+	}
+
+	public String getFileChecksum() {
+
+		return fileChecksum;
+	}
+
+	public void setFileChecksum(String value) {
+
+		this.fileChecksum = value;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v112/OffsetType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v112/OffsetType.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v112;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlValue;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "OffsetType", propOrder = {"value"})
+public class OffsetType {
+
+	@XmlValue
+	protected long value;
+
+	@XmlAttribute(name = "idRef", required = true)
+	protected String idRef;
+
+	@XmlAttribute(name = "spotID")
+	protected String spotID;
+
+	@XmlAttribute(name = "scanTime")
+	protected Double scanTime;
+
+	public long getValue() {
+
+		return value;
+	}
+
+	public void setValue(long value) {
+
+		this.value = value;
+	}
+
+	public String getIdRef() {
+
+		return idRef;
+	}
+
+	public void setIdRef(String value) {
+
+		this.idRef = value;
+	}
+
+	public String getSpotID() {
+
+		return spotID;
+	}
+
+	public void setSpotID(String value) {
+
+		this.spotID = value;
+	}
+
+	public Double getScanTime() {
+
+		return scanTime;
+	}
+
+	public void setScanTime(Double value) {
+
+		this.scanTime = value;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v112/package-info.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v112/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+@XmlSchema(namespace = "http://psi.hupo.org/ms/mzml", elementFormDefault = XmlNsForm.QUALIFIED, xmlns = {@XmlNs(namespaceURI = "http://psi.hupo.org/ms/mzml", prefix = "")})
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v112;
+
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v113/IndexListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v113/IndexListType.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v113;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "IndexListType", propOrder = {"index"})
+public class IndexListType {
+
+	@XmlElement(required = true)
+	protected List<IndexType> index;
+
+	@XmlAttribute(name = "count", required = true)
+	@XmlSchemaType(name = "nonNegativeInteger")
+	protected BigInteger count;
+
+	public List<IndexType> getIndex() {
+
+		if(index == null) {
+			index = new ArrayList<>();
+		}
+		return this.index;
+	}
+
+	public BigInteger getCount() {
+
+		return count;
+	}
+
+	public void setCount(BigInteger value) {
+
+		this.count = value;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v113/IndexType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v113/IndexType.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v113;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "IndexType", propOrder = {"offset"})
+public class IndexType {
+
+	protected List<OffsetType> offset;
+
+	@XmlAttribute(name = "name", required = true)
+	protected String name;
+
+	public List<OffsetType> getOffset() {
+
+		if(offset == null) {
+			offset = new ArrayList<>();
+		}
+		return this.offset;
+	}
+
+	public String getName() {
+
+		return name;
+	}
+
+	public void setName(String value) {
+
+		this.name = value;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v113/IndexedMzML.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v113/IndexedMzML.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v113;
+
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.MzMLType;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {"mzML", "indexList", "indexListOffset", "fileChecksum"})
+@XmlRootElement(name = "indexedmzML")
+public class IndexedMzML {
+
+	@XmlElement(required = true)
+	protected MzMLType mzML;
+
+	@XmlElement(required = true)
+	protected IndexListType indexList;
+
+	@XmlElement(required = true, type = Long.class, nillable = true)
+	protected Long indexListOffset;
+
+	@XmlElement(required = true)
+	protected String fileChecksum;
+
+	public MzMLType getMzML() {
+
+		return mzML;
+	}
+
+	public void setMzML(MzMLType value) {
+
+		this.mzML = value;
+	}
+
+	public IndexListType getIndexList() {
+
+		return indexList;
+	}
+
+	public void setIndexList(IndexListType value) {
+
+		this.indexList = value;
+	}
+
+	public Long getIndexListOffset() {
+
+		return indexListOffset;
+	}
+
+	public void setIndexListOffset(Long value) {
+
+		this.indexListOffset = value;
+	}
+
+	public String getFileChecksum() {
+
+		return fileChecksum;
+	}
+
+	public void setFileChecksum(String value) {
+
+		this.fileChecksum = value;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v113/OffsetType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v113/OffsetType.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v113;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlValue;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "OffsetType", propOrder = {"value"})
+public class OffsetType {
+
+	@XmlValue
+	protected long value;
+
+	@XmlAttribute(name = "idRef", required = true)
+	protected String idRef;
+
+	@XmlAttribute(name = "spotID")
+	protected String spotID;
+
+	@XmlAttribute(name = "scanTime")
+	protected Double scanTime;
+
+	public long getValue() {
+
+		return value;
+	}
+
+	public void setValue(long value) {
+
+		this.value = value;
+	}
+
+	public String getIdRef() {
+
+		return idRef;
+	}
+
+	public void setIdRef(String value) {
+
+		this.idRef = value;
+	}
+
+	public String getSpotID() {
+
+		return spotID;
+	}
+
+	public void setSpotID(String value) {
+
+		this.spotID = value;
+	}
+
+	public Double getScanTime() {
+
+		return scanTime;
+	}
+
+	public void setScanTime(Double value) {
+
+		this.scanTime = value;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v113/package-info.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/idx/model/v113/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+@XmlSchema(namespace = "http://psi.hupo.org/ms/mzml", elementFormDefault = XmlNsForm.QUALIFIED, xmlns = {@XmlNs(namespaceURI = "http://psi.hupo.org/ms/mzml", prefix = "")})
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.idx.model.v113;
+
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/SingleElementReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/SingleElementReader.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.io;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.util.StreamReaderDelegate;
+
+public class SingleElementReader extends StreamReaderDelegate {
+
+	private int depth = 1; // constructed while sitting on the target START_ELEMENT
+	private boolean finished;
+
+	public SingleElementReader(XMLStreamReader parent) {
+
+		super(parent);
+	}
+
+	@Override
+	public boolean hasNext() throws XMLStreamException {
+
+		return !finished && super.hasNext();
+	}
+
+	@Override
+	public int next() throws XMLStreamException {
+
+		if(finished) {
+			return XMLStreamConstants.END_DOCUMENT;
+		}
+		int event = super.next();
+		if(event == XMLStreamConstants.START_ELEMENT) {
+			depth++;
+		} else if(event == XMLStreamConstants.END_ELEMENT && --depth == 0) {
+			finished = true;
+		}
+		return event;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlHelper.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlHelper.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.io;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.util.StreamReaderDelegate;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+
+public class XmlHelper {
+
+	private XmlHelper() {
+
+	}
+
+	public static <T> T unmarshalElementAtOffset(File file, long byteOffset, Class<T> type) throws JAXBException, XMLStreamException, IOException {
+
+		JAXBContext ctx = JAXBContext.newInstance(type);
+		Unmarshaller unmarshaller = ctx.createUnmarshaller();
+
+		XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+		xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+		xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+
+		String wrapperStart = buildWrapperStart(readRootNamespaceDeclarations(file, xmlInputFactory));
+
+		try (FileChannel channel = FileChannel.open(file.toPath(), StandardOpenOption.READ)) {
+			channel.position(byteOffset);
+
+			InputStream prefix = new ByteArrayInputStream(wrapperStart.getBytes(StandardCharsets.UTF_8));
+			InputStream body = Channels.newInputStream(channel); // positioned at byteOffset
+
+			try (InputStream in = new BufferedInputStream(new SequenceInputStream(prefix, body))) {
+				XMLStreamReader raw = xmlInputFactory.createXMLStreamReader(in, "UTF-8");
+
+				while(raw.getEventType() != XMLStreamConstants.START_ELEMENT) {
+					if(!raw.hasNext()) {
+						throw new XMLStreamException("No <frag> at offset " + byteOffset);
+					}
+					raw.next();
+				}
+				if(raw.nextTag() != XMLStreamConstants.START_ELEMENT) {
+					throw new XMLStreamException("No element inside <frag> at offset " + byteOffset);
+				}
+
+				XMLStreamReader reader = new SingleElementReader(raw);
+				return unmarshaller.unmarshal(reader, type).getValue();
+			}
+		}
+	}
+
+	/**
+	 * Skips parsing the whole XML tree.
+	 */
+	public static <T> T parseFiltered(File file, Class<T> type, String advanceTo, String stopTag) throws IOException, JAXBException, XMLStreamException {
+
+		XMLInputFactory factory = XMLInputFactory.newFactory();
+		factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+		factory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
+
+		try (FileInputStream inputStream = new FileInputStream(file)) {
+			XMLStreamReader reader = factory.createXMLStreamReader(inputStream);
+
+			if(advanceTo != null) {
+				while(reader.hasNext()) {
+					int event = reader.next();
+					if(event == XMLStreamConstants.START_ELEMENT && advanceTo.equals(reader.getLocalName())) {
+						break;
+					}
+				}
+			}
+
+			XMLStreamReader filteredReader = new StreamReaderDelegate(reader) {
+
+				@Override
+				public int next() throws XMLStreamException {
+
+					while(true) {
+						int event = super.next();
+
+						if(event == XMLStreamConstants.START_ELEMENT && stopTag.equals(getLocalName())) {
+
+							int skipDepth = 1;
+
+							while(skipDepth > 0 && super.hasNext()) {
+								event = super.next();
+
+								if(event == XMLStreamConstants.START_ELEMENT) {
+									skipDepth++;
+								} else if(event == XMLStreamConstants.END_ELEMENT) {
+									skipDepth--;
+								}
+							}
+
+							continue;
+						}
+
+						return event;
+					}
+				}
+			};
+
+			JAXBContext context = JAXBContext.newInstance(type);
+			Unmarshaller unmarshaller = context.createUnmarshaller();
+
+			return unmarshaller.unmarshal(filteredReader, type).getValue();
+		}
+	}
+
+	private static List<String[]> readRootNamespaceDeclarations(File file, XMLInputFactory xmlInputFactory) throws IOException, XMLStreamException {
+
+		try (InputStream inputStream = new BufferedInputStream(Files.newInputStream(file.toPath()))) {
+			XMLStreamReader xmlStreamReader = xmlInputFactory.createXMLStreamReader(inputStream);
+			while(xmlStreamReader.getEventType() != XMLStreamConstants.START_ELEMENT) {
+				xmlStreamReader.next();
+			}
+			int n = xmlStreamReader.getNamespaceCount();
+			List<String[]> decls = new ArrayList<>(n);
+			for(int i = 0; i < n; i++) {
+				decls.add(new String[]{xmlStreamReader.getNamespacePrefix(i), xmlStreamReader.getNamespaceURI(i)}); // prefix may be null
+			}
+			xmlStreamReader.close();
+			return decls;
+		}
+	}
+
+	private static String buildWrapperStart(List<String[]> declarations) {
+
+		StringBuilder stringBuilder = new StringBuilder("<frag");
+		for(String[] declaration : declarations) {
+			String prefix = declaration[0];
+			String uri = declaration[1];
+			if(prefix == null || prefix.isEmpty()) {
+				stringBuilder.append(" xmlns=\"").append(uri).append('"');
+			} else {
+				stringBuilder.append(" xmlns:").append(prefix).append("=\"").append(uri).append('"');
+			}
+		}
+		return stringBuilder.append('>').toString();
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/AcquisitionListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/AcquisitionListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ public class AcquisitionListType extends ParamGroupType {
 
 	@XmlElement(required = true)
 	protected List<AcquisitionType> acquisition;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/AcquisitionSettingsListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/AcquisitionSettingsListType.java
@@ -32,6 +32,7 @@ public class AcquisitionSettingsListType {
 
 	@XmlElement(required = true)
 	protected List<AcquisitionSettingsType> acquisitionSettings;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/AcquisitionSettingsType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/AcquisitionSettingsType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,12 +30,15 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 public class AcquisitionSettingsType extends ParamGroupType {
 
 	protected SourceFileRefListType sourceFileRefList;
+
 	protected TargetListType targetList;
+
 	@XmlAttribute(name = "id", required = true)
 	@XmlJavaTypeAdapter(CollapsedStringAdapter.class)
 	@XmlID
 	@XmlSchemaType(name = "ID")
 	protected String id;
+
 	@XmlAttribute(name = "instrumentConfigurationRef", required = true)
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/AcquisitionType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/AcquisitionType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -28,16 +28,20 @@ public class AcquisitionType extends ParamGroupType {
 
 	@XmlAttribute(name = "number", required = true)
 	protected int number;
+
 	@XmlAttribute(name = "spectrumRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	protected Object spectrumRef;
+
 	@XmlAttribute(name = "sourceFileRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	protected Object sourceFileRef;
+
 	@XmlAttribute(name = "externalNativeID")
 	protected String externalNativeID;
+
 	@XmlAttribute(name = "externalSpectrumID")
 	protected String externalSpectrumID;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/BinaryDataArrayListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/BinaryDataArrayListType.java
@@ -32,6 +32,7 @@ public class BinaryDataArrayListType {
 
 	@XmlElement(required = true)
 	protected List<BinaryDataArrayType> binaryDataArray;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/BinaryDataArrayType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/BinaryDataArrayType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -31,13 +31,16 @@ public class BinaryDataArrayType extends ParamGroupType {
 
 	@XmlElement(required = true)
 	protected byte[] binary;
+
 	@XmlAttribute(name = "arrayLength")
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger arrayLength;
+
 	@XmlAttribute(name = "dataProcessingRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	protected Object dataProcessingRef;
+
 	@XmlAttribute(name = "encodedLength", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger encodedLength;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/CVListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/CVListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ public class CVListType {
 
 	@XmlElement(required = true)
 	protected List<CVType> cv;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/CVParamType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/CVParamType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,16 +30,22 @@ public class CVParamType {
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	protected Object cvRef;
+
 	@XmlAttribute(name = "accession", required = true)
 	protected String accession;
+
 	@XmlAttribute(name = "value")
 	protected String value;
+
 	@XmlAttribute(name = "name", required = true)
 	protected String name;
+
 	@XmlAttribute(name = "unitAccession")
 	protected String unitAccession;
+
 	@XmlAttribute(name = "unitName")
 	protected String unitName;
+
 	@XmlAttribute(name = "unitCvRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/CVType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/CVType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,10 +33,13 @@ public class CVType {
 	@XmlID
 	@XmlSchemaType(name = "ID")
 	protected String id;
+
 	@XmlAttribute(name = "fullName", required = true)
 	protected String fullName;
+
 	@XmlAttribute(name = "version")
 	protected String version;
+
 	@XmlAttribute(name = "URI", required = true)
 	@XmlSchemaType(name = "anyURI")
 	protected String uri;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/ChromatogramListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/ChromatogramListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ public class ChromatogramListType {
 
 	@XmlElement(required = true)
 	protected List<ChromatogramType> chromatogram;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/ChromatogramType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/ChromatogramType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -34,18 +34,23 @@ public class ChromatogramType extends ParamGroupType {
 
 	@XmlElement(required = true)
 	protected BinaryDataArrayListType binaryDataArrayList;
+
 	@XmlAttribute(name = "id", required = true)
 	@XmlJavaTypeAdapter(CollapsedStringAdapter.class)
 	@XmlID
 	@XmlSchemaType(name = "ID")
 	protected String id;
+
 	@XmlAttribute(name = "nativeID", required = true)
 	protected String nativeID;
+
 	@XmlAttribute(name = "index", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger index;
+
 	@XmlAttribute(name = "defaultArrayLength", required = true)
 	protected int defaultArrayLength;
+
 	@XmlAttribute(name = "dataProcessingRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/ComponentListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/ComponentListType.java
@@ -34,6 +34,7 @@ public class ComponentListType {
 
 	@XmlElementRefs({@XmlElementRef(name = "source", namespace = "http://psi.hupo.org/schema_revision/mzML_1.0.0", type = JAXBElement.class, required = false), @XmlElementRef(name = "detector", namespace = "http://psi.hupo.org/schema_revision/mzML_1.0.0", type = JAXBElement.class, required = false), @XmlElementRef(name = "analyzer", namespace = "http://psi.hupo.org/schema_revision/mzML_1.0.0", type = JAXBElement.class, required = false)})
 	protected List<JAXBElement<ComponentType>> sourceOrAnalyzerOrDetector;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/DataProcessingListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/DataProcessingListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ public class DataProcessingListType {
 
 	@XmlElement(required = true)
 	protected List<DataProcessingType> dataProcessing;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/DataProcessingType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/DataProcessingType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -35,11 +35,13 @@ public class DataProcessingType {
 
 	@XmlElement(required = true)
 	protected List<ProcessingMethodType> processingMethod;
+
 	@XmlAttribute(name = "id", required = true)
 	@XmlJavaTypeAdapter(CollapsedStringAdapter.class)
 	@XmlID
 	@XmlSchemaType(name = "ID")
 	protected String id;
+
 	@XmlAttribute(name = "softwareRef", required = true)
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/FileDescriptionType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/FileDescriptionType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,7 +29,9 @@ public class FileDescriptionType {
 
 	@XmlElement(required = true)
 	protected ParamGroupType fileContent;
+
 	protected SourceFileListType sourceFileList;
+
 	protected List<ParamGroupType> contact;
 
 	public ParamGroupType getFileContent() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/InstrumentConfigurationListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/InstrumentConfigurationListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ public class InstrumentConfigurationListType {
 
 	@XmlElement(required = true)
 	protected List<InstrumentConfigurationType> instrumentConfiguration;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/InstrumentConfigurationType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/InstrumentConfigurationType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -31,7 +31,9 @@ public class InstrumentConfigurationType extends ParamGroupType {
 
 	@XmlElement(required = true)
 	protected ComponentListType componentList;
+
 	protected SoftwareRefType softwareRef;
+
 	@XmlAttribute(name = "id", required = true)
 	@XmlJavaTypeAdapter(CollapsedStringAdapter.class)
 	@XmlID

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/MzMLType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/MzMLType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,25 +30,37 @@ import jakarta.xml.bind.annotation.XmlType;
 public class MzMLType implements Serializable {
 
 	private static final long serialVersionUID = 10L;
+
 	@XmlElement(required = true)
 	protected CVListType cvList;
+
 	@XmlElement(required = true)
 	protected FileDescriptionType fileDescription;
+
 	protected ReferenceableParamGroupListType referenceableParamGroupList;
+
 	protected SampleListType sampleList;
+
 	@XmlElement(required = true)
 	protected InstrumentConfigurationListType instrumentConfigurationList;
+
 	@XmlElement(required = true)
 	protected SoftwareListType softwareList;
+
 	@XmlElement(required = true)
 	protected DataProcessingListType dataProcessingList;
+
 	protected AcquisitionSettingsListType acquisitionSettingsList;
+
 	@XmlElement(required = true)
 	protected RunType run;
+
 	@XmlAttribute(name = "accession")
 	protected String accession;
+
 	@XmlAttribute(name = "version", required = true)
 	protected String version;
+
 	@XmlAttribute(name = "id")
 	protected String id;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/PrecursorListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/PrecursorListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ public class PrecursorListType {
 
 	@XmlElement(required = true)
 	protected List<PrecursorType> precursor;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/PrecursorType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/PrecursorType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -28,20 +28,26 @@ import jakarta.xml.bind.annotation.XmlType;
 public class PrecursorType {
 
 	protected ParamGroupType isolationWindow;
+
 	@XmlElement(required = true)
 	protected SelectedIonListType selectedIonList;
+
 	@XmlElement(required = true)
 	protected ParamGroupType activation;
+
 	@XmlAttribute(name = "spectrumRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	protected Object spectrumRef;
+
 	@XmlAttribute(name = "sourceFileRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	protected Object sourceFileRef;
+
 	@XmlAttribute(name = "externalNativeID")
 	protected String externalNativeID;
+
 	@XmlAttribute(name = "externalSpectrumID")
 	protected String externalSpectrumID;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/ReferenceableParamGroupListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/ReferenceableParamGroupListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ public class ReferenceableParamGroupListType {
 
 	@XmlElement(required = true)
 	protected List<ReferenceableParamGroupType> referenceableParamGroup;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/ReferenceableParamGroupType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/ReferenceableParamGroupType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,7 +32,9 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 public class ReferenceableParamGroupType {
 
 	protected List<CVParamType> cvParam;
+
 	protected List<UserParamType> userParam;
+
 	@XmlAttribute(name = "id", required = true)
 	@XmlJavaTypeAdapter(CollapsedStringAdapter.class)
 	@XmlID

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/RunType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/RunType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,22 +33,28 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 public class RunType extends ParamGroupType {
 
 	protected SourceFileRefListType sourceFileRefList;
+
 	@XmlElement(required = true)
 	protected SpectrumListType spectrumList;
+
 	protected ChromatogramListType chromatogramList;
+
 	@XmlAttribute(name = "id", required = true)
 	@XmlJavaTypeAdapter(CollapsedStringAdapter.class)
 	@XmlID
 	@XmlSchemaType(name = "ID")
 	protected String id;
+
 	@XmlAttribute(name = "defaultInstrumentConfigurationRef", required = true)
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	protected Object defaultInstrumentConfigurationRef;
+
 	@XmlAttribute(name = "sampleRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	protected Object sampleRef;
+
 	@XmlAttribute(name = "startTimeStamp")
 	@XmlSchemaType(name = "dateTime")
 	protected XMLGregorianCalendar startTimeStamp;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SampleListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SampleListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ public class SampleListType {
 
 	@XmlElement(required = true)
 	protected List<SampleType> sample;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SampleType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SampleType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,6 +33,7 @@ public class SampleType extends ParamGroupType {
 	@XmlID
 	@XmlSchemaType(name = "ID")
 	protected String id;
+
 	@XmlAttribute(name = "name")
 	protected String name;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/ScanType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/ScanType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,6 +29,7 @@ public class ScanType extends ParamGroupType {
 
 	@XmlElement(required = true)
 	protected ScanWindowListType scanWindowList;
+
 	@XmlAttribute(name = "instrumentConfigurationRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/ScanWindowListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/ScanWindowListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,6 +27,7 @@ public class ScanWindowListType {
 
 	@XmlElement(required = true)
 	protected List<ScanWindowType> scanWindow;
+
 	@XmlAttribute(name = "count", required = true)
 	protected int count;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SelectedIonListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SelectedIonListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ public class SelectedIonListType {
 
 	@XmlElement(required = true)
 	protected List<ParamGroupType> selectedIon;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SoftwareListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SoftwareListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ public class SoftwareListType {
 
 	@XmlElement(required = true)
 	protected List<SoftwareType> software;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SoftwareParamType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SoftwareParamType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,10 +27,13 @@ public class SoftwareParamType {
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	protected Object cvRef;
+
 	@XmlAttribute(name = "accession", required = true)
 	protected String accession;
+
 	@XmlAttribute(name = "name", required = true)
 	protected String name;
+
 	@XmlAttribute(name = "version", required = true)
 	protected String version;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SoftwareType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SoftwareType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -31,6 +31,7 @@ public class SoftwareType {
 
 	@XmlElement(required = true)
 	protected SoftwareParamType softwareParam;
+
 	@XmlAttribute(name = "id", required = true)
 	@XmlJavaTypeAdapter(CollapsedStringAdapter.class)
 	@XmlID

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SourceFileListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SourceFileListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ public class SourceFileListType {
 
 	@XmlElement(required = true)
 	protected List<SourceFileType> sourceFile;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SourceFileRefListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SourceFileRefListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,6 +27,7 @@ import jakarta.xml.bind.annotation.XmlType;
 public class SourceFileRefListType {
 
 	protected List<SourceFileRefType> sourceFileRef;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SourceFileType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SourceFileType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,8 +33,10 @@ public class SourceFileType extends ParamGroupType {
 	@XmlID
 	@XmlSchemaType(name = "ID")
 	protected String id;
+
 	@XmlAttribute(name = "name", required = true)
 	protected String name;
+
 	@XmlAttribute(name = "location", required = true)
 	@XmlSchemaType(name = "anyURI")
 	protected String location;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SpectrumListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SpectrumListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,6 +30,7 @@ import jakarta.xml.bind.annotation.XmlType;
 public class SpectrumListType {
 
 	protected List<SpectrumType> spectrum;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SpectrumType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/SpectrumType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -34,25 +34,33 @@ public class SpectrumType extends ParamGroupType {
 
 	@XmlElement(required = true)
 	protected SpectrumDescriptionType spectrumDescription;
+
 	protected BinaryDataArrayListType binaryDataArrayList;
+
 	@XmlAttribute(name = "id", required = true)
 	@XmlJavaTypeAdapter(CollapsedStringAdapter.class)
 	@XmlID
 	@XmlSchemaType(name = "ID")
 	protected String id;
+
 	@XmlAttribute(name = "nativeID", required = true)
 	protected String nativeID;
+
 	@XmlAttribute(name = "spotID")
 	protected String spotID;
+
 	@XmlAttribute(name = "index", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger index;
+
 	@XmlAttribute(name = "defaultArrayLength", required = true)
 	protected int defaultArrayLength;
+
 	@XmlAttribute(name = "dataProcessingRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	protected Object dataProcessingRef;
+
 	@XmlAttribute(name = "sourceFileRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/TargetListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/TargetListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ public class TargetListType {
 
 	@XmlElement(required = true)
 	protected List<ParamGroupType> target;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	protected BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/UserParamType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v10/UserParamType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -28,14 +28,19 @@ public class UserParamType {
 
 	@XmlAttribute(name = "name", required = true)
 	protected String name;
+
 	@XmlAttribute(name = "type")
 	protected String type;
+
 	@XmlAttribute(name = "value")
 	protected String value;
+
 	@XmlAttribute(name = "unitAccession")
 	protected String unitAccession;
+
 	@XmlAttribute(name = "unitName")
 	protected String unitName;
+
 	@XmlAttribute(name = "unitCvRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/BinaryDataArrayListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/BinaryDataArrayListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,6 +29,7 @@ public class BinaryDataArrayListType {
 
 	@XmlElement(required = true)
 	private List<BinaryDataArrayType> binaryDataArray;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/BinaryDataArrayType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/BinaryDataArrayType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -28,13 +28,16 @@ public class BinaryDataArrayType extends ParamGroupType {
 
 	@XmlElement(required = true)
 	private byte[] binary;
+
 	@XmlAttribute(name = "arrayLength")
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger arrayLength; // optional, may override defaultArrayLength, not to be used for m/z, intensity and time
+
 	@XmlAttribute(name = "dataProcessingRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	private Object dataProcessingRef;
+
 	@XmlAttribute(name = "encodedLength", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger encodedLength;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/CVListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/CVListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,6 +29,7 @@ public class CVListType {
 
 	@XmlElement(required = true)
 	private List<CVType> cv;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/CVParamType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/CVParamType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,16 +27,22 @@ public class CVParamType {
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	private CVType cvRef;
+
 	@XmlAttribute(name = "accession", required = true)
 	private String accession;
+
 	@XmlAttribute(name = "value")
 	private String value;
+
 	@XmlAttribute(name = "name", required = true)
 	private String name;
+
 	@XmlAttribute(name = "unitAccession")
 	private String unitAccession;
+
 	@XmlAttribute(name = "unitName")
 	private String unitName;
+
 	@XmlAttribute(name = "unitCvRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/CVType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/CVType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,10 +30,13 @@ public class CVType {
 	@XmlID
 	@XmlSchemaType(name = "ID")
 	private String id;
+
 	@XmlAttribute(name = "fullName", required = true)
 	private String fullName;
+
 	@XmlAttribute(name = "version")
 	private String version;
+
 	@XmlAttribute(name = "URI", required = true)
 	@XmlSchemaType(name = "anyURI")
 	private String uri;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ChromatogramListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ChromatogramListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,9 +30,11 @@ public class ChromatogramListType {
 
 	@XmlElement(required = true)
 	private List<ChromatogramType> chromatogram;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;
+
 	@XmlAttribute(name = "defaultDataProcessingRef", required = true)
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ChromatogramType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ChromatogramType.java
@@ -19,11 +19,13 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlIDREF;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "ChromatogramType", propOrder = {"precursor", "product", "binaryDataArrayList"})
+@XmlRootElement(name = "chromatogram")
 public class ChromatogramType extends ParamGroupType {
 
 	private PrecursorType precursor;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ChromatogramType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ChromatogramType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,16 +27,22 @@ import jakarta.xml.bind.annotation.XmlType;
 public class ChromatogramType extends ParamGroupType {
 
 	private PrecursorType precursor;
+
 	private ProductType product;
+
 	@XmlElement(required = true)
 	private BinaryDataArrayListType binaryDataArrayList;
+
 	@XmlAttribute(name = "id", required = true)
 	private String id;
+
 	@XmlAttribute(name = "index", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger index;
+
 	@XmlAttribute(name = "defaultArrayLength", required = true)
 	private int defaultArrayLength;
+
 	@XmlAttribute(name = "dataProcessingRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ComponentListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ComponentListType.java
@@ -29,10 +29,13 @@ public class ComponentListType {
 
 	@XmlElement(required = true)
 	private List<SourceComponentType> source;
+
 	@XmlElement(required = true)
 	private List<AnalyzerComponentType> analyzer;
+
 	@XmlElement(required = true)
 	private List<DetectorComponentType> detector;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ComponentType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ComponentType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/DataProcessingListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/DataProcessingListType.java
@@ -29,6 +29,7 @@ public class DataProcessingListType {
 
 	@XmlElement(required = true)
 	private List<DataProcessingType> dataProcessing;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/DataProcessingType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/DataProcessingType.java
@@ -31,6 +31,7 @@ public class DataProcessingType {
 
 	@XmlElement(required = true)
 	private List<ProcessingMethodType> processingMethod;
+
 	@XmlAttribute(name = "id", required = true)
 	@XmlJavaTypeAdapter(CollapsedStringAdapter.class)
 	@XmlID

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/DetectorComponentType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/DetectorComponentType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/FileDescriptionType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/FileDescriptionType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,7 +26,9 @@ public class FileDescriptionType {
 
 	@XmlElement(required = true)
 	private ParamGroupType fileContent;
+
 	private SourceFileListType sourceFileList;
+
 	private List<ParamGroupType> contact;
 
 	public ParamGroupType getFileContent() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/InstrumentConfigurationListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/InstrumentConfigurationListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,6 +29,7 @@ public class InstrumentConfigurationListType {
 
 	@XmlElement(required = true)
 	private List<InstrumentConfigurationType> instrumentConfiguration;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/InstrumentConfigurationType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/InstrumentConfigurationType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,12 +27,15 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 public class InstrumentConfigurationType extends ParamGroupType {
 
 	private ComponentListType componentList;
+
 	private SoftwareRefType softwareRef;
+
 	@XmlAttribute(name = "id", required = true)
 	@XmlJavaTypeAdapter(CollapsedStringAdapter.class)
 	@XmlID
 	@XmlSchemaType(name = "ID")
 	private String id;
+
 	@XmlAttribute(name = "scanSettingsRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/MzMLType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/MzMLType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,25 +27,37 @@ import jakarta.xml.bind.annotation.XmlType;
 public class MzMLType implements Serializable {
 
 	private static final long serialVersionUID = 110L;
+
 	@XmlElement(required = true)
 	private CVListType cvList;
+
 	@XmlElement(required = true)
 	private FileDescriptionType fileDescription;
+
 	private ReferenceableParamGroupListType referenceableParamGroupList;
+
 	private SampleListType sampleList;
+
 	@XmlElement(required = true)
 	private SoftwareListType softwareList;
+
 	private ScanSettingsListType scanSettingsList;
+
 	@XmlElement(required = true)
 	private InstrumentConfigurationListType instrumentConfigurationList;
+
 	@XmlElement(required = true)
 	private DataProcessingListType dataProcessingList;
+
 	@XmlElement(required = true)
 	private RunType run;
+
 	@XmlAttribute(name = "accession")
 	private String accession;
+
 	@XmlAttribute(name = "version", required = true)
 	private String version;
+
 	@XmlAttribute(name = "id")
 	private String id;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ParamGroupType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ParamGroupType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/PrecursorListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/PrecursorListType.java
@@ -29,6 +29,7 @@ public class PrecursorListType {
 
 	@XmlElement(required = true)
 	private List<PrecursorType> precursor;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/PrecursorType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/PrecursorType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -25,15 +25,20 @@ import jakarta.xml.bind.annotation.XmlType;
 public class PrecursorType {
 
 	private ParamGroupType isolationWindow;
+
 	private SelectedIonListType selectedIonList;
+
 	@XmlElement(required = true)
 	private ParamGroupType activation;
+
 	@XmlAttribute(name = "spectrumRef")
 	private String spectrumRef;
+
 	@XmlAttribute(name = "sourceFileRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	private Object sourceFileRef;
+
 	@XmlAttribute(name = "externalSpectrumID")
 	private String externalSpectrumID;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ProcessingMethodType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ProcessingMethodType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -28,6 +28,7 @@ public class ProcessingMethodType extends ParamGroupType {
 	@XmlAttribute(name = "order", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger order;
+
 	@XmlAttribute(name = "softwareRef", required = true)
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ProductListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ProductListType.java
@@ -29,6 +29,7 @@ public class ProductListType {
 
 	@XmlElement(required = true)
 	private List<ProductType> product;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ReferenceableParamGroupListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ReferenceableParamGroupListType.java
@@ -29,6 +29,7 @@ public class ReferenceableParamGroupListType {
 
 	@XmlElement(required = true)
 	private List<ReferenceableParamGroupType> referenceableParamGroup;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ReferenceableParamGroupType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ReferenceableParamGroupType.java
@@ -29,7 +29,9 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 public class ReferenceableParamGroupType {
 
 	private List<CVParamType> cvParam;
+
 	private List<UserParamType> userParam;
+
 	@XmlAttribute(name = "id", required = true)
 	@XmlJavaTypeAdapter(CollapsedStringAdapter.class)
 	@XmlID

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/RunType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/RunType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,24 +29,30 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 public class RunType extends ParamGroupType {
 
 	private SpectrumListType spectrumList;
+
 	private ChromatogramListType chromatogramList;
+
 	@XmlAttribute(name = "id", required = true)
 	@XmlJavaTypeAdapter(CollapsedStringAdapter.class)
 	@XmlID
 	@XmlSchemaType(name = "ID")
 	private String id;
+
 	@XmlAttribute(name = "defaultInstrumentConfigurationRef", required = true)
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	private InstrumentConfigurationType defaultInstrumentConfigurationRef;
+
 	@XmlAttribute(name = "defaultSourceFileRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	private SourceFileType defaultSourceFileRef;
+
 	@XmlAttribute(name = "sampleRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	private SampleType sampleRef;
+
 	@XmlAttribute(name = "startTimeStamp")
 	@XmlSchemaType(name = "dateTime")
 	private XMLGregorianCalendar startTimeStamp;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SampleListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SampleListType.java
@@ -29,6 +29,7 @@ public class SampleListType {
 
 	@XmlElement(required = true)
 	private List<SampleType> sample;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SampleType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SampleType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,6 +30,7 @@ public class SampleType extends ParamGroupType {
 	@XmlID
 	@XmlSchemaType(name = "ID")
 	private String id;
+
 	@XmlAttribute(name = "name")
 	private String name;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ScanListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ScanListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,6 +29,7 @@ public class ScanListType extends ParamGroupType {
 
 	@XmlElement(required = true)
 	private List<ScanType> scan;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ScanSettingsListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ScanSettingsListType.java
@@ -29,6 +29,7 @@ public class ScanSettingsListType {
 
 	@XmlElement(required = true)
 	private List<ScanSettingsType> scanSettings;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ScanSettingsType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ScanSettingsType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,7 +26,9 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 public class ScanSettingsType extends ParamGroupType {
 
 	private SourceFileRefListType sourceFileRefList;
+
 	private TargetListType targetList;
+
 	@XmlAttribute(name = "id", required = true)
 	@XmlJavaTypeAdapter(CollapsedStringAdapter.class)
 	@XmlID

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ScanType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ScanType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,14 +24,18 @@ import jakarta.xml.bind.annotation.XmlType;
 public class ScanType extends ParamGroupType {
 
 	private ScanWindowListType scanWindowList;
+
 	@XmlAttribute(name = "spectrumRef")
 	private String spectrumRef;
+
 	@XmlAttribute(name = "sourceFileRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	private Object sourceFileRef;
+
 	@XmlAttribute(name = "externalSpectrumID")
 	private String externalSpectrumID;
+
 	@XmlAttribute(name = "instrumentConfigurationRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ScanWindowListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ScanWindowListType.java
@@ -27,6 +27,7 @@ public class ScanWindowListType {
 
 	@XmlElement(required = true)
 	private List<ParamGroupType> scanWindow;
+
 	@XmlAttribute(name = "count", required = true)
 	private int count;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SelectedIonListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SelectedIonListType.java
@@ -29,6 +29,7 @@ public class SelectedIonListType {
 
 	@XmlElement(required = true)
 	private List<ParamGroupType> selectedIon;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SoftwareListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SoftwareListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,6 +29,7 @@ public class SoftwareListType {
 
 	@XmlElement(required = true)
 	private List<SoftwareType> software;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SoftwareType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SoftwareType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,6 +30,7 @@ public class SoftwareType extends ParamGroupType {
 	@XmlID
 	@XmlSchemaType(name = "ID")
 	private String id;
+
 	@XmlAttribute(name = "version", required = true)
 	private String version;
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SourceFileListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SourceFileListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,6 +29,7 @@ public class SourceFileListType {
 
 	@XmlElement(required = true)
 	private List<SourceFileType> sourceFile;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SourceFileRefListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SourceFileRefListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,6 +27,7 @@ import jakarta.xml.bind.annotation.XmlType;
 public class SourceFileRefListType {
 
 	private List<SourceFileRefType> sourceFileRef;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SourceFileType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SourceFileType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,8 +30,10 @@ public class SourceFileType extends ParamGroupType {
 	@XmlID
 	@XmlSchemaType(name = "ID")
 	private String id;
+
 	@XmlAttribute(name = "name", required = true)
 	private String name;
+
 	@XmlAttribute(name = "location", required = true)
 	@XmlSchemaType(name = "anyURI")
 	private String location;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SpectrumListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SpectrumListType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -28,9 +28,11 @@ import jakarta.xml.bind.annotation.XmlType;
 public class SpectrumListType {
 
 	private List<SpectrumType> spectrum;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;
+
 	@XmlAttribute(name = "defaultDataProcessingRef", required = true)
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SpectrumType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SpectrumType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,22 +26,31 @@ import jakarta.xml.bind.annotation.XmlType;
 public class SpectrumType extends ParamGroupType {
 
 	private ScanListType scanList;
+
 	private PrecursorListType precursorList;
+
 	private ProductListType productList;
+
 	private BinaryDataArrayListType binaryDataArrayList;
+
 	@XmlAttribute(name = "id", required = true)
 	private String id;
+
 	@XmlAttribute(name = "spotID")
 	private String spotID;
+
 	@XmlAttribute(name = "index", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger") // zero based
 	private BigInteger index;
+
 	@XmlAttribute(name = "defaultArrayLength", required = true)
 	private int defaultArrayLength;
+
 	@XmlAttribute(name = "dataProcessingRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")
 	private Object dataProcessingRef;
+
 	@XmlAttribute(name = "sourceFileRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SpectrumType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/SpectrumType.java
@@ -18,11 +18,13 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlIDREF;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "SpectrumType", propOrder = {"scanList", "precursorList", "productList", "binaryDataArrayList"})
+@XmlRootElement(name = "spectrum")
 public class SpectrumType extends ParamGroupType {
 
 	private ScanListType scanList;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/TargetListType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/TargetListType.java
@@ -29,6 +29,7 @@ public class TargetListType {
 
 	@XmlElement(required = true)
 	private List<ParamGroupType> target;
+
 	@XmlAttribute(name = "count", required = true)
 	@XmlSchemaType(name = "nonNegativeInteger")
 	private BigInteger count;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/UserParamType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/UserParamType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -25,14 +25,19 @@ public class UserParamType {
 
 	@XmlAttribute(name = "name", required = true)
 	private String name;
+
 	@XmlAttribute(name = "type")
 	private String type;
+
 	@XmlAttribute(name = "value")
 	private String value;
+
 	@XmlAttribute(name = "unitAccession")
 	private String unitAccession;
+
 	@XmlAttribute(name = "unitName")
 	private String unitName;
+
 	@XmlAttribute(name = "unitCvRef")
 	@XmlIDREF
 	@XmlSchemaType(name = "IDREF")

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/IndexedChromatogramImportConverterTinyProteoWizard110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/IndexedChromatogramImportConverterTinyProteoWizard110_ITest.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorChromatogram;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorChromatogram;
+import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class IndexedChromatogramImportConverterTinyProteoWizard110_ITest {
+
+	private IVendorChromatogram chromatogram;
+
+	@BeforeAll
+	public void setUp() {
+
+		File importFile = new File("testData/files/import/tiny.pwiz.1.1.mzML");
+		ChromatogramImportConverterIndexed converter = new ChromatogramImportConverterIndexed();
+		IProcessingInfo<IChromatogramMSD> processingInfo = converter.convert(importFile, new NullProgressMonitor());
+		chromatogram = (VendorChromatogram)processingInfo.getProcessingResult();
+	}
+
+	@Test
+	public void testInstrument() {
+
+		assertEquals("LCQ Deca", chromatogram.getInstrument());
+	}
+
+	@Test
+	public void testSample() {
+
+		assertEquals("Sample 1", chromatogram.getSampleName());
+	}
+
+	@Test
+	public void testOperator() {
+
+		assertEquals("William Pennington, Higglesworth University, 12 Higglesworth Avenue, 12045, HI, USA, http://www.higglesworth.edu/, wpennington@higglesworth.edu", chromatogram.getOperator());
+	}
+
+	@Test
+	public void testEditHistory() {
+
+		assertEquals("deisotoping", chromatogram.getEditHistory().get(0).getDescription());
+		assertEquals("charge deconvolution", chromatogram.getEditHistory().get(1).getDescription());
+		assertEquals("peak picking", chromatogram.getEditHistory().get(2).getDescription());
+		assertEquals("Conversion to mzML", chromatogram.getEditHistory().get(3).getDescription());
+	}
+
+	@Test
+	public void testNumberOfScans() {
+
+		assertEquals(4, chromatogram.getNumberOfScans());
+	}
+
+	@Test
+	public void testStartRetentionTime() {
+
+		assertEquals(353430, chromatogram.getStartRetentionTime());
+	}
+
+	@Test
+	public void testStopRetentionTime() {
+
+		assertEquals(42050, chromatogram.getStopRetentionTime());
+	}
+
+	@Test
+	public void testTotalSignal() {
+
+		assertEquals(350.0f, chromatogram.getTotalSignal(), 0);
+	}
+
+	@Test
+	public void testMaxIonAbundance() {
+
+		assertEquals(20.0f, chromatogram.getMaxIonAbundance(), 0);
+	}
+
+	@Test
+	public void testFirstScan() {
+
+		IRegularMassSpectrum massSpectrum = (IRegularMassSpectrum)chromatogram.getScan(1);
+		// assertEquals(Polarity.POSITIVE, massSpectrum.getPolarity()); // TODO ChromatogramReaderVersion110.setReferencedPolarity
+		assertEquals("scan=19", massSpectrum.getIdentifier());
+		assertEquals(15, massSpectrum.getNumberOfIons(), "Ions");
+		assertEquals(15f, massSpectrum.getIon(0).getAbundance(), 0);
+		assertEquals(14f, massSpectrum.getIon(1).getAbundance(), 0);
+		assertEquals(13f, massSpectrum.getIon(2).getAbundance(), 0);
+		assertEquals(12f, massSpectrum.getIon(3).getAbundance(), 0);
+		assertEquals(11f, massSpectrum.getIon(4).getAbundance(), 0);
+		assertEquals(10f, massSpectrum.getIon(5).getAbundance(), 0);
+		assertEquals(9f, massSpectrum.getIon(6).getAbundance(), 0);
+		assertEquals(8f, massSpectrum.getIon(7).getAbundance(), 0);
+		assertEquals(7f, massSpectrum.getIon(8).getAbundance(), 0);
+		assertEquals(6f, massSpectrum.getIon(9).getAbundance(), 0);
+		assertEquals(5f, massSpectrum.getIon(10).getAbundance(), 0);
+		assertEquals(4f, massSpectrum.getIon(11).getAbundance(), 0);
+		assertEquals(3f, massSpectrum.getIon(12).getAbundance(), 0);
+		assertEquals(2f, massSpectrum.getIon(13).getAbundance(), 0);
+		assertEquals(1f, massSpectrum.getIon(14).getAbundance(), 0);
+	}
+}


### PR DESCRIPTION
Indexed mzML is an extension from @hupo-psi that adds random access capabilities to mzML by adding file offsets at the end. This is a first step into reading support which is useful for large files.