### PR TITLE
Remove unused function

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.calculator/src/org/eclipse/chemclipse/chromatogram/xxd/calculator/preferences/PreferenceSupplier.java
@@ -36,11 +36,6 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 		return INSTANCE(PreferenceSupplier.class);
 	}
 
-	public static boolean isAvailable() {
-
-		return Activator.getContext() != null;
-	}
-
 	@Override
 	public String getPreferenceNode() {
 


### PR DESCRIPTION
as it is in fact unused. https://github.com/eclipse-chemclipse/chemclipse/commit/d2fcecc89e39d183589bf4350db1a47609396c51 added the function without context.