### PR TITLE
Filter the target folder

### DIFF
--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.entropy.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.entropy.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.peakmax.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.peakmax.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.sumarea.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.sumarea.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.calculator.peak.resolution.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.calculator.peak.resolution.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.classifier.supplier.durbinwatson.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.classifier.supplier.durbinwatson.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.invert.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.invert.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.zeroset.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.zeroset.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.identifier.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.identifier.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.timeranges.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.timeranges.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.thirdderivative.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.thirdderivative.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.image.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.image.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.pdf.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.pdf.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.container.zip.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.container.zip.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.csd.converter.supplier.arw.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.csd.converter.supplier.arw.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.csd.converter.supplier.xy.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.csd.converter.supplier.xy.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.msd.classifier.supplier.molpeak.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.classifier.supplier.molpeak.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.amdis.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.amdis.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.excel.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.excel.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mmass.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mmass.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzdata.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzdata.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzxml.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.mzxml.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.sirius.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.converter.supplier.sirius.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.msd.filter.supplier.centroiding.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.filter.supplier.centroiding.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.msd.filter.supplier.normalizer.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.filter.supplier.normalizer.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.msd.identifier.supplier.nist.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.msd.identifier.supplier.nist.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.nmr.converter.supplier.nmrml.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.nmr.converter.supplier.nmrml.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.nmr.processing.supplier.base.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.nmr.processing.supplier.base.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.pcr.converter.supplier.rdes.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.pcr.converter.supplier.rdes.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.pcr.converter.supplier.rdml.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.pcr.converter.supplier.rdml.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.pcr.report.supplier.tabular.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.pcr.report.supplier.tabular.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.pcr.report.supplier.txt.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.pcr.report.supplier.txt.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.base.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.base.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.compilation.base.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.compilation.base.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.compilation.core.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.compilation.core.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.app.core.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.rcp.compilation.community.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.ux.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.ux.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.vsd.converter.supplier.csv.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.vsd.converter.supplier.csv.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.wsd.converter.supplier.arw.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.wsd.converter.supplier.arw.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.wsd.converter.supplier.scf.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.wsd.converter.supplier.scf.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.ascii.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.ascii.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.cml.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.cml.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.csv.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.csv.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.mzml.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.mzml.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.ocx.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.converter.supplier.ocx.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.identifier.supplier.cactus.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.identifier.supplier.cactus.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.identifier.supplier.pubchem.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.identifier.supplier.pubchem.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/features/org.eclipse.chemclipse.xxd.process.supplier.pca.feature/.project
+++ b/chemclipse/features/org.eclipse.chemclipse.xxd.process.supplier.pca.feature/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.converter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.converter/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.model/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.alignment.model/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.filter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.filter/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.identifier/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.firstderivative.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.firstderivative.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.firstderivative/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector.supplier.firstderivative/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.csd.peak.detector/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.method.model/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.method.model/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.ui/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.entropy/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.entropy/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.comparison.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.ionremover/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.splitter/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.identifier/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.peakmax.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.peakmax.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.peakmax/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.peakmax/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.sumarea.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.sumarea.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.sumarea/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.integrator.supplier.sumarea/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.peak.detector/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.peak.detector/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.vsd.filter.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.vsd.filter.ui/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.vsd.filter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.vsd.filter/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.vsd.peak.detector/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.vsd.peak.detector/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.filter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.filter/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector.supplier.firstderivative.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector.supplier.firstderivative.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector.supplier.firstderivative/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector.supplier.firstderivative/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.peak.detector/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.peak.resolution.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.peak.resolution.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.peak.resolution/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.peak.resolution/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.ui/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.classifier.supplier.durbinwatson.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.classifier.supplier.durbinwatson.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.classifier.supplier.durbinwatson/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.classifier.supplier.durbinwatson/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.classifier.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.classifier.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.classifier/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.classifier/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.invert/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.invert/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.zeroset.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.zeroset.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.zeroset/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.zeroset/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file.ui/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.file/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.timeranges.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.timeranges.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.timeranges/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier.supplier.timeranges/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.identifier/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.integrator/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.firstderivative/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.thirdderivative/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.peak.detector.supplier.thirdderivative/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.quantitation/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.image.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.image.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.pdf.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.pdf.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.pdf/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.pdf/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.container.supplier.zip/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.container.supplier.zip/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.container/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.container/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.arw.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.arw.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.arw/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.arw/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.xy.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.xy.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.xy/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.supplier.xy/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.converter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.converter/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.csd.model/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.csd.model/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.feature.branding/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.feature.branding/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.fsd.converter.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.fsd.converter.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.fsd.converter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.fsd.converter/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.fsd.model/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.fsd.model/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.keystore/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.keystore/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.logging/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.logging/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.model.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model.ui/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.model/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.model/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak.ui/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.classifier.supplier.molpeak/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.amdis/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.cml/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.cml/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.excel.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.excel.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.excel/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.excel/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.sirius/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.filter.supplier.centroiding/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.filter.supplier.centroiding/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.filter.supplier.normalizer.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.filter.supplier.normalizer.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.filter.supplier.normalizer/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.filter.supplier.normalizer/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist.ui/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier.supplier.nist/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.identifier/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/.project
@@ -35,4 +35,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter.supplier.nmrml/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter.supplier.nmrml/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.model/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.model/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.processing.supplier.base.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.processing.supplier.base.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.processing.supplier.base/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.processing.supplier.base/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.numeric/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.numeric/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdes/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdes/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdml.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdml.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdml/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdml/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.model/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.model/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.csv/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.tabular/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.txt.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.txt.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.txt/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.report.supplier.txt/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.pdfbox.extensions/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pdfbox.extensions/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing.ui/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.processing/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.processing/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.progress.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.progress.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.progress/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.progress/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app.ui/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.app/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.app/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.compilation.community.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.compilation.community.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.rcp.ui.icons/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.rcp.ui.icons/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.tsd.converter.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.tsd.converter.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.tsd.converter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.tsd.converter/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.tsd.model/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.tsd.model/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.csd.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.csd.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.pcr.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.wsd.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.wsd.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.supplier.cml/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.supplier.cml/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.supplier.csv/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.supplier.csv/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.converter/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.vsd.model/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.arw.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.arw.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.arw/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.arw/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.cml/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.cml/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.scf/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.scf/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.spectroml/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.spectroml/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.model/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.classification.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.classification.ui/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.classification/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.classification/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ascii/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ascii/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.cml/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.cml/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.csv/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx.ui/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.ocx/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.filter/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.cactus.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.cactus.ui/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.cactus/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.cactus/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.pubchem.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.pubchem.ui/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.pubchem/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.pubchem/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.ui/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.model/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.model/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.ui/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/.project
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process/.project
@@ -30,4 +30,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/.project
+++ b/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/.project
@@ -8,4 +8,15 @@
 	</buildSpec>
 	<natures>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/.project
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/.project
@@ -8,4 +8,15 @@
 	</buildSpec>
 	<natures>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/releng/org.eclipse.chemclipse.utils/.project
+++ b/chemclipse/releng/org.eclipse.chemclipse.utils/.project
@@ -8,4 +8,15 @@
 	</buildSpec>
 	<natures>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.converter.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.converter.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.model.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.alignment.model.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.csd.filter.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.csd.filter.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.classifier.supplier.wnc.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.alfassi.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.distance.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.entropy.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.comparison.supplier.entropy.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.backfolding.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.coda.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.denoising.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.identifier.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.identifier.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.msd.peak.detector.supplier.firstderivative.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.amdiscalri.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.dyson.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.calculator.supplier.noise.stein.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.classifier.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.classifier.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.meannormalizer.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.mediannormalizer.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.multiplier.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.normalizer.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.rtshifter.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.savitzkygolay.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.scan.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.unitsumnormalizer.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.integrator.supplier.trapezoid.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.quantitation.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.quantitation.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.xxd.quantitation.supplier.chemclipse.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.converter.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.keystore.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.keystore.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.model.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.amdis.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.cml.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.cml.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.excel.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.matlab.parafac.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mmass.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mmass.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzdata.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.mzxml.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.sirius.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.converter.supplier.sirius.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.identifier.supplier.nist.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.model.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.msd.swt.ui.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.msd.swt.ui.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.nmr.converter.supplier.nmrml.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.nmr.converter.supplier.nmrml.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.numeric.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.numeric.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.pcr.converter.supplier.rdml.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.pcr.converter.supplier.rdml.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.pcr.report.supplier.tabular.excel.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.pdfbox.extensions.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.pdfbox.extensions.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.processing.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.processing.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.progress.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.progress.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.rcp.app.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.rcp.app.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.support.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.support.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.support.ui.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.support.ui.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.swt.ui.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.swt.ui.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.tsd.converter.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.tsd.converter.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.ux.extension.xxd.ui.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.ux.extension.xxd.ui.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.vsd.converter.supplier.cml.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.vsd.converter.supplier.cml.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.cml.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.cml.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.scf.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.scf.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.spectroml.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.wsd.converter.supplier.spectroml.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.wsd.model.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.wsd.model.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.classification.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.classification.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ascii.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ascii.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.csv.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.csv.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.jcampdx.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.mzml.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.mzml.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.ocx.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.filter.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.filter.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.identifier.supplier.pubchem.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.identifier.supplier.pubchem.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.identifier.supplier.wikidata.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.model.fragment.test/.project
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.model.fragment.test/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1784561644509</id>
+			<name>Tycho target folder</name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>


### PR DESCRIPTION
[Resource Filters](https://help.eclipse.org/latest/index.jsp?topic=%252Forg.eclipse.platform.doc.user%252Fconcepts%252Fresourcefilters.htm) was the only way how I could get rid of the `/target` folder, which contains derived files from @eclipse-tycho such as all the `.class` files but also `plugin.xml` which is always annoying when searching project-wide or using open resource.