### PR TITLE
Split match quality icon into separate column in Peak/Scan list

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/PeakScanListLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/PeakScanListLabelProvider.java
@@ -22,6 +22,7 @@ import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IPeakModel;
 import org.eclipse.chemclipse.model.core.IScan;
+import org.eclipse.chemclipse.model.core.ITargetSupplier;
 import org.eclipse.chemclipse.model.identifier.IComparisonResult;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.identifier.IPeakComparisonResult;
@@ -40,6 +41,7 @@ import org.eclipse.swt.graphics.Image;
 
 public class PeakScanListLabelProvider extends AbstractChemClipseLabelProvider {
 
+	public static final String MATCH_QUALITY = ExtensionMessages.rating;
 	public static final String BEST_TARGET = ExtensionMessages.bestTarget;
 	public static final String ACTIVE_FOR_ANALYSIS = ExtensionMessages.activeForAnalysis;
 	public static final String TYPE = ExtensionMessages.type;
@@ -73,13 +75,14 @@ public class PeakScanListLabelProvider extends AbstractChemClipseLabelProvider {
 
 	private double chromatogramPeakArea = 0.0d;
 
-	public static final int INDEX_BEST_TARGET = 4;
+	public static final int INDEX_BEST_TARGET = 5;
 
 	public static final String[] TITLES = { //
 			ACTIVE_FOR_ANALYSIS, //
 			TYPE, //
 			RETENTION_TIME, //
 			AREA_PERCENT, //
+			MATCH_QUALITY, //
 			BEST_TARGET, //
 			RELATIVE_RETENTION_TIME, //
 			RETENTION_INDEX, //
@@ -105,6 +108,7 @@ public class PeakScanListLabelProvider extends AbstractChemClipseLabelProvider {
 			60, //
 			60, //
 			60, //
+			30, //
 			180, //
 			100, //
 			60, //
@@ -162,6 +166,11 @@ public class PeakScanListLabelProvider extends AbstractChemClipseLabelProvider {
 			}
 		} else if(columnIndex == 1) {
 			return getPeakScanImage(element);
+		} else if(columnIndex == 4) {
+			if(element instanceof ITargetSupplier targetSupplier) {
+				IIdentificationTarget target = TargetSupport.getBestIdentificationTarget(targetSupplier);
+				return IdentificationTargetSupport.getRatingSymbol(target);
+			}
 		}
 		return null;
 	}
@@ -209,12 +218,15 @@ public class PeakScanListLabelProvider extends AbstractChemClipseLabelProvider {
 				}
 				break;
 			case 4:
-				text = TargetSupport.getBestTargetLibraryField(peak);
+				text = BLANK;
 				break;
 			case 5:
-				text = decimalFormat.format(peakModel.getPeakMaximum().getRelativeRetentionTime() / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
+				text = TargetSupport.getBestTargetLibraryField(peak);
 				break;
 			case 6:
+				text = decimalFormat.format(peakModel.getPeakMaximum().getRelativeRetentionTime() / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
+				break;
+			case 7:
 				if(org.eclipse.chemclipse.model.preferences.PreferenceSupplier.showRetentionIndexWithoutDecimals()) {
 					DecimalFormat integerFormat = getIntegerDecimalFormatInstance();
 					text = integerFormat.format(peakModel.getPeakMaximum().getRetentionIndex());
@@ -222,7 +234,7 @@ public class PeakScanListLabelProvider extends AbstractChemClipseLabelProvider {
 					text = decimalFormat.format(peakModel.getPeakMaximum().getRetentionIndex());
 				}
 				break;
-			case 7:
+			case 8:
 				if(org.eclipse.chemclipse.model.preferences.PreferenceSupplier.showAreaWithoutDecimals()) {
 					DecimalFormat integerFormat = getIntegerDecimalFormatInstance();
 					text = integerFormat.format(peak.getIntegratedArea());
@@ -230,82 +242,82 @@ public class PeakScanListLabelProvider extends AbstractChemClipseLabelProvider {
 					text = decimalFormat.format(peak.getIntegratedArea());
 				}
 				break;
-			case 8:
+			case 9:
 				text = decimalFormat.format(peakModel.getStartRetentionTime() / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
 				break;
-			case 9:
+			case 10:
 				text = decimalFormat.format(peakModel.getStopRetentionTime() / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
 				break;
-			case 10:
+			case 11:
 				text = decimalFormat.format(peakModel.getWidthByInflectionPoints() / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
 				break;
-			case 11:
 			case 12:
+			case 13:
 				if(peak instanceof IChromatogramPeakMSD chromatogramPeak) {
 					switch(columnIndex) {
-						case 11:
+						case 12:
 							text = Integer.toString(chromatogramPeak.getScanMax());
 							break;
-						case 12:
+						case 13:
 							text = decimalFormat.format(chromatogramPeak.getSignalToNoiseRatio());
 							break;
 					}
 				} else if(peak instanceof IChromatogramPeakCSD chromatogramPeak) {
 					switch(columnIndex) {
-						case 11:
+						case 12:
 							text = Integer.toString(chromatogramPeak.getScanMax());
 							break;
-						case 12:
+						case 13:
 							text = decimalFormat.format(chromatogramPeak.getSignalToNoiseRatio());
 							break;
 					}
 				} else if(peak instanceof IChromatogramPeakWSD chromatogramPeak) {
 					switch(columnIndex) {
-						case 11:
+						case 12:
 							text = Integer.toString(chromatogramPeak.getScanMax());
 							break;
-						case 12:
+						case 13:
 							float sn = chromatogramPeak.getSignalToNoiseRatio();
 							text = Float.isNaN(sn) ? NO_VALUE : decimalFormat.format(sn);
 							break;
 					}
 				} else if(peak instanceof IChromatogramPeakFSD chromatogramPeak) {
 					switch(columnIndex) {
-						case 11:
+						case 12:
 							text = Integer.toString(chromatogramPeak.getScanMax());
 							break;
-						case 12:
+						case 13:
 							float sn = chromatogramPeak.getSignalToNoiseRatio();
 							text = Float.isNaN(sn) ? NO_VALUE : decimalFormat.format(sn);
 							break;
 					}
 				}
 				break;
-			case 13:
+			case 14:
 				text = decimalFormat.format(peakModel.getLeading());
 				break;
-			case 14:
+			case 15:
 				text = decimalFormat.format(peakModel.getTailing());
 				break;
-			case 15:
+			case 16:
 				text = peak.getModelDescription();
 				break;
-			case 16:
+			case 17:
 				text = peak.getDetectorDescription();
 				break;
-			case 17:
+			case 18:
 				text = peak.getIntegratorDescription();
 				break;
-			case 18:
+			case 19:
 				text = Integer.toString(peak.getSuggestedNumberOfComponents());
 				break;
-			case 19:
+			case 20:
 				text = (!peak.getInternalStandards().isEmpty()) ? ISTD : BLANK;
 				break;
-			case 20:
+			case 21:
 				text = PeakClassifierSupport.getClassifier(peak);
 				break;
-			case 21:
+			case 22:
 				text = peakModel.isStrictModel() ? "S" : "";
 				break;
 		}
@@ -332,12 +344,15 @@ public class PeakScanListLabelProvider extends AbstractChemClipseLabelProvider {
 				text = NO_VALUE;
 				break;
 			case 4:
-				text = TargetSupport.getBestTargetLibraryField(scan);
+				text = BLANK;
 				break;
 			case 5:
-				text = decimalFormat.format(scan.getRelativeRetentionTime() / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
+				text = TargetSupport.getBestTargetLibraryField(scan);
 				break;
 			case 6:
+				text = decimalFormat.format(scan.getRelativeRetentionTime() / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
+				break;
+			case 7:
 				if(org.eclipse.chemclipse.model.preferences.PreferenceSupplier.showRetentionIndexWithoutDecimals()) {
 					DecimalFormat integerFormat = getIntegerDecimalFormatInstance();
 					text = integerFormat.format(scan.getRetentionIndex());
@@ -345,7 +360,6 @@ public class PeakScanListLabelProvider extends AbstractChemClipseLabelProvider {
 					text = decimalFormat.format(scan.getRetentionIndex());
 				}
 				break;
-			case 7:
 			case 8:
 			case 9:
 			case 10:
@@ -353,13 +367,11 @@ public class PeakScanListLabelProvider extends AbstractChemClipseLabelProvider {
 			case 12:
 			case 13:
 			case 14:
-				text = NO_VALUE;
-				break;
 			case 15:
-				text = BLANK;
+				text = NO_VALUE;
 				break;
 			case 16:
-				text = NO_VALUE;
+				text = BLANK;
 				break;
 			case 17:
 				text = NO_VALUE;
@@ -368,8 +380,11 @@ public class PeakScanListLabelProvider extends AbstractChemClipseLabelProvider {
 				text = NO_VALUE;
 				break;
 			case 19:
+				text = NO_VALUE;
+				break;
 			case 20:
 			case 21:
+			case 22:
 				text = BLANK;
 				break;
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/PeakScanListTableComparator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/PeakScanListTableComparator.java
@@ -18,6 +18,7 @@ import org.eclipse.chemclipse.fsd.model.core.IChromatogramPeakFSD;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.core.ITargetSupplier;
+import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.support.PeakClassifierSupport;
 import org.eclipse.chemclipse.model.targets.TargetSupport;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
@@ -85,96 +86,105 @@ public class PeakScanListTableComparator extends AbstractRecordTableComparator {
 				break;
 			case 4:
 				if(object1 instanceof ITargetSupplier targetSupplier1 && object2 instanceof ITargetSupplier targetSupplier2) {
+					IIdentificationTarget target1 = TargetSupport.getBestIdentificationTarget(targetSupplier1);
+					IIdentificationTarget target2 = TargetSupport.getBestIdentificationTarget(targetSupplier2);
+					float score1 = target1 != null ? target1.getComparisonResult().getRatingSupplier().getScore() : 0;
+					float score2 = target2 != null ? target2.getComparisonResult().getRatingSupplier().getScore() : 0;
+					sortOrder = Float.compare(score2, score1);
+				}
+				break;
+			case 5:
+				if(object1 instanceof ITargetSupplier targetSupplier1 && object2 instanceof ITargetSupplier targetSupplier2) {
 					String name1 = TargetSupport.getBestTargetLibraryField(targetSupplier1);
 					String name2 = TargetSupport.getBestTargetLibraryField(targetSupplier2);
 					sortOrder = org.eclipse.chemclipse.model.preferences.PreferenceSupplier.isSortCaseSensitive() ? name2.compareTo(name1) : name2.compareToIgnoreCase(name1);
 				}
 				break;
-			case 5:
+			case 6:
 				sortOrder = Integer.compare(getRelativeRetentionTime(object2), getRelativeRetentionTime(object1));
 				break;
-			case 6:
+			case 7:
 				sortOrder = Float.compare(getRetentionIndex(object2), getRetentionIndex(object1));
 				break;
-			case 7:
+			case 8:
 				sortOrder = Double.compare(getIntegratedArea(object2), getIntegratedArea(object1));
 				break;
-			case 8:
+			case 9:
 				sortOrder = Integer.compare(getStartRetentionTime(object2), getStartRetentionTime(object1));
 				break;
-			case 9:
+			case 10:
 				sortOrder = Integer.compare(getStopRetentionTime(object2), getStopRetentionTime(object1));
 				break;
-			case 10:
+			case 11:
 				sortOrder = Integer.compare(getWidth(object2), getWidth(object1));
 				break;
-			case 11:
 			case 12:
+			case 13:
 				if(object1 instanceof IChromatogramPeakMSD chromatogramPeak1 && object2 instanceof IChromatogramPeakMSD chromatogramPeak2) {
 					switch(getPropertyIndex()) {
-						case 11:
+						case 12:
 							sortOrder = chromatogramPeak2.getScanMax() - chromatogramPeak1.getScanMax();
 							break;
-						case 12:
+						case 13:
 							sortOrder = Float.compare(chromatogramPeak2.getSignalToNoiseRatio(), chromatogramPeak1.getSignalToNoiseRatio());
 							break;
 					}
 				} else if(object1 instanceof IChromatogramPeakCSD chromatogramPeak1 && object2 instanceof IChromatogramPeakCSD chromatogramPeak2) {
 					switch(getPropertyIndex()) {
-						case 11:
+						case 12:
 							sortOrder = chromatogramPeak2.getScanMax() - chromatogramPeak1.getScanMax();
 							break;
-						case 12:
+						case 13:
 							sortOrder = Float.compare(chromatogramPeak2.getSignalToNoiseRatio(), chromatogramPeak1.getSignalToNoiseRatio());
 							break;
 					}
 				} else if(object1 instanceof IChromatogramPeakWSD chromatogramPeak1 && object2 instanceof IChromatogramPeakWSD chromatogramPeak2) {
 					switch(getPropertyIndex()) {
-						case 11:
+						case 12:
 							sortOrder = chromatogramPeak2.getScanMax() - chromatogramPeak1.getScanMax();
 							break;
-						case 12:
+						case 13:
 							sortOrder = Float.compare(chromatogramPeak2.getSignalToNoiseRatio(), chromatogramPeak1.getSignalToNoiseRatio());
 							break;
 					}
 				} else if(object1 instanceof IChromatogramPeakFSD chromatogramPeak1 && object2 instanceof IChromatogramPeakFSD chromatogramPeak2) {
 					switch(getPropertyIndex()) {
-						case 11:
+						case 12:
 							sortOrder = chromatogramPeak2.getScanMax() - chromatogramPeak1.getScanMax();
 							break;
-						case 12:
+						case 13:
 							sortOrder = Float.compare(chromatogramPeak2.getSignalToNoiseRatio(), chromatogramPeak1.getSignalToNoiseRatio());
 							break;
 					}
 				}
 				break;
-			case 13:
+			case 14:
 				sortOrder = Float.compare(getLeading(object2), getLeading(object1));
 				break;
-			case 14:
+			case 15:
 				sortOrder = Float.compare(getTailing(object2), getTailing(object1));
 				break;
-			case 15:
+			case 16:
 				sortOrder = getModelDescription(object2).compareTo(getModelDescription(object1));
 				break;
-			case 16:
+			case 17:
 				sortOrder = getDetectorDescription(object2).compareTo(getDetectorDescription(object1));
 				break;
-			case 17:
+			case 18:
 				sortOrder = getIntegratorDescription(object2).compareTo(getIntegratorDescription(object1));
 				break;
-			case 18:
+			case 19:
 				sortOrder = Integer.compare(getSuggestedNumberOfComponents(object2), getSuggestedNumberOfComponents(object1));
 				break;
-			case 19:
+			case 20:
 				sortOrder = Integer.compare(getInternalStandards(object2), getInternalStandards(object1));
 				break;
-			case 20:
+			case 21:
 				String classifier1 = PeakClassifierSupport.getClassifier(object1);
 				String classifier2 = PeakClassifierSupport.getClassifier(object2);
 				sortOrder = org.eclipse.chemclipse.model.preferences.PreferenceSupplier.isSortCaseSensitive() ? classifier2.compareTo(classifier1) : classifier2.compareToIgnoreCase(classifier1);
 				break;
-			case 21:
+			case 22:
 				if(object1 instanceof IPeak peak1 && object2 instanceof IPeak peak2) {
 					sortOrder = Boolean.compare(peak2.getPeakModel().isStrictModel(), peak1.getPeakModel().isStrictModel());
 				} else {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedTargetsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedTargetsUI.java
@@ -682,8 +682,8 @@ public class ExtendedTargetsUI extends Composite implements IExtendedPartUI {
 
 		if(object instanceof ITargetSupplier) {
 			String dataDescription;
-			if(object instanceof IChromatogram) {
-				dataDescription = ChromatogramDataSupport.getChromatogramLabel((IChromatogram)object);
+			if(object instanceof IChromatogram chromatogram) {
+				dataDescription = ChromatogramDataSupport.getChromatogramLabel(chromatogram);
 			} else if(object instanceof IPeak peak) {
 				dataDescription = peakDataSupport.getPeakLabel(peak);
 			} else if(object instanceof IScan scan) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakScanListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/PeakScanListUI.java
@@ -28,7 +28,6 @@ import org.eclipse.chemclipse.msd.model.core.IPeaksMSD;
 import org.eclipse.chemclipse.support.ui.provider.ListContentProvider;
 import org.eclipse.chemclipse.support.ui.swt.ExtendedTableViewer;
 import org.eclipse.chemclipse.swt.ui.support.Colors;
-import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.IdentificationTargetSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.PeakScanListEditingSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.PeakScanListFilter;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider.PeakScanListLabelProvider;
@@ -145,14 +144,12 @@ public class PeakScanListUI extends ExtendedTableViewer {
 								cell.setBackground(Colors.LIGHT_YELLOW);
 								cell.setForeground(Colors.BLACK);
 							}
-							cell.setImage(IdentificationTargetSupport.getRatingSymbol(IIdentificationTarget.getIdentificationTarget(peak)));
 						} else if(element instanceof IScan scan) {
 							cell.setText(TargetSupport.getBestTargetLibraryField(scan));
 							if(hasDuplicateTarget(scan)) {
 								cell.setBackground(Colors.LIGHT_YELLOW);
 								cell.setForeground(Colors.BLACK);
 							}
-							cell.setImage(IdentificationTargetSupport.getRatingSymbol(IIdentificationTarget.getIdentificationTarget(scan)));
 						}
 					}
 				}


### PR DESCRIPTION
That way it behaves the same as in the Targets view, which means you can now sort by match quality.