### PR TITLE
Make BatchJobEditor a pure E4 part

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/META-INF/MANIFEST.MF
@@ -8,16 +8,14 @@ Bundle-Activator: org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batch
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess;bundle-version="0.8.0",
- org.eclipse.core.resources,
- org.eclipse.ui.ide,
  org.eclipse.chemclipse.logging;bundle-version="0.8.0",
- org.eclipse.jface.text,
- org.eclipse.ui.editors,
  org.eclipse.chemclipse.processing;bundle-version="0.8.0",
  org.eclipse.chemclipse.processing.ui;bundle-version="0.8.0",
  org.eclipse.chemclipse.xxd.process;bundle-version="0.8.0",
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
  org.eclipse.e4.core.di;bundle-version="1.2.0",
+ org.eclipse.e4.ui.di;bundle-version="0.10.1",
+ org.eclipse.e4.ui.model.workbench;bundle-version="1.1.0",
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.rcp.ui.icons;bundle-version="0.8.0",
  org.eclipse.chemclipse.support.ui;bundle-version="0.8.0",
@@ -29,3 +27,5 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: ChemClipse
 Bundle-Localization: OSGI-INF/l10n/bundle
+Import-Package: jakarta.annotation;version="2.1.1",
+ jakarta.inject;version="[2.0.0,3.0.0]"

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/plugin.xml
@@ -23,15 +23,17 @@
       </wizard>
    </extension>
    <extension
-         point="org.eclipse.ui.editors">
-      <editor
-            class="org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui.editors.BatchJobEditor"
-            contributorClass="org.eclipse.ui.texteditor.BasicTextEditorActionContributor"
-            extensions="obj"
-            icon="platform:/plugin/org.eclipse.chemclipse.rcp.ui.icons/icons/16x16/batchprocess.gif"
-            id="org.eclipse.chemclipse.chromatogram.xxd.batchprocess.ui.editors.BatchProcessJobEditor"
-            name="Batch Process Job">
-      </editor>
+         point="org.eclipse.core.runtime.adapters">
+      <factory
+            adaptableType="org.eclipse.chemclipse.ux.extension.xxd.ui.internal.editors.BatchJobFileSupplier"
+            class="org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui.internal.provider.BatchJobFileEditorAdapterFactory">
+         <adapter
+               type="org.eclipse.chemclipse.ux.extension.ui.provider.ISupplierFileEditorSupport">
+         </adapter>
+         <adapter
+               type="org.eclipse.chemclipse.ux.extension.ui.editors.EditorDescriptor">
+         </adapter>
+      </factory>
    </extension>
    <extension
          point="org.eclipse.ui.preferencePages">

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/ui/editors/BatchJobEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/ui/editors/BatchJobEditor.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Philip Wenig - initial API and implementation
  * Christoph Läubrich - rework dirty flag handling
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -37,9 +38,15 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.methods.ProcessMethod;
 import org.eclipse.chemclipse.processing.supplier.IProcessSupplierContext;
 import org.eclipse.chemclipse.processing.ui.support.ProcessingInfoPartSupport;
+import org.eclipse.chemclipse.support.ui.workbench.EditorSupport;
+import org.eclipse.chemclipse.ux.extension.ui.editors.IChemClipseEditor;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.swt.BatchJobUI;
 import org.eclipse.chemclipse.xxd.process.support.ProcessTypeSupport;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.e4.ui.di.Focus;
+import org.eclipse.e4.ui.di.Persist;
+import org.eclipse.e4.ui.model.application.ui.MDirtyable;
+import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.swt.SWT;
@@ -48,28 +55,34 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.IEditorInput;
-import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IEditorSite;
-import org.eclipse.ui.IFileEditorInput;
-import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.part.EditorPart;
 
-public class BatchJobEditor extends EditorPart implements IRunnableWithProgress {
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+
+public class BatchJobEditor implements IChemClipseEditor, IRunnableWithProgress {
+
+	public static final String ID = "org.eclipse.chemclipse.chromatogram.xxd.batchprocess.ui.editors.BatchProcessJobEditor";
+	public static final String CONTRIBUTION_URI = "bundleclass://org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui.editors.BatchJobEditor";
+	public static final String ICON_URI = "platform:/plugin/org.eclipse.chemclipse.rcp.ui.icons/icons/16x16/batchprocess.gif";
+	public static final String TOOLTIP = "Batch Process Job";
 
 	private static final Logger logger = Logger.getLogger(BatchJobEditor.class);
 
+	@Inject
+	private MPart part;
+	@Inject
+	private MDirtyable dirtyable;
+
 	private File file;
-	private boolean isDirty = false;
 	private BatchProcessJob batchProcessJob;
 	private BatchJobUI batchJobUI;
 
 	private IProcessSupplierContext supplierContext;
 
-	@Override
-	public void doSave(IProgressMonitor monitor) {
+	@Persist
+	public void save() {
 
-		if(file != null) {
+		if(file != null && batchJobUI != null) {
 			try {
 				JobWriter writer = new JobWriter();
 				batchProcessJob = getBatchProcessJob(batchJobUI.getDataType());
@@ -86,7 +99,11 @@ public class BatchJobEditor extends EditorPart implements IRunnableWithProgress 
 	}
 
 	@Override
-	public void doSaveAs() {
+	public boolean saveAs() {
+
+		if(batchJobUI == null) {
+			return false;
+		}
 
 		Display display = Display.getCurrent();
 		Shell shell = display.getActiveShell();
@@ -102,6 +119,7 @@ public class BatchJobEditor extends EditorPart implements IRunnableWithProgress 
 			try {
 				monitor.run(false, false, runnable);
 				updateDirtyStatus(false);
+				return true;
 			} catch(InvocationTargetException e) {
 				logger.warn(e);
 				logger.warn(e.getCause());
@@ -110,39 +128,8 @@ public class BatchJobEditor extends EditorPart implements IRunnableWithProgress 
 				Thread.currentThread().interrupt();
 			}
 		}
-	}
 
-	@Override
-	public void init(IEditorSite site, IEditorInput input) throws PartInitException {
-
-		setSite(site);
-		setInput(input);
-
-		String fileName = input.getName();
-		fileName = fileName.substring(0, fileName.length() - 4);
-		setPartName(fileName);
-
-		if(batchProcessJob == null && input instanceof IFileEditorInput fileEditorInput) {
-			file = fileEditorInput.getFile().getLocation().toFile();
-			ImportRunnable runnable = new ImportRunnable(file);
-			ProgressMonitorDialog monitor = new ProgressMonitorDialog(site.getShell());
-			try {
-				monitor.run(false, false, runnable);
-				batchProcessJob = runnable.getBatchProcessJob();
-			} catch(InvocationTargetException e) {
-				throw new PartInitException("The file couldn't be loaded.", e.getTargetException());
-			} catch(InterruptedException e) {
-				Thread.currentThread().interrupt();
-			}
-		} else {
-			throw new PartInitException("The file couldn't be loaded.");
-		}
-	}
-
-	@Override
-	public boolean isDirty() {
-
-		return isDirty;
+		return false;
 	}
 
 	/**
@@ -150,20 +137,26 @@ public class BatchJobEditor extends EditorPart implements IRunnableWithProgress 
 	 */
 	protected void updateDirtyStatus(boolean dirty) {
 
-		this.isDirty = dirty;
-		firePropertyChange(IEditorPart.PROP_DIRTY);
+		dirtyable.setDirty(dirty);
 	}
 
-	@Override
-	public boolean isSaveAsAllowed() {
+	@Focus
+	public void setFocus() {
 
-		return true;
+		if(batchJobUI != null) {
+			batchJobUI.setFocus();
+		}
 	}
 
-	@Override
-	public void createPartControl(Composite parent) {
+	@PostConstruct
+	private void createControl(Composite parent) {
 
 		parent.setLayout(new FillLayout());
+
+		loadBatchProcessJob(parent.getShell());
+		if(batchProcessJob == null) {
+			return;
+		}
 
 		supplierContext = new ProcessTypeSupport();
 		DataType dataType = batchProcessJob.getDataType();
@@ -172,10 +165,31 @@ public class BatchJobEditor extends EditorPart implements IRunnableWithProgress 
 		batchJobUI.doLoad(getBatchJobFiles(), new ProcessMethod(batchProcessJob.getProcessMethod()));
 	}
 
-	@Override
-	public void setFocus() {
+	private void loadBatchProcessJob(Shell shell) {
 
-		batchJobUI.setFocus();
+		Object object = part.getObject();
+		if(object instanceof Map<?, ?> map) {
+			file = new File((String)map.get(EditorSupport.MAP_FILE));
+		}
+
+		if(file != null) {
+			String fileName = file.getName();
+			if(fileName.length() > 4) {
+				fileName = fileName.substring(0, fileName.length() - 4);
+			}
+			part.setLabel(fileName);
+			ImportRunnable runnable = new ImportRunnable(file);
+			ProgressMonitorDialog monitor = new ProgressMonitorDialog(shell);
+			try {
+				monitor.run(false, false, runnable);
+				batchProcessJob = runnable.getBatchProcessJob();
+			} catch(InvocationTargetException e) {
+				logger.warn("The file couldn't be loaded: " + file.getAbsolutePath());
+				logger.warn(e.getTargetException());
+			} catch(InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
 	}
 
 	private List<File> getBatchJobFiles() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/ui/handlers/BatchProcessHandler.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/ui/handlers/BatchProcessHandler.java
@@ -12,7 +12,13 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui.handlers;
 
+import java.io.File;
+
 import org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui.wizards.WizardProcessor;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.model.types.DataType;
+import org.eclipse.chemclipse.ux.extension.ui.provider.ISupplierEditorSupport;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.editors.ProjectExplorerSupportFactory;
 import org.eclipse.e4.core.contexts.Active;
 import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.jface.wizard.WizardDialog;
@@ -20,10 +26,23 @@ import org.eclipse.swt.widgets.Shell;
 
 public class BatchProcessHandler {
 
+	private static final Logger logger = Logger.getLogger(BatchProcessHandler.class);
+
 	@Execute
 	public void execute(@Active Shell shell) {
 
-		WizardDialog wizardDialog = new WizardDialog(shell, new WizardProcessor());
+		WizardProcessor wizard = new WizardProcessor();
+		WizardDialog wizardDialog = new WizardDialog(shell, wizard);
 		wizardDialog.open();
+		/*
+		 * The wizard dialog is closed at this point, so the E4 part service can resolve the active window.
+		 */
+		File batchProcessFile = wizard.getBatchProcessFile();
+		if(batchProcessFile != null) {
+			ISupplierEditorSupport supplierEditorSupport = new ProjectExplorerSupportFactory(DataType.OBJ).getInstanceEditorSupport();
+			if(!supplierEditorSupport.openEditor(batchProcessFile)) {
+				logger.warn("Failed to open editor.");
+			}
+		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/ui/internal/provider/BatchJobFileEditorAdapterFactory.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/ui/internal/provider/BatchJobFileEditorAdapterFactory.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Aleksandar Kurtakov - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui.internal.provider;
+
+import org.eclipse.chemclipse.ux.extension.ui.editors.EditorDescriptor;
+import org.eclipse.chemclipse.ux.extension.ui.provider.ISupplierFileEditorSupport;
+import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.editors.BatchJobFileSupplier;
+import org.eclipse.core.runtime.IAdapterFactory;
+
+public class BatchJobFileEditorAdapterFactory implements IAdapterFactory {
+
+	private static final BatchJobFileEditorSupport EDITOR_SUPPORT = new BatchJobFileEditorSupport();
+
+	@Override
+	public <T> T getAdapter(Object adaptableObject, Class<T> adapterType) {
+
+		if(adaptableObject instanceof BatchJobFileSupplier && (adapterType == ISupplierFileEditorSupport.class || adapterType == EditorDescriptor.class)) {
+			return adapterType.cast(EDITOR_SUPPORT);
+		}
+		return null;
+	}
+
+	@Override
+	public Class<?>[] getAdapterList() {
+
+		return new Class<?>[]{ISupplierFileEditorSupport.class, EditorDescriptor.class};
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/ui/internal/provider/BatchJobFileEditorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/ui/internal/provider/BatchJobFileEditorSupport.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Aleksandar Kurtakov - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui.internal.provider;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+
+import org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui.editors.BatchJobEditor;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.model.core.support.HeaderField;
+import org.eclipse.chemclipse.processing.converter.ISupplier;
+import org.eclipse.chemclipse.ux.extension.ui.editors.EditorDescriptor;
+import org.eclipse.chemclipse.ux.extension.ui.provider.AbstractSupplierFileEditorSupport;
+import org.eclipse.jface.resource.ImageDescriptor;
+
+public class BatchJobFileEditorSupport extends AbstractSupplierFileEditorSupport implements EditorDescriptor {
+
+	private static final Logger logger = Logger.getLogger(BatchJobFileEditorSupport.class);
+
+	public BatchJobFileEditorSupport() {
+
+		super(Collections.emptyList());
+	}
+
+	@Override
+	public String getType() {
+
+		return TYPE_OBJ;
+	}
+
+	@Override
+	public ImageDescriptor getImageDescriptor() {
+
+		try {
+			return ImageDescriptor.createFromURL(URI.create(BatchJobEditor.ICON_URI).toURL());
+		} catch(MalformedURLException e) {
+			logger.warn(e);
+			return null;
+		}
+	}
+
+	@Override
+	public boolean openEditor(File file, boolean batch) {
+
+		return openEditor(file, Collections.emptyMap(), batch);
+	}
+
+	@Override
+	public boolean openEditor(File file, Map<HeaderField, String> headerMap, boolean batch) {
+
+		openEditor(file, null, BatchJobEditor.ID, BatchJobEditor.CONTRIBUTION_URI, BatchJobEditor.ICON_URI, BatchJobEditor.TOOLTIP, headerMap, batch);
+		return true;
+	}
+
+	@Override
+	public boolean openEditor(File file, ISupplier supplier) {
+
+		return openEditor(file, false);
+	}
+
+	@Override
+	public boolean openEditor(File file, Map<HeaderField, String> headerMap, ISupplier supplier) {
+
+		return openEditor(file, headerMap, false);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/ui/wizards/WizardProcessor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.ui/src/org/eclipse/chemclipse/chromatogram/xxd/process/supplier/batchprocess/ui/wizards/WizardProcessor.java
@@ -17,11 +17,7 @@ import java.io.File;
 import org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.io.JobWriter;
 import org.eclipse.chemclipse.chromatogram.xxd.process.supplier.batchprocess.model.BatchProcessJob;
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.model.types.DataType;
-import org.eclipse.chemclipse.support.l10n.SupportMessages;
 import org.eclipse.chemclipse.support.ui.wizards.AbstractWizard;
-import org.eclipse.chemclipse.ux.extension.ui.provider.ISupplierEditorSupport;
-import org.eclipse.chemclipse.ux.extension.xxd.ui.internal.editors.ProjectExplorerSupportFactory;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 
@@ -31,6 +27,8 @@ public class WizardProcessor extends AbstractWizard {
 
 	private PageDataType pageDataType;
 	private BatchProcessWizardElements wizardElements;
+
+	private File batchProcessFile;
 
 	public WizardProcessor() {
 
@@ -61,7 +59,12 @@ public class WizardProcessor extends AbstractWizard {
 			logger.warn(e);
 		}
 
-		runOpenEditor(file, monitor);
+		this.batchProcessFile = file;
+	}
+
+	public File getBatchProcessFile() {
+
+		return batchProcessFile;
 	}
 
 	private BatchProcessJob createBatchProcessJob() {
@@ -70,16 +73,5 @@ public class WizardProcessor extends AbstractWizard {
 		batchProcessJob.setDataType(pageDataType.getDataType());
 
 		return batchProcessJob;
-	}
-
-	private void runOpenEditor(File file, IProgressMonitor monitor) {
-
-		monitor.subTask(SupportMessages.taskOpenEditor);
-		ISupplierEditorSupport supplierEditorSupport = new ProjectExplorerSupportFactory(DataType.OBJ).getInstanceEditorSupport();
-		getShell().getDisplay().asyncExec(() -> {
-			if(!supplierEditorSupport.openEditor(file)) {
-				logger.warn("Failed to open editor.");
-			}
-		});
 	}
 }


### PR DESCRIPTION
Drops BatchJobEditor's EditorPart/org.eclipse.ui.editors registration in favor of an E4 MPart (IChemClipseEditor + PostConstruct/Persist/Focus annotated methods), mirroring EditorCalibration.

Files of type .obj opening now routes through the generic E4 openEditor(...) helper, resolved via Adapters.adapt(...) on BatchJobFileSupplier. The editor is opened by BatchProcessHandler once the wizard dialog is closed, so the E4 part service can resolve the active window.