### PR TITLE
Use primitive hash helpers

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.converter/src/org/eclipse/chemclipse/chromatogram/alignment/converter/retentionindices/RetentionIndicesSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.converter/src/org/eclipse/chemclipse/chromatogram/alignment/converter/retentionindices/RetentionIndicesSupplier.java
@@ -150,7 +150,7 @@ public class RetentionIndicesSupplier implements IRetentionIndicesSupplier {
 	@Override
 	public int hashCode() {
 
-		return id.hashCode() + description.hashCode() + filterName.hashCode() + fileExtension.hashCode() + Boolean.valueOf(exportable).hashCode() + Boolean.valueOf(importable).hashCode();
+		return id.hashCode() + description.hashCode() + filterName.hashCode() + fileExtension.hashCode() + Boolean.hashCode(exportable) + Boolean.hashCode(importable);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.converter/src/org/eclipse/chemclipse/chromatogram/alignment/converter/retentionindices/RetentionIndicesSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.converter/src/org/eclipse/chemclipse/chromatogram/alignment/converter/retentionindices/RetentionIndicesSupplier.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.alignment.converter.retentionindices;
 
+import java.util.Objects;
+
 public class RetentionIndicesSupplier implements IRetentionIndicesSupplier {
 
 	private String id = "";
@@ -150,7 +152,7 @@ public class RetentionIndicesSupplier implements IRetentionIndicesSupplier {
 	@Override
 	public int hashCode() {
 
-		return id.hashCode() + description.hashCode() + filterName.hashCode() + fileExtension.hashCode() + Boolean.hashCode(exportable) + Boolean.hashCode(importable);
+		return Objects.hash(id, description, filterName, fileExtension, exportable, importable);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.model/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndex.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.model/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndex.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.alignment.model.core;
 
+import java.util.Objects;
+
 public class RetentionIndex implements IRetentionIndex, Comparable<IRetentionIndex> {
 
 	public static final int MIN_RETENTION_TIME = 0;
@@ -140,8 +142,7 @@ public class RetentionIndex implements IRetentionIndex, Comparable<IRetentionInd
 	@Override
 	public int hashCode() {
 
-		// index, retentionTime, name
-		return 7 * Double.hashCode(index) + 9 * Integer.hashCode(retentionTime) + 11 * name.hashCode();
+		return Objects.hash(index, retentionTime, name);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.model/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndex.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.model/src/org/eclipse/chemclipse/chromatogram/alignment/model/core/RetentionIndex.java
@@ -141,7 +141,7 @@ public class RetentionIndex implements IRetentionIndex, Comparable<IRetentionInd
 	public int hashCode() {
 
 		// index, retentionTime, name
-		return 7 * Double.valueOf(index).hashCode() + 9 * Integer.valueOf(retentionTime).hashCode() + 11 * name.hashCode();
+		return 7 * Double.hashCode(index) + 9 * Integer.hashCode(retentionTime) + 11 * name.hashCode();
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/model/TargetTrace.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc/src/org/eclipse/chemclipse/chromatogram/msd/classifier/supplier/wnc/model/TargetTrace.java
@@ -92,7 +92,7 @@ public class TargetTrace {
 	@Override
 	public int hashCode() {
 
-		return 7 * Integer.valueOf(ion).hashCode() + 11 * name.hashCode();
+		return 7 * Integer.hashCode(ion) + 11 * name.hashCode();
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/support/DetectorSlope.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/support/DetectorSlope.java
@@ -51,7 +51,7 @@ public class DetectorSlope extends Slope implements IDetectorSlope {
 	@Override
 	public int hashCode() {
 
-		return 7 * Integer.valueOf(retentionTime).hashCode();
+		return 7 * Integer.hashCode(retentionTime);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/support/RawPeak.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/src/org/eclipse/chemclipse/chromatogram/peak/detector/support/RawPeak.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,6 +20,7 @@ public class RawPeak implements IRawPeak {
 	private int stopScan = 0;
 
 	public RawPeak(int startScan, int maximumScan, int stopScan) {
+
 		if(startScan < maximumScan && maximumScan < stopScan) {
 			this.startScan = startScan;
 			this.maximumScan = maximumScan;
@@ -79,7 +80,7 @@ public class RawPeak implements IRawPeak {
 	@Override
 	public int hashCode() {
 
-		return 7 * Integer.valueOf(startScan).hashCode() + 11 * Integer.valueOf(maximumScan).hashCode() + 13 * Integer.valueOf(stopScan).hashCode();
+		return 7 * Integer.hashCode(startScan) + 11 * Integer.hashCode(maximumScan) + 13 * Integer.hashCode(stopScan);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/AbstractChromatogramIntegrationResult.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/AbstractChromatogramIntegrationResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,6 +20,7 @@ public abstract class AbstractChromatogramIntegrationResult implements IChromato
 	private double ion;
 
 	public AbstractChromatogramIntegrationResult(double ion, double chromatogramArea, double backgroundArea) {
+
 		this.ion = ion;
 		this.chromatogramArea = chromatogramArea;
 		this.backgroundArea = backgroundArea;
@@ -77,7 +78,7 @@ public abstract class AbstractChromatogramIntegrationResult implements IChromato
 	@Override
 	public int hashCode() {
 
-		return Double.valueOf(chromatogramArea).hashCode() + Double.valueOf(chromatogramArea).hashCode() + integratorType.hashCode() + Double.valueOf(ion).hashCode();
+		return Double.hashCode(chromatogramArea) + Double.hashCode(chromatogramArea) + integratorType.hashCode() + Double.hashCode(ion);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/AbstractPeakIntegrationResult.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/src/org/eclipse/chemclipse/chromatogram/xxd/integrator/result/AbstractPeakIntegrationResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -208,7 +208,7 @@ public abstract class AbstractPeakIntegrationResult implements IPeakIntegrationR
 	@Override
 	public int hashCode() {
 
-		return Double.valueOf(integratedArea).hashCode() + Float.valueOf(tailing).hashCode() + Integer.valueOf(width).hashCode() + integratorType.hashCode() + peakType.hashCode() + modelDescription.hashCode() + Float.valueOf(sn).hashCode() + Integer.valueOf(startRetentionTime).hashCode() + Integer.valueOf(stopRetentionTime).hashCode() + Float.valueOf(purity).hashCode() + integratedTraces.hashCode();
+		return Double.hashCode(integratedArea) + Float.hashCode(tailing) + Integer.hashCode(width) + integratorType.hashCode() + peakType.hashCode() + modelDescription.hashCode() + Float.hashCode(sn) + Integer.hashCode(startRetentionTime) + Integer.hashCode(stopRetentionTime) + Float.hashCode(purity) + integratedTraces.hashCode();
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -195,7 +195,7 @@ public abstract class AbstractSupplier implements ISupplierSetter {
 	@Override
 	public int hashCode() {
 
-		return id.hashCode() + description.hashCode() + filterName.hashCode() + fileExtension.hashCode() + fileName.hashCode() + directoryExtension.hashCode() + Boolean.valueOf(exportable).hashCode() + Boolean.valueOf(importable).hashCode();
+		return id.hashCode() + description.hashCode() + filterName.hashCode() + fileExtension.hashCode() + fileName.hashCode() + directoryExtension.hashCode() + Boolean.hashCode(exportable) + Boolean.hashCode(importable);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/columns/RetentionIndexEntry.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/columns/RetentionIndexEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -80,7 +80,7 @@ public class RetentionIndexEntry implements IRetentionIndexEntry {
 	@Override
 	public int hashCode() {
 
-		return 7 * Integer.valueOf(retentionTime).hashCode() + 11 * Float.valueOf(retentionIndex).hashCode();
+		return 7 * Integer.hashCode(retentionTime) + 11 * Float.hashCode(retentionIndex);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractChromatogram.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/core/AbstractChromatogram.java
@@ -940,7 +940,7 @@ public abstract class AbstractChromatogram extends AbstractMeasurementTarget imp
 	public int hashCode() {
 
 		// for performance reason we here only take some basic information into account
-		return 7 * Integer.valueOf(getNumberOfScans()).hashCode() + 7 * Integer.valueOf(getStartRetentionTime()).hashCode() + 9 * Integer.valueOf(getStopRetentionTime()).hashCode();
+		return 7 * Integer.hashCode(getNumberOfScans()) + 7 * Integer.hashCode(getStartRetentionTime()) + 9 * Integer.hashCode(getStopRetentionTime());
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/AbstractLibraryInformation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/identifier/AbstractLibraryInformation.java
@@ -505,7 +505,7 @@ public abstract class AbstractLibraryInformation implements ILibraryInformation 
 	@Override
 	public int hashCode() {
 
-		return 7 * name.hashCode() + 11 * getCasNumber().hashCode() + 13 * comments.hashCode() + 11 * miscellaneous.hashCode() + 7 * formula.hashCode() + 11 * Double.valueOf(molWeight).hashCode();
+		return 7 * name.hashCode() + 11 * getCasNumber().hashCode() + 13 * comments.hashCode() + 11 * miscellaneous.hashCode() + 7 * formula.hashCode() + 11 * Double.hashCode(molWeight);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/selection/AbstractChromatogramSelection.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/selection/AbstractChromatogramSelection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -408,7 +408,7 @@ public abstract class AbstractChromatogramSelection implements IChromatogramSele
 	@Override
 	public int hashCode() {
 
-		return 7 * getChromatogram().hashCode() + 11 * Integer.valueOf(getStartRetentionTime()).hashCode() + 13 * Integer.valueOf(getStopRetentionTime()).hashCode();
+		return 7 * getChromatogram().hashCode() + 11 * Integer.hashCode(getStartRetentionTime()) + 13 * Integer.hashCode(getStopRetentionTime());
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/signals/AbstractTotalScanSignal.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/signals/AbstractTotalScanSignal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -86,7 +86,7 @@ public abstract class AbstractTotalScanSignal implements ITotalScanSignal {
 	@Override
 	public int hashCode() {
 
-		return 7 * Integer.valueOf(getRetentionTime()).hashCode() + 9 * Float.valueOf(getRetentionIndex()).hashCode() + 11 * Float.valueOf(getTotalSignal()).hashCode();
+		return 7 * Integer.hashCode(getRetentionTime()) + 9 * Float.hashCode(getRetentionIndex()) + 11 * Float.hashCode(getTotalSignal());
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/BackgroundAbundanceRange.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/BackgroundAbundanceRange.java
@@ -76,7 +76,7 @@ public class BackgroundAbundanceRange implements IBackgroundAbundanceRange {
 	@Override
 	public int hashCode() {
 
-		return 7 * Float.valueOf(getStartBackgroundAbundance()).hashCode() + 11 * Float.valueOf(getStopBackgroundAbundance()).hashCode();
+		return 7 * Float.hashCode(getStartBackgroundAbundance()) + 11 * Float.hashCode(getStopBackgroundAbundance());
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/RetentionTimeRange.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/RetentionTimeRange.java
@@ -78,7 +78,7 @@ public class RetentionTimeRange implements IRetentionTimeRange {
 	@Override
 	public int hashCode() {
 
-		return 7 * Integer.valueOf(startRetentionTime).hashCode() + 11 * Integer.valueOf(stopRetentionTime).hashCode();
+		return 7 * Integer.hashCode(startRetentionTime) + 11 * Integer.hashCode(stopRetentionTime);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/ScanRange.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/ScanRange.java
@@ -77,7 +77,7 @@ public class ScanRange implements IScanRange {
 	@Override
 	public int hashCode() {
 
-		return 7 * Integer.valueOf(getStartScan()).hashCode() + 11 * Integer.valueOf(getStopScan()).hashCode();
+		return 7 * Integer.hashCode(getStartScan()) + 11 * Integer.hashCode(getStopScan());
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/internal/results/Hit.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/src/org/eclipse/chemclipse/msd/identifier/supplier/nist/internal/results/Hit.java
@@ -152,7 +152,7 @@ public class Hit {
 	@Override
 	public int hashCode() {
 
-		return 7 * name.hashCode() + 11 * formula.hashCode() + 13 * Float.valueOf(matchFactor).hashCode() + 17 * Float.valueOf(reverseMatchFactor).hashCode() + 13 * Float.valueOf(probability).hashCode() + 11 * cas.hashCode() + 7 * Integer.valueOf(molecularWeight).hashCode();
+		return 7 * name.hashCode() + 11 * formula.hashCode() + 13 * Float.hashCode(matchFactor) + 17 * Float.hashCode(reverseMatchFactor) + 13 * Float.hashCode(probability) + 11 * cas.hashCode() + 7 * Integer.hashCode(molecularWeight);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIon.java
@@ -193,7 +193,7 @@ public abstract class AbstractIon implements IIon {
 	@Override
 	public int hashCode() {
 
-		return 7 * Double.valueOf(ion).hashCode() + 11 * Float.valueOf(abundance).hashCode();
+		return 7 * Double.hashCode(ion) + 11 * Float.hashCode(abundance);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIonTransition.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIonTransition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -202,7 +202,7 @@ public abstract class AbstractIonTransition implements IIonTransition {
 	@Override
 	public int hashCode() {
 
-		return compoundName.hashCode() + 7 * Double.valueOf(q1StartIon).hashCode() + 11 * Double.valueOf(q1StopIon).hashCode() + 13 * Double.valueOf(q3StartIon).hashCode() + 17 * Double.valueOf(q3StopIon).hashCode() + 13 * Double.valueOf(collisionEnergy).hashCode() + 11 * Integer.valueOf(transitionGroup).hashCode() + 7 * Double.valueOf(q1Resolution).hashCode() + 11 * Double.valueOf(q3Resolution).hashCode();
+		return compoundName.hashCode() + 7 * Double.hashCode(q1StartIon) + 11 * Double.hashCode(q1StopIon) + 13 * Double.hashCode(q3StartIon) + 17 * Double.hashCode(q3StopIon) + 13 * Double.hashCode(collisionEnergy) + 11 * Integer.hashCode(transitionGroup) + 7 * Double.hashCode(q1Resolution) + 11 * Double.hashCode(q3Resolution);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractScanMSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractScanMSD.java
@@ -798,7 +798,7 @@ public abstract class AbstractScanMSD extends AbstractScan implements IScanMSD {
 	@Override
 	public int hashCode() {
 
-		return 7 * Double.valueOf(getBasePeak()).hashCode() + 11 * Float.valueOf(getBasePeakAbundance()).hashCode() + 13 * Float.valueOf(getNumberOfIons()).hashCode() + 15 * Float.valueOf(getTotalSignal()).hashCode() + 13 * Boolean.valueOf(isNormalized).hashCode() + 11 * Float.valueOf(normalizationBase).hashCode();
+		return 7 * Double.hashCode(getBasePeak()) + 11 * Float.hashCode(getBasePeakAbundance()) + 13 * Float.hashCode(getNumberOfIons()) + 15 * Float.hashCode(getTotalSignal()) + 13 * Boolean.hashCode(isNormalized) + 11 * Float.hashCode(normalizationBase);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/ExtractedIonSignal.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/ExtractedIonSignal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -363,9 +363,9 @@ public class ExtractedIonSignal implements IExtractedIonSignal {
 	@Override
 	public int hashCode() {
 
-		return 7 * Integer.valueOf(startIon).hashCode() + //
-				9 * Integer.valueOf(stopIon).hashCode() + //
-				11 * Integer.valueOf(getNumberOfIonValues()).hashCode() + //
+		return 7 * Integer.hashCode(startIon) + //
+				9 * Integer.hashCode(stopIon) + //
+				11 * Integer.hashCode(getNumberOfIonValues()) + //
 				13 * Float.valueOf(getTotalSignal()).hashCode();
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/IonRange.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/xic/IonRange.java
@@ -76,7 +76,7 @@ public class IonRange implements IIonRange {
 	@Override
 	public int hashCode() {
 
-		return 7 * Integer.valueOf(getStartIon()).hashCode() + 11 * Integer.valueOf(getStopIon()).hashCode();
+		return 7 * Integer.hashCode(getStartIon()) + 11 * Integer.hashCode(getStopIon());
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.numeric/src/org/eclipse/chemclipse/numeric/core/Point.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.numeric/src/org/eclipse/chemclipse/numeric/core/Point.java
@@ -66,7 +66,7 @@ public class Point implements IPoint {
 	@Override
 	public int hashCode() {
 
-		return Double.valueOf(x).hashCode() + Double.valueOf(y).hashCode();
+		return Double.hashCode(x) + Double.hashCode(y);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.numeric/src/org/eclipse/chemclipse/numeric/equations/LinearEquation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.numeric/src/org/eclipse/chemclipse/numeric/equations/LinearEquation.java
@@ -97,7 +97,7 @@ public class LinearEquation implements IEquation {
 	@Override
 	public int hashCode() {
 
-		return 7 * Double.valueOf(a).hashCode() + 11 * Double.valueOf(b).hashCode();
+		return 7 * Double.hashCode(a) + 11 * Double.hashCode(b);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.numeric/src/org/eclipse/chemclipse/numeric/geometry/Slope.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.numeric/src/org/eclipse/chemclipse/numeric/geometry/Slope.java
@@ -59,7 +59,7 @@ public class Slope implements ISlope {
 	@Override
 	public int hashCode() {
 
-		return 7 * Double.valueOf(slope).hashCode();
+		return 7 * Double.hashCode(slope);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/xwc/ExtractedWavelengthSignal.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/src/org/eclipse/chemclipse/wsd/model/xwc/ExtractedWavelengthSignal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -333,10 +333,10 @@ public class ExtractedWavelengthSignal implements IExtractedWavelengthSignal {
 	@Override
 	public int hashCode() {
 
-		return 7 * Integer.valueOf(startWavelength).hashCode() + //
-				9 * Integer.valueOf(stopWavelength).hashCode() + //
-				11 * Integer.valueOf(getNumberOfWavelengthValues()).hashCode() + //
-				13 * Float.valueOf(getTotalSignal()).hashCode();
+		return 7 * Integer.hashCode(startWavelength) + //
+				9 * Integer.hashCode(stopWavelength) + //
+				11 * Integer.hashCode(getNumberOfWavelengthValues()) + //
+				13 * Float.hashCode(getTotalSignal());
 	}
 
 	@Override


### PR DESCRIPTION
This reduces allocations and is cleaner.