### PR TITLE
Fix column indices not updating

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/ColumnIndicesPart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/ColumnIndicesPart.java
@@ -38,6 +38,8 @@ public class ColumnIndicesPart extends AbstractLibraryInformationPart<ExtendedCo
 	@Override
 	protected boolean updateData(List<Object> objects, String topic) {
 
+		super.updateData(objects, topic);
+
 		if(objects.size() == 1) {
 			if(isChromatogramEvent(topic)) {
 				getControl().updateInput();
@@ -55,7 +57,7 @@ public class ColumnIndicesPart extends AbstractLibraryInformationPart<ExtendedCo
 	@Override
 	protected boolean isUpdateTopic(String topic) {
 
-		return isChromatogramEvent(topic) || isCloseEvent(topic);
+		return super.isUpdateTopic(topic) || isChromatogramEvent(topic) || isCloseEvent(topic);
 	}
 
 	private boolean isChromatogramEvent(String topic) {


### PR DESCRIPTION
This addresses a flaw from https://github.com/eclipse-chemclipse/chemclipse/pull/2887 because there is already https://github.com/eclipse-chemclipse/chemclipse/blob/be8c9b76910a79ac32580204504656e291000e62/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/AbstractLibraryInformationPart.java#L43-L50 which is inherited. https://github.com/eclipse-chemclipse/chemclipse/blob/be8c9b76910a79ac32580204504656e291000e62/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/ColumnIndicesPart.java#L24