### PR TITLE
Read mzML 1.1.0 in a more streaming manner

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverter.java
@@ -17,9 +17,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.Serializable;
-
-import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.converter.chromatogram.AbstractChromatogramImportConverter;
 import org.eclipse.chemclipse.logging.core.Logger;
@@ -36,9 +33,6 @@ import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.XmlReader10;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.XmlReader110;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.xml.sax.SAXException;
-
-import jakarta.xml.bind.JAXBException;
 
 public class ChromatogramImportConverter extends AbstractChromatogramImportConverter<IChromatogram> {
 
@@ -53,51 +47,37 @@ public class ChromatogramImportConverter extends AbstractChromatogramImportConve
 
 		IProcessingInfo<IChromatogram> processingInfo = super.validate(file);
 		if(!processingInfo.hasErrorMessages()) {
-			Serializable serializable = getMzML(file, processingInfo);
-			if(serializable instanceof org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.MzMLType mzML) {
-				IChromatogramMSDReader chromatogramReaderMSD = new ChromatogramMSDReaderVersion110(mzML);
-				if(chromatogramReaderMSD != null) {
-					importChromatogramMSD(chromatogramReaderMSD, file, monitor, processingInfo);
-				}
-				IChromatogramWSDReader chromatogramReaderWSD = new ChromatogramWSDReaderVersion110(mzML);
-				if(chromatogramReaderWSD != null) {
-					importChromatogramWSD(chromatogramReaderWSD, file, monitor, processingInfo);
-				}
-			} else if(serializable instanceof org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v10.MzMLType mzML) {
-				IChromatogramMSDReader chromatogramReaderMSD = new ChromatogramMSDReaderVersion10(mzML);
-				if(chromatogramReaderMSD != null) {
-					importChromatogramMSD(chromatogramReaderMSD, file, monitor, processingInfo);
-				}
+			String version = getVersion(file, processingInfo);
+			if(XmlReader110.VERSION.equals(version)) {
+				IChromatogramMSDReader chromatogramReaderMSD = new ChromatogramMSDReaderVersion110();
+				importChromatogramMSD(chromatogramReaderMSD, file, monitor, processingInfo);
+				IChromatogramWSDReader chromatogramReaderWSD = new ChromatogramWSDReaderVersion110();
+				importChromatogramWSD(chromatogramReaderWSD, file, monitor, processingInfo);
+			} else if(XmlReader10.VERSION.equals(version)) {
+				IChromatogramMSDReader chromatogramReaderMSD = new ChromatogramMSDReaderVersion10();
+				importChromatogramMSD(chromatogramReaderMSD, file, monitor, processingInfo);
 			}
 		}
 		return processingInfo;
 	}
 
-	private Serializable getMzML(File file, IProcessingInfo<?> processingInfo) {
+	private String getVersion(File file, IProcessingInfo<?> processingInfo) {
 
 		try (final FileReader fileReader = new FileReader(file)) {
 			final char[] charBuffer = new char[500];
 			fileReader.read(charBuffer);
 			final String header = new String(charBuffer);
 			if(header.contains(XmlReader110.VERSION)) {
-				org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.MzMLType mzML = XmlReader110.getMzML(file);
-				return mzML;
+				return XmlReader110.VERSION;
 			} else if(header.contains(XmlReader10.VERSION)) {
-				org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v10.MzMLType mzML = XmlReader10.getMzML(file);
-				return mzML;
+				return XmlReader10.VERSION;
 			} else {
 				processingInfo.addErrorMessage(DESCRIPTION, "Unknown version");
 			}
-		} catch(FileNotFoundException ex) {
-			logger.error(ex);
-		} catch(IOException ex) {
-			logger.error(ex);
-		} catch(SAXException ex) {
-			logger.error(ex);
-		} catch(JAXBException ex) {
-			logger.error(ex);
-		} catch(ParserConfigurationException ex) {
-			logger.error(ex);
+		} catch(FileNotFoundException e) {
+			logger.error(e);
+		} catch(IOException e) {
+			logger.error(e);
 		}
 		return null;
 	}
@@ -107,6 +87,9 @@ public class ChromatogramImportConverter extends AbstractChromatogramImportConve
 		monitor.subTask(IMPORT_CHROMATOGRAM);
 		try {
 			IChromatogramMSD chromatogram = chromatogramReaderMSD.read(file, monitor);
+			if(chromatogram.getNumberOfScans() == 0) {
+				return;
+			}
 			if(processingInfo.getProcessingResult() == null) {
 				processingInfo.setProcessingResult(chromatogram);
 			} else {
@@ -127,6 +110,9 @@ public class ChromatogramImportConverter extends AbstractChromatogramImportConve
 		monitor.subTask(IMPORT_CHROMATOGRAM);
 		try {
 			IChromatogramWSD chromatogram = chromatogramReaderWSD.read(file, monitor);
+			if(chromatogram.getNumberOfScans() == 0) {
+				return;
+			}
 			if(processingInfo.getProcessingResult() == null) {
 				processingInfo.setProcessingResult(chromatogram);
 			} else {
@@ -143,17 +129,13 @@ public class ChromatogramImportConverter extends AbstractChromatogramImportConve
 
 		IProcessingInfo<IChromatogramOverview> processingInfo = super.validate(file);
 		if(!processingInfo.hasErrorMessages()) {
-			Serializable serializable = getMzML(file, processingInfo);
-			if(serializable instanceof org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.MzMLType mzML) {
-				IChromatogramMSDReader chromatogramReaderMSD = new ChromatogramMSDReaderVersion110(mzML);
-				if(chromatogramReaderMSD != null) {
-					readOverviewMSD(file, chromatogramReaderMSD, monitor, processingInfo);
-				}
-			} else if(serializable instanceof org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v10.MzMLType mzML) {
-				IChromatogramMSDReader chromatogramReaderMSD = new ChromatogramMSDReaderVersion10(mzML);
-				if(chromatogramReaderMSD != null) {
-					readOverviewMSD(file, chromatogramReaderMSD, monitor, processingInfo);
-				}
+			String version = getVersion(file, processingInfo);
+			if(XmlReader110.VERSION.equals(version)) {
+				IChromatogramMSDReader chromatogramReaderMSD = new ChromatogramMSDReaderVersion110();
+				readOverviewMSD(file, chromatogramReaderMSD, monitor, processingInfo);
+			} else if(XmlReader10.VERSION.equals(version)) {
+				IChromatogramMSDReader chromatogramReaderMSD = new ChromatogramMSDReaderVersion10();
+				readOverviewMSD(file, chromatogramReaderMSD, monitor, processingInfo);
 			}
 		}
 		return processingInfo;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramMSDReaderVersion10.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramMSDReaderVersion10.java
@@ -17,6 +17,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.zip.DataFormatException;
 
+import javax.xml.parsers.ParserConfigurationException;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.chemclipse.converter.io.AbstractChromatogramReader;
 import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
@@ -57,24 +59,26 @@ import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v10.SpectrumDesc
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v10.SpectrumType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v10.UserParamType;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.xml.sax.SAXException;
+
+import jakarta.xml.bind.JAXBException;
 
 public class ChromatogramMSDReaderVersion10 extends AbstractChromatogramReader implements IChromatogramMSDReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramMSDReaderVersion10.class);
 
-	private MzMLType mzML;
-
-	public ChromatogramMSDReaderVersion10(MzMLType mzML) {
-
-		this.mzML = mzML;
-	}
-
 	@Override
 	public IChromatogramOverview readOverview(File file, IProgressMonitor monitor) throws IOException {
 
 		IVendorChromatogramMSD chromatogram = null;
-		chromatogram = new VendorChromatogramMSD();
-		readTIC(mzML.getRun(), chromatogram);
+		try {
+			MzMLType mzML = XmlReader10.getMzML(file);
+			chromatogram = new VendorChromatogramMSD();
+			readTIC(mzML.getRun(), chromatogram);
+		} catch(SAXException | IOException | JAXBException
+				| ParserConfigurationException e) {
+			logger.error(e);
+		}
 		return chromatogram;
 	}
 
@@ -82,13 +86,19 @@ public class ChromatogramMSDReaderVersion10 extends AbstractChromatogramReader i
 	public IChromatogramMSD read(File file, IProgressMonitor monitor) throws IOException {
 
 		IVendorChromatogramMSD chromatogram = null;
-		chromatogram = new VendorChromatogramMSD();
-		chromatogram.setFile(file);
-		readContact(mzML, chromatogram);
-		readSample(mzML, chromatogram);
-		readInstrument(mzML, chromatogram);
-		readEditHistory(mzML, chromatogram);
-		readSpectrum(mzML, chromatogram, monitor);
+		try {
+			MzMLType mzML = XmlReader10.getMzML(file);
+			chromatogram = new VendorChromatogramMSD();
+			chromatogram.setFile(file);
+			readContact(mzML, chromatogram);
+			readSample(mzML, chromatogram);
+			readInstrument(mzML, chromatogram);
+			readEditHistory(mzML, chromatogram);
+			readSpectrum(mzML, chromatogram, monitor);
+		} catch(SAXException | IOException | JAXBException
+				| ParserConfigurationException e) {
+			logger.error(e);
+		}
 		return chromatogram;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramMSDReaderVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramMSDReaderVersion110.java
@@ -13,9 +13,16 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mzml.io;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.List;
+import java.util.Map;
 import java.util.zip.DataFormatException;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -40,6 +47,7 @@ import org.eclipse.chemclipse.msd.model.implementation.RegularMassSpectrum;
 import org.eclipse.chemclipse.support.history.EditInformation;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.BinaryReader110;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.MetadataReader110;
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.XmlHelper;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.XmlReader110;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.BinaryDataArrayType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.CVParamType;
@@ -52,87 +60,173 @@ import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.PrecursorTy
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.ProcessingMethodType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.ProductType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.ReferenceableParamGroupRefType;
-import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.RunType;
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.ReferenceableParamGroupType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.ScanType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.SelectedIonListType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.SoftwareType;
-import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.SpectrumListType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.SpectrumType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.UserParamType;
 import org.eclipse.core.runtime.IProgressMonitor;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 public class ChromatogramMSDReaderVersion110 extends AbstractChromatogramReader implements IChromatogramMSDReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramMSDReaderVersion110.class);
 
-	private MzMLType mzML;
-
-	public ChromatogramMSDReaderVersion110(MzMLType mzML) {
-
-		this.mzML = mzML;
-	}
-
 	@Override
 	public IChromatogramOverview readOverview(File file, IProgressMonitor monitor) throws IOException {
 
 		IVendorChromatogramMSD chromatogram = null;
-		chromatogram = new VendorChromatogramMSD();
-		MetadataReader110.readMetadata(mzML, chromatogram);
-		readTIC(mzML.getRun(), chromatogram);
+		try {
+			MzMLType mzMLwithoutRun = XmlHelper.parseFiltered(file, MzMLType.class, "mzML", "run");
+			chromatogram = new VendorChromatogramMSD();
+			MetadataReader110.readMetadata(mzMLwithoutRun, chromatogram);
+		} catch(IOException | JAXBException | XMLStreamException e) {
+			logger.error(e);
+		}
+
+		readChromatograms(file, chromatogram, true);
 		return chromatogram;
 	}
 
 	@Override
 	public IChromatogramMSD read(File file, IProgressMonitor monitor) throws IOException {
 
-		IVendorChromatogramMSD chromatogram = new VendorChromatogramMSD();
-		chromatogram.setFile(file);
-		MetadataReader110.readMetadata(mzML, chromatogram);
-		readSpectrum(mzML, chromatogram, monitor);
-		readEditHistory(mzML, chromatogram);
+		IVendorChromatogramMSD chromatogram = null;
+		MzMLType mzMLwithoutRun = null;
+		try {
+			mzMLwithoutRun = XmlHelper.parseFiltered(file, MzMLType.class, "mzML", "run");
+			chromatogram = new VendorChromatogramMSD();
+			chromatogram.setFile(file);
+			MetadataReader110.readMetadata(mzMLwithoutRun, chromatogram);
+			readEditHistory(mzMLwithoutRun, chromatogram);
+		} catch(IOException | JAXBException | XMLStreamException e) {
+			logger.error(e);
+		}
+
+		if(mzMLwithoutRun == null || chromatogram == null) {
+			return chromatogram;
+		}
+
+		readSpectra(file, mzMLwithoutRun, chromatogram, monitor);
+		if(chromatogram.getNumberOfScans() == 0) {
+			readChromatograms(file, chromatogram, false);
+		}
+
 		return chromatogram;
 	}
 
-	private void readTIC(RunType run, IVendorChromatogramMSD chromatogram) {
+	private void readSpectra(File file, MzMLType mzML, IVendorChromatogramMSD chromatogram, IProgressMonitor monitor) {
 
-		for(ChromatogramType chromatogramType : run.getChromatogramList().getChromatogram()) {
-			if(chromatogramType.getCvParam().stream().anyMatch(n -> //
-			n.getAccession().equals("MS:1000235") && n.getName().equals("total ion current chromatogram"))) {
-				chromatogram.setDataName(chromatogramType.getId());
-				Pair<double[], double[]> binaryData = readBinaryData(chromatogramType);
-				XmlChromatogramReader.addTotalSignals(binaryData.getValue(), binaryData.getKey(), chromatogram);
+		try {
+			XMLInputFactory factory = XMLInputFactory.newFactory();
+			XMLStreamReader reader = factory.createXMLStreamReader(new FileInputStream(file));
+
+			JAXBContext context = JAXBContext.newInstance(SpectrumType.class);
+			Unmarshaller spectrumUnmarshaller = context.createUnmarshaller();
+
+			int cycleNumber = isMultiStageMassSpectrum(mzML) ? 1 : 0;
+			Map<String, ReferenceableParamGroupType> paramGroups = MetadataReader110.buildParamGroupMap(mzML);
+
+			while(reader.hasNext()) {
+				if(monitor.isCanceled()) {
+					return;
+				}
+				if(reader.isStartElement()) {
+					String localName = reader.getLocalName();
+					if("spectrumList".equals(localName)) {
+						int spectrumCount = IProgressMonitor.UNKNOWN;
+						String countAttr = reader.getAttributeValue(null, "count");
+						if(countAttr != null) {
+							try {
+								spectrumCount = Integer.parseInt(countAttr);
+							} catch(NumberFormatException e) {
+								logger.warn(e);
+							}
+						}
+						monitor.beginTask(ConverterMessages.readScans, spectrumCount);
+						reader.next();
+						continue;
+					}
+					if("spectrum".equals(localName)) {
+						JAXBElement<SpectrumType> element = spectrumUnmarshaller.unmarshal(reader, SpectrumType.class);
+						SpectrumType spectrum = element.getValue();
+						if(spectrum.getCvParam().stream().noneMatch(n -> n.getAccession().equals("MS:1000806") && n.getName().equals("absorption spectrum"))) {
+							readSpectrum(element.getValue(), cycleNumber, chromatogram, paramGroups);
+						}
+						monitor.worked(1);
+						// no reader.next() as unmarshal already advanced past </spectrum>
+						continue;
+					}
+				}
+				reader.next();
 			}
+			reader.close();
+		} catch(XMLStreamException e) {
+			logger.error(e);
+		} catch(JAXBException e) {
+			logger.error(e);
+		} catch(FileNotFoundException e) {
+			logger.error(e);
 		}
 	}
 
-	private void readSpectrum(MzMLType mzML, IVendorChromatogramMSD chromatogram, IProgressMonitor monitor) {
+	private void readChromatograms(File file, IVendorChromatogramMSD chromatogram, boolean overview) {
 
-		SpectrumListType spectrumList = mzML.getRun().getSpectrumList();
-		if(spectrumList == null) {
-			readTIC(mzML.getRun(), chromatogram);
-			readSRM(mzML.getRun(), chromatogram);
-			return;
+		try {
+			XMLInputFactory factory = XMLInputFactory.newFactory();
+			XMLStreamReader reader = factory.createXMLStreamReader(new FileInputStream(file));
+
+			JAXBContext context;
+
+			context = JAXBContext.newInstance(ChromatogramType.class);
+
+			Unmarshaller chromatogramUnmarshaller = context.createUnmarshaller();
+
+			while(reader.hasNext()) {
+				int event = reader.next();
+				if(event == XMLStreamConstants.START_ELEMENT && "chromatogram".equals(reader.getLocalName())) {
+					JAXBElement<ChromatogramType> element = chromatogramUnmarshaller.unmarshal(reader, ChromatogramType.class);
+					readTIC(element.getValue(), chromatogram);
+					if(!overview) {
+						readSRM(element.getValue(), chromatogram);
+					}
+				}
+			}
+			reader.close();
+		} catch(JAXBException | FileNotFoundException | XMLStreamException e) {
+			logger.error(e);
 		}
-		monitor.beginTask(ConverterMessages.readScans, spectrumList.getCount().intValue());
-		int cycleNumber = isMultiStageMassSpectrum(mzML) ? 1 : 0;
-		for(SpectrumType spectrum : mzML.getRun().getSpectrumList().getSpectrum()) {
-			if(monitor.isCanceled()) {
-				return;
-			}
-			IRegularMassSpectrum massSpectrum = readMassSpectrum(spectrum);
-			if(massSpectrum.getMassSpectrometer() < 2) {
-				cycleNumber++;
-			}
-			if(cycleNumber >= 1) {
-				massSpectrum.setCycleNumber(cycleNumber);
-			}
-			setRetentionTime(spectrum, massSpectrum);
-			massSpectrum.setIdentifier(spectrum.getId());
-			setReferencedPolarity(spectrum, massSpectrum);
-			readIons(spectrum, massSpectrum, chromatogram);
-			chromatogram.addScan(massSpectrum);
-			monitor.worked(1);
+	}
+
+	private void readTIC(ChromatogramType chromatogramType, IVendorChromatogramMSD chromatogram) {
+
+		if(chromatogramType.getCvParam().stream().anyMatch(n -> //
+		n.getAccession().equals("MS:1000235") && n.getName().equals("total ion current chromatogram"))) {
+			chromatogram.setDataName(chromatogramType.getId());
+			Pair<double[], double[]> binaryData = readBinaryData(chromatogramType);
+			XmlChromatogramReader.addTotalSignals(binaryData.getValue(), binaryData.getKey(), chromatogram);
 		}
+	}
+
+	private void readSpectrum(SpectrumType spectrum, int cycleNumber, IVendorChromatogramMSD chromatogram, Map<String, ReferenceableParamGroupType> paramGroups) {
+
+		IRegularMassSpectrum massSpectrum = readMassSpectrum(spectrum);
+		if(massSpectrum.getMassSpectrometer() < 2) {
+			cycleNumber++;
+		}
+		if(cycleNumber >= 1) {
+			massSpectrum.setCycleNumber(cycleNumber);
+		}
+		setRetentionTime(spectrum, massSpectrum);
+		massSpectrum.setIdentifier(spectrum.getId());
+		setReferencedPolarity(spectrum, massSpectrum, paramGroups);
+		readIons(spectrum, massSpectrum, chromatogram);
+		chromatogram.addScan(massSpectrum);
 	}
 
 	public static void setRetentionTime(SpectrumType spectrum, IRegularMassSpectrum massSpectrum) {
@@ -162,34 +256,32 @@ public class ChromatogramMSDReaderVersion110 extends AbstractChromatogramReader 
 		}
 	}
 
-	private void readSRM(RunType run, IVendorChromatogramMSD chromatogram) {
+	private void readSRM(ChromatogramType chromatogramType, IVendorChromatogramMSD chromatogram) {
 
-		for(ChromatogramType chromatogramType : run.getChromatogramList().getChromatogram()) {
-			if(chromatogramType.getCvParam().stream().anyMatch(n -> //
-			n.getAccession().equals("MS:1001473") && n.getName().equals("selected reaction monitoring chromatogram"))) {
-				IVendorChromatogramMSD referencedChromatogram = new VendorChromatogramMSD();
-				referencedChromatogram.setDataName(chromatogramType.getId());
+		if(chromatogramType.getCvParam().stream().anyMatch(n -> //
+		n.getAccession().equals("MS:1001473") && n.getName().equals("selected reaction monitoring chromatogram"))) {
+			IVendorChromatogramMSD referencedChromatogram = new VendorChromatogramMSD();
+			referencedChromatogram.setDataName(chromatogramType.getId());
 
-				Pair<double[], double[]> binaryData = readBinaryData(chromatogramType);
+			Pair<double[], double[]> binaryData = readBinaryData(chromatogramType);
 
-				double precursorIon = getPrecursorIon(chromatogramType);
-				double productIon = getProductIon(chromatogramType);
-				double collisionEnergy = getCollisionEnergy(chromatogramType);
-				IIonTransition ionTransition = new IonTransition(precursorIon, productIon, collisionEnergy, 1, 1, 0);
-				chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
+			double precursorIon = getPrecursorIon(chromatogramType);
+			double productIon = getProductIon(chromatogramType);
+			double collisionEnergy = getCollisionEnergy(chromatogramType);
+			IIonTransition ionTransition = new IonTransition(precursorIon, productIon, collisionEnergy, 1, 1, 0);
+			chromatogram.getIonTransitionSettings().getIonTransitions().add(ionTransition);
 
-				addIonSRM(binaryData.getValue(), binaryData.getKey(), ionTransition, referencedChromatogram);
+			addIonSRM(binaryData.getValue(), binaryData.getKey(), ionTransition, referencedChromatogram);
 
-				for(CVParamType cvParam : chromatogramType.getCvParam()) {
-					for(IScan scan : referencedChromatogram.getScans()) {
-						if(scan instanceof IRegularMassSpectrum massSpectrum) {
-							setPolarity(cvParam, massSpectrum);
-						}
+			for(CVParamType cvParam : chromatogramType.getCvParam()) {
+				for(IScan scan : referencedChromatogram.getScans()) {
+					if(scan instanceof IRegularMassSpectrum massSpectrum) {
+						setPolarity(cvParam, massSpectrum);
 					}
 				}
-
-				chromatogram.getReferencedChromatograms().add(referencedChromatogram);
 			}
+
+			chromatogram.getReferencedChromatograms().add(referencedChromatogram);
 		}
 	}
 
@@ -360,14 +452,17 @@ public class ChromatogramMSDReaderVersion110 extends AbstractChromatogramReader 
 		}
 	}
 
-	private static void setReferencedPolarity(SpectrumType spectrum, IRegularMassSpectrum massSpectrum) {
+	private static void setReferencedPolarity(SpectrumType spectrum, IRegularMassSpectrum massSpectrum, Map<String, ReferenceableParamGroupType> paramGroups) {
 
 		if(spectrum.getReferenceableParamGroupRef() == null) {
 			return;
 		}
-		List<ReferenceableParamGroupRefType> groupTypes = spectrum.getReferenceableParamGroupRef();
-		for(ReferenceableParamGroupRefType groupType : groupTypes) {
-			for(CVParamType cvParam : groupType.getRef().getCvParam()) {
+		for(ReferenceableParamGroupRefType groupType : spectrum.getReferenceableParamGroupRef()) {
+			ReferenceableParamGroupType group = paramGroups.get(groupType.getRef());
+			if(group == null) {
+				continue;
+			}
+			for(CVParamType cvParam : group.getCvParam()) {
 				setPolarity(cvParam, massSpectrum);
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/wsd/converter/supplier/mzml/converter/io/ChromatogramWSDReaderVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/wsd/converter/supplier/mzml/converter/io/ChromatogramWSDReaderVersion110.java
@@ -13,13 +13,22 @@
 package org.eclipse.chemclipse.wsd.converter.supplier.mzml.converter.io;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.zip.DataFormatException;
 
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.chemclipse.converter.io.AbstractChromatogramReader;
+import org.eclipse.chemclipse.converter.l10n.ConverterMessages;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
+import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.wsd.converter.io.IChromatogramWSDReader;
 import org.eclipse.chemclipse.wsd.converter.supplier.mzml.converter.model.IVendorChromatogramWSD;
 import org.eclipse.chemclipse.wsd.converter.supplier.mzml.converter.model.IVendorScanSignal;
@@ -30,34 +39,36 @@ import org.eclipse.chemclipse.wsd.converter.supplier.mzml.converter.model.Vendor
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.BinaryReader110;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.MetadataReader110;
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.XmlHelper;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.BinaryDataArrayType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.CVParamType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.ChromatogramType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.MzMLType;
-import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.RunType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.SpectrumType;
 import org.eclipse.core.runtime.IProgressMonitor;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 public class ChromatogramWSDReaderVersion110 extends AbstractChromatogramReader implements IChromatogramWSDReader {
 
 	private static final Logger logger = Logger.getLogger(ChromatogramWSDReaderVersion110.class);
 
-	private MzMLType mzML;
-
-	public ChromatogramWSDReaderVersion110(MzMLType mzML) {
-
-		this.mzML = mzML;
-	}
-
 	@Override
 	public IChromatogramOverview readOverview(File file, IProgressMonitor monitor) throws IOException {
 
 		IVendorChromatogramWSD chromatogram = null;
-		chromatogram = new VendorChromatogramWSD();
-		chromatogram.setFile(file);
-		chromatogram = (IVendorChromatogramWSD)MetadataReader110.readMetadata(mzML, chromatogram);
-		RunType run = mzML.getRun();
-		readSingleWavelengthSignal(run, chromatogram);
+		try {
+			MzMLType mzMLwithoutRun = XmlHelper.parseFiltered(file, MzMLType.class, "mzML", "run");
+			chromatogram = new VendorChromatogramWSD();
+			chromatogram.setFile(file);
+			chromatogram = (IVendorChromatogramWSD)MetadataReader110.readMetadata(mzMLwithoutRun, chromatogram);
+			readChromatograms(file, chromatogram);
+		} catch(IOException | JAXBException | XMLStreamException e) {
+			logger.error(e);
+		}
 		return chromatogram;
 	}
 
@@ -65,25 +76,109 @@ public class ChromatogramWSDReaderVersion110 extends AbstractChromatogramReader 
 	public IChromatogramWSD read(File file, IProgressMonitor monitor) throws IOException {
 
 		IVendorChromatogramWSD chromatogram = null;
-		chromatogram = new VendorChromatogramWSD();
-		chromatogram.setFile(file);
-		chromatogram = (IVendorChromatogramWSD)MetadataReader110.readMetadata(mzML, chromatogram);
-		RunType run = mzML.getRun();
-		readSingleWavelengthSignal(run, chromatogram);
+		MzMLType mzMLwithoutRun = null;
+
 		try {
-			readFullSpectrum(run, chromatogram);
-		} catch(DataFormatException e) {
+			mzMLwithoutRun = XmlHelper.parseFiltered(file, MzMLType.class, "mzML", "run");
+			chromatogram = new VendorChromatogramWSD();
+			chromatogram.setFile(file);
+			chromatogram = (IVendorChromatogramWSD)MetadataReader110.readMetadata(mzMLwithoutRun, chromatogram);
+		} catch(IOException | JAXBException | XMLStreamException e) {
 			logger.error(e);
 		}
+		if(mzMLwithoutRun == null || chromatogram == null) {
+			return chromatogram;
+		}
+
+		readChromatograms(file, chromatogram);
+		readSpectra(file, mzMLwithoutRun, chromatogram, monitor);
+
 		return chromatogram;
 	}
 
-	private void readFullSpectrum(RunType run, IVendorChromatogramWSD chromatogram) throws DataFormatException {
+	private void readChromatograms(File file, IVendorChromatogramWSD chromatogram) {
 
-		int i = 1;
-		for(SpectrumType spectrum : run.getSpectrumList().getSpectrum()) {
-			double[] wavelengths = new double[0];
-			double[] intensities = new double[0];
+		try {
+			XMLInputFactory factory = XMLInputFactory.newFactory();
+			XMLStreamReader reader = factory.createXMLStreamReader(new FileInputStream(file));
+
+			JAXBContext context;
+
+			context = JAXBContext.newInstance(ChromatogramType.class);
+
+			Unmarshaller chromatogramUnmarshaller = context.createUnmarshaller();
+
+			while(reader.hasNext()) {
+				int event = reader.next();
+				if(event == XMLStreamConstants.START_ELEMENT && "chromatogram".equals(reader.getLocalName())) {
+					JAXBElement<ChromatogramType> element = chromatogramUnmarshaller.unmarshal(reader, ChromatogramType.class);
+					readSingleWavelengthSignal(element.getValue(), chromatogram);
+				}
+			}
+			reader.close();
+		} catch(JAXBException | FileNotFoundException | XMLStreamException e) {
+			logger.error(e);
+		}
+	}
+
+	private void readSpectra(File file, MzMLType mzML, IVendorChromatogramWSD chromatogram, IProgressMonitor monitor) {
+
+		try {
+			XMLInputFactory factory = XMLInputFactory.newFactory();
+			XMLStreamReader reader = factory.createXMLStreamReader(new FileInputStream(file));
+
+			JAXBContext context = JAXBContext.newInstance(SpectrumType.class);
+			Unmarshaller spectrumUnmarshaller = context.createUnmarshaller();
+
+			while(reader.hasNext()) {
+				if(monitor.isCanceled()) {
+					return;
+				}
+				if(reader.isStartElement()) {
+					String localName = reader.getLocalName();
+					if("spectrumList".equals(localName)) {
+						int spectrumCount = IProgressMonitor.UNKNOWN;
+						String countAttr = reader.getAttributeValue(null, "count");
+						if(countAttr != null) {
+							try {
+								spectrumCount = Integer.parseInt(countAttr);
+							} catch(NumberFormatException e) {
+								logger.warn(e);
+							}
+						}
+						monitor.beginTask(ConverterMessages.readScans, spectrumCount);
+						reader.next();
+						continue;
+					}
+					if("spectrum".equals(localName)) {
+						JAXBElement<SpectrumType> element = spectrumUnmarshaller.unmarshal(reader, SpectrumType.class);
+						SpectrumType spectrum = element.getValue();
+						if(spectrum.getCvParam().stream().anyMatch(n -> n.getAccession().equals("MS:1000806") && n.getName().equals("absorption spectrum"))) {
+							readSpectrum(spectrum, chromatogram);
+						}
+						monitor.worked(1);
+						// no reader.next() as unmarshal already advanced past </spectrum>
+						continue;
+					}
+				}
+				reader.next();
+			}
+			reader.close();
+		} catch(XMLStreamException e) {
+			logger.error(e);
+		} catch(JAXBException e) {
+			logger.error(e);
+		} catch(FileNotFoundException e) {
+			logger.error(e);
+		}
+	}
+
+	private void readSpectrum(SpectrumType spectrum, IVendorChromatogramWSD chromatogram) {
+
+		double[] wavelengths = new double[0];
+		double[] intensities = new double[0];
+
+		try {
 			for(BinaryDataArrayType binaryDataArrayType : spectrum.getBinaryDataArrayList().getBinaryDataArray()) {
 				Pair<String, double[]> binaryData = BinaryReader110.parseBinaryData(binaryDataArrayType);
 				if(binaryData.getKey().equals("wavelength")) {
@@ -92,38 +187,41 @@ public class ChromatogramWSDReaderVersion110 extends AbstractChromatogramReader 
 					intensities = binaryData.getValue();
 				}
 			}
-			if(!chromatogram.getScans().isEmpty()) {
-				IVendorScanWSD scan = (IVendorScanWSD)chromatogram.getScan(i);
-				if(scan != null) {
-					scan.deleteScanSignals(); // otherwise the total signal is added upon
-					addSpectrum(wavelengths, intensities, scan);
+		} catch(DataFormatException e) {
+			logger.error(e);
+		}
+
+		if(!chromatogram.getScans().isEmpty()) {
+			for(IScan scan : chromatogram.getScans()) {
+				if(scan instanceof IVendorScanWSD scanWSD) {
+					scanWSD.deleteScanSignals(); // otherwise the total signal is added upon
+					addSpectrum(wavelengths, intensities, scanWSD);
 				}
 			}
-			i++;
 		}
 	}
 
-	private void readSingleWavelengthSignal(RunType run, IVendorChromatogramWSD chromatogram) {
+	private void readSingleWavelengthSignal(ChromatogramType chromatogramType, IVendorChromatogramWSD chromatogram) {
 
 		double[] retentionTimes = new double[0];
 		double[] intensities = new double[0];
+
 		float lowestWavelength = 0f;
 		float highestWavelength = 0f;
+
 		try {
-			for(ChromatogramType chromatogramType : run.getChromatogramList().getChromatogram()) {
-				for(CVParamType cvParam : chromatogramType.getCvParam()) {
-					if(cvParam.getAccession().equals("MS:1000618") && cvParam.getName().equals("highest observed wavelength")) {
-						highestWavelength = Float.parseFloat(cvParam.getValue());
-					} else if(cvParam.getAccession().equals("MS:1000619") && cvParam.getName().equals("lowest observed wavelength")) {
-						lowestWavelength = Float.parseFloat(cvParam.getValue());
-					} else if(cvParam.getAccession().equals("MS:1000812") && cvParam.getName().equals("absorption chromatogram")) {
-						for(BinaryDataArrayType binaryDataArrayType : chromatogramType.getBinaryDataArrayList().getBinaryDataArray()) {
-							Pair<String, double[]> binaryData = BinaryReader110.parseBinaryData(binaryDataArrayType);
-							if(binaryData.getKey().equals("time")) {
-								retentionTimes = binaryData.getValue();
-							} else if(binaryData.getKey().equals("intensity")) {
-								intensities = binaryData.getValue();
-							}
+			for(CVParamType cvParam : chromatogramType.getCvParam()) {
+				if(cvParam.getAccession().equals("MS:1000618") && cvParam.getName().equals("highest observed wavelength")) {
+					highestWavelength = Float.parseFloat(cvParam.getValue());
+				} else if(cvParam.getAccession().equals("MS:1000619") && cvParam.getName().equals("lowest observed wavelength")) {
+					lowestWavelength = Float.parseFloat(cvParam.getValue());
+				} else if(cvParam.getAccession().equals("MS:1000812") && cvParam.getName().equals("absorption chromatogram")) {
+					for(BinaryDataArrayType binaryDataArrayType : chromatogramType.getBinaryDataArrayList().getBinaryDataArray()) {
+						Pair<String, double[]> binaryData = BinaryReader110.parseBinaryData(binaryDataArrayType);
+						if(binaryData.getKey().equals("time")) {
+							retentionTimes = binaryData.getValue();
+						} else if(binaryData.getKey().equals("intensity")) {
+							intensities = binaryData.getValue();
 						}
 					}
 				}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/MetadataReader110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/MetadataReader110.java
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.converter.supplier.mzml.io;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.support.history.EditInformation;
@@ -22,7 +24,9 @@ import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.InstrumentC
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.MzMLType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.ParamGroupType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.ProcessingMethodType;
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.ReferenceableParamGroupListType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.ReferenceableParamGroupRefType;
+import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.ReferenceableParamGroupType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.SampleListType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.SampleType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.SoftwareType;
@@ -52,12 +56,16 @@ public class MetadataReader110 {
 			}
 		}
 
+		Map<String, ReferenceableParamGroupType> paramGroups = buildParamGroupMap(mzML);
 		for(InstrumentConfigurationType instrument : mzML.getInstrumentConfigurationList().getInstrumentConfiguration()) {
 
 			List<ReferenceableParamGroupRefType> referenceableParamGroupRef = instrument.getReferenceableParamGroupRef();
 			if(referenceableParamGroupRef != null) {
 				for(ReferenceableParamGroupRefType referenceableParamGroupRefType : referenceableParamGroupRef) {
-					readInstrument(referenceableParamGroupRefType.getRef().getCvParam(), chromatogram);
+					ReferenceableParamGroupType group = paramGroups.get(referenceableParamGroupRefType.getRef());
+					if(group != null) {
+						readInstrument(group.getCvParam(), chromatogram);
+					}
 				}
 			}
 
@@ -76,6 +84,19 @@ public class MetadataReader110 {
 		}
 
 		return chromatogram;
+	}
+
+	// In a streaming implementation all automatic IDREFs are lost so save them for reconnection later.
+	public static Map<String, ReferenceableParamGroupType> buildParamGroupMap(MzMLType mzML) {
+
+		Map<String, ReferenceableParamGroupType> map = new HashMap<>();
+		ReferenceableParamGroupListType groupList = mzML.getReferenceableParamGroupList();
+		if(groupList != null) {
+			for(ReferenceableParamGroupType group : groupList.getReferenceableParamGroup()) {
+				map.put(group.getId(), group);
+			}
+		}
+		return map;
 	}
 
 	private static void readInstrument(List<CVParamType> cvParams, IChromatogram chromatogram) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlReader110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlReader110.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,6 +39,9 @@ public class XmlReader110 {
 
 	}
 
+	/**
+	 * Attention: This builds a full DOM tree which is expensive.
+	 */
 	public static MzMLType getMzML(File file) throws SAXException, IOException, JAXBException, ParserConfigurationException {
 
 		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
@@ -64,6 +67,23 @@ public class XmlReader110 {
 		if(cvParam.getUnitAccession().equals("UO:0000031") && cvParam.getUnitName().equals("minute")) {
 			multiplicator = (float)IChromatogramOverview.MINUTE_CORRELATION_FACTOR;
 		}
+		return multiplicator;
+	}
+
+	public static float getTimeMultiplicator(String unitAccession, String unitName) {
+
+		float multiplicator = 1f;
+
+		if("UO:0000028".equals(unitAccession) && "millisecond".equals(unitName)) {
+			multiplicator = 1f;
+		}
+		if("UO:0000010".equals(unitAccession) && "second".equals(unitName)) {
+			multiplicator = (float)IChromatogramOverview.SECOND_CORRELATION_FACTOR;
+		}
+		if("UO:0000031".equals(unitAccession) && "minute".equals(unitName)) {
+			multiplicator = (float)IChromatogramOverview.MINUTE_CORRELATION_FACTOR;
+		}
+
 		return multiplicator;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ReferenceableParamGroupRefType.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/model/v110/ReferenceableParamGroupRefType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,6 @@ package org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
-import jakarta.xml.bind.annotation.XmlIDREF;
-import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
 
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -24,16 +22,14 @@ import jakarta.xml.bind.annotation.XmlType;
 public class ReferenceableParamGroupRefType {
 
 	@XmlAttribute(name = "ref", required = true)
-	@XmlIDREF
-	@XmlSchemaType(name = "IDREF")
-	private ReferenceableParamGroupType ref;
+	private String ref;
 
-	public ReferenceableParamGroupType getRef() {
+	public String getRef() {
 
 		return ref;
 	}
 
-	public void setRef(ReferenceableParamGroupType value) {
+	public void setRef(String value) {
 
 		this.ref = value;
 	}

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverterHandCrafted110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportConverterHandCrafted110_ITest.java
@@ -17,8 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 
 import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.IVendorChromatogramMSD;
-import org.eclipse.chemclipse.msd.converter.supplier.mzml.converter.model.VendorChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.supplier.mzml.converter.model.IVendorChromatogramWSD;
 import org.eclipse.chemclipse.wsd.converter.supplier.mzml.converter.model.VendorChromatogramWSD;
@@ -32,7 +30,6 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImportConverterHandCrafted110_ITest {
 
-	private IVendorChromatogramMSD chromatogramMSD;
 	private IVendorChromatogramWSD chromatogramWSD;
 
 	@BeforeAll
@@ -41,8 +38,7 @@ public class ChromatogramImportConverterHandCrafted110_ITest {
 		File importFile = new File("testData/files/import/PDA.mzML");
 		ChromatogramImportConverter converter = new ChromatogramImportConverter();
 		IProcessingInfo<IChromatogram> processingInfo = converter.convert(importFile, new NullProgressMonitor());
-		chromatogramMSD = (VendorChromatogramMSD)processingInfo.getProcessingResult(); // TODO: there actually is none
-		chromatogramWSD = (VendorChromatogramWSD)chromatogramMSD.getReferencedChromatograms().get(0);
+		chromatogramWSD = (VendorChromatogramWSD)processingInfo.getProcessingResult();
 	}
 
 	@Test
@@ -84,7 +80,7 @@ public class ChromatogramImportConverterHandCrafted110_ITest {
 	@Test
 	public void testTotalSignal() {
 
-		assertEquals(225.0f, chromatogramWSD.getTotalSignal(), 0, "Total Signal");
+		assertEquals(1800f, chromatogramWSD.getTotalSignal(), 0, "Total Signal");
 	}
 
 	@Test


### PR DESCRIPTION
I really like having a full DOM tree to get type safety everywhere. However, that also means all `BinaryDataArray`s are in memory all at the same time, which makes large mzML files explode into RAM during import. I try to do the best of both worlds here: mzML metadata is parsed as a DOM tree. All the `<spectrum>` entries of each scan are, however, parsed one at a time. A downside to this approach that I had to work around is that `@XmlIDREF` is no longer working, so I need to keep track of those manually as string dictionaries without type safety.