### PR TITLE
Fix ion compare for non-nominalized m/z

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractIon.java
@@ -158,14 +158,12 @@ public abstract class AbstractIon implements IIon {
 	}
 
 	/**
-	 * Compares the mass/charge ration of two ions. Returns the
-	 * following values: a.compareTo(b) 0 a == b : 28 == 28 -1 a &lt; b : 18 &lt; 28
-	 * +1 a &gt; b : 28 &gt; 18
+	 * Compares the mass/charge ration of two ions.
 	 */
 	@Override
 	public int compareTo(IIon other) {
 
-		return (int)(this.ion - other.getIon());
+		return Double.compare(this.ion, other.getIon());
 	}
 
 	@Override


### PR DESCRIPTION
The previous code only worked with nominalized unit mass. If you compare 10.15 and 10.25 for example, after subtraction, you get 0.1, which is 0 after cast to int, so the masses are assumed equal. **This is a breaking change** but hopefully in the right direction.