### PR TITLE
Add platform PerspectiveSwitcher to the top trim bar

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/Application.e4xmi
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/Application.e4xmi
@@ -101,6 +101,15 @@
       <children xsi:type="menu:ToolBar" xmi:id="_dz9NIF6nEe2sw_cXqaBWMw" elementId="org.eclipse.chemclipse.rcp.app.ui.toolbar.plugins">
         <children xsi:type="menu:HandledToolItem" xmi:id="_G9eogOToEeK3p9M57zVYqQ" elementId="org.eclipse.chemclipse.rcp.app.ui.handledtoolitem.updates" visible="false" label="Updates" iconURI="platform:/plugin/org.eclipse.chemclipse.rcp.ui.icons/icons/16x16/updates.gif" enabled="false" command="_LrC6QDiWEeKDEdWQrkwLnQ"/>
       </children>
+      <children xsi:type="menu:ToolControl" xmi:id="_oBxRMHw0EfGlceNpx4XSsQ" elementId="PerspectiveSpacer" contributionURI="bundleclass://org.eclipse.e4.ui.workbench.renderers.swt/org.eclipse.e4.ui.workbench.renderers.swt.LayoutModifierToolControl">
+        <tags>stretch</tags>
+        <tags>SHOW_RESTORE_MENU</tags>
+      </children>
+      <children xsi:type="menu:ToolControl" xmi:id="_quxC8Hw0EfGlceNpx4XSsQ" elementId="org.eclipse.e4.ui.PerspectiveSwitcher" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.e4.ui.workbench.addons.perspectiveswitcher.PerspectiveSwitcher">
+        <tags>Draggable</tags>
+        <tags>HIDEABLE</tags>
+        <tags>SHOW_RESTORE_MENU</tags>
+      </children>
     </trimBars>
     <trimBars xmi:id="_CT96oF6VEeO_3ZCXGA_PQg" elementId="org.eclipse.ui.trim.status" side="Bottom">
       <children xsi:type="menu:ToolControl" xmi:id="_6CqUoHB1EemL5_T8nUqtDA" elementId="org.eclipse.ui.StatusLine" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.StandardTrim">
@@ -174,4 +183,5 @@
   <addons xmi:id="_4q-U0CGaEeutTb-F-_fKDg" elementId="org.eclipse.chemclipse.rcp.app.ui.addon.contextSupport" contributionURI="bundleclass://org.eclipse.chemclipse.support.ui/org.eclipse.chemclipse.support.ui.activator.ContextAddon"/>
   <addons xmi:id="_rRrvoCgVEeu5Pepo04c08Q" elementId="org.eclipse.chemclipse.ux.extension.xxd.ui.addons.PerspectiveSupport" contributionURI="bundleclass://org.eclipse.chemclipse.ux.extension.xxd.ui/org.eclipse.chemclipse.ux.extension.xxd.ui.addons.PerspectiveSupport"/>
   <addons xmi:id="_y_CRsEfLEfGSmdLsAusSyg" elementId="org.eclipse.chemclipse.progress.ui.addons.ProgressAddon" contributionURI="bundleclass://org.eclipse.chemclipse.progress.ui/org.eclipse.chemclipse.progress.ui.addons.ProgressAddon"/>
+  <addons xmi:id="_tYqL4Hw3EfGlceNpx4XSsQ" elementId="org.eclipse.chemclipse.rcp.app.ui.addon.perspectiveSwitcherAddon" contributionURI="bundleclass://org.eclipse.chemclipse.rcp.app.ui/org.eclipse.chemclipse.rcp.app.ui.addons.PerspectiveSwitcherAddon"/>
 </application:Application>

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/addons/PerspectiveSwitcherAddon.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/addons/PerspectiveSwitcherAddon.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Alexander Kurtakov - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.rcp.app.ui.addons;
+
+import java.util.List;
+
+import org.eclipse.chemclipse.rcp.app.ui.preferences.PreferenceSupplier;
+import org.eclipse.e4.ui.model.application.MApplication;
+import org.eclipse.e4.ui.model.application.ui.menu.MToolControl;
+import org.eclipse.e4.ui.workbench.modeling.EModelService;
+
+import jakarta.annotation.PostConstruct;
+
+/**
+ * Some installations only use a single perspective. The perspective switcher is
+ * left out of the trim bar in such a case.
+ */
+public class PerspectiveSwitcherAddon {
+
+	/*
+	 * The element ids are defined by the Eclipse platform and must not be changed.
+	 * PerspectiveSwitcher.PERSPECTIVE_SWITCHER_ID is the id for model contributed
+	 * switchers. The id "PerspectiveSwitcher" is reserved for the compatibility
+	 * layer, which detaches such an element from the model unless the perspective
+	 * bar has been requested via IWorkbenchWindowConfigurer.
+	 */
+	private static final String ELEMENT_ID_PERSPECTIVE_SWITCHER = "org.eclipse.e4.ui.PerspectiveSwitcher";
+	private static final String ELEMENT_ID_PERSPECTIVE_SPACER = "PerspectiveSpacer";
+
+	@PostConstruct
+	public void postConstruct(MApplication application, EModelService modelService) {
+
+		/*
+		 * The tool controls are adjusted before the trim bar is rendered.
+		 * The value is applied in both directions, otherwise a persisted state
+		 * would keep the switcher hidden once the preference is enabled again.
+		 */
+		boolean showPerspectiveSwitcher = PreferenceSupplier.getShowPerspectiveSwitcher();
+		setToBeRendered(application, modelService, ELEMENT_ID_PERSPECTIVE_SWITCHER, showPerspectiveSwitcher);
+		setToBeRendered(application, modelService, ELEMENT_ID_PERSPECTIVE_SPACER, showPerspectiveSwitcher);
+	}
+
+	private void setToBeRendered(MApplication application, EModelService modelService, String elementId, boolean toBeRendered) {
+
+		List<MToolControl> toolControls = modelService.findElements(application, elementId, MToolControl.class, null);
+		for(MToolControl toolControl : toolControls) {
+			toolControl.setToBeRendered(toBeRendered);
+		}
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/preferences/PreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/preferences/PreferencePage.java
@@ -18,6 +18,7 @@ import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.rcp.app.profiles.Profiles;
 import org.eclipse.chemclipse.rcp.app.ui.Activator;
 import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpacerFieldEditor;
+import org.eclipse.e4.ui.workbench.IWorkbench;
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.IPreferencePageContainer;
@@ -34,9 +35,12 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Text;
-import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.dialogs.PreferencesUtil;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
 
 public class PreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
 
@@ -44,6 +48,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	private Label selectedProfileFieldEditor;
 	private Combo availableProfilesCombo;
 	private Text newProfileNameText;
+	private boolean showPerspectiveSwitcher;
 
 	public PreferencePage() {
 
@@ -63,9 +68,11 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 		/*
 		 * Change perspectives dialog
 		 */
+		showPerspectiveSwitcher = getPreferenceStore().getBoolean(PreferenceSupplier.P_SHOW_PERSPECTIVE_SWITCHER);
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_PERSPECTIVE_DIALOG, "Show the perspective dialog.", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_CHANGE_PERSPECTIVE_AUTOMATICALLY, "Change perspectives and views automatically.", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_PERSPECTIVE_SWITCHER, "Show the perspective switcher in the toolbar (restart required).", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		/*
 		 * Profiles
@@ -196,6 +203,57 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 		});
 	}
 
+	@Override
+	public boolean performOk() {
+
+		boolean performOk = super.performOk();
+		if(performOk) {
+			boolean showPerspectiveSwitcherNew = getPreferenceStore().getBoolean(PreferenceSupplier.P_SHOW_PERSPECTIVE_SWITCHER);
+			if(showPerspectiveSwitcher != showPerspectiveSwitcherNew) {
+				showPerspectiveSwitcher = showPerspectiveSwitcherNew;
+				requestRestart();
+			}
+		}
+		return performOk;
+	}
+
+	/**
+	 * The perspective switcher is evaluated when the application model is created.
+	 */
+	private void requestRestart() {
+
+		MessageBox messageBox = new MessageBox(getShell(), SWT.ICON_QUESTION | SWT.YES | SWT.NO);
+		messageBox.setText("Restart?");
+		messageBox.setMessage("The perspective switcher setting takes effect after a restart. Do you want to restart now?");
+		if(messageBox.open() == SWT.YES) {
+			/*
+			 * Let the preference dialog close first.
+			 */
+			getShell().getDisplay().asyncExec(this::restart);
+		}
+	}
+
+	private void restart() {
+
+		Bundle bundle = FrameworkUtil.getBundle(getClass());
+		BundleContext bundleContext = (bundle != null) ? bundle.getBundleContext() : null;
+		if(bundleContext == null) {
+			return;
+		}
+		ServiceReference<IWorkbench> serviceReference = bundleContext.getServiceReference(IWorkbench.class);
+		if(serviceReference == null) {
+			return;
+		}
+		try {
+			IWorkbench workbench = bundleContext.getService(serviceReference);
+			if(workbench != null) {
+				workbench.restart();
+			}
+		} finally {
+			bundleContext.ungetService(serviceReference);
+		}
+	}
+
 	private void setProfileName(String name) {
 
 		/*
@@ -244,7 +302,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	}
 
 	@Override
-	public void init(IWorkbench workbench) {
+	public void init(org.eclipse.ui.IWorkbench workbench) {
 
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/src/org/eclipse/chemclipse/rcp/app/ui/preferences/PreferenceSupplier.java
@@ -23,6 +23,8 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static final boolean DEF_SHOW_PERSPECTIVE_DIALOG = true;
 	public static final String P_CHANGE_PERSPECTIVE_AUTOMATICALLY = "changePerspectiveAutomatically";
 	public static final boolean DEF_CHANGE_PERSPECTIVE_AUTOMATICALLY = true;
+	public static final String P_SHOW_PERSPECTIVE_SWITCHER = "showPerspectiveSwitcher";
+	public static final boolean DEF_SHOW_PERSPECTIVE_SWITCHER = true;
 
 	public static IPreferenceSupplier INSTANCE() {
 
@@ -45,6 +47,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 		putDefault(P_SELECTED_PROFILE, DEF_SELECTED_PROFILE);
 		putDefault(P_SHOW_PERSPECTIVE_DIALOG, DEF_SHOW_PERSPECTIVE_DIALOG);
 		putDefault(P_CHANGE_PERSPECTIVE_AUTOMATICALLY, DEF_CHANGE_PERSPECTIVE_AUTOMATICALLY);
+		putDefault(P_SHOW_PERSPECTIVE_SWITCHER, DEF_SHOW_PERSPECTIVE_SWITCHER);
 	}
 
 	public static void setChangePerspectivesAutomatically(boolean changeAutomatically) {
@@ -87,5 +90,21 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static void setChangePerspectiveAutomatically(boolean changePerspectiveAutomatically) {
 
 		INSTANCE().setBoolean(P_CHANGE_PERSPECTIVE_AUTOMATICALLY, changePerspectiveAutomatically);
+	}
+
+	/**
+	 * Returns whether the perspective switcher shall be shown in the top trim bar or not.
+	 */
+	public static boolean getShowPerspectiveSwitcher() {
+
+		return INSTANCE().getBoolean(P_SHOW_PERSPECTIVE_SWITCHER);
+	}
+
+	/**
+	 * Sets whether the perspective switcher shall be shown in the top trim bar or not.
+	 */
+	public static void setShowPerspectiveSwitcher(boolean showPerspectiveSwitcher) {
+
+		INSTANCE().setBoolean(P_SHOW_PERSPECTIVE_SWITCHER, showPerspectiveSwitcher);
 	}
 }


### PR DESCRIPTION
Plug the platform e4 PerspectiveSwitcher addon into the top trim bar and
right-align it via a stretch spacer, matching the Eclipse IDE layout.

The switcher can be hidden via its context menu or turned off
permanently via the showPerspectiveSwitcher preference.

Number of shown perspectives is limited to 5 and stored in preferences
for users. If all perspectives are closed, Welcome is opened.