### PR TITLE
Workaround duplicate feedback part ids

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.processing.ui/src/org/eclipse/chemclipse/processing/ui/support/ProcessingInfoPartSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing.ui/src/org/eclipse/chemclipse/processing/ui/support/ProcessingInfoPartSupport.java
@@ -16,11 +16,19 @@ package org.eclipse.chemclipse.processing.ui.support;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.processing.core.IMessageProvider;
 import org.eclipse.chemclipse.processing.ui.Activator;
+import org.eclipse.chemclipse.processing.ui.parts.ProcessingInfoPart;
 import org.eclipse.chemclipse.support.events.IPerspectiveAndViewIds;
 import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.di.annotations.Creatable;
 import org.eclipse.e4.ui.di.UISynchronize;
+import org.eclipse.e4.ui.model.application.MApplication;
+import org.eclipse.e4.ui.model.application.ui.MUIElement;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPlaceholder;
+import org.eclipse.e4.ui.model.application.ui.basic.MPart;
+import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
+import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
 import org.eclipse.e4.ui.workbench.modeling.EPartService.PartState;
 import org.eclipse.swt.SWT;
@@ -39,8 +47,12 @@ public class ProcessingInfoPartSupport {
 	private static final String MESSAGE = "Please check the 'Feedback' part.";
 
 	private UISynchronize uiSynchronize = null;
+
 	@Inject
 	private ProcessingInfoUpdateNotifier processingInfoUpdateNotifier;
+
+	@Inject
+	private MApplication application;
 
 	@Inject
 	private IEclipseContext context;
@@ -100,11 +112,7 @@ public class ProcessingInfoPartSupport {
 					 * Focus the view if requested, this will open the feedback view if required.
 					 */
 					if(focusProcessingInfoPart) {
-						//lazy resolve EPartService instead of injecting it so there is time for EPartService to be initialized
-						EPartService windowPartService = context.get(EPartService.class);
-						if(windowPartService != null) {
-							windowPartService.showPart(IPerspectiveAndViewIds.VIEW_FEEDBACK, PartState.VISIBLE);
-						}
+						showFeedbackPart(messageProvider);
 					}
 				});
 			}
@@ -123,6 +131,47 @@ public class ProcessingInfoPartSupport {
 		}
 
 		update(messageProvider, messageProvider.hasErrorMessages());
+	}
+
+	/*
+	 * Several perspectives share the feedback part id, so showPart(String, PartState) is ambiguous.
+	 * Look up the part in the active perspective instead using part service comes from the
+	 * window directly, not the context's active child.
+	 * The message is pushed into the shown part directly since a freshly
+	 * created part's own injected notifier may not be the same instance this class updated.
+	 */
+	private void showFeedbackPart(IMessageProvider messageProvider) {
+
+		MWindow window = application.getSelectedElement();
+		if(window == null) {
+			return;
+		}
+		EPartService windowPartService = window.getContext().get(EPartService.class);
+		if(windowPartService == null) {
+			return;
+		}
+		EModelService modelService = context.get(EModelService.class);
+		MPart feedbackPart = null;
+		if(modelService != null) {
+			MPerspective activePerspective = modelService.getActivePerspective(window);
+			MUIElement searchRoot = (activePerspective != null) ? activePerspective : window;
+			MUIElement element = modelService.find(IPerspectiveAndViewIds.VIEW_FEEDBACK, searchRoot);
+			if(element instanceof MPart) {
+				feedbackPart = (MPart)element;
+			} else if(element instanceof MPlaceholder placeholder && placeholder.getRef() instanceof MPart part) {
+				feedbackPart = part;
+			}
+		}
+		MPart shownPart;
+		if(feedbackPart != null) {
+			shownPart = windowPartService.showPart(feedbackPart, PartState.VISIBLE);
+		} else {
+			// fall back to the (potentially ambiguous) id based lookup if nothing could be found in the active perspective
+			shownPart = windowPartService.showPart(IPerspectiveAndViewIds.VIEW_FEEDBACK, PartState.VISIBLE);
+		}
+		if(shownPart != null && shownPart.getObject() instanceof ProcessingInfoPart processingInfoPart) {
+			processingInfoPart.update(messageProvider);
+		}
 	}
 
 	private UISynchronize getUISynchronize() {


### PR DESCRIPTION
Several perspectives share the feedback part id, so showPart(String, PartState) is ambiguous.
Look up the part in the active perspective instead using part service comes from the window directly, not the context's active child. The message is pushed into the shown part directly since a freshly created part's own injected notifier may not be the same instance this class updated.