### PR TITLE
Add configurable chart compression for profile MS

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/META-INF/MANIFEST.MF
@@ -20,7 +20,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.nebula.visualization.xygraph;bundle-version="1.0.0",
  org.eclipse.chemclipse.support.ui;bundle-version="0.8.0",
  org.eclipse.e4.core.services;bundle-version="2.0.0",
- org.eclipse.chemclipse.processing.ui;bundle-version="0.9.0"
+ org.eclipse.chemclipse.processing.ui;bundle-version="0.9.0",
+ org.eclipse.swtchart.extensions;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-25
 Export-Package: org.eclipse.chemclipse.msd.swt.ui.components.identification,
  org.eclipse.chemclipse.msd.swt.ui.components.massspectrum,

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/preferences/PreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/preferences/PreferencePage.java
@@ -14,8 +14,10 @@ package org.eclipse.chemclipse.msd.swt.ui.preferences;
 
 import org.eclipse.chemclipse.msd.swt.ui.Activator;
 import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpacerFieldEditor;
+import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.swtchart.extensions.charts.ChartOptions;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
@@ -32,6 +34,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	@Override
 	public void createFieldEditors() {
 
+		addField(new ComboFieldEditor(PreferenceSupplier.P_PROFILE_MASS_SPECTRUM_CHART_COMPRESSION_TYPE, "Chart compression:", ChartOptions.COMPRESSION_TYPES, getFieldEditorParent()));
 		addField(new DirectoryFieldEditor(PreferenceSupplier.P_PATH_MASS_SPECTRUM_LIBRARIES, "Path mass spectrum libraries.", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/preferences/PreferenceSupplier.java
@@ -15,6 +15,7 @@ package org.eclipse.chemclipse.msd.swt.ui.preferences;
 import org.eclipse.chemclipse.msd.swt.ui.Activator;
 import org.eclipse.chemclipse.support.preferences.AbstractPreferenceSupplier;
 import org.eclipse.chemclipse.support.preferences.IPreferenceSupplier;
+import org.eclipse.swtchart.extensions.linecharts.ICompressionSupport;
 
 public class PreferenceSupplier extends AbstractPreferenceSupplier {
 
@@ -23,6 +24,9 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	 */
 	public static final String P_PATH_MASS_SPECTRUM_LIBRARIES = "pathMassSpectrumLibraries";
 	public static final String DEF_PATH_MASS_SPECTRUM_LIBRARIES = "";
+
+	public static final String P_PROFILE_MASS_SPECTRUM_CHART_COMPRESSION_TYPE = "profileMassSpectrumChartCompressionType";
+	public static final String DEF_PROFILE_MASS_SPECTRUM_CHART_COMPRESSION_TYPE = ICompressionSupport.COMPRESSION_AUTO;
 
 	public static final String P_SHOW_MASS_SPECTRUM_SELECTION_COMBO = "showMassSpectrumSelectionCombo";
 	public static final boolean DEF_SHOW_MASS_SPECTRUM_SELECTION_COMBO = false;
@@ -45,6 +49,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public void initializeDefaults() {
 
 		putDefault(P_PATH_MASS_SPECTRUM_LIBRARIES, DEF_PATH_MASS_SPECTRUM_LIBRARIES);
+		putDefault(P_PROFILE_MASS_SPECTRUM_CHART_COMPRESSION_TYPE, DEF_PROFILE_MASS_SPECTRUM_CHART_COMPRESSION_TYPE);
 		putDefault(PreferenceSupplier.P_SHOW_MASS_SPECTRUM_SELECTION_COMBO, PreferenceSupplier.DEF_SHOW_MASS_SPECTRUM_SELECTION_COMBO);
 		putDefault(PreferenceSupplier.P_MASS_SPECTRUM_SHOW_METHODS_TOOLBAR, PreferenceSupplier.DEF_MASS_SPECTRUM_SHOW_METHODS_TOOLBAR);
 	}
@@ -52,6 +57,11 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static String getPathMassSpectrumLibraries() {
 
 		return INSTANCE().get(P_PATH_MASS_SPECTRUM_LIBRARIES, DEF_PATH_MASS_SPECTRUM_LIBRARIES);
+	}
+
+	public static String getProfileMassSpectrumChartCompression() {
+
+		return INSTANCE().get(P_PROFILE_MASS_SPECTRUM_CHART_COMPRESSION_TYPE, DEF_PROFILE_MASS_SPECTRUM_CHART_COMPRESSION_TYPE);
 	}
 
 	public static void setPathMassSpectrumLibraries(String pathMassSpectrumLibraries) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
@@ -35,6 +35,7 @@ import org.eclipse.chemclipse.msd.converter.massspectrum.MassSpectrumConverterSu
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.swt.ui.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.processing.converter.ISupplier;
 import org.eclipse.chemclipse.processing.core.DefaultProcessingResult;
 import org.eclipse.chemclipse.processing.core.ICategories;
@@ -80,6 +81,7 @@ import org.eclipse.swtchart.extensions.core.ISeriesData;
 import org.eclipse.swtchart.extensions.core.RangeRestriction;
 import org.eclipse.swtchart.extensions.core.ScrollableChart;
 import org.eclipse.swtchart.extensions.core.SeriesData;
+import org.eclipse.swtchart.extensions.linecharts.ICompressionSupport;
 import org.eclipse.swtchart.extensions.linecharts.ILineSeriesData;
 import org.eclipse.swtchart.extensions.linecharts.ILineSeriesSettings;
 import org.eclipse.swtchart.extensions.linecharts.LineChart;
@@ -93,7 +95,6 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 
 	private static final Logger logger = Logger.getLogger(MassSpectrumChartProfile.class);
 
-	private static final int MAX_NUMBER_MZ = 25000;
 	private static final DecimalFormatSymbols ENGLISH_SYMBOLS = new DecimalFormatSymbols(Locale.ENGLISH);
 
 	private IScanMSD massSpectrum = null;
@@ -143,11 +144,51 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 				lineSeriesDataList.add(peakLineSeriesData);
 				createAnnotations(standaloneMassSpectrum);
 			}
-			addSeriesData(lineSeriesDataList, MAX_NUMBER_MZ);
+			int compression = getCompressionLength(PreferenceSupplier.getProfileMassSpectrumChartCompression());
+			addSeriesData(lineSeriesDataList, compression);
 			updateAxis();
 			updateMenu();
 			UpdateNotifier.update(massSpectrum);
 		}
+	}
+
+	public int getCompressionLength(String compressionType) {
+
+		int numberIons = massSpectrum.getNumberOfIons();
+		int compressionToLength = 0;
+		switch(compressionType) {
+			case ICompressionSupport.COMPRESSION_AUTO:
+				if(numberIons >= 100000) {
+					compressionToLength = ICompressionSupport.EXTREME_COMPRESSION;
+				} else if(numberIons >= 10000) {
+					compressionToLength = ICompressionSupport.HIGH_COMPRESSION;
+				} else if(numberIons >= 5000) {
+					compressionToLength = ICompressionSupport.MEDIUM_COMPRESSION;
+				} else {
+					compressionToLength = ICompressionSupport.LOW_COMPRESSION;
+				}
+				break;
+			case ICompressionSupport.COMPRESSION_NONE:
+				compressionToLength = ICompressionSupport.NO_COMPRESSION;
+				break;
+			case ICompressionSupport.COMPRESSION_LOW:
+				compressionToLength = ICompressionSupport.LOW_COMPRESSION;
+				break;
+			case ICompressionSupport.COMPRESSION_MEDIUM:
+				compressionToLength = ICompressionSupport.MEDIUM_COMPRESSION;
+				break;
+			case ICompressionSupport.COMPRESSION_HIGH:
+				compressionToLength = ICompressionSupport.HIGH_COMPRESSION;
+				break;
+			case ICompressionSupport.COMPRESSION_EXTREME:
+				compressionToLength = ICompressionSupport.EXTREME_COMPRESSION;
+				break;
+			default:
+				compressionToLength = ICompressionSupport.MEDIUM_COMPRESSION;
+				break;
+		}
+
+		return compressionToLength;
 	}
 
 	private void updateAxis() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumEditor.java
@@ -233,8 +233,8 @@ public class MassSpectrumEditor extends Composite implements IChangeListener {
 			fileDialog.setFilterExtensions(converterSupport.getFilterExtensions());
 			fileDialog.setFilterNames(converterSupport.getFilterNames());
 		} catch(NoConverterAvailableException e) {
-			fileDialog.setFilterExtensions(new String[]{"*.*"});
-			fileDialog.setFilterNames(new String[]{"All Files"});
+			fileDialog.setFilterExtensions("*.*");
+			fileDialog.setFilterNames("All Files");
 		}
 
 		fileDialog.setFilterPath(PreferenceSupplier.getPathMassSpectrumLibraries());


### PR DESCRIPTION
I basically mirror the chromatogram chart here as a noisy 20.000 ion MALDI-TOF MS spectrum causes considerable lag.