### PR TITLE
Add scan chart axis settings

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
@@ -534,7 +534,7 @@
         label="Peaks Chart X Axis Milliseconds Grid Color"
         value="192,192,192">
         <description>
-            The color of the chromatogram chart grid.
+            The color of the chart grid.
         </description>
     </colorDefinition>
     <colorDefinition
@@ -543,7 +543,7 @@
         label="Peaks Chart X Axis Milliseconds Line Color"
         value="0,0,0">
         <description>
-            The color of the chromatogram chart line.
+            The color of the chart line.
         </description>
     </colorDefinition>
     <fontDefinition
@@ -562,7 +562,7 @@
         label="Peaks Chart Y Axis Grid Color"
         value="192,192,192">
         <description>
-            The color of the chromatogram chart grid.
+            The color of the chart grid.
         </description>
     </colorDefinition>
     <colorDefinition
@@ -571,7 +571,7 @@
         label="Peaks Chart Y Axis Line Color"
         value="0,0,0">
         <description>
-            The color of the chromatogram chart line.
+            The color of the chart line.
         </description>
     </colorDefinition>
     <fontDefinition
@@ -590,7 +590,7 @@
         label="Peaks Chart X Axis Grid Color"
         value="192,192,192">
         <description>
-            The color of the chromatogram chart grid.
+            The color of the chart grid.
         </description>
     </colorDefinition>
     <colorDefinition
@@ -599,7 +599,7 @@
         label="Peaks Chart X Axis Line Color"
         value="0,0,0">
         <description>
-            The color of the chromatogram chart line.
+            The color of the chart line.
         </description>
     </colorDefinition>
     <fontDefinition
@@ -618,7 +618,7 @@
         label="Peaks Chart Y Axis Relative Response Grid Color"
         value="192,192,192">
         <description>
-            The color of the chromatogram chart grid.
+            The color of the chart grid.
         </description>
     </colorDefinition>
     <colorDefinition
@@ -627,7 +627,7 @@
         label="Peaks Chart Y Axis Relative Response Line Color"
         value="0,0,0">
         <description>
-            The color of the chromatogram chart line.
+            The color of the chart line.
         </description>
     </colorDefinition>
     <fontDefinition

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
@@ -777,6 +777,33 @@
             The title font.
         </description>
     </fontDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisIntensity.GridColor"
+        label="Chromatogram Chart Axis Intensity Grid Color"
+        value="192,192,192">
+        <description>
+            The color of the chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisIntensity.LineColor"
+        label="Scan Chart Axis Intensity Line Color"
+        value="0,0,0">
+        <description>
+            The color of the chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisIntensity.Font"
+        label="Scan Chart Axis Intensity Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font
+        </description>
+    </fontDefinition>
 </extension>
 <extension
          point="org.eclipse.ui.commands">

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
@@ -804,6 +804,33 @@
             The title font
         </description>
     </fontDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisIons.GridColor"
+        label="Scan Chart Axis Ions Grid Color"
+        value="192,192,192">
+        <description>
+            The color of the chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisIons.LineColor"
+        label="Scan Chart Axis Intensity Line Color"
+        value="0,0,0">
+        <description>
+            The color of the chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisIons.Font"
+        label="Scan Chart Axis Intensity Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font
+        </description>
+    </fontDefinition>
 </extension>
 <extension
          point="org.eclipse.ui.commands">

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
@@ -750,6 +750,33 @@
             The m/z label font.
         </description>
     </fontDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisRelativeIntensity.GridColor"
+        label="Scan Chart Y Axis Relative Response Grid Color"
+        value="192,192,192">
+        <description>
+            The color of the chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisRelativeIntensity.LineColor"
+        label="Scan Chart Y Axis Relative Response Line Color"
+        value="0,0,0">
+        <description>
+            The color of the chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisRelativeIntensity.Font"
+        label="Scan Chart Y Axis Relative Response Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font.
+        </description>
+    </fontDefinition>
 </extension>
 <extension
          point="org.eclipse.ui.commands">

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferencePagePeaksAxes.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferencePagePeaksAxes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 Lablicate GmbH.
+ * Copyright (c) 2018, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -46,7 +46,6 @@ public class PreferencePagePeaksAxes extends FieldEditorPreferencePage implement
 		addField(new ComboFieldEditor(PreferenceSupplier.P_POSITION_X_AXIS_MILLISECONDS_PEAKS, "Position X Axis (Milliseconds):", ChartOptions.POSITIONS, getFieldEditorParent()));
 		addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_X_AXIS_MILLISECONDS_PEAKS, "Color X Axis (Milliseconds):", getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_MILLISECONDS_PEAKS, "GridLine Style X Axis (Milliseconds):", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_PEAKS, "GridLine Color X Axis (Milliseconds):", getFieldEditorParent()));
 
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Minutes", getFieldEditorParent()));
@@ -54,7 +53,6 @@ public class PreferencePagePeaksAxes extends FieldEditorPreferencePage implement
 		addField(new ComboFieldEditor(PreferenceSupplier.P_POSITION_X_AXIS_MINUTES_PEAKS, "Position X Axis (Minutes):", ChartOptions.POSITIONS, getFieldEditorParent()));
 		addField(new ColorFieldEditor(PreferenceSupplier.P_COLOR_X_AXIS_MINUTES_PEAKS, "Color X Axis (Minutes):", getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_MINUTES_PEAKS, "GridLine Style X Axis (Minutes):", ChartOptions.LINE_STYLES, getFieldEditorParent()));
-		addField(new ColorFieldEditor(PreferenceSupplier.P_GRIDLINE_COLOR_X_AXIS_MINUTES_PEAKS, "GridLine Color X Axis (Minutes):", getFieldEditorParent()));
 
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Intensity", getFieldEditorParent()));

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferencePageScans.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferencePageScans.java
@@ -12,9 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.preferences;
 
-import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.DoubleFieldEditor;
 import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.ExtendedIntegerFieldEditor;
-import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.LabelFieldEditor;
 import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpacerFieldEditor;
 import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpinnerFieldEditor;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
@@ -39,7 +37,6 @@ public class PreferencePageScans extends FieldEditorPreferencePage implements IW
 	@Override
 	public void createFieldEditors() {
 
-		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new SpinnerFieldEditor(PreferenceSupplier.P_SCAN_LABEL_HIGHEST_INTENSITIES, "Label Intensities:", PreferenceSupplier.MIN_SCAN_LABEL_HIGHEST_INTENSITIES, PreferenceSupplier.MAX_SCAN_LABEL_HIGHEST_INTENSITIES, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SCAN_LABEL_MODULO_INTENSITIES, "Add additional intensity labels", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_AUTOFOCUS_SUBTRACT_SCAN_PART, "Autofocus subtract scan part", getFieldEditorParent()));
@@ -53,15 +50,6 @@ public class PreferencePageScans extends FieldEditorPreferencePage implements IW
 		addField(new SpinnerFieldEditor(PreferenceSupplier.P_MAX_COPY_SCAN_TRACES, "Copy Traces", PreferenceSupplier.MIN_TRACES, PreferenceSupplier.MAX_TRACES, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SORT_COPY_TRACES, "Sort Traces", getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_TRACES_EXPORT_OPTION, "Traces Export Option", TracesExportOption.getOptions(), getFieldEditorParent()));
-
-		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		addField(new LabelFieldEditor("The primary X|Y axis scale is used to set the values.", getFieldEditorParent()));
-		addField(new BooleanFieldEditor(PreferenceSupplier.P_SCAN_CHART_ENABLE_FIXED_RANGE_X, "Fixed range X", getFieldEditorParent()));
-		addField(new DoubleFieldEditor(PreferenceSupplier.P_SCAN_CHART_FIXED_RANGE_START_X, "Start X", PreferenceSupplier.MIN_RANGE, PreferenceSupplier.MAX_RANGE, getFieldEditorParent()));
-		addField(new DoubleFieldEditor(PreferenceSupplier.P_SCAN_CHART_FIXED_RANGE_STOP_X, "Stop X", PreferenceSupplier.MIN_RANGE, PreferenceSupplier.MAX_RANGE, getFieldEditorParent()));
-		addField(new BooleanFieldEditor(PreferenceSupplier.P_SCAN_CHART_ENABLE_FIXED_RANGE_Y, "Fixed range Y", getFieldEditorParent()));
-		addField(new DoubleFieldEditor(PreferenceSupplier.P_SCAN_CHART_FIXED_RANGE_START_Y, "Start Y", PreferenceSupplier.MIN_RANGE, PreferenceSupplier.MAX_RANGE, getFieldEditorParent()));
-		addField(new DoubleFieldEditor(PreferenceSupplier.P_SCAN_CHART_FIXED_RANGE_STOP_Y, "Stop Y", PreferenceSupplier.MIN_RANGE, PreferenceSupplier.MAX_RANGE, getFieldEditorParent()));
 
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new ExtendedIntegerFieldEditor(PreferenceSupplier.P_TRACES_VIRTUAL_TABLE, "Traces Virtual Table", PreferenceSupplier.MIN_TRACES_VIRTUAL_TABLE, PreferenceSupplier.MAX_TRACES_VIRTUAL_TABLE, getFieldEditorParent()));

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
@@ -300,6 +300,17 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static final String P_SCAN_CHART_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY = "scanChartShowYAxisTitleRelativeIntensity";
 	public static final boolean DEF_SCAN_CHART_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY = true;
 
+	public static final String P_SCAN_CHART_FORMAT_Y_AXIS_INTENSITY = "scanChartFormatYAxisIntensity";
+	public static final String DEF_SCAN_CHART_FORMAT_Y_AXIS_INTENSITY = "0.0#E0";
+	public static final String P_SCAN_CHART_SHOW_Y_AXIS_INTENSITY = "scanChartShowYAxisIntensity";
+	public static final boolean DEF_SCAN_CHART_SHOW_Y_AXIS_INTENSITY = true;
+	public static final String P_SCAN_CHART_POSITION_Y_AXIS_INTENSITY = "scanChartPositionYAxisIntensity";
+	public static final String DEF_SCAN_CHART_POSITION_Y_AXIS_INTENSITY = Position.Primary.toString();
+	public static final String P_SCAN_CHART_GRIDLINE_STYLE_Y_AXIS_INTENSITY = "scanChartGridlineStyleYAxisIntensity";
+	public static final String DEF_SCAN_CHART_GRIDLINE_STYLE_Y_AXIS_INTENSITY = LineStyle.NONE.toString();
+	public static final String P_SCAN_CHART_SHOW_Y_AXIS_TITLE_INTENSITY = "scanChartShowYAxisTitleIntensity";
+	public static final boolean DEF_SCAN_CHART_SHOW_Y_AXIS_TITLE_INTENSITY = true;
+
 	public static final String P_TRACES_VIRTUAL_TABLE = "tracesVirtualTable";
 	public static final int DEF_TRACES_VIRTUAL_TABLE = 5000;
 	public static final String P_LIMIT_SIM_TRACES = "limitSimTraces";
@@ -942,6 +953,12 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 		putDefault(P_SCAN_CHART_POSITION_Y_AXIS_RELATIVE_INTENSITY, DEF_SCAN_CHART_POSITION_Y_AXIS_RELATIVE_INTENSITY);
 		putDefault(P_SCAN_CHART_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY, DEF_SCAN_CHART_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY);
 		putDefault(P_SCAN_CHART_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY, DEF_SCAN_CHART_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY);
+
+		putDefault(P_SCAN_CHART_FORMAT_Y_AXIS_INTENSITY, DEF_SCAN_CHART_FORMAT_Y_AXIS_INTENSITY);
+		putDefault(P_SCAN_CHART_SHOW_Y_AXIS_INTENSITY, DEF_SCAN_CHART_SHOW_Y_AXIS_INTENSITY);
+		putDefault(P_SCAN_CHART_POSITION_Y_AXIS_INTENSITY, DEF_SCAN_CHART_POSITION_Y_AXIS_INTENSITY);
+		putDefault(P_SCAN_CHART_GRIDLINE_STYLE_Y_AXIS_INTENSITY, DEF_SCAN_CHART_GRIDLINE_STYLE_Y_AXIS_INTENSITY);
+		putDefault(P_SCAN_CHART_SHOW_Y_AXIS_TITLE_INTENSITY, DEF_SCAN_CHART_SHOW_Y_AXIS_TITLE_INTENSITY);
 
 		putDefault(P_TRACES_VIRTUAL_TABLE, DEF_TRACES_VIRTUAL_TABLE);
 		putDefault(P_LIMIT_SIM_TRACES, DEF_LIMIT_SIM_TRACES);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
@@ -311,6 +311,15 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static final String P_SCAN_CHART_SHOW_Y_AXIS_TITLE_INTENSITY = "scanChartShowYAxisTitleIntensity";
 	public static final boolean DEF_SCAN_CHART_SHOW_Y_AXIS_TITLE_INTENSITY = true;
 
+	public static final String P_SCAN_CHART_SHOW_X_AXIS_IONS = "scanChartShowXAxisIons";
+	public static final boolean DEF_SCAN_CHART_SHOW_X_AXIS_IONS = true;
+	public static final String P_SCAN_CHART_POSITION_X_AXIS_IONS = "scanChartPositionXAxisIons";
+	public static final String DEF_SCAN_CHART_POSITION_X_AXIS_IONS = Position.Primary.toString();
+	public static final String P_SCAN_CHART_GRIDLINE_STYLE_X_AXIS_IONS = "scanChartGridlineStyleXAxisIons";
+	public static final String DEF_SCAN_CHART_GRIDLINE_STYLE_X_AXIS_IONS = LineStyle.NONE.toString();
+	public static final String P_SCAN_CHART_SHOW_X_AXIS_TITLE_IONS = "scanChartShowXAxisTitleIons";
+	public static final boolean DEF_SCAN_CHART_SHOW_X_AXIS_TITLE_IONS = true;
+
 	public static final String P_TRACES_VIRTUAL_TABLE = "tracesVirtualTable";
 	public static final int DEF_TRACES_VIRTUAL_TABLE = 5000;
 	public static final String P_LIMIT_SIM_TRACES = "limitSimTraces";
@@ -955,6 +964,11 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 		putDefault(P_SCAN_CHART_POSITION_Y_AXIS_INTENSITY, DEF_SCAN_CHART_POSITION_Y_AXIS_INTENSITY);
 		putDefault(P_SCAN_CHART_GRIDLINE_STYLE_Y_AXIS_INTENSITY, DEF_SCAN_CHART_GRIDLINE_STYLE_Y_AXIS_INTENSITY);
 		putDefault(P_SCAN_CHART_SHOW_Y_AXIS_TITLE_INTENSITY, DEF_SCAN_CHART_SHOW_Y_AXIS_TITLE_INTENSITY);
+
+		putDefault(P_SCAN_CHART_SHOW_X_AXIS_IONS, DEF_SCAN_CHART_SHOW_X_AXIS_IONS);
+		putDefault(P_SCAN_CHART_POSITION_X_AXIS_IONS, DEF_SCAN_CHART_POSITION_X_AXIS_IONS);
+		putDefault(P_SCAN_CHART_GRIDLINE_STYLE_X_AXIS_IONS, DEF_SCAN_CHART_GRIDLINE_STYLE_X_AXIS_IONS);
+		putDefault(P_SCAN_CHART_SHOW_X_AXIS_TITLE_IONS, DEF_SCAN_CHART_SHOW_X_AXIS_TITLE_IONS);
 
 		putDefault(P_TRACES_VIRTUAL_TABLE, DEF_TRACES_VIRTUAL_TABLE);
 		putDefault(P_LIMIT_SIM_TRACES, DEF_LIMIT_SIM_TRACES);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
@@ -272,7 +272,9 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static final String P_SCAN_IDENTIFER = "scanIdentifier";
 	public static final String DEF_SCAN_IDENTIFER = "";
 	public static final String P_RESOLVE_DATABASE_UUID = "resolveDatabaseUUID";
-
+	/*
+	 * Scan Chart
+	 */
 	public static final boolean DEF_RESOLVE_DATABASE_UUID = false;
 	public static final String P_SCAN_CHART_ENABLE_FIXED_RANGE_X = "scanChartEnableFixedRangeX";
 	public static final boolean DEF_SCAN_CHART_ENABLE_FIXED_RANGE_X = false;
@@ -286,6 +288,17 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static final double DEF_SCAN_CHART_FIXED_RANGE_START_Y = 0.0d;
 	public static final String P_SCAN_CHART_FIXED_RANGE_STOP_Y = "scanChartFixedRangeStopY";
 	public static final double DEF_SCAN_CHART_FIXED_RANGE_STOP_Y = 0.0d;
+
+	public static final String P_SCAN_CHART_FORMAT_Y_AXIS_RELATIVE_INTENSITY = "scanChartFormatYAxisRelativeIntensity";
+	public static final String DEF_SCAN_CHART_FORMAT_Y_AXIS_RELATIVE_INTENSITY = "0.###";
+	public static final String P_SCAN_CHART_SHOW_Y_AXIS_RELATIVE_INTENSITY = "scanChartShowYAxisRelativeIntensity";
+	public static final boolean DEF_SCAN_CHART_SHOW_Y_AXIS_RELATIVE_INTENSITY = true;
+	public static final String P_SCAN_CHART_POSITION_Y_AXIS_RELATIVE_INTENSITY = "scanChartPositionYAxisRelativeIntensity";
+	public static final String DEF_SCAN_CHART_POSITION_Y_AXIS_RELATIVE_INTENSITY = Position.Secondary.toString();
+	public static final String P_SCAN_CHART_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY = "scanChartGridlineStyleYAxisRelativeIntensity";
+	public static final String DEF_SCAN_CHART_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY = LineStyle.DOT.toString();
+	public static final String P_SCAN_CHART_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY = "scanChartShowYAxisTitleRelativeIntensity";
+	public static final boolean DEF_SCAN_CHART_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY = true;
 
 	public static final String P_TRACES_VIRTUAL_TABLE = "tracesVirtualTable";
 	public static final int DEF_TRACES_VIRTUAL_TABLE = 5000;
@@ -923,6 +936,12 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 		putDefault(P_SCAN_CHART_ENABLE_FIXED_RANGE_Y, DEF_SCAN_CHART_ENABLE_FIXED_RANGE_Y);
 		putDefault(P_SCAN_CHART_FIXED_RANGE_START_Y, DEF_SCAN_CHART_FIXED_RANGE_START_Y);
 		putDefault(P_SCAN_CHART_FIXED_RANGE_STOP_Y, DEF_SCAN_CHART_FIXED_RANGE_STOP_Y);
+
+		putDefault(P_SCAN_CHART_FORMAT_Y_AXIS_RELATIVE_INTENSITY, DEF_SCAN_CHART_FORMAT_Y_AXIS_RELATIVE_INTENSITY);
+		putDefault(P_SCAN_CHART_SHOW_Y_AXIS_RELATIVE_INTENSITY, DEF_SCAN_CHART_SHOW_Y_AXIS_RELATIVE_INTENSITY);
+		putDefault(P_SCAN_CHART_POSITION_Y_AXIS_RELATIVE_INTENSITY, DEF_SCAN_CHART_POSITION_Y_AXIS_RELATIVE_INTENSITY);
+		putDefault(P_SCAN_CHART_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY, DEF_SCAN_CHART_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY);
+		putDefault(P_SCAN_CHART_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY, DEF_SCAN_CHART_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY);
 
 		putDefault(P_TRACES_VIRTUAL_TABLE, DEF_TRACES_VIRTUAL_TABLE);
 		putDefault(P_LIMIT_SIM_TRACES, DEF_LIMIT_SIM_TRACES);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
@@ -625,8 +625,6 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static final String P_SHOW_X_AXIS_POSITION_MARKER_MINUTES = "showXAxisPositionMarkerMinutes";
 	public static final boolean DEF_SHOW_X_AXIS_POSITION_MARKER_MINUTES = true;
 
-	public static final String P_TITLE_X_AXIS_SCANS = "titleXAxisScans";
-	public static final String DEF_TITLE_X_AXIS_SCANS = "Scan";
 	public static final String P_FORMAT_X_AXIS_SCANS = "formatXAxisScans";
 	public static final String DEF_FORMAT_X_AXIS_SCANS = "0.###";
 	public static final String P_SHOW_X_AXIS_SCANS = "showXAxisScans";
@@ -1183,7 +1181,6 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 		putDefault(P_SHOW_X_AXIS_LINE_MINUTES, DEF_SHOW_X_AXIS_LINE_MINUTES);
 		putDefault(P_SHOW_X_AXIS_POSITION_MARKER_MINUTES, DEF_SHOW_X_AXIS_POSITION_MARKER_MINUTES);
 
-		putDefault(P_TITLE_X_AXIS_SCANS, DEF_TITLE_X_AXIS_SCANS);
 		putDefault(P_FORMAT_X_AXIS_SCANS, DEF_FORMAT_X_AXIS_SCANS);
 		putDefault(P_SHOW_X_AXIS_SCANS, DEF_SHOW_X_AXIS_SCANS);
 		putDefault(P_POSITION_X_AXIS_SCANS, DEF_POSITION_X_AXIS_SCANS);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
@@ -389,8 +389,6 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static final String DEF_COLOR_X_AXIS_MILLISECONDS_PEAKS = "0,0,0";
 	public static final String P_GRIDLINE_STYLE_X_AXIS_MILLISECONDS_PEAKS = "gridlineStyleXAxisMillisecondsPeaks";
 	public static final String DEF_GRIDLINE_STYLE_X_AXIS_MILLISECONDS_PEAKS = LineStyle.DOT.toString();
-	public static final String P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_PEAKS = "gridlineColorXAxisMillisecondsPeaks";
-	public static final String DEF_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_PEAKS = "192,192,192";
 
 	public static final String P_SHOW_X_AXIS_MINUTES_PEAKS = "showXAxisMinutesPeaks";
 	public static final boolean DEF_SHOW_X_AXIS_MINUTES_PEAKS = true;
@@ -400,8 +398,6 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static final String DEF_COLOR_X_AXIS_MINUTES_PEAKS = "0,0,0";
 	public static final String P_GRIDLINE_STYLE_X_AXIS_MINUTES_PEAKS = "gridlineStyleXAxisMinutesPeaks";
 	public static final String DEF_GRIDLINE_STYLE_X_AXIS_MINUTES_PEAKS = LineStyle.DOT.toString();
-	public static final String P_GRIDLINE_COLOR_X_AXIS_MINUTES_PEAKS = "gridlineColorXAxisMinutesPeaks";
-	public static final String DEF_GRIDLINE_COLOR_X_AXIS_MINUTES_PEAKS = "192,192,192";
 
 	public static final String P_SHOW_Y_AXIS_INTENSITY_PEAKS = "showYAxisIntensityPeaks";
 	public static final boolean DEF_SHOW_Y_AXIS_INTENSITY_PEAKS = true;
@@ -1003,13 +999,11 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 		putDefault(P_POSITION_X_AXIS_MILLISECONDS_PEAKS, DEF_POSITION_X_AXIS_MILLISECONDS_PEAKS);
 		putDefault(P_COLOR_X_AXIS_MILLISECONDS_PEAKS, DEF_COLOR_X_AXIS_MILLISECONDS_PEAKS);
 		putDefault(P_GRIDLINE_STYLE_X_AXIS_MILLISECONDS_PEAKS, DEF_GRIDLINE_STYLE_X_AXIS_MILLISECONDS_PEAKS);
-		putDefault(P_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_PEAKS, DEF_GRIDLINE_COLOR_X_AXIS_MILLISECONDS_PEAKS);
 
 		putDefault(P_SHOW_X_AXIS_MINUTES_PEAKS, DEF_SHOW_X_AXIS_MINUTES_PEAKS);
 		putDefault(P_POSITION_X_AXIS_MINUTES_PEAKS, DEF_POSITION_X_AXIS_MINUTES_PEAKS);
 		putDefault(P_COLOR_X_AXIS_MINUTES_PEAKS, DEF_COLOR_X_AXIS_MINUTES_PEAKS);
 		putDefault(P_GRIDLINE_STYLE_X_AXIS_MINUTES_PEAKS, DEF_GRIDLINE_STYLE_X_AXIS_MINUTES_PEAKS);
-		putDefault(P_GRIDLINE_COLOR_X_AXIS_MINUTES_PEAKS, DEF_GRIDLINE_COLOR_X_AXIS_MINUTES_PEAKS);
 
 		putDefault(P_SHOW_Y_AXIS_INTENSITY_PEAKS, DEF_SHOW_Y_AXIS_INTENSITY_PEAKS);
 		putDefault(P_POSITION_Y_AXIS_INTENSITY_PEAKS, DEF_POSITION_Y_AXIS_INTENSITY_PEAKS);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ScanChartAxisIntensity.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ScanChartAxisIntensity.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.preferences;
 
+import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.DoubleFieldEditor;
+import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.LabelFieldEditor;
+import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpacerFieldEditor;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.jface.preference.BooleanFieldEditor;
@@ -40,6 +43,12 @@ public class ScanChartAxisIntensity extends FieldEditorPreferencePage implements
 		addField(new ComboFieldEditor(PreferenceSupplier.P_SCAN_CHART_POSITION_Y_AXIS_INTENSITY, ExtensionMessages.position + ":", ChartOptions.POSITIONS, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_SCAN_CHART_GRIDLINE_STYLE_Y_AXIS_INTENSITY, ExtensionMessages.gridLineStyle + ":", ChartOptions.LINE_STYLES, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SCAN_CHART_SHOW_Y_AXIS_TITLE_INTENSITY, ExtensionMessages.showAxisTitle, getFieldEditorParent()));
+
+		addField(new SpacerFieldEditor(getFieldEditorParent()));
+		addField(new LabelFieldEditor("The axis scale is used to set the values.", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_SCAN_CHART_ENABLE_FIXED_RANGE_Y, "Fixed range Y", getFieldEditorParent()));
+		addField(new DoubleFieldEditor(PreferenceSupplier.P_SCAN_CHART_FIXED_RANGE_START_Y, "Start Y", PreferenceSupplier.MIN_RANGE, PreferenceSupplier.MAX_RANGE, getFieldEditorParent()));
+		addField(new DoubleFieldEditor(PreferenceSupplier.P_SCAN_CHART_FIXED_RANGE_STOP_Y, "Stop Y", PreferenceSupplier.MIN_RANGE, PreferenceSupplier.MAX_RANGE, getFieldEditorParent()));
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ScanChartAxisIntensity.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ScanChartAxisIntensity.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.ux.extension.xxd.ui.preferences;
+
+import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.ComboFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.StringFieldEditor;
+import org.eclipse.swtchart.extensions.charts.ChartOptions;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+
+public class ScanChartAxisIntensity extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+
+	public ScanChartAxisIntensity() {
+
+		super(GRID);
+		setPreferenceStore(Activator.getDefault().getPreferenceStore());
+		setTitle("Scan Chart Intensity");
+		setDescription("");
+	}
+
+	@Override
+	public void createFieldEditors() {
+
+		addField(new StringFieldEditor(PreferenceSupplier.P_SCAN_CHART_FORMAT_Y_AXIS_INTENSITY, ExtensionMessages.format + ":", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_SCAN_CHART_SHOW_Y_AXIS_INTENSITY, ExtensionMessages.show, getFieldEditorParent()));
+		addField(new ComboFieldEditor(PreferenceSupplier.P_SCAN_CHART_POSITION_Y_AXIS_INTENSITY, ExtensionMessages.position + ":", ChartOptions.POSITIONS, getFieldEditorParent()));
+		addField(new ComboFieldEditor(PreferenceSupplier.P_SCAN_CHART_GRIDLINE_STYLE_Y_AXIS_INTENSITY, ExtensionMessages.gridLineStyle + ":", ChartOptions.LINE_STYLES, getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_SCAN_CHART_SHOW_Y_AXIS_TITLE_INTENSITY, ExtensionMessages.showAxisTitle, getFieldEditorParent()));
+	}
+
+	@Override
+	public void init(IWorkbench workbench) {
+
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ScanChartAxisIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ScanChartAxisIon.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.ux.extension.xxd.ui.preferences;
+
+import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.ComboFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.swtchart.extensions.charts.ChartOptions;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+
+public class ScanChartAxisIon extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+
+	public ScanChartAxisIon() {
+
+		super(GRID);
+		setPreferenceStore(Activator.getDefault().getPreferenceStore());
+		setTitle("Scan Chart Ion Axis");
+		setDescription("");
+	}
+
+	@Override
+	public void createFieldEditors() {
+
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_SCAN_CHART_SHOW_X_AXIS_IONS, ExtensionMessages.show, getFieldEditorParent()));
+		addField(new ComboFieldEditor(PreferenceSupplier.P_SCAN_CHART_POSITION_X_AXIS_IONS, ExtensionMessages.position + ":", ChartOptions.POSITIONS, getFieldEditorParent()));
+		addField(new ComboFieldEditor(PreferenceSupplier.P_SCAN_CHART_GRIDLINE_STYLE_X_AXIS_IONS, ExtensionMessages.gridLineStyle + ":", ChartOptions.LINE_STYLES, getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_SCAN_CHART_SHOW_X_AXIS_TITLE_IONS, ExtensionMessages.showAxisTitle, getFieldEditorParent()));
+	}
+
+	@Override
+	public void init(IWorkbench workbench) {
+
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ScanChartAxisIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ScanChartAxisIon.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.ux.extension.xxd.ui.preferences;
 
+import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.DoubleFieldEditor;
+import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.LabelFieldEditor;
+import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpacerFieldEditor;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.jface.preference.BooleanFieldEditor;
@@ -38,6 +41,12 @@ public class ScanChartAxisIon extends FieldEditorPreferencePage implements IWork
 		addField(new ComboFieldEditor(PreferenceSupplier.P_SCAN_CHART_POSITION_X_AXIS_IONS, ExtensionMessages.position + ":", ChartOptions.POSITIONS, getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_SCAN_CHART_GRIDLINE_STYLE_X_AXIS_IONS, ExtensionMessages.gridLineStyle + ":", ChartOptions.LINE_STYLES, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SCAN_CHART_SHOW_X_AXIS_TITLE_IONS, ExtensionMessages.showAxisTitle, getFieldEditorParent()));
+
+		addField(new SpacerFieldEditor(getFieldEditorParent()));
+		addField(new LabelFieldEditor("The axis scale is used to set the values.", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_SCAN_CHART_ENABLE_FIXED_RANGE_X, "Fixed range X", getFieldEditorParent()));
+		addField(new DoubleFieldEditor(PreferenceSupplier.P_SCAN_CHART_FIXED_RANGE_START_X, "Start X", PreferenceSupplier.MIN_RANGE, PreferenceSupplier.MAX_RANGE, getFieldEditorParent()));
+		addField(new DoubleFieldEditor(PreferenceSupplier.P_SCAN_CHART_FIXED_RANGE_STOP_X, "Stop X", PreferenceSupplier.MIN_RANGE, PreferenceSupplier.MAX_RANGE, getFieldEditorParent()));
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ScanChartAxisRelativeIntensity.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ScanChartAxisRelativeIntensity.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.ux.extension.xxd.ui.preferences;
+
+import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.ComboFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.StringFieldEditor;
+import org.eclipse.swtchart.extensions.charts.ChartOptions;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+
+public class ScanChartAxisRelativeIntensity extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+
+	public ScanChartAxisRelativeIntensity() {
+
+		super(GRID);
+		setPreferenceStore(Activator.getDefault().getPreferenceStore());
+		setTitle("Scan Chart Intensity %");
+		setDescription("");
+	}
+
+	@Override
+	public void createFieldEditors() {
+
+		addField(new StringFieldEditor(PreferenceSupplier.P_SCAN_CHART_FORMAT_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.format + ":", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_SCAN_CHART_SHOW_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.show, getFieldEditorParent()));
+		addField(new ComboFieldEditor(PreferenceSupplier.P_SCAN_CHART_POSITION_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.position + ":", ChartOptions.POSITIONS, getFieldEditorParent()));
+		addField(new ComboFieldEditor(PreferenceSupplier.P_SCAN_CHART_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY, ExtensionMessages.gridLineStyle + ":", ChartOptions.LINE_STYLES, getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_SCAN_CHART_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY, ExtensionMessages.showAxisTitle, getFieldEditorParent()));
+	}
+
+	@Override
+	public void init(IWorkbench workbench) {
+
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanChartUI.java
@@ -51,6 +51,7 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageScans;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageSubtract;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferenceSupplier;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.ScanChartAxisIntensity;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.ScanChartAxisRelativeIntensity;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.ChromatogramUpdateSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.ScanDataSupport;
@@ -79,6 +80,7 @@ import org.eclipse.swtchart.Range;
 import org.eclipse.swtchart.extensions.axisconverter.PercentageConverter;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.core.IChartSettings;
+import org.eclipse.swtchart.extensions.core.IPrimaryAxisSettings;
 import org.eclipse.swtchart.extensions.core.ISecondaryAxisSettings;
 import org.eclipse.swtchart.extensions.core.SecondaryAxisSettings;
 
@@ -742,6 +744,7 @@ public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 
 		List<Class<? extends IPreferencePage>> preferencePages = new ArrayList<>();
 		preferencePages.add(PreferencePageScans.class);
+		preferencePages.add(ScanChartAxisIntensity.class);
 		preferencePages.add(ScanChartAxisRelativeIntensity.class);
 		preferencePages.add(PreferencePageSubtract.class);
 
@@ -750,10 +753,27 @@ public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 
 	void adjustAxisSettings() {
 
+		adjustAxisIntensity();
 		adjustAxisRelativeIntensity();
 
 		IChartSettings chartSettings = chartControl.get().getChartSettings();
 		chartControl.get().applySettings(chartSettings);
+	}
+
+	private void adjustAxisIntensity() {
+
+		IChartSettings chartSettings = chartControl.get().getChartSettings();
+		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
+		primaryAxisSettingsY.setTitle(ExtensionMessages.intensity);
+
+		String positionNode = PreferenceSupplier.P_SCAN_CHART_POSITION_Y_AXIS_INTENSITY;
+		String patternNode = PreferenceSupplier.P_SCAN_CHART_FORMAT_Y_AXIS_INTENSITY;
+		String gridLineStyleNode = PreferenceSupplier.P_SCAN_CHART_GRIDLINE_STYLE_Y_AXIS_INTENSITY;
+
+		ChartSupport.setAxisSettingsExtended(primaryAxisSettingsY, positionNode, patternNode, gridLineStyleNode);
+		ChartSupport.themeAxis(primaryAxisSettingsY, ExtendedScanChartUI.class.getName() + ".AxisIntensity");
+		primaryAxisSettingsY.setVisible(ChartSupport.getBoolean(PreferenceSupplier.P_SCAN_CHART_SHOW_Y_AXIS_INTENSITY));
+		primaryAxisSettingsY.setTitleVisible(ChartSupport.getBoolean(PreferenceSupplier.P_SCAN_CHART_SHOW_Y_AXIS_TITLE_INTENSITY));
 	}
 
 	private void adjustAxisRelativeIntensity() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanChartUI.java
@@ -46,9 +46,12 @@ import org.eclipse.chemclipse.ux.extension.ui.swt.ChartGridSupport;
 import org.eclipse.chemclipse.ux.extension.ui.swt.IExtendedPartUI;
 import org.eclipse.chemclipse.ux.extension.ui.swt.ISettingsHandler;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChartSupport;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageScans;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageSubtract;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferenceSupplier;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.ScanChartAxisRelativeIntensity;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.ChromatogramUpdateSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.ScanDataSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.wizards.SubtractScanWizard;
@@ -73,7 +76,11 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swtchart.IAxis;
 import org.eclipse.swtchart.Range;
+import org.eclipse.swtchart.extensions.axisconverter.PercentageConverter;
 import org.eclipse.swtchart.extensions.core.BaseChart;
+import org.eclipse.swtchart.extensions.core.IChartSettings;
+import org.eclipse.swtchart.extensions.core.ISecondaryAxisSettings;
+import org.eclipse.swtchart.extensions.core.SecondaryAxisSettings;
 
 public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 
@@ -238,19 +245,21 @@ public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 
 		this.scan = scan;
 
-		IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
-		ScanDataSupport scanDataSupport = new ScanDataSupport();
 		scanFilterUI.get().setInput(scan);
 		scanIdentifierControl.get().setInput(scan);
 		scanWebIdentifierUI.get().setInput(scan);
+		ScanDataSupport scanDataSupport = new ScanDataSupport();
 		toolbarInfo.get().setText(scanDataSupport.getScanLabel(scan));
 		setDetectorSignalType(scan);
 		updateScanChart(scan);
 		updateInfoLabels();
 		updateButtons();
+		adjustAxisSettings();
 		/*
 		 * Set a fixed range on demand.
 		 */
+		IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
+
 		boolean isFixedRangeX = preferenceStore.getBoolean(PreferenceSupplier.P_SCAN_CHART_ENABLE_FIXED_RANGE_X);
 		boolean isFixedRangeY = preferenceStore.getBoolean(PreferenceSupplier.P_SCAN_CHART_ENABLE_FIXED_RANGE_Y);
 
@@ -310,6 +319,7 @@ public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 		enableChartGrid(chartControl, buttonChartGrid.get(), IMAGE_CHART_GRID, new ChartGridSupport());
 
 		updateButtons();
+		adjustAxisSettings();
 	}
 
 	private void createToolbarMain(Composite parent) {
@@ -710,6 +720,7 @@ public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 			scanIdentifierControl.get().updateIdentifier();
 			tracesClipboardControl.get().updateOption();
 			fireUpdate();
+			adjustAxisSettings();
 		};
 
 		Button button = createSettingsButtonBasic(parent);
@@ -731,9 +742,53 @@ public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 
 		List<Class<? extends IPreferencePage>> preferencePages = new ArrayList<>();
 		preferencePages.add(PreferencePageScans.class);
+		preferencePages.add(ScanChartAxisRelativeIntensity.class);
 		preferencePages.add(PreferencePageSubtract.class);
 
 		return preferencePages;
+	}
+
+	void adjustAxisSettings() {
+
+		adjustAxisRelativeIntensity();
+
+		IChartSettings chartSettings = chartControl.get().getChartSettings();
+		chartControl.get().applySettings(chartSettings);
+	}
+
+	private void adjustAxisRelativeIntensity() {
+
+		IChartSettings chartSettings = chartControl.get().getChartSettings();
+		ISecondaryAxisSettings axisSettings = ChartSupport.getSecondaryAxisSettingsY(ExtensionMessages.relativeIntensity, chartSettings);
+
+		String positionNode = PreferenceSupplier.P_SCAN_CHART_POSITION_Y_AXIS_RELATIVE_INTENSITY;
+		String patternNode = PreferenceSupplier.P_SCAN_CHART_FORMAT_Y_AXIS_RELATIVE_INTENSITY;
+		String gridLineStyleNode = PreferenceSupplier.P_SCAN_CHART_GRIDLINE_STYLE_Y_AXIS_RELATIVE_INTENSITY;
+
+		boolean isShowAxis = ChartSupport.getBoolean(PreferenceSupplier.P_SCAN_CHART_SHOW_Y_AXIS_RELATIVE_INTENSITY);
+		boolean isShowAxisTitle = ChartSupport.getBoolean(PreferenceSupplier.P_SCAN_CHART_SHOW_Y_AXIS_TITLE_RELATIVE_INTENSITY);
+
+		if(isShowAxis) {
+			if(axisSettings == null) {
+				ISecondaryAxisSettings secondaryAxisSettingsY = new SecondaryAxisSettings(ExtensionMessages.relativeIntensity, new PercentageConverter(SWT.VERTICAL, true));
+				ChartSupport.setAxisSettingsExtended(secondaryAxisSettingsY, positionNode, patternNode, gridLineStyleNode);
+				ChartSupport.themeAxis(secondaryAxisSettingsY, ExtendedScanChartUI.class.getName() + ".AxisRelativeIntensity");
+				secondaryAxisSettingsY.setTitleVisible(isShowAxisTitle);
+				chartSettings.getSecondaryAxisSettingsListY().add(secondaryAxisSettingsY);
+			} else {
+				ChartSupport.setAxisSettingsExtended(axisSettings, positionNode, patternNode, gridLineStyleNode);
+				ChartSupport.themeAxis(axisSettings, ExtendedScanChartUI.class.getName() + ".AxisRelativeIntensity");
+				axisSettings.setTitle(ExtensionMessages.relativeIntensity);
+				axisSettings.setVisible(true);
+				axisSettings.setTitleVisible(isShowAxisTitle);
+			}
+		} else {
+			if(axisSettings != null) {
+				axisSettings.setTitle(ExtensionMessages.relativeIntensity);
+				axisSettings.setVisible(false);
+				axisSettings.setTitleVisible(isShowAxisTitle);
+			}
+		}
 	}
 
 	private void createSaveButton(Composite parent) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanChartUI.java
@@ -52,6 +52,7 @@ import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageScan
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageSubtract;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.ScanChartAxisIntensity;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.ScanChartAxisIon;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.ScanChartAxisRelativeIntensity;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.ChromatogramUpdateSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.ScanDataSupport;
@@ -744,6 +745,7 @@ public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 
 		List<Class<? extends IPreferencePage>> preferencePages = new ArrayList<>();
 		preferencePages.add(PreferencePageScans.class);
+		preferencePages.add(ScanChartAxisIon.class);
 		preferencePages.add(ScanChartAxisIntensity.class);
 		preferencePages.add(ScanChartAxisRelativeIntensity.class);
 		preferencePages.add(PreferencePageSubtract.class);
@@ -753,11 +755,27 @@ public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 
 	void adjustAxisSettings() {
 
+		adjustAxisIons();
 		adjustAxisIntensity();
 		adjustAxisRelativeIntensity();
 
 		IChartSettings chartSettings = chartControl.get().getChartSettings();
 		chartControl.get().applySettings(chartSettings);
+	}
+
+	private void adjustAxisIons() {
+
+		IChartSettings chartSettings = chartControl.get().getChartSettings();
+		IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
+		primaryAxisSettingsX.setTitle(ExtensionMessages.ion);
+
+		String positionNode = PreferenceSupplier.P_SCAN_CHART_POSITION_X_AXIS_IONS;
+		String gridLineStyleNode = PreferenceSupplier.P_SCAN_CHART_GRIDLINE_STYLE_X_AXIS_IONS;
+
+		ChartSupport.setAxisSettingsExtended(primaryAxisSettingsX, positionNode, "0", gridLineStyleNode);
+		ChartSupport.themeAxis(primaryAxisSettingsX, ExtendedScanChartUI.class.getName() + ".AxisIons");
+		primaryAxisSettingsX.setVisible(ChartSupport.getBoolean(PreferenceSupplier.P_SCAN_CHART_SHOW_X_AXIS_IONS));
+		primaryAxisSettingsX.setTitleVisible(ChartSupport.getBoolean(PreferenceSupplier.P_SCAN_CHART_SHOW_X_AXIS_TITLE_IONS));
 	}
 
 	private void adjustAxisIntensity() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -232,7 +232,6 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 	private static final String MAIN_MENU_SCAN = "org.eclipse.chemclipse.ux.extension.ui.menu.scan";
 	private static final String MENU_CONTRIBUTOR_URI = "org.eclipse.chemclipse.ux.extension.xxd.ui.swt.editors.ExtendedChromatogramUI";
 
-	private String titleScans = Activator.getDefault().getPreferenceStore().getString(PreferenceSupplier.P_TITLE_X_AXIS_SCANS);
 	private ICommandService commandService = PlatformUI.getWorkbench().getService(ICommandService.class);
 
 	private AtomicReference<ProcessorToolbarUI> processorToolbarControl = new AtomicReference<>();
@@ -1698,15 +1697,14 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 			IChromatogram chromatogram = chromatogramSelection.getChromatogram();
 			if(chromatogram != null) {
 				IChartSettings chartSettings = chromatogramChartControl.get().getChartSettings();
-				ISecondaryAxisSettings axisSettings = ChartSupport.getSecondaryAxisSettingsX(titleScans, chartSettings);
-				String title = preferenceStore.getString(PreferenceSupplier.P_TITLE_X_AXIS_SCANS);
+				ISecondaryAxisSettings axisSettings = ChartSupport.getSecondaryAxisSettingsX(ExtensionMessages.scan, chartSettings);
 
 				if(preferenceStore.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_SCANS)) {
 					if(axisSettings == null) {
 						try {
 							int scanDelay = chromatogram.getScanDelay();
 							int scanInterval = chromatogram.getScanInterval();
-							ISecondaryAxisSettings secondaryAxisSettingsX = new SecondaryAxisSettings(title, new MillisecondsToScanNumberConverter(scanDelay, scanInterval));
+							ISecondaryAxisSettings secondaryAxisSettingsX = new SecondaryAxisSettings(ExtensionMessages.scan, new MillisecondsToScanNumberConverter(scanDelay, scanInterval));
 							secondaryAxisSettingsX.setTitleVisible(preferenceStore.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_TITLE_SCANS));
 							setScanAxisSettings(secondaryAxisSettingsX);
 							chartSettings.getSecondaryAxisSettingsListX().add(secondaryAxisSettingsX);
@@ -1714,18 +1712,17 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 							logger.warn(e);
 						}
 					} else {
-						axisSettings.setTitle(title);
+						axisSettings.setTitle(ExtensionMessages.scan);
 						setScanAxisSettings(axisSettings);
 					}
 				} else /*
 						 * Remove
 						 */
 				if(axisSettings != null) {
-					axisSettings.setTitle(title);
+					axisSettings.setTitle(ExtensionMessages.scan);
 					chartSettings.getSecondaryAxisSettingsListX().remove(axisSettings);
 				}
 				chromatogramChartControl.get().applySettings(chartSettings);
-				titleScans = title;
 			}
 		}
 	}


### PR DESCRIPTION
This gives it the same level of configurability we give the chromatogram chart. Change the font, size or hide axis titles completely. Same for grid (styles) or line colors.