### PR TITLE
Avoid ion transitions in MS1 spectra to save memory

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/converter/model/VendorIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/converter/model/VendorIon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 Lablicate GmbH.
+ * Copyright (c) 2022, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mmass.converter.model;
 
 import org.eclipse.chemclipse.msd.model.core.AbstractIon;
-import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 
 public class VendorIon extends AbstractIon implements IVendorIon {
 
@@ -21,15 +20,10 @@ public class VendorIon extends AbstractIon implements IVendorIon {
 	 * Renew the serialVersionUID any time you have changed some fields or
 	 * methods.
 	 */
-	private static final long serialVersionUID = 8373011421208386797L;
+	private static final long serialVersionUID = 8373011421208386798L;
 
 	public VendorIon(double ion, float abundance) {
 
 		super(ion, abundance);
-	}
-
-	public VendorIon(double ion, float abundance, IIonTransition ionTransition) {
-
-		super(ion, abundance, ionTransition);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion104.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion104.java
@@ -40,6 +40,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorChromat
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -126,7 +127,7 @@ public class ChromatogramReaderVersion104 extends AbstractChromatogramReader {
 			if(massSpectrum.getPrecursorIon() != 0) {
 				double collisionEnergy = getCollisionEnergy(spectrum.getAcqDesc());
 				IIonTransition ionTransition = new IonTransition(massSpectrum.getPrecursorIon(), mz[index], collisionEnergy, 1, 1, 0);
-				massSpectrum.addIon(new VendorIon(mz[index], intensity, ionTransition), false);
+				massSpectrum.addIon(new VendorIonMSn(mz[index], intensity, ionTransition), false);
 				chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
 			} else {
 				massSpectrum.addIon(new VendorIon(mz[index], intensity), false);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion105.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion105.java
@@ -40,6 +40,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorChromat
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
@@ -143,7 +144,7 @@ public class ChromatogramReaderVersion105 extends AbstractChromatogramReader {
 			if(massSpectrum.getPrecursorIon() != 0) {
 				double collisionEnergy = getCollisionEnergy(spectrum.getSpectrumDesc());
 				IIonTransition ionTransition = new IonTransition(massSpectrum.getPrecursorIon(), mz[index], collisionEnergy, 1, 1, 0);
-				massSpectrum.addIon(new VendorIon(mz[index], intensity, ionTransition), false);
+				massSpectrum.addIon(new VendorIonMSn(mz[index], intensity, ionTransition), false);
 				chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
 			} else {
 				massSpectrum.addIon(new VendorIon(mz[index], intensity), false);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/model/IVendorIonMSn.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/model/IVendorIonMSn.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzdata.model;
+
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
+
+public interface IVendorIonMSn extends IIonMSn {
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/model/VendorIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/model/VendorIon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mzdata.model;
 
 import org.eclipse.chemclipse.msd.model.core.AbstractIon;
-import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 
 public class VendorIon extends AbstractIon implements IVendorIon {
 
@@ -21,15 +20,10 @@ public class VendorIon extends AbstractIon implements IVendorIon {
 	 * Renew the serialVersionUID any time you have changed some fields or
 	 * methods.
 	 */
-	private static final long serialVersionUID = 2317506100290058045L;
+	private static final long serialVersionUID = 2317506100290058046L;
 
 	public VendorIon(double ion, float abundance) {
 
 		super(ion, abundance);
-	}
-
-	public VendorIon(double ion, float abundance, IIonTransition ionTransition) {
-
-		super(ion, abundance, ionTransition);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/model/VendorIonMSn.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/model/VendorIonMSn.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Philip Wenig - initial API and implementation
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzdata.model;
+
+import org.eclipse.chemclipse.msd.model.core.AbstractIonMSn;
+import org.eclipse.chemclipse.msd.model.core.IIonTransition;
+
+public class VendorIonMSn extends AbstractIonMSn implements IVendorIon {
+
+	/**
+	 * Renew the serialVersionUID any time you have changed some fields or
+	 * methods.
+	 */
+	private static final long serialVersionUID = -1963037036476879340L;
+
+	public VendorIonMSn(double ion, float abundance, IIonTransition ionTransition) {
+
+		super(ion, abundance, ionTransition);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion20.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion20.java
@@ -34,6 +34,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorChromato
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
@@ -176,7 +177,7 @@ public class ChromatogramReaderVersion20 extends AbstractChromatogramReader {
 			if(massSpectrum.getMassSpectrometer() >= 2) {
 				float collisionEnergy = scan.getCollisionEnergy() != null ? scan.getCollisionEnergy().floatValue() : 0f;
 				IIonTransition ionTransition = new IonTransition(massSpectrum.getPrecursorIon(), mz, collisionEnergy, 1, 1, 0);
-				massSpectrum.addIon(new VendorIon(mz, intensity, ionTransition), false);
+				massSpectrum.addIon(new VendorIonMSn(mz, intensity, ionTransition), false);
 				chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
 			} else {
 				massSpectrum.addIon(new VendorIon(mz, intensity), false);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion21.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion21.java
@@ -34,6 +34,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorChromato
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
@@ -176,7 +177,7 @@ public class ChromatogramReaderVersion21 extends AbstractChromatogramReader {
 			if(massSpectrum.getMassSpectrometer() >= 2) {
 				float collisionEnergy = scan.getCollisionEnergy() != null ? scan.getCollisionEnergy().floatValue() : 0f;
 				IIonTransition ionTransition = new IonTransition(massSpectrum.getPrecursorIon(), mz, collisionEnergy, 1, 1, 0);
-				massSpectrum.addIon(new VendorIon(mz, intensity, ionTransition), false);
+				massSpectrum.addIon(new VendorIonMSn(mz, intensity, ionTransition), false);
 				chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
 			} else {
 				massSpectrum.addIon(new VendorIon(mz, intensity), false);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion22.java
@@ -34,6 +34,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorChromato
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
@@ -176,7 +177,7 @@ public class ChromatogramReaderVersion22 extends AbstractChromatogramReader {
 			if(massSpectrum.getMassSpectrometer() >= 2) {
 				float collisionEnergy = scan.getCollisionEnergy() != null ? scan.getCollisionEnergy().floatValue() : 0f;
 				IIonTransition ionTransition = new IonTransition(massSpectrum.getPrecursorIon(), mz, collisionEnergy, 1, 1, 0);
-				massSpectrum.addIon(new VendorIon(mz, intensity, ionTransition), false);
+				massSpectrum.addIon(new VendorIonMSn(mz, intensity, ionTransition), false);
 				chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
 			} else {
 				massSpectrum.addIon(new VendorIon(mz, intensity), false);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion30.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion30.java
@@ -35,6 +35,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorChromato
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
@@ -155,7 +156,7 @@ public class ChromatogramReaderVersion30 extends AbstractChromatogramReader {
 						if(msLevel >= 2) {
 							float collisionEnergy = scan.getCollisionEnergy() != null ? scan.getCollisionEnergy().floatValue() : 0f;
 							IIonTransition ionTransition = new IonTransition(massSpectrum.getPrecursorIon(), mz, collisionEnergy, 1, 1, 0);
-							massSpectrum.addIon(new VendorIon(mz, intensity, ionTransition), false);
+							massSpectrum.addIon(new VendorIonMSn(mz, intensity, ionTransition), false);
 							chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
 						} else {
 							massSpectrum.addIon(new VendorIon(mz, intensity), false);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion31.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion31.java
@@ -35,6 +35,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorChromato
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
@@ -155,7 +156,7 @@ public class ChromatogramReaderVersion31 extends AbstractChromatogramReader {
 						if(msLevel >= 2) {
 							float collisionEnergy = scan.getCollisionEnergy() != null ? scan.getCollisionEnergy().floatValue() : 0f;
 							IIonTransition ionTransition = new IonTransition(massSpectrum.getPrecursorIon(), mz, collisionEnergy, 1, 1, 0);
-							massSpectrum.addIon(new VendorIon(mz, intensity, ionTransition), false);
+							massSpectrum.addIon(new VendorIonMSn(mz, intensity, ionTransition), false);
 							chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
 						} else {
 							massSpectrum.addIon(new VendorIon(mz, intensity), false);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion32.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion32.java
@@ -37,6 +37,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorChromato
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
@@ -158,7 +159,7 @@ public class ChromatogramReaderVersion32 extends AbstractChromatogramReader {
 						if(msLevel >= 2) {
 							float collisionEnergy = scan.getCollisionEnergy() != null ? scan.getCollisionEnergy().floatValue() : 0f;
 							IIonTransition ionTransition = new IonTransition(massSpectrum.getPrecursorIon(), mz, collisionEnergy, 1, 1, 0);
-							massSpectrum.addIon(new VendorIon(mz, intensity, ionTransition), false);
+							massSpectrum.addIon(new VendorIonMSn(mz, intensity, ionTransition), false);
 							chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
 						} else {
 							massSpectrum.addIon(new VendorIon(mz, intensity), false);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/model/IVendorIonMSn.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/model/IVendorIonMSn.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzxml.model;
+
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
+
+public interface IVendorIonMSn extends IIonMSn {
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/model/VendorIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/model/VendorIon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mzxml.model;
 
 import org.eclipse.chemclipse.msd.model.core.AbstractIon;
-import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 
 public class VendorIon extends AbstractIon implements IVendorIon {
 
@@ -21,7 +20,7 @@ public class VendorIon extends AbstractIon implements IVendorIon {
 	 * Renew the serialVersionUID any time you have changed some fields or
 	 * methods.
 	 */
-	private static final long serialVersionUID = 7041172932689251592L;
+	private static final long serialVersionUID = 7041172932689251593L;
 
 	public VendorIon(double ion) {
 
@@ -31,10 +30,5 @@ public class VendorIon extends AbstractIon implements IVendorIon {
 	public VendorIon(double ion, float abundance) {
 
 		super(ion, abundance);
-	}
-
-	public VendorIon(double ion, float abundance, IIonTransition ionTransition) {
-
-		super(ion, abundance, ionTransition);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/model/VendorIonMSn.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/model/VendorIonMSn.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzxml.model;
+
+import org.eclipse.chemclipse.msd.model.core.AbstractIonMSn;
+import org.eclipse.chemclipse.msd.model.core.IIonTransition;
+
+public class VendorIonMSn extends AbstractIonMSn implements IVendorIonMSn {
+
+	/**
+	 * Renew the serialVersionUID any time you have changed some fields or
+	 * methods.
+	 */
+	private static final long serialVersionUID = -8939009897048287120L;
+
+	public VendorIonMSn(double ion, float abundance, IIonTransition ionTransition) {
+
+		super(ion, abundance, ionTransition);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIon.java
@@ -30,12 +30,11 @@ public abstract class AbstractIon implements IIon {
 	 * Renew the serialVersionUID any time you have changed some fields or
 	 * methods.
 	 */
-	private static final long serialVersionUID = -2481473608026036078L;
+	private static final long serialVersionUID = -2481473608026036079L;
 	private static final int MAX_PRECISION = 6;
 
 	private double ion = 0.0d;
 	private float abundance = 0.0f;
-	private IIonTransition ionTransition;
 
 	protected AbstractIon(double ion) {
 
@@ -58,27 +57,6 @@ public abstract class AbstractIon implements IIon {
 		setAbundance(abundance);
 	}
 
-	protected AbstractIon(double ion, float abundance, IIonTransition ionTransition) throws NullPointerException {
-
-		/*
-		 * Why is setIon(ion) ... used here instead of this.ion = ion?<br/> The
-		 * methods setIon(float ion) and setAbundance(float abundance) are
-		 * overridden by AbstractSupplierIon. Why?<br/> We do not
-		 * actually know which range of ion and abundance values each supplier
-		 * does support. Therefore the methods are overridden in
-		 * AbstractSupplierIon.<br/> Depending on the value range each
-		 * implementation of ISupplierIon has declared, the values will
-		 * be accepted or an exception will be thrown.
-		 */
-		setIon(ion);
-		setAbundance(abundance);
-		if(ionTransition != null) {
-			this.ionTransition = ionTransition;
-		} else {
-			throw new NullPointerException("The given ion transition instance should be not null.");
-		}
-	}
-
 	protected AbstractIon(IIon ion) throws IllegalArgumentException {
 
 		/*
@@ -96,26 +74,6 @@ public abstract class AbstractIon implements IIon {
 			setAbundance(ion.getAbundance());
 		} else {
 			throw new IllegalArgumentException("The given ion instance should be not null.");
-		}
-	}
-
-	protected AbstractIon(IIon ion, IIonTransition ionTransition) throws IllegalArgumentException {
-
-		/*
-		 * Why is setIon(ion) ... used here instead of this.ion = ion?<br/> The
-		 * methods setIon(float ion) and setAbundance(float abundance) are
-		 * overridden by AbstractSupplierIon. Why?<br/> We do not
-		 * actually know which range of ion and abundance values each supplier
-		 * does support. Therefore the methods are overridden in
-		 * AbstractSupplierIon.<br/> Depending on the value range each
-		 * implementation of ISupplierIon has declared, the values will
-		 * be accepted or an exception will be thrown.
-		 */
-		this(ion);
-		if(ionTransition != null) {
-			this.ionTransition = ionTransition;
-		} else {
-			throw new IllegalArgumentException("The given ion transition instance should be not null.");
 		}
 	}
 
@@ -199,12 +157,6 @@ public abstract class AbstractIon implements IIon {
 		return true;
 	}
 
-	@Override
-	public IIonTransition getIonTransition() {
-
-		return ionTransition;
-	}
-
 	/**
 	 * Compares the mass/charge ration of two ions. Returns the
 	 * following values: a.compareTo(b) 0 a == b : 28 == 28 -1 a &lt; b : 18 &lt; 28
@@ -235,17 +187,13 @@ public abstract class AbstractIon implements IIon {
 			return false;
 		}
 		AbstractIon other = (AbstractIon)otherObject;
-		return ion == other.getIon() && abundance == other.getAbundance() && ionTransition == other.getIonTransition();
+		return ion == other.getIon() && abundance == other.getAbundance();
 	}
 
 	@Override
 	public int hashCode() {
 
-		int ionTransitionHashCode = 0;
-		if(ionTransition != null) {
-			ionTransitionHashCode = ionTransition.hashCode();
-		}
-		return 7 * Double.valueOf(ion).hashCode() + 11 * Float.valueOf(abundance).hashCode() + ionTransitionHashCode;
+		return 7 * Double.valueOf(ion).hashCode() + 11 * Float.valueOf(abundance).hashCode();
 	}
 
 	@Override
@@ -257,8 +205,6 @@ public abstract class AbstractIon implements IIon {
 		builder.append("ion=" + ion);
 		builder.append(",");
 		builder.append("abundance=" + abundance);
-		builder.append(",");
-		builder.append("ionTransition=" + ionTransition);
 		builder.append("]");
 		return builder.toString();
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIonMSn.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIonMSn.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Philip Wenig - initial API and implementation
+ * Alexander Kerner - implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.model.core;
+
+import java.util.Objects;
+
+public abstract class AbstractIonMSn extends AbstractIon implements IIonMSn {
+
+	private static final long serialVersionUID = 7699261561713484081L;
+
+	private IIonTransition ionTransition;
+
+	protected AbstractIonMSn(double ion, float abundance, IIonTransition ionTransition) throws NullPointerException {
+
+		/*
+		 * Why is setIon(ion) ... used here instead of this.ion = ion?<br/> The
+		 * methods setIon(float ion) and setAbundance(float abundance) are
+		 * overridden by AbstractSupplierIon. Why?<br/> We do not
+		 * actually know which range of ion and abundance values each supplier
+		 * does support. Therefore the methods are overridden in
+		 * AbstractSupplierIon.<br/> Depending on the value range each
+		 * implementation of ISupplierIon has declared, the values will
+		 * be accepted or an exception will be thrown.
+		 */
+		super(ion, abundance);
+		if(ionTransition != null) {
+			this.ionTransition = ionTransition;
+		} else {
+			throw new NullPointerException("The given ion transition instance should be not null.");
+		}
+	}
+
+	protected AbstractIonMSn(IIon ion, IIonTransition ionTransition) throws IllegalArgumentException {
+
+		/*
+		 * Why is setIon(ion) ... used here instead of this.ion = ion?<br/> The
+		 * methods setIon(float ion) and setAbundance(float abundance) are
+		 * overridden by AbstractSupplierIon. Why?<br/> We do not
+		 * actually know which range of ion and abundance values each supplier
+		 * does support. Therefore the methods are overridden in
+		 * AbstractSupplierIon.<br/> Depending on the value range each
+		 * implementation of ISupplierIon has declared, the values will
+		 * be accepted or an exception will be thrown.
+		 */
+		super(ion);
+		if(ionTransition != null) {
+			this.ionTransition = ionTransition;
+		} else {
+			throw new IllegalArgumentException("The given ion transition instance should be not null.");
+		}
+	}
+
+	@Override
+	public IIonTransition getIonTransition() {
+
+		return ionTransition;
+	}
+
+	@Override
+	public boolean equals(Object otherObject) {
+
+		if(this == otherObject) {
+			return true;
+		}
+		if(otherObject == null) {
+			return false;
+		}
+		if(getClass() != otherObject.getClass()) {
+			return false;
+		}
+		AbstractIonMSn other = (AbstractIonMSn)otherObject;
+		return getIon() == other.getIon() && getAbundance() == other.getAbundance() && Objects.equals(ionTransition, other.getIonTransition());
+	}
+
+	@Override
+	public int hashCode() {
+
+		int ionTransitionHashCode = 0;
+		if(ionTransition != null) {
+			ionTransitionHashCode = ionTransition.hashCode();
+		}
+		return super.hashCode() + ionTransitionHashCode;
+	}
+
+	@Override
+	public String toString() {
+
+		StringBuilder builder = new StringBuilder();
+		builder.append(getClass().getName());
+		builder.append("[");
+		builder.append("ion=" + getIon());
+		builder.append(",");
+		builder.append("abundance=" + getAbundance());
+		builder.append(",");
+		builder.append("ionTransition=" + ionTransition);
+		builder.append("]");
+		return builder.toString();
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractScanMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractScanMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.chemclipse.logging.core.Logger;
@@ -726,7 +727,7 @@ public abstract class AbstractScanMSD extends AbstractScan implements IScanMSD {
 		int limit = (ionsList.size() > 30) ? 30 : ionsList.size();
 		for(int i = 0; i < limit; i++) {
 			IIon ion = ionsList.get(i);
-			if(ion.getIonTransition() != null) {
+			if(ion instanceof IIonMSn ionMSn && ionMSn.getIonTransition() != null) {
 				return true;
 			}
 		}
@@ -912,25 +913,25 @@ public abstract class AbstractScanMSD extends AbstractScan implements IScanMSD {
 
 	private boolean checkIon(IIon ion1, IIon ion2) {
 
-		if(ion1 != null && ion2 != null) {
-			if(ion1.getIon() == ion2.getIon()) {
-				/*
-				 * If it is the same ion, the ion transitions could be different.
-				 */
-				IIonTransition ionTransition1 = ion1.getIonTransition();
-				IIonTransition ionTransition2 = ion2.getIonTransition();
-				if(ionTransition1 == null && ionTransition2 == null) {
-					return true;
-				} else {
-					if(ionTransition1 == null) {
-						return ionTransition2.equals(ionTransition1);
-					} else {
-						return ionTransition1.equals(ionTransition2);
-					}
-				}
-			}
+		if(ion1 == null || ion2 == null) {
+			return false;
 		}
 
-		return false;
+		if(Double.compare(ion1.getIon(), ion2.getIon()) != 0) {
+			return false;
+		}
+
+		// Both MSn: compare transitions too
+		if(ion1 instanceof IIonMSn msnIon1 && ion2 instanceof IIonMSn msnIon2) {
+			return Objects.equals(msnIon1.getIonTransition(), msnIon2.getIonTransition());
+		}
+
+		// Mixed MS1/MSn at same m/z are NOT the same ion
+		if((ion1 instanceof IIonMSn) ^ (ion2 instanceof IIonMSn)) {
+			return false;
+		}
+
+		// Both are MS1 ions at same m/z
+		return true;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IIon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,7 @@ package org.eclipse.chemclipse.msd.model.core;
 import org.eclipse.core.runtime.IAdaptable;
 
 /**
- * This Interface declares a simple ion.<br/>
+ * This Interface declares a simple MS1 ion.<br/>
  * For example:<br/>
  * Nitrogen: N2<br/>
  * ion -> 28.00<br/>
@@ -74,12 +74,4 @@ public interface IIon extends IIonSerializable, IAdaptable, Comparable<IIon> {
 	 * @return true if the value is valid
 	 */
 	boolean setAbundance(float abundance);
-
-	/**
-	 * Returns the ion transition.
-	 * If no triple quadrupole / ion transition is used, null will be returned.
-	 *
-	 * @return {@link IIonTransition}
-	 */
-	IIonTransition getIonTransition();
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IIonMSn.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IIonMSn.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Philip Wenig - initial API and implementation
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.model.core;
+
+/**
+ * This interface declares an ion from an MS experiment with fragmentation steps.
+ */
+public interface IIonMSn extends IIon {
+
+	IIonTransition getIonTransition();
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/Ion.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/Ion.java
@@ -14,7 +14,6 @@ package org.eclipse.chemclipse.msd.model.implementation;
 
 import org.eclipse.chemclipse.msd.model.core.AbstractIon;
 import org.eclipse.chemclipse.msd.model.core.IIon;
-import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 
 /**
  * If a new ion type should be implemented, extend the abstract class {@link AbstractIon} and not this class.
@@ -25,7 +24,7 @@ public class Ion extends AbstractIon {
 	 * Renew the serialVersionUID any time you have changed some fields or
 	 * methods.
 	 */
-	private static final long serialVersionUID = -1398709539024021636L;
+	private static final long serialVersionUID = -1398709539024021637L;
 
 	public Ion(double ion) {
 
@@ -40,15 +39,5 @@ public class Ion extends AbstractIon {
 	public Ion(IIon ion) {
 
 		super(ion);
-	}
-
-	public Ion(double ion, float abundance, IIonTransition ionTransition) {
-
-		super(ion, abundance, ionTransition);
-	}
-
-	public Ion(IIon ion, IIonTransition ionTransition) {
-
-		super(ion, ionTransition);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/IonMSn.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/implementation/IonMSn.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Philip Wenig - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.model.implementation;
+
+import org.eclipse.chemclipse.msd.model.core.AbstractIonMSn;
+import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonTransition;
+
+/**
+ * If a new ion type should be implemented, extend the abstract class {@link AbstractIonMSn} and not this class.
+ */
+public class IonMSn extends AbstractIonMSn {
+
+	/**
+	 * Renew the serialVersionUID any time you have changed some fields or
+	 * methods.
+	 */
+	private static final long serialVersionUID = -2534953352415243410L;
+
+	public IonMSn(double ion, float abundance, IIonTransition ionTransition) {
+
+		super(ion, abundance, ionTransition);
+	}
+
+	public IonMSn(IIon ion, IIonTransition ionTransition) {
+
+		super(ion, ionTransition);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/support/ScanSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/support/ScanSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.eclipse.chemclipse.msd.model.core.AbstractIon;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.support.text.ValueFormat;
@@ -36,14 +37,16 @@ public class ScanSupport {
 
 		String label = "";
 		if(ion != null) {
-			IIonTransition ionTransition = ion.getIonTransition();
 			StringBuilder builder = new StringBuilder();
-			if(ionTransition != null) {
-				builder.append(ionTransition.getQ1Ion());
-				builder.append(" > ");
-				builder.append(ValueFormat.getDecimalFormatEnglish("0.0").format(ion.getIon()));
-				builder.append(" @");
-				builder.append((int)ionTransition.getCollisionEnergy());
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition != null) {
+					builder.append(ionTransition.getQ1Ion());
+					builder.append(" > ");
+					builder.append(ValueFormat.getDecimalFormatEnglish("0.0").format(ion.getIon()));
+					builder.append(" @");
+					builder.append((int)ionTransition.getCollisionEnergy());
+				}
 			} else {
 				builder.append(ion.getIon());
 			}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/support/TandemDataSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/support/TandemDataSupport.java
@@ -27,6 +27,7 @@ import org.eclipse.chemclipse.model.support.ChromatogramSupport;
 import org.eclipse.chemclipse.model.support.HeaderUtil;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.implementation.ChromatogramMSD;
@@ -74,7 +75,7 @@ public class TandemDataSupport {
 					 */
 					for(TraceTandemMSD trace : traces) {
 						for(IIon ion : scanMSD.getIons()) {
-							if(matches(trace, ion)) {
+							if(ion instanceof IIonMSn ionMSn && matches(trace, ionMSn)) {
 								/*
 								 * Collect
 								 */
@@ -123,7 +124,7 @@ public class TandemDataSupport {
 		return chromatograms;
 	}
 
-	private static boolean matches(TraceTandemMSD trace, IIon ion) {
+	private static boolean matches(TraceTandemMSD trace, IIonMSn ion) {
 
 		IIonTransition ionTransition = ion.getIonTransition();
 		if(ionTransition != null) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/provider/IonListLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/provider/IonListLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,7 @@ package org.eclipse.chemclipse.msd.swt.ui.internal.provider;
 
 import java.text.DecimalFormat;
 
-import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
@@ -47,7 +47,7 @@ public class IonListLabelProvider extends AbstractChemClipseLabelProvider {
 		 */
 		DecimalFormat decimalFormat = getDecimalFormat();
 		String text = "";
-		if(element instanceof IIon ion) {
+		if(element instanceof IIonMSn ion) {
 			IIonTransition ionTransition = ion.getIonTransition();
 			switch(columnIndex) {
 				case 0: // m/z (normal 28.3 or with Transition 128 > 78.4)

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/provider/IonListTableComparator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/internal/provider/IonListTableComparator.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.swt.ui.internal.provider;
 
-import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.support.ui.swt.AbstractRecordTableComparator;
 import org.eclipse.jface.viewers.Viewer;
@@ -26,7 +26,7 @@ public class IonListTableComparator extends AbstractRecordTableComparator {
 		 * SYNCHRONIZE: PeakListLabelProvider PeakListLabelComparator PeakListView
 		 */
 		int sortOrder = 0;
-		if(e1 instanceof IIon ion1 && e2 instanceof IIon ion2) {
+		if(e1 instanceof IIonMSn ion1 && e2 instanceof IIonMSn ion2) {
 			IIonTransition ionTransition1 = ion1.getIonTransition();
 			IIonTransition ionTransition2 = ion2.getIonTransition();
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/ScanLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/ScanLabelProvider.java
@@ -19,6 +19,7 @@ import org.eclipse.chemclipse.fsd.model.core.IScanSignalFSD;
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.model.types.DataType;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
@@ -166,7 +167,7 @@ public class ScanLabelProvider extends ColumnLabelProvider implements ITableLabe
 	private String getTandemMSD(Object element, int columnIndex) {
 
 		String text = "";
-		if(element instanceof IIon ion) {
+		if(element instanceof IIonMSn ion) {
 			IIonTransition ionTransition = ion.getIonTransition();
 			switch(columnIndex) {
 				case 0:

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/ScanSignalListFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/ScanSignalListFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,7 @@ package org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider;
 
 import org.eclipse.chemclipse.csd.model.core.IScanCSD;
 import org.eclipse.chemclipse.fsd.model.core.IScanSignalFSD;
-import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.vsd.model.core.ISignalVSD;
 import org.eclipse.chemclipse.wsd.model.core.IScanSignalWSD;
@@ -52,7 +52,7 @@ public class ScanSignalListFilter extends ViewerFilter {
 			searchText = searchText.toLowerCase();
 		}
 
-		if(element instanceof IIon ion) {
+		if(element instanceof IIonMSn ion) {
 			IIonTransition ionTransition = ion.getIonTransition();
 			if(ionTransition != null) {
 				if(Double.toString(ionTransition.getQ3Ion()).contains(searchText)) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/ScanTableComparator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/ScanTableComparator.java
@@ -16,6 +16,7 @@ import org.eclipse.chemclipse.csd.model.core.IScanCSD;
 import org.eclipse.chemclipse.fsd.model.core.IScanSignalFSD;
 import org.eclipse.chemclipse.model.types.DataType;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.support.ui.swt.AbstractRecordTableComparator;
 import org.eclipse.chemclipse.vsd.model.core.ISignalVSD;
@@ -91,7 +92,7 @@ public class ScanTableComparator extends AbstractRecordTableComparator {
 	private int getTandemMSD(Object e1, Object e2) {
 
 		int sortOrder = 0;
-		if(e1 instanceof IIon ion1 && e2 instanceof IIon ion2) {
+		if(e1 instanceof IIonMSn ion1 && e2 instanceof IIonMSn ion2) {
 			IIonTransition ionTransition1 = ion1.getIonTransition();
 			IIonTransition ionTransition2 = ion2.getIonTransition();
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ScanChartUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,6 +24,7 @@ import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.types.DataType;
 import org.eclipse.chemclipse.model.types.SignalType;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
@@ -542,7 +543,9 @@ public class ScanChartUI extends ScrollableChart {
 			 */
 			if(scanMSD.isTandemMS()) {
 				for(IIon ion : scanMSD.getIons()) {
-					customLabels.put(ion.getIon(), ScanSupport.getLabelTandemMS(ion));
+					if(ion instanceof IIonMSn ionMSn) {
+						customLabels.put(ion.getIon(), ScanSupport.getLabelTandemMS(ionMSn));
+					}
 				}
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/IVendorIonMSn.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/IVendorIonMSn.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model;
+
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
+
+public interface IVendorIonMSn extends IIonMSn {
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/VendorIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/VendorIon.java
@@ -13,7 +13,6 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model;
 
 import org.eclipse.chemclipse.msd.model.core.AbstractIon;
-import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 
 public class VendorIon extends AbstractIon implements IVendorIon {
 
@@ -21,15 +20,10 @@ public class VendorIon extends AbstractIon implements IVendorIon {
 	 * Renew the serialVersionUID any time you have changed some fields or
 	 * methods.
 	 */
-	private static final long serialVersionUID = 3253925456712392898L;
+	private static final long serialVersionUID = 3253925456712392899L;
 
 	public VendorIon(double ion, float abundance) {
 
 		super(ion, abundance);
-	}
-
-	public VendorIon(double ion, float abundance, IIonTransition ionTransition) {
-
-		super(ion, abundance, ionTransition);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/VendorIonMSn.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/VendorIonMSn.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model;
+
+import org.eclipse.chemclipse.msd.model.core.AbstractIonMSn;
+import org.eclipse.chemclipse.msd.model.core.IIonTransition;
+
+public class VendorIonMSn extends AbstractIonMSn implements IVendorIonMSn {
+
+	/**
+	 * Renew the serialVersionUID any time you have changed some fields or
+	 * methods.
+	 */
+	private static final long serialVersionUID = -1863220538799859386L;
+
+	public VendorIonMSn(double ion, float abundance, IIonTransition ionTransition) {
+
+		super(ion, abundance, ionTransition);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramMSDReaderVersion10.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramMSDReaderVersion10.java
@@ -26,6 +26,7 @@ import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorChromatogramMSD;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorChromatogramMSD;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
@@ -220,7 +221,7 @@ public class ChromatogramMSDReaderVersion10 extends AbstractChromatogramReader i
 		for(int i = 0; i < ions; i++) {
 			if(selectedIon != 0) {
 				IIonTransition ionTransition = new IonTransition(selectedIon, mzs[i], collisionEnergy, 1, 1, 0);
-				massSpectrum.addIon(new VendorIon(mzs[i], (float)intensities[i], ionTransition), false);
+				massSpectrum.addIon(new VendorIonMSn(mzs[i], (float)intensities[i], ionTransition), false);
 				chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
 			} else {
 				massSpectrum.addIon(new VendorIon(mzs[i], (float)intensities[i]), false);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramMSDReaderVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramMSDReaderVersion110.java
@@ -26,8 +26,10 @@ import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.msd.converter.io.IChromatogramMSDReader;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorChromatogramMSD;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorChromatogramMSD;
 import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
@@ -199,7 +201,7 @@ public class ChromatogramMSDReaderVersion110 extends AbstractChromatogramReader 
 			int retentionTime = (int)(retentionTimes[i]);
 			massSpectrum.setRetentionTime(retentionTime);
 			float intensity = (float)intensities[i];
-			VendorIon ion = new VendorIon(ionTransition.getQ3Ion(), intensity, ionTransition);
+			IVendorIonMSn ion = new VendorIonMSn(ionTransition.getQ3Ion(), intensity, ionTransition);
 			massSpectrum.addIon(ion, false);
 			chromatogram.addScan(massSpectrum);
 		}
@@ -350,7 +352,7 @@ public class ChromatogramMSDReaderVersion110 extends AbstractChromatogramReader 
 		for(int i = 0; i < ions; i++) {
 			if(selectedIon != 0) {
 				IIonTransition ionTransition = new IonTransition(selectedIon, mzs[i], collisionEnergy, 1, 1, 0);
-				massSpectrum.addIon(new VendorIon(mzs[i], (float)intensities[i], ionTransition), false);
+				massSpectrum.addIon(new VendorIonMSn(mzs[i], (float)intensities[i], ionTransition), false);
 				chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
 			} else {
 				massSpectrum.addIon(new VendorIon(mzs[i], (float)intensities[i]), false);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0802.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0802.java
@@ -49,6 +49,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
@@ -58,6 +59,7 @@ import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.implementation.ChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.implementation.PeakMassSpectrum;
@@ -463,8 +465,8 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
+
 		}
 		return massSpectrum;
 	}
@@ -487,15 +489,12 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		return massSpectrum;
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -503,8 +502,10 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -519,9 +520,9 @@ public class ChromatogramReader_0802 extends AbstractChromatogramReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private boolean isValidFileFormat(ZipFile zipFile) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0803.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0803.java
@@ -50,6 +50,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
@@ -59,6 +60,7 @@ import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.implementation.ChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.implementation.PeakMassSpectrum;
@@ -506,8 +508,7 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		return massSpectrum;
 	}
@@ -530,15 +531,12 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		return massSpectrum;
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -546,8 +544,10 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -562,9 +562,9 @@ public class ChromatogramReader_0803 extends AbstractChromatogramReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private boolean isValidFileFormat(ZipFile zipFile) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0901.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0901.java
@@ -50,6 +50,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
@@ -59,6 +60,7 @@ import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.implementation.ChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.implementation.PeakMassSpectrum;
@@ -514,8 +516,7 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		return massSpectrum;
 	}
@@ -538,15 +539,12 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		return massSpectrum;
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -554,8 +552,10 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -570,9 +570,9 @@ public class ChromatogramReader_0901 extends AbstractChromatogramReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private boolean isValidFileFormat(ZipFile zipFile) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0902.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0902.java
@@ -52,6 +52,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
@@ -61,6 +62,7 @@ import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.implementation.ChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.implementation.PeakMassSpectrum;
@@ -527,8 +529,7 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		return massSpectrum;
 	}
@@ -551,15 +552,12 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		return massSpectrum;
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -567,8 +565,10 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -583,9 +583,9 @@ public class ChromatogramReader_0902 extends AbstractChromatogramReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private boolean isValidFileFormat(ZipFile zipFile) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0903.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_0903.java
@@ -52,6 +52,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
@@ -61,6 +62,7 @@ import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.implementation.ChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.implementation.PeakMassSpectrum;
@@ -530,8 +532,7 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		return massSpectrum;
 	}
@@ -554,15 +555,12 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		return massSpectrum;
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -570,8 +568,10 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -586,9 +586,9 @@ public class ChromatogramReader_0903 extends AbstractChromatogramReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private boolean isValidFileFormat(ZipFile zipFile) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1001.java
@@ -52,6 +52,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
@@ -61,6 +62,7 @@ import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.implementation.ChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.implementation.PeakMassSpectrum;
@@ -528,8 +530,7 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		return massSpectrum;
 	}
@@ -552,15 +553,12 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		return massSpectrum;
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -568,8 +566,10 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -584,9 +584,9 @@ public class ChromatogramReader_1001 extends AbstractChromatogramReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private boolean isValidFileFormat(ZipFile zipFile) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1002.java
@@ -56,6 +56,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
@@ -574,8 +575,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -603,8 +603,7 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -614,18 +613,18 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 		return massSpectrum;
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
 		/*
-		 * Ion Transitionimport org.eclipse.chemclipse.msd.converter.supplier.chemclipse.model.peak.IPeakMassSpectrum;
+		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -640,9 +639,9 @@ public class ChromatogramReader_1002 extends AbstractChromatogramReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private boolean isValidFileFormat(ZipFile zipFile) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1003.java
@@ -58,6 +58,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScanProxy;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -623,8 +624,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -634,9 +634,7 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		return massSpectrum;
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -644,8 +642,10 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -660,9 +660,9 @@ public class ChromatogramReader_1003 extends AbstractChromatogramReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private boolean isValidFileFormat(ZipFile zipFile) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1004.java
@@ -58,6 +58,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScanProxy;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -651,8 +652,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -660,9 +660,7 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -670,8 +668,10 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -686,9 +686,9 @@ public class ChromatogramReader_1004 extends AbstractChromatogramReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private boolean isValidFileFormat(ZipFile zipFile) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1005.java
@@ -59,6 +59,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScanProxy;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -672,8 +673,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -681,9 +681,7 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -691,8 +689,10 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -710,9 +710,9 @@ public class ChromatogramReader_1005 extends AbstractChromatogramReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private boolean isValidFileFormat(ZipFile zipFile) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1006.java
@@ -58,6 +58,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScanProxy;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -758,8 +759,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -767,9 +767,7 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -777,8 +775,10 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -796,9 +796,9 @@ public class ChromatogramReader_1006 extends AbstractChromatogramReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private boolean isValidFileFormat(ZipFile zipFile) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1007.java
@@ -58,6 +58,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScanProxy;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -743,8 +744,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -752,9 +752,7 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -762,8 +760,10 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -781,9 +781,9 @@ public class ChromatogramReader_1007 extends AbstractChromatogramReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private boolean isValidFileFormat(ZipFile zipFile) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1100.java
@@ -61,6 +61,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScanProxy;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -814,8 +815,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -823,9 +823,7 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -833,8 +831,10 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -852,9 +852,9 @@ public class ChromatogramReader_1100 extends AbstractChromatogramReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private boolean isValidFileFormat(ZipFile zipFile) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1300.java
@@ -69,6 +69,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScanProxy;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -810,8 +811,7 @@ public class ChromatogramReader_1300 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -819,9 +819,7 @@ public class ChromatogramReader_1300 extends AbstractChromatogramReader {
 		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -829,8 +827,10 @@ public class ChromatogramReader_1300 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -848,9 +848,9 @@ public class ChromatogramReader_1300 extends AbstractChromatogramReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private void readSeparationColumn(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1301.java
@@ -70,6 +70,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScanProxy;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -817,8 +818,7 @@ public class ChromatogramReader_1301 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -826,9 +826,7 @@ public class ChromatogramReader_1301 extends AbstractChromatogramReader {
 		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -836,8 +834,10 @@ public class ChromatogramReader_1301 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -855,9 +855,9 @@ public class ChromatogramReader_1301 extends AbstractChromatogramReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private void readSeparationColumn(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1400.java
@@ -74,6 +74,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScanProxy;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -879,8 +880,7 @@ public class ChromatogramReader_1400 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -888,9 +888,7 @@ public class ChromatogramReader_1400 extends AbstractChromatogramReader {
 		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -898,8 +896,10 @@ public class ChromatogramReader_1400 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -917,9 +917,9 @@ public class ChromatogramReader_1400 extends AbstractChromatogramReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private void readSeparationColumn(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1500.java
@@ -74,6 +74,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScanProxy;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -889,8 +890,7 @@ public class ChromatogramReader_1500 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -898,9 +898,7 @@ public class ChromatogramReader_1500 extends AbstractChromatogramReader {
 		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -908,8 +906,10 @@ public class ChromatogramReader_1500 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -927,9 +927,9 @@ public class ChromatogramReader_1500 extends AbstractChromatogramReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private void readSeparationColumn(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1501.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1501.java
@@ -55,6 +55,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScanProxy;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -649,8 +650,7 @@ public class ChromatogramReader_1501 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -658,9 +658,7 @@ public class ChromatogramReader_1501 extends AbstractChromatogramReader {
 		reader1501.readIdentificationTargets(dataInputStream, false, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -668,8 +666,10 @@ public class ChromatogramReader_1501 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -687,9 +687,9 @@ public class ChromatogramReader_1501 extends AbstractChromatogramReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private void readSeparationColumn(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1502.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramReader_1502.java
@@ -55,6 +55,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorScanProxy;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
@@ -650,8 +651,7 @@ public class ChromatogramReader_1502 extends AbstractChromatogramReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -659,9 +659,7 @@ public class ChromatogramReader_1502 extends AbstractChromatogramReader {
 		reader.readIdentificationTargets(dataInputStream, false, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -669,8 +667,10 @@ public class ChromatogramReader_1502 extends AbstractChromatogramReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -688,9 +688,9 @@ public class ChromatogramReader_1502 extends AbstractChromatogramReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private void readSeparationColumn(DataInputStream dataInputStream, boolean closeStream, IChromatogramMSD chromatogram) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0802.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0802.java
@@ -35,6 +35,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipW
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -316,22 +317,24 @@ public class ChromatogramWriter_0802 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0803.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0803.java
@@ -36,6 +36,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipW
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -344,22 +345,24 @@ public class ChromatogramWriter_0803 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0901.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0901.java
@@ -37,6 +37,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipW
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -345,22 +346,24 @@ public class ChromatogramWriter_0901 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0902.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0902.java
@@ -36,6 +36,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipW
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -344,22 +345,24 @@ public class ChromatogramWriter_0902 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0903.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_0903.java
@@ -36,6 +36,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipW
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -344,22 +345,24 @@ public class ChromatogramWriter_0903 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1001.java
@@ -36,6 +36,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipW
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -344,22 +345,24 @@ public class ChromatogramWriter_1001 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1002.java
@@ -37,6 +37,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipW
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -354,22 +355,24 @@ public class ChromatogramWriter_1002 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1003.java
@@ -38,6 +38,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipW
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -401,22 +402,24 @@ public class ChromatogramWriter_1003 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1004.java
@@ -38,6 +38,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipW
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -423,22 +424,24 @@ public class ChromatogramWriter_1004 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1005.java
@@ -39,6 +39,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipW
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -450,24 +451,26 @@ public class ChromatogramWriter_1005 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
-				dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+					dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1006.java
@@ -40,6 +40,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipW
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -466,24 +467,26 @@ public class ChromatogramWriter_1006 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
-				dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+					dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1007.java
@@ -40,6 +40,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipW
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -466,24 +467,26 @@ public class ChromatogramWriter_1007 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
-				dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+					dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1100.java
@@ -42,6 +42,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipW
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -478,24 +479,26 @@ public class ChromatogramWriter_1100 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
-				dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+					dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1300.java
@@ -51,6 +51,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipW
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -506,24 +507,26 @@ public class ChromatogramWriter_1300 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
-				dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+					dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1301.java
@@ -53,6 +53,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IChromatogramMSDZipW
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -506,24 +507,26 @@ public class ChromatogramWriter_1301 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
-				dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+					dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1400.java
@@ -56,6 +56,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.Vend
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -598,24 +599,26 @@ public class ChromatogramWriter_1400 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
-				dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+					dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1500.java
@@ -55,6 +55,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.Vend
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -601,24 +602,26 @@ public class ChromatogramWriter_1500 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
-				dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+					dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1501.java
@@ -49,6 +49,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.Vend
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -573,24 +574,26 @@ public class ChromatogramWriter_1501 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
-				dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+					dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1502.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ChromatogramWriter_1502.java
@@ -49,6 +49,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.Vend
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
@@ -569,24 +570,26 @@ public class ChromatogramWriter_1502 extends AbstractChromatogramWriter implemen
 			/*
 			 * Ion Transition
 			 */
-			IIonTransition ionTransition = ion.getIonTransition();
-			if(ionTransition == null) {
-				dataOutputStream.writeInt(0); // No ion transition available
-			} else {
-				/*
-				 * parent m/z start, ...
-				 */
-				dataOutputStream.writeInt(1); // Ion transition available
-				writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
-				dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
-				dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
-				dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
-				dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
-				dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
-				dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
-				dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
-				dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+			if(ion instanceof IIonMSn ionMSn) {
+				IIonTransition ionTransition = ionMSn.getIonTransition();
+				if(ionTransition == null) {
+					dataOutputStream.writeInt(0); // No ion transition available
+				} else {
+					/*
+					 * parent m/z start, ...
+					 */
+					dataOutputStream.writeInt(1); // Ion transition available
+					writeString(dataOutputStream, ionTransition.getCompoundName()); // compound name
+					dataOutputStream.writeDouble(ionTransition.getQ1StartIon()); // parent m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ1StopIon()); // parent m/z stop
+					dataOutputStream.writeDouble(ionTransition.getQ3StartIon()); // daughter m/z start
+					dataOutputStream.writeDouble(ionTransition.getQ3StopIon()); // daughter m/z stop
+					dataOutputStream.writeDouble(ionTransition.getCollisionEnergy()); // collision energy
+					dataOutputStream.writeDouble(ionTransition.getQ1Resolution()); // q1 resolution
+					dataOutputStream.writeDouble(ionTransition.getQ3Resolution()); // q3 resolution
+					dataOutputStream.writeInt(ionTransition.getTransitionGroup()); // transition group
+					dataOutputStream.writeInt(ionTransition.getDwell()); // dwell
+				}
 			}
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0802.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0802.java
@@ -39,12 +39,14 @@ import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeaksMSD;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.core.PeaksMSD;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransitionSettings;
@@ -162,15 +164,12 @@ public class PeakReader_0802 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		return massSpectrum;
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -178,8 +177,10 @@ public class PeakReader_0802 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -194,9 +195,9 @@ public class PeakReader_0802 extends AbstractZipReader implements IPeakReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0803.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0803.java
@@ -39,12 +39,14 @@ import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeaksMSD;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.core.PeaksMSD;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransitionSettings;
@@ -162,15 +164,12 @@ public class PeakReader_0803 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		return massSpectrum;
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -178,8 +177,10 @@ public class PeakReader_0803 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -194,9 +195,9 @@ public class PeakReader_0803 extends AbstractZipReader implements IPeakReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0901.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0901.java
@@ -39,12 +39,14 @@ import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeaksMSD;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.core.PeaksMSD;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransitionSettings;
@@ -162,15 +164,12 @@ public class PeakReader_0901 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		return massSpectrum;
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -178,8 +177,10 @@ public class PeakReader_0901 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -194,9 +195,9 @@ public class PeakReader_0901 extends AbstractZipReader implements IPeakReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0902.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0902.java
@@ -41,12 +41,14 @@ import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeaksMSD;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.core.PeaksMSD;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransitionSettings;
@@ -164,15 +166,12 @@ public class PeakReader_0902 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		return massSpectrum;
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -180,8 +179,10 @@ public class PeakReader_0902 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -196,9 +197,9 @@ public class PeakReader_0902 extends AbstractZipReader implements IPeakReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0903.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_0903.java
@@ -41,12 +41,14 @@ import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeaksMSD;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.core.PeaksMSD;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransitionSettings;
@@ -166,15 +168,12 @@ public class PeakReader_0903 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		return massSpectrum;
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -182,8 +181,10 @@ public class PeakReader_0903 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -198,9 +199,9 @@ public class PeakReader_0903 extends AbstractZipReader implements IPeakReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1001.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1001.java
@@ -41,12 +41,14 @@ import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeakMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.IPeakModelMSD;
 import org.eclipse.chemclipse.msd.model.core.IPeaksMSD;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.core.PeaksMSD;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransitionSettings;
@@ -166,15 +168,12 @@ public class PeakReader_1001 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		return massSpectrum;
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -182,8 +181,10 @@ public class PeakReader_1001 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -198,9 +199,9 @@ public class PeakReader_1001 extends AbstractZipReader implements IPeakReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1002.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1002.java
@@ -45,6 +45,7 @@ import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
@@ -171,8 +172,7 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -224,9 +224,7 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -234,8 +232,10 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -250,9 +250,9 @@ public class PeakReader_1002 extends AbstractZipReader implements IPeakReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1003.java
@@ -45,6 +45,7 @@ import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
@@ -171,8 +172,7 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -224,9 +224,7 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -234,8 +232,10 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -250,9 +250,9 @@ public class PeakReader_1003 extends AbstractZipReader implements IPeakReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1004.java
@@ -45,6 +45,7 @@ import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
@@ -195,8 +196,7 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -246,9 +246,7 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -256,8 +254,10 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -272,9 +272,9 @@ public class PeakReader_1004 extends AbstractZipReader implements IPeakReader {
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1005.java
@@ -45,6 +45,7 @@ import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
@@ -195,8 +196,7 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -246,9 +246,7 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -256,8 +254,10 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -275,9 +275,9 @@ public class PeakReader_1005 extends AbstractZipReader implements IPeakReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1006.java
@@ -45,6 +45,7 @@ import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
@@ -212,8 +213,7 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -285,9 +285,7 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -295,8 +293,10 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -314,9 +314,9 @@ public class PeakReader_1006 extends AbstractZipReader implements IPeakReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1007.java
@@ -45,6 +45,7 @@ import org.eclipse.chemclipse.model.quantitation.IQuantitationEntry;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
@@ -212,8 +213,7 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -280,9 +280,7 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -290,8 +288,10 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -309,9 +309,9 @@ public class PeakReader_1007 extends AbstractZipReader implements IPeakReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1100.java
@@ -47,6 +47,7 @@ import org.eclipse.chemclipse.model.quantitation.InternalStandard;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
@@ -240,8 +241,7 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -308,9 +308,7 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -318,8 +316,10 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -337,9 +337,9 @@ public class PeakReader_1100 extends AbstractZipReader implements IPeakReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1300.java
@@ -49,6 +49,7 @@ import org.eclipse.chemclipse.model.quantitation.InternalStandard;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
@@ -248,8 +249,7 @@ public class PeakReader_1300 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -320,9 +320,7 @@ public class PeakReader_1300 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -330,8 +328,10 @@ public class PeakReader_1300 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -349,9 +349,9 @@ public class PeakReader_1300 extends AbstractZipReader implements IPeakReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1301.java
@@ -49,6 +49,7 @@ import org.eclipse.chemclipse.model.quantitation.InternalStandard;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
@@ -248,8 +249,7 @@ public class PeakReader_1301 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -320,9 +320,7 @@ public class PeakReader_1301 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -330,8 +328,10 @@ public class PeakReader_1301 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -349,9 +349,9 @@ public class PeakReader_1301 extends AbstractZipReader implements IPeakReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1400.java
@@ -49,6 +49,7 @@ import org.eclipse.chemclipse.model.quantitation.InternalStandard;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
@@ -266,8 +267,7 @@ public class PeakReader_1400 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -340,9 +340,7 @@ public class PeakReader_1400 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -350,8 +348,10 @@ public class PeakReader_1400 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -369,9 +369,9 @@ public class PeakReader_1400 extends AbstractZipReader implements IPeakReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1500.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -49,6 +49,7 @@ import org.eclipse.chemclipse.model.quantitation.QuantitationFlag;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
@@ -266,8 +267,7 @@ public class PeakReader_1500 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -340,9 +340,7 @@ public class PeakReader_1500 extends AbstractZipReader implements IPeakReader {
 		}
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -350,8 +348,10 @@ public class PeakReader_1500 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -369,9 +369,9 @@ public class PeakReader_1500 extends AbstractZipReader implements IPeakReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1501.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1501.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -37,6 +37,7 @@ import org.eclipse.chemclipse.model.quantitation.QuantitationFlag;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
@@ -256,8 +257,7 @@ public class PeakReader_1501 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -265,9 +265,7 @@ public class PeakReader_1501 extends AbstractZipReader implements IPeakReader {
 		reader1501.readIdentificationTargets(dataInputStream, false, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -275,8 +273,10 @@ public class PeakReader_1501 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -294,9 +294,9 @@ public class PeakReader_1501 extends AbstractZipReader implements IPeakReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1502.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/PeakReader_1502.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -37,6 +37,7 @@ import org.eclipse.chemclipse.model.quantitation.QuantitationFlag;
 import org.eclipse.chemclipse.msd.converter.io.IPeakReader;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IPeakMSD;
@@ -257,8 +258,7 @@ public class PeakReader_1502 extends AbstractZipReader implements IPeakReader {
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -266,9 +266,7 @@ public class PeakReader_1502 extends AbstractZipReader implements IPeakReader {
 		reader.readIdentificationTargets(dataInputStream, false, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -276,8 +274,10 @@ public class PeakReader_1502 extends AbstractZipReader implements IPeakReader {
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -295,9 +295,9 @@ public class PeakReader_1502 extends AbstractZipReader implements IPeakReader {
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private List<IIntegrationEntry> readIntegrationEntries(DataInputStream dataInputStream) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1003.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1003.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -75,8 +76,7 @@ public class ReaderProxy_1003 extends AbstractZipReader implements IReaderProxy 
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -84,9 +84,7 @@ public class ReaderProxy_1003 extends AbstractZipReader implements IReaderProxy 
 		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -94,8 +92,10 @@ public class ReaderProxy_1003 extends AbstractZipReader implements IReaderProxy 
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -110,9 +110,9 @@ public class ReaderProxy_1003 extends AbstractZipReader implements IReaderProxy 
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1004.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1004.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVen
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -95,8 +96,7 @@ public class ReaderProxy_1004 extends AbstractZipReader implements IReaderProxy 
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -104,9 +104,7 @@ public class ReaderProxy_1004 extends AbstractZipReader implements IReaderProxy 
 		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -114,8 +112,10 @@ public class ReaderProxy_1004 extends AbstractZipReader implements IReaderProxy 
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -130,9 +130,9 @@ public class ReaderProxy_1004 extends AbstractZipReader implements IReaderProxy 
 			int transitionGroup = dataInputStream.readInt(); // transition group
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			VendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1005.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1005.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,9 +29,11 @@ import org.eclipse.chemclipse.model.identifier.LibraryInformation;
 import org.eclipse.chemclipse.model.implementation.IdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -95,8 +97,7 @@ public class ReaderProxy_1005 extends AbstractZipReader implements IReaderProxy 
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -104,9 +105,7 @@ public class ReaderProxy_1005 extends AbstractZipReader implements IReaderProxy 
 		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -114,8 +113,10 @@ public class ReaderProxy_1005 extends AbstractZipReader implements IReaderProxy 
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -133,9 +134,9 @@ public class ReaderProxy_1005 extends AbstractZipReader implements IReaderProxy 
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			IVendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1006.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1006.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,9 +30,11 @@ import org.eclipse.chemclipse.model.identifier.LibraryInformation;
 import org.eclipse.chemclipse.model.implementation.IdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -109,8 +111,7 @@ public class ReaderProxy_1006 extends AbstractZipReader implements IReaderProxy 
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -118,9 +119,7 @@ public class ReaderProxy_1006 extends AbstractZipReader implements IReaderProxy 
 		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -128,8 +127,10 @@ public class ReaderProxy_1006 extends AbstractZipReader implements IReaderProxy 
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -147,9 +148,9 @@ public class ReaderProxy_1006 extends AbstractZipReader implements IReaderProxy 
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			IVendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1007.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1007.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,9 +30,11 @@ import org.eclipse.chemclipse.model.identifier.LibraryInformation;
 import org.eclipse.chemclipse.model.implementation.IdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -109,8 +111,7 @@ public class ReaderProxy_1007 extends AbstractZipReader implements IReaderProxy 
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -118,9 +119,7 @@ public class ReaderProxy_1007 extends AbstractZipReader implements IReaderProxy 
 		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -128,8 +127,10 @@ public class ReaderProxy_1007 extends AbstractZipReader implements IReaderProxy 
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -147,9 +148,9 @@ public class ReaderProxy_1007 extends AbstractZipReader implements IReaderProxy 
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			IVendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1100.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,9 +30,11 @@ import org.eclipse.chemclipse.model.identifier.LibraryInformation;
 import org.eclipse.chemclipse.model.implementation.IdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -109,8 +111,7 @@ public class ReaderProxy_1100 extends AbstractZipReader implements IReaderProxy 
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -118,9 +119,7 @@ public class ReaderProxy_1100 extends AbstractZipReader implements IReaderProxy 
 		readMassSpectrumIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -128,8 +127,10 @@ public class ReaderProxy_1100 extends AbstractZipReader implements IReaderProxy 
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -147,9 +148,9 @@ public class ReaderProxy_1100 extends AbstractZipReader implements IReaderProxy 
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			IVendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private void readMassSpectrumIdentificationTargets(DataInputStream dataInputStream, IScanMSD massSpectrum) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1300.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1300.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,9 +30,11 @@ import org.eclipse.chemclipse.model.identifier.LibraryInformation;
 import org.eclipse.chemclipse.model.implementation.IdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -111,8 +113,7 @@ public class ReaderProxy_1300 extends AbstractZipReader implements IReaderProxy 
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -120,9 +121,7 @@ public class ReaderProxy_1300 extends AbstractZipReader implements IReaderProxy 
 		readScanIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -130,8 +129,10 @@ public class ReaderProxy_1300 extends AbstractZipReader implements IReaderProxy 
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -149,9 +150,9 @@ public class ReaderProxy_1300 extends AbstractZipReader implements IReaderProxy 
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			IVendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private void readScanIdentificationTargets(DataInputStream dataInputStream, IScanMSD scanMSD) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1301.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1301.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,9 +30,11 @@ import org.eclipse.chemclipse.model.identifier.LibraryInformation;
 import org.eclipse.chemclipse.model.implementation.IdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -111,8 +113,7 @@ public class ReaderProxy_1301 extends AbstractZipReader implements IReaderProxy 
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -120,9 +121,7 @@ public class ReaderProxy_1301 extends AbstractZipReader implements IReaderProxy 
 		readScanIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -130,8 +129,10 @@ public class ReaderProxy_1301 extends AbstractZipReader implements IReaderProxy 
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -149,9 +150,9 @@ public class ReaderProxy_1301 extends AbstractZipReader implements IReaderProxy 
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			IVendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private void readScanIdentificationTargets(DataInputStream dataInputStream, IScanMSD scanMSD) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1400.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1400.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,9 +30,11 @@ import org.eclipse.chemclipse.model.identifier.LibraryInformation;
 import org.eclipse.chemclipse.model.implementation.IdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -111,8 +113,7 @@ public class ReaderProxy_1400 extends AbstractZipReader implements IReaderProxy 
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -120,9 +121,7 @@ public class ReaderProxy_1400 extends AbstractZipReader implements IReaderProxy 
 		readScanIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -130,8 +129,10 @@ public class ReaderProxy_1400 extends AbstractZipReader implements IReaderProxy 
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -149,9 +150,9 @@ public class ReaderProxy_1400 extends AbstractZipReader implements IReaderProxy 
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			IVendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private void readScanIdentificationTargets(DataInputStream dataInputStream, IScanMSD scanMSD) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1500.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1500.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,9 +30,11 @@ import org.eclipse.chemclipse.model.identifier.LibraryInformation;
 import org.eclipse.chemclipse.model.implementation.IdentificationTarget;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -111,8 +113,7 @@ public class ReaderProxy_1500 extends AbstractZipReader implements IReaderProxy 
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -120,9 +121,7 @@ public class ReaderProxy_1500 extends AbstractZipReader implements IReaderProxy 
 		readScanIdentificationTargets(dataInputStream, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -130,8 +129,10 @@ public class ReaderProxy_1500 extends AbstractZipReader implements IReaderProxy 
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -149,9 +150,9 @@ public class ReaderProxy_1500 extends AbstractZipReader implements IReaderProxy 
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			IVendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private void readScanIdentificationTargets(DataInputStream dataInputStream, IScanMSD scanMSD) throws IOException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1501.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1501.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,9 +20,11 @@ import java.util.zip.ZipFile;
 import org.eclipse.chemclipse.model.columns.SeparationColumnFactory;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -102,8 +104,7 @@ public class ReaderProxy_1501 extends AbstractZipReader implements IReaderProxy 
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -111,9 +112,7 @@ public class ReaderProxy_1501 extends AbstractZipReader implements IReaderProxy 
 		reader1501.readIdentificationTargets(dataInputStream, false, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -121,8 +120,10 @@ public class ReaderProxy_1501 extends AbstractZipReader implements IReaderProxy 
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -140,9 +141,9 @@ public class ReaderProxy_1501 extends AbstractZipReader implements IReaderProxy 
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			IVendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private MassSpectrumType getMassSpectrumType(short massSpectrumType) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1502.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/internal/io/ReaderProxy_1502.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,9 +20,11 @@ import java.util.zip.ZipFile;
 import org.eclipse.chemclipse.model.columns.SeparationColumnFactory;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.io.IReaderProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorIonMSn;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.IVendorScanProxy;
 import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIon;
+import org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram.VendorIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IIonTransitionSettings;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
@@ -102,8 +104,7 @@ public class ReaderProxy_1502 extends AbstractZipReader implements IReaderProxy 
 			/*
 			 * Read Ions
 			 */
-			IVendorIon ion = readIon(dataInputStream, ionTransitionSettings);
-			massSpectrum.addIon(ion);
+			readIon(dataInputStream, ionTransitionSettings, massSpectrum);
 		}
 		/*
 		 * Identification Results
@@ -111,9 +112,7 @@ public class ReaderProxy_1502 extends AbstractZipReader implements IReaderProxy 
 		reader.readIdentificationTargets(dataInputStream, false, massSpectrum);
 	}
 
-	private IVendorIon readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings) throws IOException {
-
-		IVendorIon ion;
+	private void readIon(DataInputStream dataInputStream, IIonTransitionSettings ionTransitionSettings, IScanMSD massSpectrum) throws IOException {
 
 		double mz = dataInputStream.readDouble(); // m/z
 		float abundance = dataInputStream.readFloat(); // Abundance
@@ -121,8 +120,10 @@ public class ReaderProxy_1502 extends AbstractZipReader implements IReaderProxy 
 		 * Ion Transition
 		 */
 		int transition = dataInputStream.readInt();
+
 		if(transition == 0) {
-			ion = new VendorIon(mz, abundance);
+			IVendorIon ion = new VendorIon(mz, abundance);
+			massSpectrum.addIon(ion);
 		} else {
 			/*
 			 * parent m/z start, ...
@@ -140,9 +141,9 @@ public class ReaderProxy_1502 extends AbstractZipReader implements IReaderProxy 
 
 			IIonTransition ionTransition = ionTransitionSettings.getIonTransition(compoundName, filter1FirstIon, filter1LastIon, filter3FirstIon, filter3LastIon, collisionEnergy, filter1Resolution, filter3Resolution, transitionGroup);
 			ionTransition.setDwell(dwell);
-			ion = new VendorIon(mz, abundance, ionTransition);
+			IVendorIonMSn ion = new VendorIonMSn(mz, abundance, ionTransition);
+			massSpectrum.addIon(ion);
 		}
-		return ion;
 	}
 
 	private MassSpectrumType getMassSpectrumType(short massSpectrumType) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/model/chromatogram/IVendorIonMSn.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/model/chromatogram/IVendorIonMSn.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram;
+
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
+
+public interface IVendorIonMSn extends IIonMSn {
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/model/chromatogram/VendorIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/model/chromatogram/VendorIon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,11 +13,10 @@
 package org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram;
 
 import org.eclipse.chemclipse.msd.model.core.AbstractIon;
-import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 
 public class VendorIon extends AbstractIon implements IVendorIon {
 
-	private static final long serialVersionUID = -6328005534960551275L;
+	private static final long serialVersionUID = -6328005534960551276L;
 	/*
 	 * The max value for m/z
 	 */
@@ -27,10 +26,5 @@ public class VendorIon extends AbstractIon implements IVendorIon {
 	public VendorIon(double ion, float abundance) {
 
 		super(ion, abundance);
-	}
-
-	public VendorIon(double ion, float abundance, IIonTransition ionTransition) {
-
-		super(ion, abundance, ionTransition);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/model/chromatogram/VendorIonMSn.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/model/chromatogram/VendorIonMSn.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.converter.supplier.ocx.model.chromatogram;
+
+import org.eclipse.chemclipse.msd.model.core.AbstractIonMSn;
+import org.eclipse.chemclipse.msd.model.core.IIonTransition;
+
+public class VendorIonMSn extends AbstractIonMSn implements IVendorIonMSn {
+
+	private static final long serialVersionUID = 1363756417066258878L;
+
+	public VendorIonMSn(double ion, float abundance, IIonTransition ionTransition) {
+
+		super(ion, abundance, ionTransition);
+	}
+}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMyoDta104_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMyoDta104_ITest.java
@@ -21,6 +21,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -95,6 +96,7 @@ public class ChromatogramImportConverterMyoDta104_ITest {
 		assertEquals(331, massSpectrum.getNumberOfIons(), "Ions");
 		assertEquals(Polarity.POSITIVE, massSpectrum.getPolarity());
 		assertEquals(661.65d, massSpectrum.getPrecursorIon(), 0);
-		assertEquals(28d, massSpectrum.getIons().get(0).getIonTransition().getCollisionEnergy(), 0);
+		IIonMSn ionMSn = (IIonMSn)massSpectrum.getIons().get(0);
+		assertEquals(28d, ionMSn.getIonTransition().getCollisionEnergy(), 0);
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMyoDta105_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportConverterMyoDta105_ITest.java
@@ -21,6 +21,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -96,7 +97,8 @@ public class ChromatogramImportConverterMyoDta105_ITest {
 		assertEquals(331, massSpectrum.getNumberOfIons(), "Ions");
 		assertEquals(Polarity.POSITIVE, massSpectrum.getPolarity());
 		assertEquals(661.65d, massSpectrum.getPrecursorIon(), 0);
-		assertEquals(28d, massSpectrum.getIons().get(0).getIonTransition().getCollisionEnergy(), 0);
+		IIonMSn ionMSn = (IIonMSn)massSpectrum.getIons().get(0);
+		assertEquals(28d, ionMSn.getIonTransition().getCollisionEnergy(), 0);
 		assertEquals(MassSpectrumType.CENTROID, massSpectrum.getMassSpectrumType());
 	}
 }

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportTiny105_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramImportTiny105_ITest.java
@@ -21,6 +21,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorChromatogram;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.model.VendorScan;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -100,7 +101,8 @@ public class ChromatogramImportTiny105_ITest {
 		assertEquals(43, massSpectrum.getNumberOfIons(), "Ions");
 		assertEquals(356680, massSpectrum.getRetentionTime());
 		assertEquals(445.34668d, massSpectrum.getPrecursorIon(), 0);
-		assertEquals(35d, massSpectrum.getIons().get(0).getIonTransition().getCollisionEnergy(), 0);
+		IIonMSn ionMSn = (IIonMSn)massSpectrum.getIons().iterator().next();
+		assertEquals(35d, ionMSn.getIonTransition().getCollisionEnergy(), 0);
 		assertEquals(Polarity.POSITIVE, massSpectrum.getPolarity());
 		assertEquals(MassSpectrumType.PROFILE, massSpectrum.getMassSpectrumType());
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramImportConverterTinyMzXML20_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramImportConverterTinyMzXML20_ITest.java
@@ -20,6 +20,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorChromato
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorChromatogram;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -97,7 +98,8 @@ public class ChromatogramImportConverterTinyMzXML20_ITest {
 		assertEquals(2, massSpectrum.getMassSpectrometer(), "MS");
 		assertEquals(445.3500061035156, massSpectrum.getPrecursorIon(), 0, "Precursor");
 
-		IIonTransition ionTransition = massSpectrum.getHighestIon().getIonTransition();
+		IIonMSn ionMSn = (IIonMSn)massSpectrum.getHighestIon();
+		IIonTransition ionTransition = ionMSn.getIonTransition();
 		assertEquals(35, ionTransition.getCollisionEnergy(), 0, "CE");
 		assertEquals(445, ionTransition.getQ1Ion(), 0, "Q1");
 		assertEquals(531.1, ionTransition.getQ3Ion(), 0, "Q2");

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramImportConverterTinyMzXML30_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramImportConverterTinyMzXML30_ITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,6 +20,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorChromato
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.IVendorScan;
 import org.eclipse.chemclipse.msd.converter.supplier.mzxml.model.VendorChromatogram;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -89,7 +90,8 @@ public class ChromatogramImportConverterTinyMzXML30_ITest {
 		assertEquals(Polarity.NEGATIVE, massSpectrum.getPolarity(), "Polarity");
 		assertEquals(369, massSpectrum.getRetentionTime());
 
-		IIonTransition ionTransition = massSpectrum.getIons().iterator().next().getIonTransition();
+		IIonMSn ionMSn = (IIonMSn)massSpectrum.getIons().iterator().next();
+		IIonTransition ionTransition = ionMSn.getIonTransition();
 		assertEquals(0, ionTransition.getCollisionEnergy(), 0);
 		assertEquals(91, ionTransition.getQ1Ion());
 		assertEquals(91, ionTransition.getQ3Ion(), 0);

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/MassSpectrum_27_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/MassSpectrum_27_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,7 @@ package org.eclipse.chemclipse.msd.model.implementation;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,7 @@ public class MassSpectrum_27_Test {
 		massSpectrum.addIon(nominalIon, false);
 
 		IIonTransition ionTransition = new IonTransition(210.2d, 105.6d, 15.0d, 1.2d, 1.2d, 0);
-		IIon tripleQuadIon = new Ion(105.6d, 2789.54f, ionTransition);
+		IIonMSn tripleQuadIon = new IonMSn(105.6d, 2789.54f, ionTransition);
 		massSpectrum.addIon(tripleQuadIon, false);
 	}
 
@@ -86,7 +87,7 @@ public class MassSpectrum_27_Test {
 	public void test7() throws NullPointerException {
 
 		IIonTransition ionTransition = new IonTransition(210.2d, 105.6d, 15.0d, 1.2d, 1.2d, 0);
-		IIon tripleQuadIon = new Ion(105.6d, 5000.0f, ionTransition);
+		IIonMSn tripleQuadIon = new IonMSn(105.6d, 5000.0f, ionTransition);
 		massSpectrum.addIon(false, tripleQuadIon);
 
 		IIon ion = getIon(true);
@@ -97,7 +98,7 @@ public class MassSpectrum_27_Test {
 	public void test8() throws NullPointerException {
 
 		IIonTransition ionTransition = new IonTransition(210.2d, 105.6d, 15.0d, 1.2d, 1.2d, 0);
-		IIon tripleQuadIon = new Ion(105.6d, 5000.0f, ionTransition);
+		IIonMSn tripleQuadIon = new IonMSn(105.6d, 5000.0f, ionTransition);
 		massSpectrum.addIon(true, tripleQuadIon);
 
 		IIon ion = getIon(true);
@@ -118,7 +119,7 @@ public class MassSpectrum_27_Test {
 	public void test10() {
 
 		IIonTransition ionTransition = new IonTransition(210.2d, 106.6d, 15.0d, 1.2d, 1.2d, 0);
-		IIon tripleQuadIon = new Ion(106.6d, 7800.2f, ionTransition);
+		IIonMSn tripleQuadIon = new IonMSn(106.6d, 7800.2f, ionTransition);
 		massSpectrum.addIon(false, tripleQuadIon);
 
 		assertEquals(3, massSpectrum.getNumberOfIons());
@@ -128,11 +129,11 @@ public class MassSpectrum_27_Test {
 	private IIon getIon(boolean useTransition) {
 
 		IIon nominalIon = null;
-		IIon tripleQuadIon = null;
+		IIonMSn tripleQuadIon = null;
 
 		for(IIon ion : massSpectrum.getIons()) {
-			if(ion.getIonTransition() != null) {
-				tripleQuadIon = ion;
+			if(ion instanceof IIonMSn ionMSn && ionMSn.getIonTransition() != null) {
+				tripleQuadIon = ionMSn;
 			} else {
 				nominalIon = ion;
 			}

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/MassSpectrum_31_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/MassSpectrum_31_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,7 @@ package org.eclipse.chemclipse.msd.model.implementation;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,7 +35,7 @@ public class MassSpectrum_31_Test {
 		massSpectrum.addIon(new Ion(85.43d, 3000.5f));
 		massSpectrum.addIon(new Ion(104.12d, 120000.4f));
 		IIonTransition ionTransition = new IonTransition(53.2d, 32, 10.0, 1.2d, 1.2d, 1);
-		IIon ion = new Ion(32.63d, 890520.4f, ionTransition);
+		IIonMSn ion = new IonMSn(32.63d, 890520.4f, ionTransition);
 		massSpectrum.addIon(ion);
 		massSpectrum.addIon(new Ion(105.73d, 120000.4f));
 		massSpectrum.addIon(new Ion(28.24d, 33000.5f));

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/MassSpectrum_32_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/implementation/MassSpectrum_32_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,7 @@ package org.eclipse.chemclipse.msd.model.implementation;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.junit.jupiter.api.BeforeAll;
@@ -36,7 +36,7 @@ public class MassSpectrum_32_Test {
 		massSpectrum.addIon(new Ion(85.4d, 3000.5f));
 		massSpectrum.addIon(new Ion(104.1d, 120000.4f));
 		IIonTransition ionTransition = new IonTransition(53.2d, 32, 10.0, 1.2d, 1.2d, 1);
-		IIon ion = new Ion(32.6d, 890520.4f, ionTransition);
+		IIonMSn ion = new IonMSn(32.6d, 890520.4f, ionTransition);
 		massSpectrum.addIon(ion);
 		massSpectrum.addIon(new Ion(105.7d, 120000.4f));
 		massSpectrum.addIon(new Ion(28.2d, 33000.5f));

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/support/ScanSupport_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/src/org/eclipse/chemclipse/msd/model/support/ScanSupport_1_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Lablicate GmbH.
+ * Copyright (c) 2024, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,9 +14,10 @@ package org.eclipse.chemclipse.msd.model.support;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IIonMSn;
 import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.implementation.Ion;
+import org.eclipse.chemclipse.msd.model.implementation.IonMSn;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransition;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -28,26 +29,26 @@ public class ScanSupport_1_Test {
 	@Test
 	public void test1() {
 
-		IIon ion = null;
+		IIonMSn ion = null;
 		assertEquals("", ScanSupport.getLabelTandemMS(ion));
 	}
 
 	@Test
 	public void test2() {
 
-		assertEquals("58.0", ScanSupport.getLabelTandemMS(getIon(58.0d, null)));
+		assertEquals("58.0", ScanSupport.getLabelTandemMS(new Ion(58.0d)));
 	}
 
 	@Test
 	public void test3() {
 
-		assertEquals("58.05", ScanSupport.getLabelTandemMS(getIon(58.05d, null)));
+		assertEquals("58.05", ScanSupport.getLabelTandemMS(new Ion(58.05d)));
 	}
 
 	@Test
 	public void test4() {
 
-		IIon ion = getIon(58.1d, new IonTransition(168.7, 58.1, 15, 1.0d, 1.0d, 0));
+		IIonMSn ion = new IonMSn(new Ion(58.1d), new IonTransition(168.7, 58.1, 15, 1.0d, 1.0d, 0));
 		assertEquals("169 > 58.1 @15", ScanSupport.getLabelTandemMS(ion));
 	}
 
@@ -70,15 +71,5 @@ public class ScanSupport_1_Test {
 
 		IIonTransition ionTransition = new IonTransition(168.7, 169.7, 56.3, 57.3, 15, 1.0d, 1.0d, 0);
 		assertEquals("169 > 56.8 @15", ScanSupport.getLabelTandemMS(ionTransition));
-	}
-
-	private IIon getIon(double mz, IIonTransition ionTransition) {
-
-		if(ionTransition == null) {
-			return new Ion(mz);
-		} else {
-			IIon ion = getIon(mz, null);
-			return new Ion(ion, ionTransition);
-		}
 	}
 }


### PR DESCRIPTION
This is an API change with the motivation to reduce RAM usage on mass spectra. `IIon` is generally the most abundant object in both MS and LC/GC-MS. Removing ion transitions from MS1 spectra yields 25% fewer allocations. Apparently even a null object causes overhead. Measured with @visualvm. By introducing `IIonMSn` we also get type safety for tandem MS, which should be safer than null checks on optional fields.