### PR TITLE
Improve XML file content matcher performance

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.converter/src/org/eclipse/chemclipse/converter/core/AbstractFileContentMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Lablicate GmbH.
+ * Copyright (c) 2023, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,5 +14,4 @@ package org.eclipse.chemclipse.converter.core;
 
 public abstract class AbstractFileContentMatcher implements IFileContentMatcher {
 
-	public static final long HUNDRED_MB = 100l * 1024l * 1024l;
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramFileContentMatcher.java
@@ -14,49 +14,48 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mzdata.converter;
 
 import java.io.File;
+import java.io.FileInputStream;
 
 import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
-import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.io.ReaderVersion105;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
 
 public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher {
 
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		if(file.length() > HUNDRED_MB) {
-			return true;
-		}
-		boolean isValidFormat = false;
+		boolean hasRootElement = false;
+		boolean hasRetentionTime = false;
+
 		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-			Document document = documentBuilder.parse(file);
-			NodeList root = document.getElementsByTagName(ReaderVersion105.NODE_MZ_DATA);
-			if(root.getLength() != 1) {
-				return isValidFormat;
-			}
-			NodeList spectrumList = document.getElementsByTagName(ReaderVersion105.NODE_SPECTRUM_LIST);
-			if(spectrumList.getLength() > 0) {
-				Element element = (Element)spectrumList.item(0);
-				int spectrumCount = Integer.parseInt(element.getAttribute("count"));
-				if(spectrumCount > 1) {
-					isValidFormat = true;
+			XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+			xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+			xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+			xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+			XMLStreamReader xmlStreamReader = xmlInputFactory.createXMLStreamReader(new FileInputStream(file));
+
+			int events = 0;
+			while(xmlStreamReader.hasNext() && events < 1000) {
+				int event = xmlStreamReader.next();
+				if(event == XMLStreamConstants.START_ELEMENT) {
+					String localName = xmlStreamReader.getLocalName();
+					if("mzData".equals(localName)) {
+						hasRootElement = true;
+					} else if("cvParam".equals(localName) && //
+							xmlStreamReader.getAttributeValue(null, "name").startsWith("time")) {
+						hasRetentionTime = true;
+					}
 				}
+				events++;
 			}
 		} catch(Exception e) {
-			// Print no exception.
+			// fail silently
 		}
-		return isValidFormat;
+
+		return hasRootElement && hasRetentionTime;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/MassSpectrumFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/MassSpectrumFileContentMatcher.java
@@ -14,49 +14,48 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mzdata.converter;
 
 import java.io.File;
+import java.io.FileInputStream;
 
 import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
-import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.io.ReaderVersion105;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
 
 public class MassSpectrumFileContentMatcher extends AbstractFileContentMatcher {
 
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		if(file.length() > HUNDRED_MB) {
-			return true;
-		}
-		boolean isValidFormat = false;
+		boolean hasRootElement = false;
+		boolean hasRetentionTime = false;
+
 		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-			Document document = documentBuilder.parse(file);
-			NodeList root = document.getElementsByTagName(ReaderVersion105.NODE_MZ_DATA);
-			if(root.getLength() != 1) {
-				return isValidFormat;
-			}
-			NodeList spectrumList = document.getElementsByTagName(ReaderVersion105.NODE_SPECTRUM_LIST);
-			if(spectrumList.getLength() > 0) {
-				Element element = (Element)spectrumList.item(0);
-				int spectrumCount = Integer.parseInt(element.getAttribute("count"));
-				if(spectrumCount == 1) {
-					isValidFormat = true;
+			XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+			xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+			xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+			xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+			XMLStreamReader xmlStreamReader = xmlInputFactory.createXMLStreamReader(new FileInputStream(file));
+
+			int events = 0;
+			while(xmlStreamReader.hasNext() && events < 1000) {
+				int event = xmlStreamReader.next();
+				if(event == XMLStreamConstants.START_ELEMENT) {
+					String localName = xmlStreamReader.getLocalName();
+					if("mzData".equals(localName)) {
+						hasRootElement = true;
+					} else if("cvParam".equals(localName) && //
+							xmlStreamReader.getAttributeValue(null, "name").startsWith("time")) {
+						hasRetentionTime = true;
+					}
 				}
+				events++;
 			}
 		} catch(Exception e) {
-			// Print no exception.
+			// fail silently
 		}
-		return isValidFormat;
+
+		return hasRootElement && !hasRetentionTime;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion105.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion105.java
@@ -133,7 +133,7 @@ public class ChromatogramReaderVersion105 extends AbstractChromatogramReader {
 
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document document = documentBuilder.parse(file);
-		NodeList nodeList = document.getElementsByTagName(ReaderVersion105.NODE_MZ_DATA);
+		NodeList nodeList = document.getElementsByTagName("mzData");
 
 		JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
 		Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/MassSpectrumReaderVersion105.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/MassSpectrumReaderVersion105.java
@@ -75,7 +75,7 @@ public class MassSpectrumReaderVersion105 extends AbstractMassSpectraReader {
 
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);
-			NodeList nodeList = document.getElementsByTagName(ReaderVersion105.NODE_MZ_DATA);
+			NodeList nodeList = document.getElementsByTagName("mzData");
 
 			JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
 			Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ReaderVersion105.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ReaderVersion105.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,9 +20,6 @@ import java.nio.FloatBuffer;
 import org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.v105.model.Data;
 
 public class ReaderVersion105 {
-
-	public static final String NODE_MZ_DATA = "mzData";
-	public static final String NODE_SPECTRUM_LIST = "spectrumList";
 
 	private ReaderVersion105() {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/ChromatogramFileContentMatcher.java
@@ -14,46 +14,50 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mzxml.converter;
 
 import java.io.File;
+import java.io.FileInputStream;
 
 import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
-import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.AbstractReader;
-import org.w3c.dom.Document;
-import org.w3c.dom.NodeList;
 
 public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher {
 
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		if(file.length() > HUNDRED_MB) {
-			return true;
-		}
-		boolean isValidFormat = false;
-		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-			documentBuilderFactory.setNamespaceAware(true);
+		boolean hasRootElement = false;
+		boolean hasRetentionTime = false;
 
-			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-			Document document = documentBuilder.parse(file);
-			NodeList root = document.getElementsByTagNameNS("*", AbstractReader.NODE_MZXML);
-			if(root.getLength() != 1) {
-				return isValidFormat;
-			}
-			NodeList scanList = document.getElementsByTagName(AbstractReader.NODE_SCAN);
-			if(scanList.getLength() > 1) {
-				isValidFormat = true;
+		try {
+			XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+			xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+			xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+			xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+			XMLStreamReader xmlStreamReader = xmlInputFactory.createXMLStreamReader(new FileInputStream(file));
+
+			int events = 0;
+			while(xmlStreamReader.hasNext() && events < 1000) {
+				int event = xmlStreamReader.next();
+				if(event == XMLStreamConstants.START_ELEMENT) {
+					String localName = xmlStreamReader.getLocalName();
+					if("mzXML".equals(localName)) {
+						hasRootElement = true;
+					} else if("scan".equals(localName)) {
+						String retentionTime = xmlStreamReader.getAttributeValue(null, "retentionTime");
+						if(retentionTime != null && !retentionTime.isEmpty()) {
+							hasRetentionTime = true;
+						}
+					}
+				}
+				events++;
 			}
 		} catch(Exception e) {
 			// fail silently
 		}
-		return isValidFormat;
+
+		return hasRootElement && hasRetentionTime;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/converter/MassSpectrumFileContentMatcher.java
@@ -14,45 +14,50 @@
 package org.eclipse.chemclipse.msd.converter.supplier.mzxml.converter;
 
 import java.io.File;
+import java.io.FileInputStream;
 
 import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
-import org.eclipse.chemclipse.msd.converter.supplier.mzxml.internal.io.AbstractReader;
-import org.w3c.dom.Document;
-import org.w3c.dom.NodeList;
 
 public class MassSpectrumFileContentMatcher extends AbstractFileContentMatcher {
 
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		if(file.length() > HUNDRED_MB) {
-			return true;
-		}
-		boolean isValidFormat = false;
-		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		boolean hasRootElement = false;
+		boolean hasRetentionTime = false;
 
-			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-			Document document = documentBuilder.parse(file);
-			NodeList root = document.getElementsByTagName(AbstractReader.NODE_MZXML);
-			if(root.getLength() != 1) {
-				return isValidFormat;
-			}
-			NodeList scanList = document.getElementsByTagName(AbstractReader.NODE_SCAN);
-			if(scanList.getLength() == 1) {
-				isValidFormat = true;
+		try {
+			XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+			xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+			xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+			xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+			XMLStreamReader xmlStreamReader = xmlInputFactory.createXMLStreamReader(new FileInputStream(file));
+
+			int events = 0;
+			while(xmlStreamReader.hasNext() && events < 1000) {
+				int event = xmlStreamReader.next();
+				if(event == XMLStreamConstants.START_ELEMENT) {
+					String localName = xmlStreamReader.getLocalName();
+					if("mzXML".equals(localName)) {
+						hasRootElement = true;
+					} else if("scan".equals(localName)) {
+						String retentionTime = xmlStreamReader.getAttributeValue(null, "retentionTime");
+						if(retentionTime != null && !retentionTime.isEmpty()) {
+							hasRetentionTime = true;
+						}
+					}
+				}
+				events++;
 			}
 		} catch(Exception e) {
 			// fail silently
 		}
-		return isValidFormat;
+
+		return hasRootElement && !hasRetentionTime;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramFileContentMatcher.java
@@ -16,6 +16,7 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter;
 import java.io.File;
 import java.io.FileInputStream;
 
+import javax.xml.XMLConstants;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
@@ -32,10 +33,15 @@ public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher {
 		boolean isValidFormat = false;
 		try {
 			XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+			xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+			xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+			xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 			XMLStreamReader xmlStreamReader = xmlInputFactory.createXMLStreamReader(new FileInputStream(file));
+
 			boolean hasChromatogramList = false;
 			boolean hasRootElement = false;
 			boolean hasRetentionTime = false;
+
 			int events = 0;
 			while(xmlStreamReader.hasNext() && events < 1000) {
 				int eventType = xmlStreamReader.next();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramFileContentMatcher.java
@@ -29,9 +29,6 @@ public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher {
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		if(file.length() > HUNDRED_MB) {
-			return true;
-		}
 		boolean isValidFormat = false;
 		try {
 			XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
@@ -39,7 +36,8 @@ public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher {
 			boolean hasChromatogramList = false;
 			boolean hasRootElement = false;
 			boolean hasRetentionTime = false;
-			while(xmlStreamReader.hasNext()) {
+			int events = 0;
+			while(xmlStreamReader.hasNext() && events < 1000) {
 				int eventType = xmlStreamReader.next();
 				if(eventType == XMLStreamConstants.START_ELEMENT) {
 					String elementName = xmlStreamReader.getLocalName();
@@ -55,6 +53,7 @@ public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher {
 						break;
 					}
 				}
+				events++;
 			}
 			xmlStreamReader.close();
 		} catch(Exception e) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumFileContentMatcher.java
@@ -29,9 +29,6 @@ public class MassSpectrumFileContentMatcher extends AbstractFileContentMatcher {
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		if(file.length() > HUNDRED_MB) {
-			return true;
-		}
 		boolean isValidFormat = false;
 		try {
 			XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
@@ -40,7 +37,8 @@ public class MassSpectrumFileContentMatcher extends AbstractFileContentMatcher {
 			boolean hasRootElement = false;
 			boolean hasSpectrumList = false;
 			boolean hasRetentionTime = false;
-			while(xmlStreamReader.hasNext()) {
+			int events = 0;
+			while(xmlStreamReader.hasNext() && events < 1000) {
 				int eventType = xmlStreamReader.next();
 				if(eventType == XMLStreamConstants.START_ELEMENT) {
 					String elementName = xmlStreamReader.getLocalName();
@@ -55,6 +53,7 @@ public class MassSpectrumFileContentMatcher extends AbstractFileContentMatcher {
 						hasRetentionTime = true;
 					}
 				}
+				events++;
 			}
 			if(hasRootElement && hasSpectrumList && !(hasChromatogramList || hasRetentionTime)) {
 				isValidFormat = true;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumFileContentMatcher.java
@@ -16,6 +16,7 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter;
 import java.io.File;
 import java.io.FileInputStream;
 
+import javax.xml.XMLConstants;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
@@ -32,11 +33,16 @@ public class MassSpectrumFileContentMatcher extends AbstractFileContentMatcher {
 		boolean isValidFormat = false;
 		try {
 			XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+			xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+			xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+			xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 			XMLStreamReader xmlStreamReader = xmlInputFactory.createXMLStreamReader(new FileInputStream(file));
+
 			boolean hasChromatogramList = false;
 			boolean hasRootElement = false;
 			boolean hasSpectrumList = false;
 			boolean hasRetentionTime = false;
+
 			int events = 0;
 			while(xmlStreamReader.hasNext() && events < 1000) {
 				int eventType = xmlStreamReader.next();


### PR DESCRIPTION
This uses the streaming XML file content matcher from mzML everywhere else, which makes it a lot faster on large files so we can also stop skipping those. Also a follow-up to https://github.com/eclipse-chemclipse/chemclipse/pull/3034 because I forgot about the streaming APIs.