### PR TITLE
Strip characters invalid in XMI from part labels

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/workbench/XmiSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support.ui/src/org/eclipse/chemclipse/support/ui/workbench/XmiSupport.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Aleksandar Kurtakov - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.support.ui.workbench;
+
+/**
+ * The e4 workbench model is persisted as XMI. Characters that XML is unable to
+ * represent are rejected instead of escaped, which fails the workbench auto save.
+ */
+public class XmiSupport {
+
+	private XmiSupport() {
+
+	}
+
+	/**
+	 * Drops the characters that XMI is unable to represent, e.g. control characters
+	 * read from a binary vendor file. Use it for values stored in the workbench
+	 * model, such as a part label. A <code>null</code> value is returned unchanged.
+	 */
+	public static String removeInvalidCharacters(String value) {
+
+		if(value == null || value.isEmpty() || value.codePoints().allMatch(XmiSupport::isValidCharacter)) {
+			return value;
+		}
+		StringBuilder builder = new StringBuilder(value.length());
+		value.codePoints().filter(XmiSupport::isValidCharacter).forEach(builder::appendCodePoint);
+		return builder.toString();
+	}
+
+	/**
+	 * Tests the code point against the <code>Char</code> production of XML 1.0.
+	 * Unpaired surrogates are invalid, as {@link String#codePoints()} yields them as
+	 * individual code points in the surrogate range.
+	 */
+	public static boolean isValidCharacter(int codePoint) {
+
+		return codePoint == 0x9 || codePoint == 0xA || codePoint == 0xD //
+				|| (codePoint >= 0x20 && codePoint <= 0xD7FF) //
+				|| (codePoint >= 0xE000 && codePoint <= 0xFFFD) //
+				|| (codePoint >= 0x10000 && codePoint <= 0x10FFFF);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/DatabaseEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/DatabaseEditor.java
@@ -36,6 +36,7 @@ import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.chemclipse.support.events.IPerspectiveAndViewIds;
 import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
 import org.eclipse.chemclipse.support.ui.workbench.EditorSupport;
+import org.eclipse.chemclipse.support.ui.workbench.XmiSupport;
 import org.eclipse.chemclipse.swt.ui.notifier.UpdateNotifierUI;
 import org.eclipse.chemclipse.ux.extension.msd.ui.support.DatabaseImportRunnable;
 import org.eclipse.chemclipse.ux.extension.msd.ui.swt.MassSpectrumLibraryUI;
@@ -202,7 +203,7 @@ public class DatabaseEditor implements IChemClipseEditor {
 	private void createPages(Composite parent) {
 
 		if(massSpectra != null && massSpectra.getMassSpectrum(1) != null) {
-			part.setLabel(("".equals(massSpectra.getName())) ? massSpectrumFile.getName() : massSpectra.getName());
+			part.setLabel(XmiSupport.removeInvalidCharacters(("".equals(massSpectra.getName())) ? massSpectrumFile.getName() : massSpectra.getName()));
 			createEditorPage(parent);
 		} else {
 			part.setLabel("Database Editor");

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/MassSpectrumEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/MassSpectrumEditor.java
@@ -40,6 +40,7 @@ import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.chemclipse.support.events.IPerspectiveAndViewIds;
 import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
 import org.eclipse.chemclipse.support.ui.workbench.EditorSupport;
+import org.eclipse.chemclipse.support.ui.workbench.XmiSupport;
 import org.eclipse.chemclipse.swt.ui.notifier.UpdateNotifierUI;
 import org.eclipse.chemclipse.ux.extension.msd.ui.internal.support.MassSpectrumImportRunnable;
 import org.eclipse.chemclipse.ux.extension.msd.ui.swt.ExtendedMassSpectrumUI;
@@ -293,7 +294,7 @@ public class MassSpectrumEditor implements IMassSpectrumEditor {
 				}
 			}
 		}
-		part.setLabel(name);
+		part.setLabel(XmiSupport.removeInvalidCharacters(name));
 	}
 
 	public void registerEvent(String topic, String property) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/ISupplierFileEditorSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/provider/ISupplierFileEditorSupport.java
@@ -31,6 +31,7 @@ import org.eclipse.chemclipse.processing.converter.ISupplierFileIdentifier;
 import org.eclipse.chemclipse.support.events.IPerspectiveAndViewIds;
 import org.eclipse.chemclipse.support.ui.activator.ContextAddon;
 import org.eclipse.chemclipse.support.ui.workbench.EditorSupport;
+import org.eclipse.chemclipse.support.ui.workbench.XmiSupport;
 import org.eclipse.chemclipse.ux.extension.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.ui.editors.IChromatogramEditor;
 import org.eclipse.chemclipse.ux.extension.ui.preferences.PreferenceSupplierDataExplorer;
@@ -161,13 +162,13 @@ public interface ISupplierFileEditorSupport extends ISupplierFileIdentifier {
 							} else if(object instanceof IChromatogramVSD) {
 								type = " [VSD]";
 							}
-							part.setLabel(chromatogram.getName() + type);
+							part.setLabel(XmiSupport.removeInvalidCharacters(chromatogram.getName() + type));
 						} else if(object instanceof IMassSpectra massSpectra) {
-							part.setLabel(massSpectra.getName());
+							part.setLabel(XmiSupport.removeInvalidCharacters(massSpectra.getName()));
 						} else if(object instanceof ISpectrumVSD) {
 							part.setLabel("VSD");
 						} else if(object instanceof IMeasurement measurement) {
-							part.setLabel(measurement.getDataName());
+							part.setLabel(XmiSupport.removeInvalidCharacters(measurement.getDataName()));
 						}
 					} else {
 						part.setObject(null);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/AbstractChromatogramEditor.java
@@ -55,6 +55,7 @@ import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.chemclipse.support.settings.UserManagement;
 import org.eclipse.chemclipse.support.ui.workbench.EditorSupport;
+import org.eclipse.chemclipse.support.ui.workbench.XmiSupport;
 import org.eclipse.chemclipse.swt.ui.notifier.UpdateNotifierUI;
 import org.eclipse.chemclipse.ux.extension.ui.editors.IChromatogramEditor;
 import org.eclipse.chemclipse.ux.extension.ui.parts.AbstractUpdater;
@@ -271,8 +272,12 @@ public abstract class AbstractChromatogramEditor extends AbstractUpdater<Extende
 		setControl(extendedChromatogramUI);
 
 		if(chromatogramSelection != null) {
-			part.setLabel(ChromatogramDataSupport.getChromatogramEditorLabel(chromatogramSelection, false));
-			part.setTooltip(ChromatogramDataSupport.getReferenceLabel(chromatogramSelection.getChromatogram(), 0, false));
+			/*
+			 * The label and tooltip are built from vendor data, which may contain
+			 * characters that the workbench model is unable to serialize to XML.
+			 */
+			part.setLabel(XmiSupport.removeInvalidCharacters(ChromatogramDataSupport.getChromatogramEditorLabel(chromatogramSelection, false)));
+			part.setTooltip(XmiSupport.removeInvalidCharacters(ChromatogramDataSupport.getReferenceLabel(chromatogramSelection.getChromatogram(), 0, false)));
 			chromatogramSelection.update(true);
 		}
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ScanEditorNMR.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/editors/ScanEditorNMR.java
@@ -59,6 +59,7 @@ import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.chemclipse.support.ui.workbench.EditorSupport;
+import org.eclipse.chemclipse.support.ui.workbench.XmiSupport;
 import org.eclipse.chemclipse.swt.ui.notifier.UpdateNotifierUI;
 import org.eclipse.chemclipse.ux.extension.ui.editors.IScanEditorNMR;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
@@ -198,7 +199,7 @@ public class ScanEditorNMR implements IScanEditorNMR {
 		if(object instanceof IComplexSignalMeasurement<?>) {
 			selection = new DataNMRSelection();
 			String label = addToSelection((IComplexSignalMeasurement<?>)object, selection);
-			part.setLabel(label);
+			part.setLabel(XmiSupport.removeInvalidCharacters(label));
 			Display.getDefault().asyncExec(this::updateSelection);
 		}
 	}


### PR DESCRIPTION
The e4 workbench model is persisted as XMI, which rejects characters it is unable to represent instead of escaping them. A part label built from vendor data then fails the workbench auto save.

Sanitize where a value enters the workbench model, so that the measurement data itself stays byte faithful.