### PR TITLE
Notify scan chart after importing ions from scan proxies

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractRegularMassSpectrumProxy.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractRegularMassSpectrumProxy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,7 @@ package org.eclipse.chemclipse.msd.model.core;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.chemclipse.model.notifier.UpdateNotifier;
 import org.eclipse.chemclipse.msd.model.core.support.IMarkedIons;
 import org.eclipse.core.runtime.IProgressMonitor;
 
@@ -275,6 +276,7 @@ public abstract class AbstractRegularMassSpectrumProxy extends AbstractRegularMa
 		if(isProxy) {
 			isProxy = false;
 			importIons(monitor);
+			UpdateNotifier.update(this);
 		}
 	}
 }


### PR DESCRIPTION
For indexed mzML I don't just import the ions but set up the whole metadata around the scan, which is inaccessible unless the whole `<spectrum>` that also includes the binary blob is deserialized, so I do it in the proxy:

https://github.com/eclipse-chemclipse/chemclipse/blob/3c69cbbb9373873932b40aab73af3b0c4cc9f84f/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/VendorScanProxy.java#L62-L64

That means after the proxy is read, the scan charts need an update to display profile instead of centroidation and show the correct polarization, MSn etc.