### PR TITLE
Don't check ions for performance reasons

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/calculator/operations/SavitzkyGolayPerIonOperation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/calculator/operations/SavitzkyGolayPerIonOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 Lablicate GmbH.
+ * Copyright (c) 2022, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -71,10 +71,13 @@ public class SavitzkyGolayPerIonOperation extends AbstractOperation implements I
 
 		try {
 			previousScans = new ArrayList<>();
+			monitor.beginTask("Copy Scans", chromatogramSelection.getChromatogram().getNumberOfScans());
 			for(IScan scan : chromatogramSelection.getChromatogram().getScans()) {
 				IScanMSD scanMSD = (IScanMSD)scan;
 				previousScans.add(scanMSD.makeDeepCopy());
+				monitor.worked(1);
 			}
+			monitor.done();
 			ExtractedMatrix extractedMatrix = new ExtractedMatrix(chromatogramSelection);
 			double[][] matrix = extractedMatrix.getMatrix();
 			SavitzkyGolayProcessor.apply(matrix, filterSettings);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractPeakMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractPeakMassSpectrum.java
@@ -100,7 +100,7 @@ public abstract class AbstractPeakMassSpectrum extends AbstractRegularMassSpectr
 		for(IIon ion : ions) {
 			abundance = (ion.getAbundance() / actualPercentageIntensity) * 100.0f;
 			peakIon = new PeakIon(ion.getIon(), abundance);
-			addIon(peakIon);
+			addIon(peakIon, false);
 		}
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/VendorScanProxy.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/model/VendorScanProxy.java
@@ -84,7 +84,7 @@ public class VendorScanProxy extends AbstractRegularMassSpectrumProxy implements
 		IVendorScanProxy massSpectrum = (IVendorScanProxy)super.clone();
 		for(IIon ion : getIons()) {
 			IVendorIon vendorIon = new VendorIon(ion.getIon(), ion.getAbundance());
-			massSpectrum.addIon(vendorIon);
+			massSpectrum.addIon(vendorIon, false);
 		}
 		return massSpectrum;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/model/chromatogram/VendorScanProxy.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/src/org/eclipse/chemclipse/msd/converter/supplier/ocx/model/chromatogram/VendorScanProxy.java
@@ -65,7 +65,6 @@ public class VendorScanProxy extends AbstractRegularMassSpectrumProxy implements
 	public IVendorScan makeDeepCopy() throws CloneNotSupportedException {
 
 		IVendorScanProxy massSpectrum = (IVendorScanProxy)super.clone();
-		IVendorIon chemClipseIon;
 		/*
 		 * The instance variables have been copied by super.clone();.<br/> The
 		 * ions in the ion list need not to be removed via
@@ -75,8 +74,8 @@ public class VendorScanProxy extends AbstractRegularMassSpectrumProxy implements
 		 * Make a deep copy of all ions.
 		 */
 		for(IIon ion : getIons()) {
-			chemClipseIon = new VendorIon(ion.getIon(), ion.getAbundance());
-			massSpectrum.addIon(chemClipseIon);
+			IVendorIon vendorIon = new VendorIon(ion.getIon(), ion.getAbundance());
+			massSpectrum.addIon(vendorIon, false);
 		}
 		return massSpectrum;
 	}


### PR DESCRIPTION
The same bottleneck from https://github.com/eclipse-chemclipse/chemclipse/pull/907 also hits LC-MS chromatograms with several hundred thousand ions per spectrum. I tested first derivative peak detection and Savitzky-Golay smoothing per ion, which forces a full import of all ions.