### PR TITLE
Fix Data Explorer ignoring the user selected import supplier

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/workbench/EditorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/workbench/EditorSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,6 +20,7 @@ public class EditorSupport {
 	 * Use: Map<HeaderField, String>
 	 */
 	public static final String MAP_HEADER_MAP = "HeaderMap"; //$NON-NLS-1$
+	public static final String MAP_SUPPLIER_ID = "SupplierId"; //$NON-NLS-1$
 
 	private EditorSupport() {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/ISupplierFileEditorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/ISupplierFileEditorSupport.java
@@ -86,6 +86,11 @@ public interface ISupplierFileEditorSupport extends ISupplierFileIdentifier {
 
 	default void openEditor(File file, Object object, String elementId, String contributionURI, String iconURI, String tooltip, Map<HeaderField, String> headerMap, boolean batch) {
 
+		openEditor(file, object, elementId, contributionURI, iconURI, tooltip, headerMap, null, batch);
+	}
+
+	default void openEditor(File file, Object object, String elementId, String contributionURI, String iconURI, String tooltip, Map<HeaderField, String> headerMap, String supplierId, boolean batch) {
+
 		EModelService modelService = Activator.getDefault().getModelService();
 		MApplication application = Activator.getDefault().getApplication();
 		EPartService partService = Activator.getDefault().getPartService();
@@ -175,6 +180,7 @@ public interface ISupplierFileEditorSupport extends ISupplierFileIdentifier {
 					map.put(EditorSupport.MAP_FILE, file.getAbsolutePath());
 					map.put(EditorSupport.MAP_BATCH, batch);
 					map.put(EditorSupport.MAP_HEADER_MAP, headerMap);
+					map.put(EditorSupport.MAP_SUPPLIER_ID, supplierId);
 					part.setObject(map);
 					part.setLabel(file.getName());
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
@@ -358,7 +358,8 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 				 */
 				File file = new File((String)map.get(EditorSupport.MAP_FILE));
 				boolean batch = (boolean)map.get(EditorSupport.MAP_BATCH);
-				chromatogramSelection = loadChromatogramSelection(file, batch);
+				String supplierId = (String)map.get(EditorSupport.MAP_SUPPLIER_ID);
+				chromatogramSelection = loadChromatogramSelection(file, supplierId, batch);
 				if(chromatogramSelection != null) {
 					IChromatogram chromatogram = chromatogramSelection.getChromatogram();
 					if(map.get(EditorSupport.MAP_HEADER_MAP) instanceof Map headerMap) {
@@ -395,11 +396,11 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 		return chromatogramSelection;
 	}
 
-	private synchronized IChromatogramSelection loadChromatogramSelection(File file, boolean batch) throws ChromatogramIsNullException {
+	private synchronized IChromatogramSelection loadChromatogramSelection(File file, String supplierId, boolean batch) throws ChromatogramIsNullException {
 
 		IChromatogramSelection chromatogramSelection = null;
 		ProgressMonitorDialog dialog = new ProgressMonitorDialog(shell);
-		ChromatogramImportRunnable runnable = new ChromatogramImportRunnable(file, dataType);
+		ChromatogramImportRunnable runnable = new ChromatogramImportRunnable(file, dataType, supplierId);
 
 		try {
 			/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/runnables/ChromatogramImportRunnable.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/runnables/ChromatogramImportRunnable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -48,11 +48,19 @@ public class ChromatogramImportRunnable implements IRunnableWithProgress {
 
 	private List<File> files = new ArrayList<>();
 	private DataType dataType;
+	private String supplierId;
 	private List<IChromatogramSelection> chromatogramSelections = new ArrayList<>();
 
 	public ChromatogramImportRunnable(File file, DataType dataType) {
 
-		this(Arrays.asList(file), dataType);
+		this(file, dataType, null);
+	}
+
+	public ChromatogramImportRunnable(File file, DataType dataType, String supplierId) {
+
+		this.files.addAll(Arrays.asList(file));
+		this.dataType = dataType;
+		this.supplierId = supplierId;
 	}
 
 	public ChromatogramImportRunnable(List<File> files, DataType dataType) {
@@ -90,31 +98,56 @@ public class ChromatogramImportRunnable implements IRunnableWithProgress {
 					case MSD_TANDEM:
 					case MSD_HIGHRES:
 					case MSD:
-						IProcessingInfo<IChromatogramMSD> processingInfoMSD = ChromatogramConverterMSD.getInstance().convert(file, monitor);
+						IProcessingInfo<IChromatogramMSD> processingInfoMSD;
+						if(supplierId != null) {
+							processingInfoMSD = ChromatogramConverterMSD.getInstance().convert(file, supplierId, monitor);
+						} else {
+							processingInfoMSD = ChromatogramConverterMSD.getInstance().convert(file, monitor);
+						}
 						ProcessingInfoPartSupport.getInstance().update(processingInfoMSD);
 						IChromatogramMSD chromatogramMSD = processingInfoMSD.getProcessingResult();
 						chromatogramSelections.add(new ChromatogramSelectionMSD(chromatogramMSD, fireUpdate));
 						break;
 					case CSD:
-						IProcessingInfo<IChromatogramCSD> processingInfoCSD = ChromatogramConverterCSD.getInstance().convert(file, monitor);
+						IProcessingInfo<IChromatogramCSD> processingInfoCSD;
+						if(supplierId != null) {
+							processingInfoCSD = ChromatogramConverterCSD.getInstance().convert(file, supplierId, monitor);
+						} else {
+							processingInfoCSD = ChromatogramConverterCSD.getInstance().convert(file, monitor);
+						}
 						ProcessingInfoPartSupport.getInstance().update(processingInfoCSD);
 						IChromatogramCSD chromatogramCSD = processingInfoCSD.getProcessingResult();
 						chromatogramSelections.add(new ChromatogramSelectionCSD(chromatogramCSD, fireUpdate));
 						break;
 					case WSD:
-						IProcessingInfo<IChromatogramWSD> processingInfoWSD = ChromatogramConverterWSD.getInstance().convert(file, monitor);
+						IProcessingInfo<IChromatogramWSD> processingInfoWSD;
+						if(supplierId != null) {
+							processingInfoWSD = ChromatogramConverterWSD.getInstance().convert(file, supplierId, monitor);
+						} else {
+							processingInfoWSD = ChromatogramConverterWSD.getInstance().convert(file, monitor);
+						}
 						ProcessingInfoPartSupport.getInstance().update(processingInfoWSD);
 						IChromatogramWSD chromatogramWSD = processingInfoWSD.getProcessingResult();
 						chromatogramSelections.add(new ChromatogramSelectionWSD(chromatogramWSD, fireUpdate));
 						break;
 					case VSD:
-						IProcessingInfo<IChromatogramVSD> processingInfoVSD = ChromatogramConverterVSD.getInstance().convert(file, monitor);
+						IProcessingInfo<IChromatogramVSD> processingInfoVSD;
+						if(supplierId != null) {
+							processingInfoVSD = ChromatogramConverterVSD.getInstance().convert(file, supplierId, monitor);
+						} else {
+							processingInfoVSD = ChromatogramConverterVSD.getInstance().convert(file, monitor);
+						}
 						ProcessingInfoPartSupport.getInstance().update(processingInfoVSD);
 						IChromatogramVSD chromatogramVSD = processingInfoVSD.getProcessingResult();
 						chromatogramSelections.add(new ChromatogramSelectionVSD(chromatogramVSD, fireUpdate));
 						break;
 					case FSD:
-						IProcessingInfo<IChromatogramFSD> processingInfoFSD = ChromatogramConverterFSD.getInstance().convert(file, monitor);
+						IProcessingInfo<IChromatogramFSD> processingInfoFSD;
+						if(supplierId != null) {
+							processingInfoFSD = ChromatogramConverterFSD.getInstance().convert(file, supplierId, monitor);
+						} else {
+							processingInfoFSD = ChromatogramConverterFSD.getInstance().convert(file, monitor);
+						}
 						ProcessingInfoPartSupport.getInstance().update(processingInfoFSD);
 						IChromatogramFSD chromatogramFSD = processingInfoFSD.getProcessingResult();
 						chromatogramSelections.add(new ChromatogramSelectionFSD(chromatogramFSD, fireUpdate));

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/part/support/SupplierEditorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/part/support/SupplierEditorSupport.java
@@ -195,7 +195,12 @@ public class SupplierEditorSupport extends AbstractSupplierFileEditorSupport imp
 			parameterContext.dispose();
 		}
 
-		return openEditor(file, headerMap, false);
+		if(isSupplierFile(file)) {
+			refreshEditorReferences();
+			openEditor(file, null, elementId, contributionURI, iconURI, tooltip, headerMap, supplier.getId(), false);
+			return true;
+		}
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
For example since https://github.com/eclipse-chemclipse/chemclipse/pull/2946 we now have two suppliers to open the same file. There is a right-click menu, but the user choice was ignored. It always used the first in the (top of the plugin.xml) no matter your choosing. This fixes it by passing through the chosen supplier.

The same bug also appears for other data types. I just limited the scope to chromatograms to keep the diff more manageable.