### PR TITLE
Update jaxb-osgi to 4.0.9

### DIFF
--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -28,12 +28,12 @@
 	<unit id="org.eclipse.jdt.junit6.runtime"/>
 	<repository location="https://download.eclipse.org/releases/2026-06/"/>
 </location>
-<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="com.sun.xml.bind.jaxb-osgi" missingManifest="error" type="Maven">
+<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="false" label="com.sun.xml.bind.jaxb-osgi" missingManifest="error" type="Maven">
 	<dependencies>
 		<dependency>
 			<groupId>com.sun.xml.bind</groupId>
 			<artifactId>jaxb-osgi</artifactId>
-			<version>4.0.8</version>
+			<version>4.0.9</version>
 			<type>jar</type>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Version 4.0.9 contains fix for
https://github.com/eclipse-ee4j/jaxb-ri/issues/1970 . Also don't include the source bundle in the target platform just to be double sure.