### PR TITLE
Fix mzML without TIC not being detected as chromatogram

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramFileContentMatcher.java
@@ -24,6 +24,8 @@ import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
 
 public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher {
 
+	private static final String CV_SCAN_START_TIME = "MS:1000016";
+
 	@Override
 	public boolean checkFileFormat(File file) {
 
@@ -36,6 +38,7 @@ public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher {
 			XMLStreamReader xmlStreamReader = xmlInputFactory.createXMLStreamReader(new FileInputStream(file));
 			boolean hasChromatogramList = false;
 			boolean hasRootElement = false;
+			boolean hasRetentionTime = false;
 			while(xmlStreamReader.hasNext()) {
 				int eventType = xmlStreamReader.next();
 				if(eventType == XMLStreamConstants.START_ELEMENT) {
@@ -44,8 +47,10 @@ public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher {
 						hasRootElement = true;
 					} else if(elementName.equals("chromatogramList")) {
 						hasChromatogramList = true;
+					} else if(CV_SCAN_START_TIME.equals(xmlStreamReader.getAttributeValue(null, "accession"))) {
+						hasRetentionTime = true;
 					}
-					if(hasRootElement && hasChromatogramList) {
+					if(hasRootElement && (hasChromatogramList || hasRetentionTime)) {
 						isValidFormat = true;
 						break;
 					}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumFileContentMatcher.java
@@ -24,6 +24,8 @@ import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
 
 public class MassSpectrumFileContentMatcher extends AbstractFileContentMatcher {
 
+	private static final String CV_SCAN_START_TIME = "MS:1000016";
+
 	@Override
 	public boolean checkFileFormat(File file) {
 
@@ -37,6 +39,7 @@ public class MassSpectrumFileContentMatcher extends AbstractFileContentMatcher {
 			boolean hasChromatogramList = false;
 			boolean hasRootElement = false;
 			boolean hasSpectrumList = false;
+			boolean hasRetentionTime = false;
 			while(xmlStreamReader.hasNext()) {
 				int eventType = xmlStreamReader.next();
 				if(eventType == XMLStreamConstants.START_ELEMENT) {
@@ -48,10 +51,12 @@ public class MassSpectrumFileContentMatcher extends AbstractFileContentMatcher {
 						break;
 					} else if(elementName.equals("spectrumList")) {
 						hasSpectrumList = true;
+					} else if(CV_SCAN_START_TIME.equals(xmlStreamReader.getAttributeValue(null, "accession"))) {
+						hasRetentionTime = true;
 					}
 				}
 			}
-			if(hasRootElement && hasSpectrumList && !hasChromatogramList) {
+			if(hasRootElement && hasSpectrumList && !(hasChromatogramList || hasRetentionTime)) {
 				isValidFormat = true;
 			}
 			xmlStreamReader.close();


### PR DESCRIPTION
Bruker/Agilent YEP files converted with @ProteoWizard come with an empty/non-existing TIC so we detected them as mass spectra. The presence of a retention time still gives it away.