### PR TITLE
Make DatabaseEditor a pure E4 part and fix saving

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/DatabaseEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/DatabaseEditor.java
@@ -57,19 +57,13 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.IEditorInput;
-import org.eclipse.ui.IEditorSite;
-import org.eclipse.ui.IFileEditorInput;
-import org.eclipse.ui.IURIEditorInput;
-import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.part.EditorPart;
 import org.osgi.service.event.EventHandler;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 
-public class DatabaseEditor extends EditorPart implements IChemClipseEditor {
+public class DatabaseEditor implements IChemClipseEditor {
 
 	public static final String ID = "org.eclipse.chemclipse.ux.extension.msd.ui.part.massSpectrumLibraryEditor";
 	public static final String CONTRIBUTION_URI = "bundleclass://org.eclipse.chemclipse.ux.extension.msd.ui/org.eclipse.chemclipse.ux.extension.msd.ui.editors.DatabaseEditor";
@@ -142,14 +136,13 @@ public class DatabaseEditor extends EditorPart implements IChemClipseEditor {
 		try {
 			dialog.run(true, false, runnable);
 		} catch(InvocationTargetException e) {
-			doSaveAs();
+			saveAs();
 		} catch(InterruptedException e) {
 			logger.warn(e);
 			Thread.currentThread().interrupt();
 		}
 	}
 
-	@Override
 	@Focus
 	public void setFocus() {
 
@@ -174,65 +167,6 @@ public class DatabaseEditor extends EditorPart implements IChemClipseEditor {
 	}
 
 	@Override
-	public void doSave(IProgressMonitor monitor) {
-
-		if(massSpectra != null) {
-			try {
-				boolean saveSuccessful = DatabaseFileSupport.saveMassSpectra(massSpectra);
-				isDirty = !saveSuccessful;
-				if(dirtyable != null) {
-					dirtyable.setDirty(isDirty);
-				}
-			} catch(NoConverterAvailableException e) {
-				logger.warn(e);
-			}
-		}
-	}
-
-	@Override
-	public void doSaveAs() {
-
-		try {
-			DatabaseFileSupport.saveMassSpectra(Display.getCurrent().getActiveShell(), massSpectra, "Mass Spectra");
-		} catch(NoConverterAvailableException e) {
-			logger.warn(e);
-		}
-	}
-
-	@Override
-	public void init(IEditorSite site, IEditorInput input) throws PartInitException {
-
-		setSite(site);
-		setInput(input);
-
-		String fileName = input.getName();
-		fileName = fileName.substring(0, fileName.length() - 4);
-		setPartName(fileName);
-
-		if(input instanceof IFileEditorInput fileEditorInput) {
-			File file = fileEditorInput.getFile().getLocation().toFile();
-			importMassSpectra(file, true);
-		} else if(input instanceof IURIEditorInput uriEditorInput) {
-			File file = new File(uriEditorInput.getURI());
-			importMassSpectra(file, true);
-		} else {
-			throw new PartInitException("Unimplemented editor input " + input.getClass());
-		}
-	}
-
-	@Override
-	public boolean isDirty() {
-
-		return isDirty;
-	}
-
-	@Override
-	public boolean isSaveAsAllowed() {
-
-		return true;
-	}
-
-	@Override
 	public boolean saveAs() {
 
 		try {
@@ -242,13 +176,6 @@ public class DatabaseEditor extends EditorPart implements IChemClipseEditor {
 			return false;
 		}
 		return true;
-	}
-
-	@Override
-	public void createPartControl(Composite parent) {
-
-		initializeEditor(parent);
-		updateMassSpectrumListUI();
 	}
 
 	private void initializeEditor(Composite parent) {
@@ -398,7 +325,8 @@ public class DatabaseEditor extends EditorPart implements IChemClipseEditor {
 			if(converterId != null && !converterId.equals("")) {
 				monitor.subTask("Save Mass Spectra");
 				IProcessingInfo<File> processingInfo = DatabaseConverter.convert(massSpectrumFile, massSpectra, false, converterId, monitor);
-				isDirty = !processingInfo.hasErrorMessages();
+				isDirty = processingInfo.hasErrorMessages();
+				massSpectra.setDirty(isDirty);
 				if(dirtyable != null) {
 					dirtyable.setDirty(isDirty);
 				}


### PR DESCRIPTION
The editor is only ever opened as an E4 part (bundleclass URI), yet it also extended EditorPart. That dual nature let the E3 compatibility SaveHandler claim Ctrl+S: it calls `getSite().getPage()`, but since `init()` is never invoked on an E4-created part `getSite()` is null, so save threw an NPE and `@Persist save()` never ran. Dropping EditorPart lets Ctrl+S fall through to the E4 `@Persist` handler.

Also fix the dirty flag: on a successful export `hasErrorMessages()` is false, but the value was negated, so a save re-marked the editor dirty instead of clearing it. Clear both the editor and model dirty state.