### PR TITLE
Reduce visual clutter in MALDI-TOF MS charts

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/preferences/PreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/preferences/PreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -53,6 +53,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_MASS_SPECTRUM_SHOW_METHODS_TOOLBAR, "Show Methods Toolbar", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_MASS_SPECTRUM_SHOW_RELATIVE_INTENSITY, "Show Relative Intensity", getFieldEditorParent()));
 	}
 
 	/*

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/preferences/PreferenceSupplier.java
@@ -42,6 +42,9 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static final String P_MASS_SPECTRUM_SHOW_METHODS_TOOLBAR = "massSpectrumShowMethodsToolbar";
 	public static final boolean DEF_MASS_SPECTRUM_SHOW_METHODS_TOOLBAR = false;
 
+	public static final String P_MASS_SPECTRUM_SHOW_RELATIVE_INTENSITY = "massSpectrumShowRelativeIntensity";
+	public static final boolean DEF_MASS_SPECTRUM_SHOW_RELATIVE_INTENSITY = false;
+
 	public static IPreferenceSupplier INSTANCE() {
 
 		return INSTANCE(PreferenceSupplier.class);
@@ -62,6 +65,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 		putDefault(P_LIBRARY_MSD_LIMIT_SORTING, Integer.toString(DEF_LIBRARY_MSD_LIMIT_SORTING));
 		putDefault(PreferenceSupplier.P_SHOW_MASS_SPECTRUM_SELECTION_COMBO, PreferenceSupplier.DEF_SHOW_MASS_SPECTRUM_SELECTION_COMBO);
 		putDefault(PreferenceSupplier.P_MASS_SPECTRUM_SHOW_METHODS_TOOLBAR, PreferenceSupplier.DEF_MASS_SPECTRUM_SHOW_METHODS_TOOLBAR);
+		putDefault(PreferenceSupplier.P_MASS_SPECTRUM_SHOW_RELATIVE_INTENSITY, PreferenceSupplier.DEF_MASS_SPECTRUM_SHOW_RELATIVE_INTENSITY);
 	}
 
 	public static String getPathMassSpectrumLibraries() {
@@ -87,5 +91,10 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static boolean isMethodToolbarVisible() {
 
 		return INSTANCE().getBoolean(P_MASS_SPECTRUM_SHOW_METHODS_TOOLBAR);
+	}
+
+	public static boolean isRelativeIntensityAxisVisible() {
+
+		return INSTANCE().getBoolean(P_MASS_SPECTRUM_SHOW_RELATIVE_INTENSITY);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.support.comparator,
  org.eclipse.chemclipse.support.events,
  org.eclipse.chemclipse.support.files,
+ org.eclipse.chemclipse.support.formats,
  org.eclipse.chemclipse.support.history,
  org.eclipse.chemclipse.support.l10n,
  org.eclipse.chemclipse.support.literature,

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/formats/MagnitudeScaledDecimalFormat.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/formats/MagnitudeScaledDecimalFormat.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.support.formats;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.FieldPosition;
+import java.text.ParsePosition;
+
+public class MagnitudeScaledDecimalFormat extends DecimalFormat {
+
+	private static final long serialVersionUID = 7786246213111283025L;
+
+	private final int exponent;
+
+	public MagnitudeScaledDecimalFormat(String pattern, DecimalFormatSymbols symbols, int exponent) {
+
+		super(pattern, symbols);
+		this.exponent = exponent;
+	}
+
+	@Override
+	public StringBuffer format(double number, StringBuffer toAppendTo, FieldPosition pos) {
+
+		double scale = Math.pow(10, exponent);
+		return super.format(number / scale, toAppendTo, pos);
+	}
+
+	@Override
+	public Number parse(String source, ParsePosition parsePosition) {
+
+		Number result = super.parse(source, parsePosition);
+		if(result != null) {
+			return result.doubleValue() * Math.pow(10, exponent);
+		}
+		return result;
+	}
+
+	public static int orderOfMagnitude(Number number) {
+
+		return (int)Math.floor(Math.log(number.doubleValue()) / Math.log(10));
+	}
+
+	public static String toSuperscript(String exponent) {
+
+		return exponent //
+						.replace("0", "⁰") //
+						.replace("1", "¹") //
+						.replace("2", "²") //
+						.replace("3", "³") //
+						.replace("4", "⁴") //
+						.replace("5", "⁵") //
+						.replace("6", "⁶") //
+						.replace("7", "⁷") //
+						.replace("8", "⁸") //
+						.replace("9", "⁹");
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
@@ -44,6 +44,7 @@ import org.eclipse.chemclipse.processing.supplier.IProcessorPreferences;
 import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 import org.eclipse.chemclipse.processing.system.ProcessSettingsSupport;
 import org.eclipse.chemclipse.processing.ui.support.ProcessingInfoPartSupport;
+import org.eclipse.chemclipse.support.formats.MagnitudeScaledDecimalFormat;
 import org.eclipse.chemclipse.ux.extension.msd.ui.handlers.DynamicHandler;
 import org.eclipse.chemclipse.ux.extension.msd.ui.internal.provider.UpdateMenuEntry;
 import org.eclipse.chemclipse.ux.extension.ui.editors.ProcessorSupplierMenuEntry;
@@ -98,12 +99,13 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 
 	private static final int MAX_NUMBER_MZ = 50000;
 	private static final int LABEL_COUNT = 5;
+	private static final DecimalFormatSymbols ENGLISH_SYMBOLS = new DecimalFormatSymbols(Locale.ENGLISH);
 
 	public enum LabelOption {
 		NOMIMAL, EXACT, CUSTOM;
 	}
 
-	private final DecimalFormat decimalFormatMZ = new DecimalFormat("0", new DecimalFormatSymbols(Locale.ENGLISH));
+	private final DecimalFormat decimalFormatMZ = new DecimalFormat("0", ENGLISH_SYMBOLS);
 	private final LabelPaintListener labelPaintListener = new LabelPaintListener();
 
 	private IScanMSD massSpectrum = null;
@@ -138,6 +140,7 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 			barSeriesDataList.add(barSeriesData);
 			modifyRangeRestriction(false);
 			addSeriesData(barSeriesDataList, MAX_NUMBER_MZ);
+			updateAxis();
 			updateMenu();
 		}
 	}
@@ -164,6 +167,16 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 		if(!barSeriesDataList.isEmpty()) {
 			addSeriesData(barSeriesDataList, MAX_NUMBER_MZ);
 		}
+	}
+
+	private void updateAxis() {
+
+		IChartSettings chartSettings = getChartSettings();
+		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
+		int exponent = MagnitudeScaledDecimalFormat.orderOfMagnitude(massSpectrum.getHighestAbundance().getAbundance());
+		primaryAxisSettingsY.setDecimalFormat(new MagnitudeScaledDecimalFormat("0.#", ENGLISH_SYMBOLS, exponent));
+		primaryAxisSettingsY.setHorizontalLabel("×10" + MagnitudeScaledDecimalFormat.toSuperscript(String.valueOf(exponent)));
+		applySettings(chartSettings);
 	}
 
 	private void modifyRangeRestriction(boolean mirrored) {
@@ -325,18 +338,17 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 
 		IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
 		primaryAxisSettingsX.setTitle("m/z");
-		primaryAxisSettingsX.setDecimalFormat(new DecimalFormat(("0.0##"), new DecimalFormatSymbols(Locale.ENGLISH)));
+		primaryAxisSettingsX.setDecimalFormat(new DecimalFormat(("0"), ENGLISH_SYMBOLS));
 
 		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
 		primaryAxisSettingsY.setTitle("Intensity");
-		primaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.0#E0"), new DecimalFormatSymbols(Locale.ENGLISH)));
 	}
 
 	private void addSecondaryAxisSet(IChartSettings chartSettings) {
 
 		ISecondaryAxisSettings secondaryAxisSettingsY = new SecondaryAxisSettings("Relative Intensity [%]", new PercentageConverter(SWT.VERTICAL, true));
 		secondaryAxisSettingsY.setPosition(Position.Secondary);
-		secondaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.00"), new DecimalFormatSymbols(Locale.ENGLISH)));
+		secondaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0"), ENGLISH_SYMBOLS));
 		chartSettings.getSecondaryAxisSettingsListY().add(secondaryAxisSettingsY);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
@@ -30,6 +30,7 @@ import org.eclipse.chemclipse.msd.converter.massspectrum.MassSpectrumConverterSu
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.swt.ui.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.processing.converter.ISupplier;
 import org.eclipse.chemclipse.processing.core.DefaultProcessingResult;
 import org.eclipse.chemclipse.processing.core.ICategories;
@@ -218,7 +219,9 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 		rangeRestriction.setExtendMaxY(0.1d);
 
 		setPrimaryAxisSet(chartSettings);
-		addSecondaryAxisSet(chartSettings);
+		if(PreferenceSupplier.isRelativeIntensityAxisVisible()) {
+			addSecondaryAxisSet(chartSettings);
+		}
 
 		Color white = getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND);
 		chartSettings.setBackground(white);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
@@ -49,6 +49,7 @@ import org.eclipse.chemclipse.processing.supplier.IProcessorPreferences;
 import org.eclipse.chemclipse.processing.supplier.ProcessExecutionContext;
 import org.eclipse.chemclipse.processing.system.ProcessSettingsSupport;
 import org.eclipse.chemclipse.processing.ui.support.ProcessingInfoPartSupport;
+import org.eclipse.chemclipse.support.formats.MagnitudeScaledDecimalFormat;
 import org.eclipse.chemclipse.ux.extension.msd.ui.handlers.DynamicHandler;
 import org.eclipse.chemclipse.ux.extension.msd.ui.internal.provider.UpdateMenuEntry;
 import org.eclipse.chemclipse.ux.extension.ui.editors.ProcessorSupplierMenuEntry;
@@ -97,6 +98,7 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 	private static final Logger logger = Logger.getLogger(MassSpectrumChartProfile.class);
 
 	private static final int MAX_NUMBER_MZ = 25000;
+	private static final DecimalFormatSymbols ENGLISH_SYMBOLS = new DecimalFormatSymbols(Locale.ENGLISH);
 
 	private IScanMSD massSpectrum = null;
 
@@ -146,9 +148,20 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 				createAnnotations(standaloneMassSpectrum);
 			}
 			addSeriesData(lineSeriesDataList, MAX_NUMBER_MZ);
+			updateAxis();
 			updateMenu();
 			UpdateNotifier.update(massSpectrum);
 		}
+	}
+
+	private void updateAxis() {
+
+		IChartSettings chartSettings = getChartSettings();
+		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
+		int exponent = MagnitudeScaledDecimalFormat.orderOfMagnitude(massSpectrum.getHighestAbundance().getAbundance());
+		primaryAxisSettingsY.setDecimalFormat(new MagnitudeScaledDecimalFormat("0.#", ENGLISH_SYMBOLS, exponent));
+		primaryAxisSettingsY.setHorizontalLabel("×10" + MagnitudeScaledDecimalFormat.toSuperscript(String.valueOf(exponent)));
+		applySettings(chartSettings);
 	}
 
 	private void initialize() {
@@ -294,18 +307,17 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 
 		IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
 		primaryAxisSettingsX.setTitle("m/z");
-		primaryAxisSettingsX.setDecimalFormat(new DecimalFormat(("0.0##"), new DecimalFormatSymbols(Locale.ENGLISH)));
+		primaryAxisSettingsX.setDecimalFormat(new DecimalFormat(("0"), ENGLISH_SYMBOLS));
 
 		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
 		primaryAxisSettingsY.setTitle("Intensity");
-		primaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.0#E0"), new DecimalFormatSymbols(Locale.ENGLISH)));
 	}
 
 	private void addSecondaryAxisSet(IChartSettings chartSettings) {
 
 		ISecondaryAxisSettings secondaryAxisSettingsY = new SecondaryAxisSettings("Relative Intensity [%]", new PercentageConverter(SWT.VERTICAL, true));
 		secondaryAxisSettingsY.setPosition(Position.Secondary);
-		secondaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.00"), new DecimalFormatSymbols(Locale.ENGLISH)));
+		secondaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0"), ENGLISH_SYMBOLS));
 		chartSettings.getSecondaryAxisSettingsListY().add(secondaryAxisSettingsY);
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
@@ -35,6 +35,7 @@ import org.eclipse.chemclipse.msd.converter.massspectrum.MassSpectrumConverterSu
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.swt.ui.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.processing.converter.ISupplier;
 import org.eclipse.chemclipse.processing.core.DefaultProcessingResult;
 import org.eclipse.chemclipse.processing.core.ICategories;
@@ -189,7 +190,9 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 		rangeRestriction.setExtendMaxY(0.5d);
 
 		setPrimaryAxisSet(chartSettings);
-		addSecondaryAxisSet(chartSettings);
+		if(PreferenceSupplier.isRelativeIntensityAxisVisible()) {
+			addSecondaryAxisSet(chartSettings);
+		}
 		applySettings(chartSettings);
 	}
 


### PR DESCRIPTION
This applies https://github.com/eclipse-swtchart/swtchart/pull/601/ to the MALDI-TOF MS perspective.

**Before:**
<img width="1109" height="335" alt="grafik" src="https://github.com/user-attachments/assets/a0e905f0-99c9-4d62-883f-fedfdb74ca1a" />

**After:**
<img width="1109" height="335" alt="grafik" src="https://github.com/user-attachments/assets/317bab4c-8fce-4694-bc4d-d4a5700224fe" />

The idea here is fewer decimal places make it easier to read and give more room to the chart itself.