### PR TITLE
Add MS Numpress compression for mzML

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml.ui/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/ui/Activator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml.ui/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/ui/Activator.java
@@ -12,21 +12,16 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.converter.supplier.mzml.ui;
 
-import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.preferences.PreferenceSupplier;
+import org.eclipse.chemclipse.support.ui.activator.AbstractActivatorUI;
 import org.osgi.framework.BundleContext;
 
-/**
- * The activator class controls the plug-in life cycle
- */
-public class Activator extends AbstractUIPlugin {
+public class Activator extends AbstractActivatorUI {
 
-	// The shared instance
 	private static Activator plugin;
 
-	/**
-	 * The constructor
-	 */
 	public Activator() {
+
 	}
 
 	@Override
@@ -34,6 +29,7 @@ public class Activator extends AbstractUIPlugin {
 
 		super.start(context);
 		plugin = this;
+		initializePreferenceStore(PreferenceSupplier.INSTANCE());
 	}
 
 	@Override
@@ -44,8 +40,6 @@ public class Activator extends AbstractUIPlugin {
 	}
 
 	/**
-	 * Returns the shared instance
-	 *
 	 * @return the shared instance
 	 */
 	public static Activator getDefault() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml.ui/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/ui/preferences/PreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml.ui/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/ui/preferences/PreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -35,7 +35,8 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_CHROMATOGRAM_VERSION_SAVE, "Save (*.mzML) as version:", PreferenceSupplier.getChromatogramVersions(), getFieldEditorParent()));
-		addField(new BooleanFieldEditor(PreferenceSupplier.P_CHROMATOGRAM_SAVE_COMPRESSION, "Compress values", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_CHROMATOGRAM_SAVE_COMPRESSION, "ZIP Compress values", getFieldEditorParent()));
+		addField(new ComboFieldEditor(PreferenceSupplier.P_SAVE_NUMPRESS, "MS Numpress compression:", PreferenceSupplier.getSaveNumpressOptions(), getFieldEditorParent()));
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/META-INF/MANIFEST.MF
@@ -19,7 +19,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.wsd.model;bundle-version="0.9.0",
  org.eclipse.chemclipse.wsd.converter;bundle-version="0.9.0",
  org.glassfish.hk2.osgi-resource-locator;bundle-version="1.0.4",
- com.sun.xml.bind.jaxb-osgi;bundle-version="4.0.6"
+ com.sun.xml.bind.jaxb-osgi;bundle-version="4.0.6",
+ wrapped.se.lth.immun.MsNumpress;bundle-version="0.1.21"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Import-Package: jakarta.xml.bind,

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramWriterVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/ChromatogramWriterVersion110.java
@@ -237,19 +237,20 @@ public class ChromatogramWriterVersion110 extends AbstractChromatogramWriter imp
 
 	private void writeScans(IChromatogram chromatogram, SpectrumListType spectrumList, IProgressMonitor monitor) {
 
+		boolean zipCompression = PreferenceSupplier.getChromatogramSaveCompression();
+		String numpress = PreferenceSupplier.getSaveNumpress();
 		monitor.beginTask(ConverterMessages.writeScans, chromatogram.getNumberOfScans());
 		for(IScan scan : chromatogram.getScans()) {
 			SpectrumType spectrum = new SpectrumType();
 			spectrum.setId("scan=" + scan.getScanNumber());
 			spectrum.setIndex(BigInteger.valueOf((scan.getScanNumber() - 1)));
 			spectrum.setScanList(createScanList(scan));
-			boolean compression = PreferenceSupplier.getChromatogramSaveCompression();
 			if(scan instanceof IScanMSD scanMSD) {
 				spectrum.getCvParam().add(XmlWriter110.createTotalIonCurrentType(scan));
 				spectrum.getCvParam().add(XmlWriter110.createBasePeakMassType(scanMSD));
 				spectrum.getCvParam().add(XmlWriter110.createBasePeakIntensity(scanMSD));
 				// full spectra
-				spectrum.setBinaryDataArrayList(XmlWriter110.createFullSpectrumBinaryDataArrayList(scanMSD, compression));
+				spectrum.setBinaryDataArrayList(XmlWriter110.createFullSpectrumBinaryDataArrayList(scanMSD, zipCompression, numpress));
 				if(scanMSD instanceof IRegularMassSpectrum massSpectrum) {
 					spectrum.getCvParam().add(XmlWriter110.createMassSpectrumDimension(massSpectrum));
 					if(massSpectrum.getPolarity() != Polarity.NONE) {
@@ -264,7 +265,7 @@ public class ChromatogramWriterVersion110 extends AbstractChromatogramWriter imp
 				spectrum.getCvParam().add(XmlWriter110.createWavelengthScanRangeLowest(scanWSD));
 				spectrum.getCvParam().add(XmlWriter110.createWavelengthScanRangeHighest(scanWSD));
 				spectrum.setDefaultArrayLength(scanWSD.getNumberOfScanSignals());
-				spectrum.setBinaryDataArrayList(XmlWriter110.createFullSpectrumBinaryDataArrayList(scanWSD, compression));
+				spectrum.setBinaryDataArrayList(XmlWriter110.createFullSpectrumBinaryDataArrayList(scanWSD, zipCompression, numpress));
 			}
 			spectrumList.getSpectrum().add(spectrum);
 			monitor.worked(1);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/MassSpectrumWriterVersion110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/io/MassSpectrumWriterVersion110.java
@@ -254,8 +254,9 @@ public class MassSpectrumWriterVersion110 implements IMassSpectraWriter {
 			spectrum.getCvParam().add(XmlWriter110.createLowestObservedIon(scanMSD));
 			spectrum.getCvParam().add(XmlWriter110.createHighestObservedIon(scanMSD));
 			// full spectra
-			boolean compression = PreferenceSupplier.getMassSpectraSaveCompression();
-			spectrum.setBinaryDataArrayList(XmlWriter110.createFullSpectrumBinaryDataArrayList(scanMSD, compression));
+			boolean zipCompression = PreferenceSupplier.getMassSpectraSaveCompression();
+			String numpress = PreferenceSupplier.getSaveNumpress();
+			spectrum.setBinaryDataArrayList(XmlWriter110.createFullSpectrumBinaryDataArrayList(scanMSD, zipCompression, numpress));
 			if(scanMSD instanceof IRegularMassSpectrum massSpectrum) {
 				spectrum.getCvParam().add(XmlWriter110.createMassSpectrumDimension(massSpectrum));
 				if(massSpectrum.getPolarity() != Polarity.NONE) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/preferences/PreferenceSupplier.java
@@ -18,14 +18,22 @@ import org.eclipse.chemclipse.support.preferences.IPreferenceSupplier;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.io.XmlReader110;
 import org.osgi.framework.FrameworkUtil;
 
+import ms.numpress.MSNumpress;
+
 public class PreferenceSupplier extends AbstractPreferenceSupplier {
 
 	public static final String P_CHROMATOGRAM_VERSION_SAVE = "chromatogramVersionSave";
 	public static final String DEF_CHROMATOGRAM_VERSION_SAVE = XmlReader110.VERSION;
+
 	public static final String P_CHROMATOGRAM_SAVE_COMPRESSION = "chromatogramSaveCompression";
 	public static final boolean DEF_CHROMATOGRAM_SAVE_COMPRESSION = true;
+
+	public static final String P_SAVE_NUMPRESS = "saveNumpress";
+	public static final String DEF_SAVE_NUMPRESS = "";
+
 	public static final String P_MASS_SPECTRA_VERSION_SAVE = "massSpectrumVersionSave";
 	public static final String DEF_MASS_SPECTRA_VERSION_SAVE = XmlReader110.VERSION;
+
 	public static final String P_MASS_SPECTRA_SAVE_COMPRESSION = "massSpectraSaveCompression";
 	public static final boolean DEF_MASS_SPECTRA_SAVE_COMPRESSION = true;
 
@@ -45,6 +53,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 
 		putDefault(P_CHROMATOGRAM_VERSION_SAVE, DEF_CHROMATOGRAM_VERSION_SAVE);
 		putDefault(P_CHROMATOGRAM_SAVE_COMPRESSION, Boolean.toString(DEF_CHROMATOGRAM_SAVE_COMPRESSION));
+		putDefault(P_SAVE_NUMPRESS, DEF_SAVE_NUMPRESS);
 		putDefault(P_MASS_SPECTRA_VERSION_SAVE, DEF_MASS_SPECTRA_VERSION_SAVE);
 		putDefault(P_MASS_SPECTRA_SAVE_COMPRESSION, Boolean.toString(DEF_MASS_SPECTRA_SAVE_COMPRESSION));
 	}
@@ -83,5 +92,24 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static boolean getMassSpectraSaveCompression() {
 
 		return INSTANCE().getBoolean(P_MASS_SPECTRA_SAVE_COMPRESSION, DEF_MASS_SPECTRA_SAVE_COMPRESSION);
+	}
+
+	public static String getSaveNumpress() {
+
+		return INSTANCE().get(P_SAVE_NUMPRESS, DEF_SAVE_NUMPRESS);
+	}
+
+	public static String[][] getSaveNumpressOptions() {
+
+		return new String[][]{{"None", ""}, //
+				{"linear prediction", MSNumpress.ACC_NUMPRESS_LINEAR}, //
+				{"positive integer", MSNumpress.ACC_NUMPRESS_PIC}, //
+				{"short logged float", MSNumpress.ACC_NUMPRESS_SLOF} //
+		};
+	}
+
+	public static void setSaveNumpress(String accession) {
+
+		INSTANCE().put(P_SAVE_NUMPRESS, accession);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/AbstractBinaryReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/AbstractBinaryReader.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.converter.supplier.mzml.io;
+
+import java.io.ByteArrayOutputStream;
+import java.util.zip.DataFormatException;
+import java.util.zip.Inflater;
+
+import ms.numpress.MSNumpress;
+
+public abstract class AbstractBinaryReader {
+
+	public static byte[] inflate(byte[] input) throws DataFormatException {
+
+		Inflater inflater = new Inflater();
+		inflater.setInput(input);
+
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		byte[] buffer = new byte[8192];
+
+		try {
+			while(!inflater.finished()) {
+				int count = inflater.inflate(buffer);
+				if(count > 0) {
+					outputStream.write(buffer, 0, count);
+				} else if(inflater.needsInput() || inflater.needsDictionary()) {
+					break;
+				}
+			}
+			return outputStream.toByteArray();
+		} finally {
+			inflater.end();
+		}
+	}
+
+	public static boolean isNumpress(String accession) {
+
+		return MSNumpress.ACC_NUMPRESS_LINEAR.equals(accession) || //
+				MSNumpress.ACC_NUMPRESS_PIC.equals(accession) || //
+				MSNumpress.ACC_NUMPRESS_SLOF.equals(accession);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/BinaryReader10.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/BinaryReader10.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,14 +18,15 @@ import java.nio.ByteOrder;
 import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
 import java.util.zip.DataFormatException;
-import java.util.zip.Inflater;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v10.BinaryDataArrayType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v10.CVParamType;
 
-public class BinaryReader10 {
+import ms.numpress.MSNumpress;
+
+public class BinaryReader10 extends AbstractBinaryReader {
 
 	private BinaryReader10() {
 
@@ -35,66 +36,79 @@ public class BinaryReader10 {
 
 		double[] values = new double[0];
 		String content = "";
-		if(binaryDataArrayType.getArrayLength() == BigInteger.ZERO) {
+
+		if(BigInteger.ZERO.equals(binaryDataArrayType.getArrayLength())) {
 			return new ImmutablePair<>(content, values);
 		}
+
 		byte[] binary = binaryDataArrayType.getBinary();
 		if(binary == null) {
 			return new ImmutablePair<>(content, values);
 		}
-		ByteBuffer byteBuffer = ByteBuffer.wrap(binary);
+
+		byte[] unzippedBinary = binary;
 		boolean compressed = false;
 		boolean doublePrecision = false;
+		String numpressAccession = null;
 		int multiplicator = 1;
+
 		for(CVParamType cvParam : binaryDataArrayType.getCvParam()) {
-			if(cvParam.getAccession().equals("MS:1000574")) {
-				if(cvParam.getName().equals("zlib compression")) {
-					compressed = true;
-				}
+			String accession = cvParam.getAccession();
+			String name = cvParam.getName();
+
+			if("MS:1000574".equals(accession) && "zlib compression".equals(name)) {
+				compressed = true;
 			}
-			if(cvParam.getAccession().equals("MS:1000521") && cvParam.getName().equals("32-bit float")) {
+
+			if(isNumpress(accession)) {
+				numpressAccession = accession;
+			}
+
+			if("MS:1000521".equals(accession) && "32-bit float".equals(name)) {
 				doublePrecision = false;
-			} else if(cvParam.getAccession().equals("MS:1000523") && cvParam.getName().equals("64-bit float")) {
+			} else if("MS:1000523".equals(accession) && "64-bit float".equals(name)) {
 				doublePrecision = true;
 			}
-			if(cvParam.getAccession().equals("MS:1000514")) {
-				if(cvParam.getName().equals("m/z array")) {
-					content = "m/z";
-				}
-			}
-			if(cvParam.getAccession().equals("MS:1000515")) {
-				if(cvParam.getName().equals("intensity array")) {
-					content = "intensity";
-				}
-			}
-			if(cvParam.getAccession().equals("MS:1000595")) {
-				if(cvParam.getName().equals("time array")) {
-					content = "time";
-					multiplicator = XmlReader10.getTimeMultiplicator(cvParam);
-				}
+
+			if("MS:1000514".equals(accession) && "m/z array".equals(name)) {
+				content = "m/z";
+			} else if("MS:1000515".equals(accession) && "intensity array".equals(name)) {
+				content = "intensity";
+			} else if("MS:1000595".equals(accession) && "time array".equals(name)) {
+				content = "time";
+				multiplicator = XmlReader10.getTimeMultiplicator(cvParam);
 			}
 		}
+
 		if(compressed) {
-			Inflater inflater = new Inflater();
-			inflater.setInput(byteBuffer.array());
-			byte[] byteArray = new byte[byteBuffer.capacity() * 10];
-			int decodedLength = inflater.inflate(byteArray);
-			byteBuffer = ByteBuffer.wrap(byteArray, 0, decodedLength);
+			unzippedBinary = inflate(unzippedBinary);
 		}
-		byteBuffer.order(ByteOrder.LITTLE_ENDIAN); // this is always the case
-		if(doublePrecision) {
-			DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
-			values = new double[doubleBuffer.capacity()];
-			for(int index = 0; index < doubleBuffer.capacity(); index++) {
-				values[index] = Double.valueOf(doubleBuffer.get(index)) * multiplicator;
+
+		if(numpressAccession != null) {
+			values = MSNumpress.decode(numpressAccession, unzippedBinary, unzippedBinary.length);
+			for(int index = 0; index < values.length; index++) {
+				values[index] *= multiplicator;
 			}
+			return new ImmutablePair<>(content, values);
 		} else {
-			FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
-			values = new double[floatBuffer.capacity()];
-			for(int index = 0; index < floatBuffer.capacity(); index++) {
-				values[index] = Double.valueOf(floatBuffer.get(index)) * multiplicator;
+			ByteBuffer byteBuffer = ByteBuffer.wrap(unzippedBinary);
+			byteBuffer.order(ByteOrder.LITTLE_ENDIAN); // this is always the case
+
+			if(doublePrecision) {
+				DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
+				values = new double[doubleBuffer.capacity()];
+				for(int index = 0; index < doubleBuffer.capacity(); index++) {
+					values[index] = Double.valueOf(doubleBuffer.get(index)) * multiplicator;
+				}
+			} else {
+				FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
+				values = new double[floatBuffer.capacity()];
+				for(int index = 0; index < floatBuffer.capacity(); index++) {
+					values[index] = Double.valueOf(floatBuffer.get(index)) * multiplicator;
+				}
 			}
 		}
+
 		return new ImmutablePair<>(content, values);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/BinaryReader110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/BinaryReader110.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,14 +18,15 @@ import java.nio.ByteOrder;
 import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
 import java.util.zip.DataFormatException;
-import java.util.zip.Inflater;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.BinaryDataArrayType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.CVParamType;
 
-public class BinaryReader110 {
+import ms.numpress.MSNumpress;
+
+public class BinaryReader110 extends AbstractBinaryReader {
 
 	private BinaryReader110() {
 
@@ -35,58 +36,81 @@ public class BinaryReader110 {
 
 		double[] values = new double[0];
 		String content = "";
-		if(binaryDataArrayType.getArrayLength() == BigInteger.ZERO) {
+
+		if(BigInteger.ZERO.equals(binaryDataArrayType.getArrayLength())) {
 			return new ImmutablePair<>(content, values);
 		}
+
 		byte[] binary = binaryDataArrayType.getBinary();
 		if(binary == null) {
 			return new ImmutablePair<>(content, values);
 		}
-		ByteBuffer byteBuffer = ByteBuffer.wrap(binary);
-		boolean compressed = false;
+
+		byte[] unzippedBinary = binary;
+		boolean zipCompressed = false;
 		boolean doublePrecision = false;
+		String numpressAccession = null;
 		float multiplicator = 1f;
+
 		for(CVParamType cvParam : binaryDataArrayType.getCvParam()) {
-			if(cvParam.getAccession().equals("MS:1000574") && cvParam.getName().equals("zlib compression")) {
-				compressed = true;
+			String accession = cvParam.getAccession();
+			String name = cvParam.getName();
+
+			if("MS:1000574".equals(accession) && "zlib compression".equals(name)) {
+				zipCompressed = true;
 			}
-			if(cvParam.getAccession().equals("MS:1000521") && cvParam.getName().equals("32-bit float")) {
+
+			if(isNumpress(accession)) {
+				numpressAccession = accession;
+			}
+
+			if("MS:1000521".equals(accession) && "32-bit float".equals(name)) {
 				doublePrecision = false;
-			} else if(cvParam.getAccession().equals("MS:1000523") && cvParam.getName().equals("64-bit float")) {
+			} else if("MS:1000523".equals(accession) && "64-bit float".equals(name)) {
 				doublePrecision = true;
 			}
-			if(cvParam.getAccession().equals("MS:1000514") && cvParam.getName().equals("m/z array")) {
+
+			if("MS:1000514".equals(accession) && "m/z array".equals(name)) {
 				content = "m/z";
-			} else if(cvParam.getAccession().equals("MS:1000617") && cvParam.getName().equals("wavelength array")) {
+			} else if("MS:1000617".equals(accession) && "wavelength array".equals(name)) {
 				content = "wavelength";
-			} else if(cvParam.getAccession().equals("MS:1000515") && cvParam.getName().equals("intensity array")) {
+			} else if("MS:1000515".equals(accession) && "intensity array".equals(name)) {
 				content = "intensity";
-			} else if(cvParam.getAccession().equals("MS:1000595") && cvParam.getName().equals("time array")) {
+			} else if("MS:1000595".equals(accession) && "time array".equals(name)) {
 				content = "time";
 				multiplicator = XmlReader110.getTimeMultiplicator(cvParam);
 			}
 		}
-		if(compressed) {
-			Inflater inflater = new Inflater();
-			inflater.setInput(byteBuffer.array());
-			byte[] byteArray = new byte[byteBuffer.capacity() * 10];
-			int decodedLength = inflater.inflate(byteArray);
-			byteBuffer = ByteBuffer.wrap(byteArray, 0, decodedLength);
+
+		if(zipCompressed) {
+			unzippedBinary = inflate(unzippedBinary);
 		}
-		byteBuffer.order(ByteOrder.LITTLE_ENDIAN); // this is always the case
-		if(doublePrecision) {
-			DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
-			values = new double[doubleBuffer.capacity()];
-			for(int index = 0; index < doubleBuffer.capacity(); index++) {
-				values[index] = Double.valueOf(doubleBuffer.get(index)) * multiplicator;
+
+		if(numpressAccession != null) {
+			values = MSNumpress.decode(numpressAccession, unzippedBinary, unzippedBinary.length);
+			for(int index = 0; index < values.length; index++) {
+				values[index] *= multiplicator;
 			}
+			return new ImmutablePair<>(content, values);
 		} else {
-			FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
-			values = new double[floatBuffer.capacity()];
-			for(int index = 0; index < floatBuffer.capacity(); index++) {
-				values[index] = Double.valueOf(floatBuffer.get(index)) * multiplicator;
+			ByteBuffer byteBuffer = ByteBuffer.wrap(unzippedBinary);
+			byteBuffer.order(ByteOrder.LITTLE_ENDIAN); // this is always the case
+
+			if(doublePrecision) {
+				DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
+				values = new double[doubleBuffer.capacity()];
+				for(int index = 0; index < doubleBuffer.capacity(); index++) {
+					values[index] = Double.valueOf(doubleBuffer.get(index)) * multiplicator;
+				}
+			} else {
+				FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
+				values = new double[floatBuffer.capacity()];
+				for(int index = 0; index < floatBuffer.capacity(); index++) {
+					values[index] = Double.valueOf(floatBuffer.get(index)) * multiplicator;
+				}
 			}
 		}
+
 		return new ImmutablePair<>(content, values);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlWriter110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlWriter110.java
@@ -205,6 +205,7 @@ public class XmlWriter110 {
 		byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
 		byteBuffer.asFloatBuffer().put(floatBuffer);
 		BinaryDataArrayType binaryDataArrayType = createBinaryDataArray(byteBuffer, compression);
+		binaryDataArrayType.setArrayLength(BigInteger.valueOf(values.length));
 		binaryDataArrayType.getCvParam().add(createFloatParamType());
 		return binaryDataArrayType;
 	}
@@ -235,6 +236,7 @@ public class XmlWriter110 {
 		byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
 		byteBuffer.asDoubleBuffer().put(doubleBuffer);
 		BinaryDataArrayType binaryDataArrayType = createBinaryDataArray(byteBuffer, compression);
+		binaryDataArrayType.setArrayLength(BigInteger.valueOf(values.length));
 		binaryDataArrayType.getCvParam().add(createDoubleParamType());
 		return binaryDataArrayType;
 	}
@@ -247,6 +249,7 @@ public class XmlWriter110 {
 	public static BinaryDataArrayType createNumpressLinearBinaryData(double[] values, boolean compression) {
 
 		BinaryDataArrayType binaryDataArrayType = createBinaryDataArray(encodeNumpressLinear(values), compression);
+		binaryDataArrayType.setArrayLength(BigInteger.valueOf(values.length));
 		binaryDataArrayType.getCvParam().add(createNumpressLinearCompressionParamType());
 		return binaryDataArrayType;
 	}
@@ -259,6 +262,7 @@ public class XmlWriter110 {
 	public static BinaryDataArrayType createNumpressSlofBinaryData(double[] values, boolean compression) {
 
 		BinaryDataArrayType binaryDataArrayType = createBinaryDataArray(encodeNumpressSlof(values), compression);
+		binaryDataArrayType.setArrayLength(BigInteger.valueOf(values.length));
 		binaryDataArrayType.getCvParam().add(createNumpressSlofCompressionParamType());
 		return binaryDataArrayType;
 	}
@@ -271,6 +275,7 @@ public class XmlWriter110 {
 	public static BinaryDataArrayType createNumpressPicBinaryData(double[] values, boolean compression) {
 
 		BinaryDataArrayType binaryDataArrayType = createBinaryDataArray(encodeNumpressPic(values), compression);
+		binaryDataArrayType.setArrayLength(BigInteger.valueOf(values.length));
 		binaryDataArrayType.getCvParam().add(createNumpressPicCompressionParamType());
 		return binaryDataArrayType;
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlWriter110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlWriter110.java
@@ -59,6 +59,7 @@ import org.eclipse.core.runtime.Platform;
 import org.osgi.framework.Version;
 
 import jakarta.xml.bind.DatatypeConverter;
+import ms.numpress.MSNumpress;
 
 public class XmlWriter110 {
 
@@ -235,6 +236,42 @@ public class XmlWriter110 {
 		byteBuffer.asDoubleBuffer().put(doubleBuffer);
 		BinaryDataArrayType binaryDataArrayType = createBinaryDataArray(byteBuffer, compression);
 		binaryDataArrayType.getCvParam().add(createDoubleParamType());
+		return binaryDataArrayType;
+	}
+
+	public static BinaryDataArrayType createNumpressLinearBinaryData(float[] values, boolean compression) {
+
+		return createNumpressLinearBinaryData(toDoubleArray(values), compression);
+	}
+
+	public static BinaryDataArrayType createNumpressLinearBinaryData(double[] values, boolean compression) {
+
+		BinaryDataArrayType binaryDataArrayType = createBinaryDataArray(encodeNumpressLinear(values), compression);
+		binaryDataArrayType.getCvParam().add(createNumpressLinearCompressionParamType());
+		return binaryDataArrayType;
+	}
+
+	public static BinaryDataArrayType createNumpressSlofBinaryData(float[] values, boolean compression) {
+
+		return createNumpressSlofBinaryData(toDoubleArray(values), compression);
+	}
+
+	public static BinaryDataArrayType createNumpressSlofBinaryData(double[] values, boolean compression) {
+
+		BinaryDataArrayType binaryDataArrayType = createBinaryDataArray(encodeNumpressSlof(values), compression);
+		binaryDataArrayType.getCvParam().add(createNumpressSlofCompressionParamType());
+		return binaryDataArrayType;
+	}
+
+	public static BinaryDataArrayType createNumpressPicBinaryData(float[] values, boolean compression) {
+
+		return createNumpressPicBinaryData(toDoubleArray(values), compression);
+	}
+
+	public static BinaryDataArrayType createNumpressPicBinaryData(double[] values, boolean compression) {
+
+		BinaryDataArrayType binaryDataArrayType = createBinaryDataArray(encodeNumpressPic(values), compression);
+		binaryDataArrayType.getCvParam().add(createNumpressPicCompressionParamType());
 		return binaryDataArrayType;
 	}
 
@@ -434,11 +471,16 @@ public class XmlWriter110 {
 
 	private static BinaryDataArrayType createBinaryDataArray(ByteBuffer byteBuffer, boolean compression) {
 
+		return createBinaryDataArray(byteBuffer.array(), compression);
+	}
+
+	private static BinaryDataArrayType createBinaryDataArray(byte[] bytes, boolean compression) {
+
 		BinaryDataArrayType binaryDataArrayType = new BinaryDataArrayType();
 		if(compression) {
 			binaryDataArrayType.getCvParam().add(createZlibCompressionParamType());
 			Deflater compresser = new Deflater();
-			compresser.setInput(byteBuffer.array());
+			compresser.setInput(bytes);
 			compresser.finish();
 			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 			byte[] readBuffer = new byte[1024];
@@ -454,7 +496,9 @@ public class XmlWriter110 {
 			binaryDataArrayType.setBinary(outputByteArray);
 			compresser.end();
 		} else {
-			binaryDataArrayType.setBinary(byteBuffer.array());
+			String characters = DatatypeConverter.printBase64Binary(bytes);
+			binaryDataArrayType.setEncodedLength(BigInteger.valueOf(characters.length()));
+			binaryDataArrayType.setBinary(bytes);
 		}
 		return binaryDataArrayType;
 	}
@@ -465,6 +509,33 @@ public class XmlWriter110 {
 		cvParamCompression.setCvRef(MS);
 		cvParamCompression.setAccession("MS:1000574");
 		cvParamCompression.setName("zlib compression");
+		return cvParamCompression;
+	}
+
+	public static CVParamType createNumpressLinearCompressionParamType() {
+
+		CVParamType cvParamCompression = new CVParamType();
+		cvParamCompression.setCvRef(MS);
+		cvParamCompression.setAccession(MSNumpress.ACC_NUMPRESS_LINEAR);
+		cvParamCompression.setName("MS-Numpress linear prediction compression");
+		return cvParamCompression;
+	}
+
+	public static CVParamType createNumpressPicCompressionParamType() {
+
+		CVParamType cvParamCompression = new CVParamType();
+		cvParamCompression.setCvRef(MS);
+		cvParamCompression.setAccession(MSNumpress.ACC_NUMPRESS_PIC);
+		cvParamCompression.setName("MS-Numpress positive integer compression");
+		return cvParamCompression;
+	}
+
+	public static CVParamType createNumpressSlofCompressionParamType() {
+
+		CVParamType cvParamCompression = new CVParamType();
+		cvParamCompression.setCvRef(MS);
+		cvParamCompression.setAccession(MSNumpress.ACC_NUMPRESS_SLOF);
+		cvParamCompression.setName("MS-Numpress short logged float compression");
 		return cvParamCompression;
 	}
 
@@ -539,6 +610,11 @@ public class XmlWriter110 {
 
 	public static BinaryDataArrayListType createFullSpectrumBinaryDataArrayList(IScanMSD scanMSD, boolean compression) {
 
+		return createFullSpectrumBinaryDataArrayList(scanMSD, compression, "");
+	}
+
+	public static BinaryDataArrayListType createFullSpectrumBinaryDataArrayList(IScanMSD scanMSD, boolean compression, String numpress) {
+
 		List<IIon> ionList = scanMSD.getIons();
 		double[] ions = new double[ionList.size()];
 		float[] abundances = new float[ionList.size()];
@@ -550,26 +626,53 @@ public class XmlWriter110 {
 		}
 		BinaryDataArrayListType binaryDataArrayList = new BinaryDataArrayListType();
 		binaryDataArrayList.setCount(BigInteger.valueOf(2));
-		binaryDataArrayList.getBinaryDataArray().add(createIonsBinaryDataArrayType(ions, compression));
-		binaryDataArrayList.getBinaryDataArray().add(createIntensityBinaryDataArrayType(abundances, compression));
+		binaryDataArrayList.getBinaryDataArray().add(createIonsBinaryDataArrayType(ions, compression, numpress));
+		binaryDataArrayList.getBinaryDataArray().add(createIntensityBinaryDataArrayType(abundances, compression, numpress));
 		return binaryDataArrayList;
 	}
 
-	private static BinaryDataArrayType createIntensityBinaryDataArrayType(float[] abundances, boolean compression) {
+	private static BinaryDataArrayType createIntensityBinaryDataArrayType(float[] abundances, boolean compression, String numpress) {
 
-		BinaryDataArrayType intensityBinaryDataArrayType = XmlWriter110.createBinaryData(abundances, compression);
+		BinaryDataArrayType intensityBinaryDataArrayType = null;
+		if(!numpress.isEmpty()) {
+			if(MSNumpress.ACC_NUMPRESS_LINEAR.equals(numpress)) {
+				intensityBinaryDataArrayType = XmlWriter110.createNumpressLinearBinaryData(abundances, compression);
+			} else if(MSNumpress.ACC_NUMPRESS_PIC.equals(numpress)) {
+				intensityBinaryDataArrayType = XmlWriter110.createNumpressPicBinaryData(abundances, compression);
+			} else if(MSNumpress.ACC_NUMPRESS_SLOF.equals(numpress)) {
+				intensityBinaryDataArrayType = XmlWriter110.createNumpressSlofBinaryData(abundances, compression);
+			}
+		} else {
+			intensityBinaryDataArrayType = XmlWriter110.createBinaryData(abundances, compression);
+		}
 		intensityBinaryDataArrayType.getCvParam().add(XmlWriter110.createIntensityArrayType());
 		return intensityBinaryDataArrayType;
 	}
 
-	private static BinaryDataArrayType createIonsBinaryDataArrayType(double[] ions, boolean compression) {
+	private static BinaryDataArrayType createIonsBinaryDataArrayType(double[] ions, boolean compression, String numpress) {
 
-		BinaryDataArrayType ionsBinaryDataArrayType = XmlWriter110.createBinaryData(ions, compression);
+		BinaryDataArrayType ionsBinaryDataArrayType = null;
+		if(!numpress.isEmpty()) {
+			if(MSNumpress.ACC_NUMPRESS_LINEAR.equals(numpress)) {
+				ionsBinaryDataArrayType = XmlWriter110.createNumpressLinearBinaryData(ions, compression);
+			} else if(MSNumpress.ACC_NUMPRESS_PIC.equals(numpress)) {
+				ionsBinaryDataArrayType = XmlWriter110.createNumpressPicBinaryData(ions, compression);
+			} else if(MSNumpress.ACC_NUMPRESS_SLOF.equals(numpress)) {
+				ionsBinaryDataArrayType = XmlWriter110.createNumpressSlofBinaryData(ions, compression);
+			}
+		} else {
+			ionsBinaryDataArrayType = XmlWriter110.createBinaryData(ions, compression);
+		}
 		ionsBinaryDataArrayType.getCvParam().add(XmlWriter110.createIonType());
 		return ionsBinaryDataArrayType;
 	}
 
 	public static BinaryDataArrayListType createFullSpectrumBinaryDataArrayList(IScanWSD scanWSD, boolean compression) {
+
+		return createFullSpectrumBinaryDataArrayList(scanWSD, compression, "");
+	}
+
+	public static BinaryDataArrayListType createFullSpectrumBinaryDataArrayList(IScanWSD scanWSD, boolean compression, String numpress) {
 
 		List<IScanSignalWSD> scanSignals = scanWSD.getScanSignals();
 		double[] wavelength = new double[scanSignals.size()];
@@ -583,15 +686,15 @@ public class XmlWriter110 {
 		BinaryDataArrayListType binaryDataArrayList = new BinaryDataArrayListType();
 		binaryDataArrayList.setCount(BigInteger.valueOf(2));
 		binaryDataArrayList.getBinaryDataArray().add(createWavelengthBinaryDataArrayType(wavelength, compression));
-		binaryDataArrayList.getBinaryDataArray().add(createIntensityBinaryDataArrayType(absorbance, compression));
+		binaryDataArrayList.getBinaryDataArray().add(createIntensityBinaryDataArrayType(absorbance, compression, ""));
 		return binaryDataArrayList;
 	}
 
 	private static BinaryDataArrayType createWavelengthBinaryDataArrayType(double[] wavelengths, boolean compression) {
 
-		BinaryDataArrayType ionsBinaryDataArrayType = XmlWriter110.createBinaryData(wavelengths, compression);
-		ionsBinaryDataArrayType.getCvParam().add(XmlWriter110.createWavelengthType());
-		return ionsBinaryDataArrayType;
+		BinaryDataArrayType wavelengthsBinaryDataArrayType = XmlWriter110.createBinaryData(wavelengths, compression);
+		wavelengthsBinaryDataArrayType.getCvParam().add(XmlWriter110.createWavelengthType());
+		return wavelengthsBinaryDataArrayType;
 	}
 
 	private static CVParamType createWavelengthType() {
@@ -602,5 +705,43 @@ public class XmlWriter110 {
 		cvParamWavelength.setName("wavelength array");
 		setUnitNanometer(cvParamWavelength);
 		return cvParamWavelength;
+	}
+
+	private static double[] toDoubleArray(float[] values) {
+
+		double[] doubles = new double[values.length];
+		for(int i = 0; i < values.length; i++) {
+			doubles[i] = values[i];
+		}
+		return doubles;
+	}
+
+	private static byte[] encodeNumpressLinear(double[] values) {
+
+		double fixedPoint = MSNumpress.optimalLinearFixedPoint(values, values.length);
+		byte[] encoded = new byte[values.length * 5 + 8];
+		int encodedLength = MSNumpress.encodeLinear(values, values.length, encoded, fixedPoint);
+		byte[] result = new byte[encodedLength];
+		System.arraycopy(encoded, 0, result, 0, encodedLength);
+		return result;
+	}
+
+	private static byte[] encodeNumpressSlof(double[] values) {
+
+		double fixedPoint = MSNumpress.optimalSlofFixedPoint(values, values.length);
+		byte[] encoded = new byte[values.length * 2 + 8];
+		int encodedLength = MSNumpress.encodeSlof(values, values.length, encoded, fixedPoint);
+		byte[] result = new byte[encodedLength];
+		System.arraycopy(encoded, 0, result, 0, encodedLength);
+		return result;
+	}
+
+	private static byte[] encodeNumpressPic(double[] values) {
+
+		byte[] encoded = new byte[values.length * 5];
+		int encodedLength = MSNumpress.encodePic(values, values.length, encoded);
+		byte[] result = new byte[encodedLength];
+		System.arraycopy(encoded, 0, result, 0, encodedLength);
+		return result;
 	}
 }

--- a/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
+++ b/chemclipse/releng/org.eclipse.chemclipse.targetplatform/org.eclipse.chemclipse.targetplatform.target
@@ -28,21 +28,11 @@
 	<unit id="org.eclipse.jdt.junit6.runtime"/>
 	<repository location="https://download.eclipse.org/releases/2026-06/"/>
 </location>
-<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="false" label="com.sun.xml.bind.jaxb-osgi" missingManifest="error" type="Maven">
-	<dependencies>
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-osgi</artifactId>
-			<version>4.0.9</version>
-			<type>jar</type>
-		</dependency>
-	</dependencies>
-</location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<repository location="https://download.eclipse.org/cbi/updates/license/"/>
 	<unit id="org.eclipse.license.feature.group"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="org.eclipse.babel.nls_eclipse_de.feature.group"/>
 	<repository location="https://download.eclipse.org/technology/babel/update-site/R0.20.0/2022-12/"/>
 </location>
@@ -65,6 +55,16 @@
 		<unit id="org.apache.xmlbeans"/>
 		<unit id="org.easymock"/>
 	</location>
+	<location includeDependencyDepth="none" includeDependencyScopes="compile" label="com.sun.xml.bind.jaxb-osgi" missingManifest="error" type="Maven">
+		<dependencies>
+			<dependency>
+				<groupId>com.sun.xml.bind</groupId>
+				<artifactId>jaxb-osgi</artifactId>
+				<version>4.0.9</version>
+				<type>jar</type>
+			</dependency>
+		</dependencies>
+	</location>
 	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="org.ejml" missingManifest="generate" type="Maven">
 		<dependencies>
 			<dependency>
@@ -83,6 +83,16 @@
 				<groupId>org.ejml</groupId>
 				<artifactId>ejml-simple</artifactId>
 				<version>0.44.0</version>
+				<type>jar</type>
+			</dependency>
+		</dependencies>
+	</location>
+	<location includeDependencyDepth="none" includeSource="true" missingManifest="generate" type="Maven">
+		<dependencies>
+			<dependency>
+				<groupId>se.lth.immun</groupId>
+				<artifactId>MsNumpress</artifactId>
+				<version>0.1.21</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.mzml.fragment.test/META-INF/MANIFEST.MF
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.mzml.fragment.test/META-INF/MANIFEST.MF
@@ -6,6 +6,8 @@ Bundle-SymbolicName: org.eclipse.chemclipse.xxd.converter.supplier.mzml.fragment
 Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: ChemClipse
 Fragment-Host: org.eclipse.chemclipse.xxd.converter.supplier.mzml;bundle-version="0.8.0"
-Import-Package: org.junit.jupiter.api;version="5.12.2"
+Import-Package: org.junit.jupiter.api;version="6.1.0",
+ org.junit.jupiter.params;version="6.1.0",
+ org.junit.jupiter.params.provider;version="6.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0"

--- a/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportExport110_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.xxd.converter.supplier.mzml.fragment.test/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramImportExport110_ITest.java
@@ -17,71 +17,70 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
+import java.util.stream.Stream;
 
 import org.eclipse.chemclipse.msd.converter.chromatogram.ChromatogramConverterMSD;
+import org.eclipse.chemclipse.msd.converter.supplier.mzml.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import ms.numpress.MSNumpress;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImportExport110_ITest {
 
-	private IChromatogramMSD chromatogram;
+	private static Stream<String> numpressPreferences() {
+
+		return Stream.of("", MSNumpress.ACC_NUMPRESS_LINEAR, MSNumpress.ACC_NUMPRESS_PIC, MSNumpress.ACC_NUMPRESS_SLOF);
+	}
+
+	private IChromatogramMSD chromatogramImport;
 	private File fileExport;
 
 	@BeforeAll
 	public void setUp() {
 
-		/*
-		 * Import
-		 */
 		String extensionPointImport = VersionConstants.CONVERTER_ID_CHROMATOGRAM;
-		/*
-		 * Export/Reimport
-		 */
+		File fileImport = new File("testData/files/import/Chromatogram1.ocb");
+		IProcessingInfo<IChromatogramMSD> processingInfoImport = ChromatogramConverterMSD.getInstance().convert(fileImport, extensionPointImport, new NullProgressMonitor());
+		chromatogramImport = processingInfoImport.getProcessingResult();
+	}
+
+	@ParameterizedTest
+	@MethodSource("numpressPreferences")
+	public void testReimport(String numpressPreference) {
+
 		File directory = new File("testData/files/export");
 		directory.mkdir();
 		String extensionPointExportReimport = "org.eclipse.chemclipse.msd.converter.supplier.mzml";
 		/*
-		 * Import the chromatogram.
-		 */
-		File fileImport = new File("testData/files/import/Chromatogram1.ocb");
-		IProcessingInfo<IChromatogramMSD> processingInfoImport = ChromatogramConverterMSD.getInstance().convert(fileImport, extensionPointImport, new NullProgressMonitor());
-		IChromatogramMSD chromatogramImport = processingInfoImport.getProcessingResult();
-		/*
 		 * Export the chromatogram.
 		 */
-		fileExport = new File("testData/files/export" + File.separator + "Test.mzML");
+		PreferenceSupplier.setSaveNumpress(numpressPreference);
+		fileExport = new File("testData/files/export" + File.separator + "Test-" + numpressPreference + ".mzML");
 		IProcessingInfo<File> processingInfoExport = ChromatogramConverterMSD.getInstance().convert(fileExport, chromatogramImport, extensionPointExportReimport, new NullProgressMonitor());
 		fileExport = processingInfoExport.getProcessingResult();
 		/*
 		 * Reimport the exported chromatogram.
 		 */
 		IProcessingInfo<IChromatogramMSD> processingInfo = ChromatogramConverterMSD.getInstance().convert(fileExport, extensionPointExportReimport, new NullProgressMonitor());
-		chromatogram = processingInfo.getProcessingResult();
+		IChromatogramMSD chromatogram = processingInfo.getProcessingResult();
+
+		assertNotNull(chromatogram);
+		assertEquals(5726, chromatogram.getNumberOfScans());
 	}
 
-	@AfterAll
+	@AfterEach
 	public void tearDown() {
 
 		fileExport.delete();
-	}
-
-	@Test
-	public void testReimport_1() {
-
-		assertNotNull(chromatogram);
-	}
-
-	@Test
-	public void testReimport_2() {
-
-		assertEquals(5726, chromatogram.getNumberOfScans());
 	}
 }


### PR DESCRIPTION
This adds support for @ms-numpress which does not do much for nominal mass GC-MS but compresses large profile LC-MS drastically. See https://www.sciencedirect.com/science/article/pii/S1535947620330838 for the official writeup and https://pyopenms.readthedocs.io/en/release_2.5.0/mzMLFileFormat.html#numpress-encoding for some practical hints.