### PR TITLE
Adjust Scan Chart for types other than MSD

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/plugin.xml
@@ -837,6 +837,87 @@
             The title font
         </description>
     </fontDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisMilliseconds.GridColor"
+        label="Scan Chart Axis Milliseconds Grid Color"
+        value="192,192,192">
+        <description>
+            The color of the chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisMilliseconds.LineColor"
+        label="Scan Chart Axis Milliseconds Line Color"
+        value="0,0,0">
+        <description>
+            The color of the chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisMilliseconds.Font"
+        label="Scan Chart Axis Milliseconds Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font
+        </description>
+    </fontDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisMinutes.GridColor"
+        label="Scan Chart Axis Minutes Grid Color"
+        value="192,192,192">
+        <description>
+            The color of the chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisMinutes.LineColor"
+        label="Scan Chart Axis Minutes Line Color"
+        value="0,0,0">
+        <description>
+            The color of the chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisMinutes.Font"
+        label="Scan Chart Axis Minutes Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font
+        </description>
+    </fontDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisWavelengths.GridColor"
+        label="Scan Chart Axis Wavelengths Grid Color"
+        value="192,192,192">
+        <description>
+            The color of the chart grid.
+        </description>
+    </colorDefinition>
+    <colorDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisWavelengths.LineColor"
+        label="Scan Chart Axis Wavelengths Line Color"
+        value="0,0,0">
+        <description>
+            The color of the chart line.
+        </description>
+    </colorDefinition>
+    <fontDefinition
+        categoryId="org.eclipse.chemclipse.ux.extension.xxd.ui.charts"
+        id="org.eclipse.chemclipse.ux.extension.xxd.ui.swt.ExtendedScanChartUI.AxisWavelengths.Font"
+        label="Scan Chart Axis Wavelengths Font"
+        value="Verdana-bold-11">
+        <description>
+            The title font
+        </description>
+    </fontDefinition>
 </extension>
 <extension
          point="org.eclipse.ui.commands">

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
@@ -320,6 +320,17 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static final String P_SCAN_CHART_SHOW_X_AXIS_TITLE_IONS = "scanChartShowXAxisTitleIons";
 	public static final boolean DEF_SCAN_CHART_SHOW_X_AXIS_TITLE_IONS = true;
 
+	public static final String P_SCAN_CHART_SHOW_X_AXIS_WAVELENGTHS = "scanChartShowXAxisWavelengths";
+	public static final boolean DEF_SCAN_CHART_SHOW_X_AXIS_WAVELENGTHS = true;
+	public static final String P_SCAN_CHART_POSITION_X_AXIS_WAVELENGTHS = "scanChartPositionXAxisWavelengths";
+	public static final String DEF_SCAN_CHART_POSITION_X_AXIS_WAVELENGTHS = Position.Primary.toString();
+	public static final String P_SCAN_CHART_FORMAT_X_AXIS_WAVELENGTHS = "scanChartFormatXAxisWavelengths";
+	public static final String DEF_SCAN_CHART_FORMAT_X_AXIS_WAVELENGTHS = "0";
+	public static final String P_SCAN_CHART_GRIDLINE_STYLE_X_AXIS_WAVELENGTHS = "scanChartGridlineStyleXAxisWavelengths";
+	public static final String DEF_SCAN_CHART_GRIDLINE_STYLE_X_AXIS_WAVELENGTHS = LineStyle.DOT.toString();
+	public static final String P_SCAN_CHART_SHOW_X_AXIS_TITLE_WAVELENGTHS = "scanChartShowXAxisTitleWavelengths";
+	public static final boolean DEF_SCAN_CHART_SHOW_X_AXIS_TITLE_WAVELENGTHS = true;
+
 	public static final String P_TRACES_VIRTUAL_TABLE = "tracesVirtualTable";
 	public static final int DEF_TRACES_VIRTUAL_TABLE = 5000;
 	public static final String P_LIMIT_SIM_TRACES = "limitSimTraces";
@@ -969,6 +980,12 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 		putDefault(P_SCAN_CHART_POSITION_X_AXIS_IONS, DEF_SCAN_CHART_POSITION_X_AXIS_IONS);
 		putDefault(P_SCAN_CHART_GRIDLINE_STYLE_X_AXIS_IONS, DEF_SCAN_CHART_GRIDLINE_STYLE_X_AXIS_IONS);
 		putDefault(P_SCAN_CHART_SHOW_X_AXIS_TITLE_IONS, DEF_SCAN_CHART_SHOW_X_AXIS_TITLE_IONS);
+
+		putDefault(P_SCAN_CHART_SHOW_X_AXIS_WAVELENGTHS, DEF_SCAN_CHART_SHOW_X_AXIS_WAVELENGTHS);
+		putDefault(P_SCAN_CHART_POSITION_X_AXIS_WAVELENGTHS, DEF_SCAN_CHART_POSITION_X_AXIS_WAVELENGTHS);
+		putDefault(P_SCAN_CHART_FORMAT_X_AXIS_WAVELENGTHS, DEF_SCAN_CHART_FORMAT_X_AXIS_WAVELENGTHS);
+		putDefault(P_SCAN_CHART_GRIDLINE_STYLE_X_AXIS_WAVELENGTHS, DEF_SCAN_CHART_GRIDLINE_STYLE_X_AXIS_WAVELENGTHS);
+		putDefault(P_SCAN_CHART_SHOW_X_AXIS_TITLE_WAVELENGTHS, DEF_SCAN_CHART_SHOW_X_AXIS_TITLE_WAVELENGTHS);
 
 		putDefault(P_TRACES_VIRTUAL_TABLE, DEF_TRACES_VIRTUAL_TABLE);
 		putDefault(P_LIMIT_SIM_TRACES, DEF_LIMIT_SIM_TRACES);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ScanChartAxisWavelength.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/ScanChartAxisWavelength.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.ux.extension.xxd.ui.preferences;
+
+import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.DoubleFieldEditor;
+import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.LabelFieldEditor;
+import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpacerFieldEditor;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.ComboFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.StringFieldEditor;
+import org.eclipse.swtchart.extensions.charts.ChartOptions;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+
+public class ScanChartAxisWavelength extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+
+	public ScanChartAxisWavelength() {
+
+		super(GRID);
+		setPreferenceStore(Activator.getDefault().getPreferenceStore());
+		setTitle("Scan Chart Wavelength Axis");
+		setDescription("");
+	}
+
+	@Override
+	public void createFieldEditors() {
+
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_SCAN_CHART_SHOW_X_AXIS_WAVELENGTHS, ExtensionMessages.show, getFieldEditorParent()));
+		addField(new ComboFieldEditor(PreferenceSupplier.P_SCAN_CHART_POSITION_X_AXIS_WAVELENGTHS, ExtensionMessages.position + ":", ChartOptions.POSITIONS, getFieldEditorParent()));
+		addField(new StringFieldEditor(PreferenceSupplier.P_SCAN_CHART_FORMAT_X_AXIS_WAVELENGTHS, ExtensionMessages.format + ":", getFieldEditorParent()));
+		addField(new ComboFieldEditor(PreferenceSupplier.P_SCAN_CHART_GRIDLINE_STYLE_X_AXIS_WAVELENGTHS, ExtensionMessages.gridLineStyle + ":", ChartOptions.LINE_STYLES, getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_SCAN_CHART_SHOW_X_AXIS_TITLE_WAVELENGTHS, ExtensionMessages.showAxisTitle, getFieldEditorParent()));
+
+		addField(new SpacerFieldEditor(getFieldEditorParent()));
+		addField(new LabelFieldEditor("The axis scale is used to set the values.", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_SCAN_CHART_ENABLE_FIXED_RANGE_X, "Fixed range X", getFieldEditorParent()));
+		addField(new DoubleFieldEditor(PreferenceSupplier.P_SCAN_CHART_FIXED_RANGE_START_X, "Start X", PreferenceSupplier.MIN_RANGE, PreferenceSupplier.MAX_RANGE, getFieldEditorParent()));
+		addField(new DoubleFieldEditor(PreferenceSupplier.P_SCAN_CHART_FIXED_RANGE_STOP_X, "Stop X", PreferenceSupplier.MIN_RANGE, PreferenceSupplier.MAX_RANGE, getFieldEditorParent()));
+	}
+
+	@Override
+	public void init(IWorkbench workbench) {
+
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanChartUI.java
@@ -754,9 +754,11 @@ public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 
 	void adjustAxisSettings() {
 
-		adjustAxisIons();
-		adjustAxisIntensity();
-		adjustAxisRelativeIntensity();
+		if(scan instanceof IScanMSD) {
+			adjustAxisIons();
+			adjustAxisIntensity();
+			adjustAxisRelativeIntensity();
+		}
 
 		IChartSettings chartSettings = chartControl.get().getChartSettings();
 		chartControl.get().applySettings(chartSettings);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanChartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedScanChartUI.java
@@ -47,12 +47,15 @@ import org.eclipse.chemclipse.ux.extension.ui.swt.ISettingsHandler;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.charts.ChartSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.ChromatogramAxisMilliseconds;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.ChromatogramAxisSeconds;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageScans;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferencePageSubtract;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.ScanChartAxisIntensity;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.ScanChartAxisIon;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.ScanChartAxisRelativeIntensity;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.ScanChartAxisWavelength;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.ChromatogramUpdateSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.support.charts.ScanDataSupport;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.wizards.SubtractScanWizard;
@@ -77,6 +80,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swtchart.IAxis;
 import org.eclipse.swtchart.Range;
+import org.eclipse.swtchart.extensions.axisconverter.MillisecondsToMinuteConverter;
 import org.eclipse.swtchart.extensions.axisconverter.PercentageConverter;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.core.IChartSettings;
@@ -745,10 +749,12 @@ public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 		List<Class<? extends IPreferencePage>> preferencePages = new ArrayList<>();
 		preferencePages.add(PreferencePageScans.class);
 		preferencePages.add(ScanChartAxisIon.class);
+		preferencePages.add(ScanChartAxisWavelength.class);
 		preferencePages.add(ScanChartAxisIntensity.class);
 		preferencePages.add(ScanChartAxisRelativeIntensity.class);
+		preferencePages.add(ChromatogramAxisSeconds.class);
+		preferencePages.add(ChromatogramAxisMilliseconds.class);
 		preferencePages.add(PreferencePageSubtract.class);
-
 		return preferencePages;
 	}
 
@@ -756,6 +762,15 @@ public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 
 		if(scan instanceof IScanMSD) {
 			adjustAxisIons();
+			adjustAxisIntensity();
+			adjustAxisRelativeIntensity();
+		} else if(scan instanceof IScanCSD) {
+			adjustAxisMinutes();
+			adjustAxisMiliseconds();
+			adjustAxisIntensity();
+			adjustAxisRelativeIntensity();
+		} else if(scan instanceof IScanWSD) {
+			adjustAxisWavelengths();
 			adjustAxisIntensity();
 			adjustAxisRelativeIntensity();
 		}
@@ -828,6 +843,81 @@ public class ExtendedScanChartUI extends Composite implements IExtendedPartUI {
 				axisSettings.setTitleVisible(isShowAxisTitle);
 			}
 		}
+	}
+
+	private void adjustAxisMiliseconds() {
+
+		IChartSettings chartSettings = chartControl.get().getChartSettings();
+		IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
+		primaryAxisSettingsX.setTitle(ExtensionMessages.miliseconds);
+
+		String positionNode = PreferenceSupplier.P_POSITION_X_AXIS_MILLISECONDS;
+		String patternNode = PreferenceSupplier.P_FORMAT_X_AXIS_MILLISECONDS;
+		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_MILLISECONDS;
+
+		ChartSupport.setAxisSettingsExtended(primaryAxisSettingsX, positionNode, patternNode, gridLineStyleNode);
+		ChartSupport.themeAxis(primaryAxisSettingsX, ExtendedScanChartUI.class.getName() + ".AxisMilliseconds");
+		primaryAxisSettingsX.setVisible(ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_MILLISECONDS));
+		primaryAxisSettingsX.setTitleVisible(ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_TITLE_MILLISECONDS));
+	}
+
+	private void adjustAxisMinutes() {
+
+		IChartSettings chartSettings = chartControl.get().getChartSettings();
+		ISecondaryAxisSettings axisSettings = ChartSupport.getSecondaryAxisSettingsX(ExtensionMessages.minutes, chartSettings);
+
+		String positionNode = PreferenceSupplier.P_POSITION_X_AXIS_MINUTES;
+		String patternNode = PreferenceSupplier.P_FORMAT_X_AXIS_MINUTES;
+		String gridLineStyleNode = PreferenceSupplier.P_GRIDLINE_STYLE_X_AXIS_MINUTES;
+		boolean isShowAxis = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_MINUTES);
+		boolean isShowAxisTitle = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_TITLE_MINUTES);
+
+		boolean drawAxisLine = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_LINE_MINUTES);
+		boolean drawPositionMarker = ChartSupport.getBoolean(PreferenceSupplier.P_SHOW_X_AXIS_POSITION_MARKER_MINUTES);
+
+		if(isShowAxis) {
+			if(axisSettings == null) {
+				ISecondaryAxisSettings secondaryAxisSettingsX = new SecondaryAxisSettings(ExtensionMessages.minutes, new MillisecondsToMinuteConverter());
+				ChartSupport.setAxisSettingsExtended(secondaryAxisSettingsX, positionNode, patternNode, gridLineStyleNode);
+				ChartSupport.themeAxis(secondaryAxisSettingsX, ExtendedScanChartUI.class.getName() + ".AxisMinutes");
+				secondaryAxisSettingsX.setTitleVisible(isShowAxisTitle);
+				secondaryAxisSettingsX.setDrawAxisLine(drawAxisLine);
+				secondaryAxisSettingsX.setDrawPositionMarker(drawPositionMarker);
+				chartSettings.getSecondaryAxisSettingsListX().add(secondaryAxisSettingsX);
+			} else {
+				ChartSupport.setAxisSettingsExtended(axisSettings, positionNode, patternNode, gridLineStyleNode);
+				ChartSupport.themeAxis(axisSettings, ExtendedScanChartUI.class.getName() + ".AxisMinutes");
+				axisSettings.setTitle(ExtensionMessages.minutes);
+				axisSettings.setVisible(true);
+				axisSettings.setTitleVisible(isShowAxisTitle);
+				axisSettings.setDrawAxisLine(drawAxisLine);
+				axisSettings.setDrawPositionMarker(drawPositionMarker);
+			}
+		} else {
+			if(axisSettings != null) {
+				axisSettings.setTitle(ExtensionMessages.minutes);
+				axisSettings.setVisible(false);
+				axisSettings.setTitleVisible(isShowAxisTitle);
+				axisSettings.setDrawAxisLine(drawAxisLine);
+				axisSettings.setDrawPositionMarker(drawPositionMarker);
+			}
+		}
+	}
+
+	private void adjustAxisWavelengths() {
+
+		IChartSettings chartSettings = chartControl.get().getChartSettings();
+		IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
+		primaryAxisSettingsX.setTitle(ExtensionMessages.wavelength);
+
+		String positionNode = PreferenceSupplier.P_SCAN_CHART_POSITION_X_AXIS_WAVELENGTHS;
+		String patternNode = PreferenceSupplier.P_SCAN_CHART_FORMAT_X_AXIS_WAVELENGTHS;
+		String gridLineStyleNode = PreferenceSupplier.P_SCAN_CHART_GRIDLINE_STYLE_X_AXIS_WAVELENGTHS;
+
+		ChartSupport.setAxisSettingsExtended(primaryAxisSettingsX, positionNode, patternNode, gridLineStyleNode);
+		ChartSupport.themeAxis(primaryAxisSettingsX, ExtendedScanChartUI.class.getName() + ".AxisWavelengths");
+		primaryAxisSettingsX.setVisible(ChartSupport.getBoolean(PreferenceSupplier.P_SCAN_CHART_SHOW_X_AXIS_WAVELENGTHS));
+		primaryAxisSettingsX.setTitleVisible(ChartSupport.getBoolean(PreferenceSupplier.P_SCAN_CHART_SHOW_X_AXIS_TITLE_WAVELENGTHS));
 	}
 
 	private void createSaveButton(Composite parent) {


### PR DESCRIPTION
In https://github.com/eclipse-chemclipse/chemclipse/pull/2967 I completely forgot about scans other than MS which causes nasty visual glitches with additional secondary axis shown.