### PR TITLE
Fix a null reference exception in parseSeparationColumn

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/ChromatogramColumnSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/src/org/eclipse/chemclipse/model/support/ChromatogramColumnSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -50,7 +50,7 @@ public class ChromatogramColumnSupport {
 			 */
 			if(parseReferences) {
 				for(IChromatogram chromatogramReference : chromatogram.getReferencedChromatograms()) {
-					if(chromatogramReference.isParseSeparationColumnEnabled()) {
+					if(chromatogramReference != null && chromatogramReference.isParseSeparationColumnEnabled()) {
 						mapSeparationColumn(chromatogramReference, columnField, separationColumnMapping);
 					}
 				}


### PR DESCRIPTION
```
java.lang.NullPointerException: Cannot invoke "org.eclipse.chemclipse.model.core.IChromatogram.isParseSeparationColumnEnabled()" because "chromatogramReference" is null
	at org.eclipse.chemclipse.model.support.ChromatogramColumnSupport.parseSeparationColumn(ChromatogramColumnSupport.java:53)
	at org.eclipse.chemclipse.model.support.ChromatogramColumnSupport.parseSeparationColumn(ChromatogramColumnSupport.java:34)
	at org.eclipse.chemclipse.converter.chromatogram.AbstractChromatogramConverter.postProcessChromatogram(AbstractChromatogramConverter.java:269)
	at org.eclipse.chemclipse.converter.chromatogram.AbstractChromatogramConverter.convert(AbstractChromatogramConverter.java:153)
	at org.eclipse.chemclipse.ux.extension.xxd.ui.internal.runnables.ChromatogramImportRunnable.run(ChromatogramImportRunnable.java:103)
	at org.eclipse.jface.operation.ModalContext$ModalContextThread.run(ModalContext.java:123)
````