### PR TITLE
Make PageUtil closeable instead of relying on finalize()

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.pdf/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/pdf/io/ReportWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.pdf/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/pdf/io/ReportWriter.java
@@ -74,12 +74,12 @@ public class ReportWriter {
 		monitor.beginTask("Render Chromatogram", size);
 		for(int i = 1; i < size; i += chunkSize) {
 			ITotalScanSignals scans = totalScanSignalExtractor.getTotalScanSignals(i, Math.min(size, i + chunkSize), false);
-			PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, PAGE_UNIT, LANDSCAPE));
-			printPageHeader(chromatogram, pageUtil);
-			ValueScaling valueScaling = new ValueScaling(chromatogram, pageUtil.getPage(), scans);
-			drawChromatogram(pageUtil, chromatogram, scans, valueScaling, monitor);
-			drawPeaks(chromatogram, valueScaling, pageUtil);
-			pageUtil.close();
+			try (PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, PAGE_UNIT, LANDSCAPE))) {
+				printPageHeader(chromatogram, pageUtil);
+				ValueScaling valueScaling = new ValueScaling(chromatogram, pageUtil.getPage(), scans);
+				drawChromatogram(pageUtil, chromatogram, scans, valueScaling, monitor);
+				drawPeaks(chromatogram, valueScaling, pageUtil);
+			}
 		}
 		document.save(file);
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.pdfbox.extensions/src/org/eclipse/chemclipse/pdfbox/extensions/core/PageUtil.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pdfbox.extensions/src/org/eclipse/chemclipse/pdfbox/extensions/core/PageUtil.java
@@ -13,6 +13,7 @@
 package org.eclipse.chemclipse.pdfbox.extensions.core;
 
 import java.awt.Color;
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -41,7 +42,7 @@ import org.eclipse.chemclipse.pdfbox.extensions.settings.ReferenceX;
 import org.eclipse.chemclipse.pdfbox.extensions.settings.ReferenceY;
 import org.eclipse.chemclipse.pdfbox.extensions.settings.TextOption;
 
-public class PageUtil {
+public class PageUtil implements Closeable {
 
 	/*
 	 * All public method values (x,y) are handled in the given unit
@@ -80,12 +81,6 @@ public class PageUtil {
 		}
 	}
 
-	@Override
-	protected void finalize() throws Throwable {
-
-		close();
-	}
-
 	public PDDocument getDocument() {
 
 		return document;
@@ -97,10 +92,11 @@ public class PageUtil {
 	}
 
 	/**
-	 * Call close when page creation is finished.
-	 * 
+	 * Call close when page creation is finished. Prefer a try-with-resources statement.
+	 *
 	 * @throws IOException
 	 */
+	@Override
 	public void close() throws IOException {
 
 		if(contentStream != null) {

--- a/chemclipse/tests/org.eclipse.chemclipse.pdfbox.extensions.fragment.test/src/org/eclipse/chemclipse/pdfbox/extensions/core/PageUtil_1_ITest.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.pdfbox.extensions.fragment.test/src/org/eclipse/chemclipse/pdfbox/extensions/core/PageUtil_1_ITest.java
@@ -80,116 +80,104 @@ public class PageUtil_1_ITest {
 
 	private PDPage printPageLeft(PDDocument document) throws IOException {
 
-		PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, false));
+		try (PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, false))) {
+			pageUtil.printText(new TextElement(10, 0, 190).setText(LINE_FIRST).setReferenceX(ReferenceX.RIGHT));
+			for(int i = 1; i <= 28; i++) {
+				pageUtil.printText(new TextElement(10, i * 10, 190).setText(LINE_CONTENT));
+			}
+			pageUtil.printText(new TextElement(10, 297, 190).setText(LINE_LAST).setReferenceY(ReferenceY.BOTTOM));
 
-		pageUtil.printText(new TextElement(10, 0, 190).setText(LINE_FIRST).setReferenceX(ReferenceX.RIGHT));
-		for(int i = 1; i <= 28; i++) {
-			pageUtil.printText(new TextElement(10, i * 10, 190).setText(LINE_CONTENT));
+			pageUtil.printLine(new LineElement(10, 10, 10, 287).setLineWidth(0.2f)); // left
+			pageUtil.printLine(new LineElement(10, 10, 200, 10).setLineWidth(0.2f)); // top
+			pageUtil.printLine(new LineElement(200, 10, 200, 287).setLineWidth(0.2f)); // right
+			pageUtil.printLine(new LineElement(10, 287, 200, 287).setLineWidth(0.2f)); // bottom
+			return pageUtil.getPage();
 		}
-		pageUtil.printText(new TextElement(10, 297, 190).setText(LINE_LAST).setReferenceY(ReferenceY.BOTTOM));
-
-		pageUtil.printLine(new LineElement(10, 10, 10, 287).setLineWidth(0.2f)); // left
-		pageUtil.printLine(new LineElement(10, 10, 200, 10).setLineWidth(0.2f)); // top
-		pageUtil.printLine(new LineElement(200, 10, 200, 287).setLineWidth(0.2f)); // right
-		pageUtil.printLine(new LineElement(10, 287, 200, 287).setLineWidth(0.2f)); // bottom
-
-		pageUtil.close();
-		return pageUtil.getPage();
 	}
 
 	private PDPage printPageLeftShorten(PDDocument document) throws IOException {
 
-		PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, false));
+		try (PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, false))) {
+			pageUtil.printText(new TextElement(10, 0, 190).setText(LINE_FIRST).setReferenceX(ReferenceX.RIGHT));
+			for(int i = 1; i <= 28; i++) {
+				pageUtil.printText(new TextElement(10, i * 10, 190).setText(LINE_CONTENT).setTextOption(TextOption.SHORTEN));
+			}
+			pageUtil.printText(new TextElement(10, 297, 190).setText(LINE_LAST).setReferenceY(ReferenceY.BOTTOM));
 
-		pageUtil.printText(new TextElement(10, 0, 190).setText(LINE_FIRST).setReferenceX(ReferenceX.RIGHT));
-		for(int i = 1; i <= 28; i++) {
-			pageUtil.printText(new TextElement(10, i * 10, 190).setText(LINE_CONTENT).setTextOption(TextOption.SHORTEN));
+			pageUtil.printLine(new LineElement(10, 10, 10, 287).setLineWidth(0.2f)); // left
+			pageUtil.printLine(new LineElement(10, 10, 200, 10).setLineWidth(0.2f)); // top
+			pageUtil.printLine(new LineElement(200, 10, 200, 287).setLineWidth(0.2f)); // right
+			pageUtil.printLine(new LineElement(10, 287, 200, 287).setLineWidth(0.2f)); // bottom
+			return pageUtil.getPage();
 		}
-		pageUtil.printText(new TextElement(10, 297, 190).setText(LINE_LAST).setReferenceY(ReferenceY.BOTTOM));
-
-		pageUtil.printLine(new LineElement(10, 10, 10, 287).setLineWidth(0.2f)); // left
-		pageUtil.printLine(new LineElement(10, 10, 200, 10).setLineWidth(0.2f)); // top
-		pageUtil.printLine(new LineElement(200, 10, 200, 287).setLineWidth(0.2f)); // right
-		pageUtil.printLine(new LineElement(10, 287, 200, 287).setLineWidth(0.2f)); // bottom
-
-		pageUtil.close();
-		return pageUtil.getPage();
 	}
 
 	private PDPage printPageRight(PDDocument document) throws IOException {
 
-		PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, true));
+		try (PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, true))) {
+			pageUtil.printText(new TextElement(10, 0, 277).setText(LINE_FIRST));
+			for(int i = 1; i <= 17; i++) {
+				pageUtil.printText(new TextElement(10, i * 10, 277).setText(LINE_CONTENT).setReferenceX(ReferenceX.RIGHT));
+			}
+			pageUtil.printText(new TextElement(10, 210, 277).setText(LINE_LAST).setReferenceY(ReferenceY.BOTTOM).setReferenceX(ReferenceX.RIGHT));
 
-		pageUtil.printText(new TextElement(10, 0, 277).setText(LINE_FIRST));
-		for(int i = 1; i <= 17; i++) {
-			pageUtil.printText(new TextElement(10, i * 10, 277).setText(LINE_CONTENT).setReferenceX(ReferenceX.RIGHT));
+			pageUtil.printLine(new LineElement(10, 10, 10, 200).setLineWidth(0.2f)); // left
+			pageUtil.printLine(new LineElement(10, 10, 287, 10).setLineWidth(0.2f)); // top
+			pageUtil.printLine(new LineElement(287, 10, 287, 200).setLineWidth(0.2f)); // right
+			pageUtil.printLine(new LineElement(10, 200, 287, 200).setLineWidth(0.2f)); // bottom
+			return pageUtil.getPage();
 		}
-		pageUtil.printText(new TextElement(10, 210, 277).setText(LINE_LAST).setReferenceY(ReferenceY.BOTTOM).setReferenceX(ReferenceX.RIGHT));
-
-		pageUtil.printLine(new LineElement(10, 10, 10, 200).setLineWidth(0.2f)); // left
-		pageUtil.printLine(new LineElement(10, 10, 287, 10).setLineWidth(0.2f)); // top
-		pageUtil.printLine(new LineElement(287, 10, 287, 200).setLineWidth(0.2f)); // right
-		pageUtil.printLine(new LineElement(10, 200, 287, 200).setLineWidth(0.2f)); // bottom
-
-		pageUtil.close();
-		return pageUtil.getPage();
 	}
 
 	private PDPage printPageRightShorten(PDDocument document) throws IOException {
 
-		PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, true));
+		try (PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, true))) {
+			pageUtil.printText(new TextElement(10, 0, 277).setText(LINE_FIRST));
+			for(int i = 1; i <= 17; i++) {
+				pageUtil.printText(new TextElement(10, i * 10, 277).setText(LINE_CONTENT).setReferenceX(ReferenceX.RIGHT).setTextOption(TextOption.SHORTEN));
+			}
+			pageUtil.printText(new TextElement(10, 210, 277).setText(LINE_LAST).setReferenceY(ReferenceY.BOTTOM).setReferenceX(ReferenceX.RIGHT));
 
-		pageUtil.printText(new TextElement(10, 0, 277).setText(LINE_FIRST));
-		for(int i = 1; i <= 17; i++) {
-			pageUtil.printText(new TextElement(10, i * 10, 277).setText(LINE_CONTENT).setReferenceX(ReferenceX.RIGHT).setTextOption(TextOption.SHORTEN));
+			pageUtil.printLine(new LineElement(10, 10, 10, 200).setLineWidth(0.2f)); // left
+			pageUtil.printLine(new LineElement(10, 10, 287, 10).setLineWidth(0.2f)); // top
+			pageUtil.printLine(new LineElement(287, 10, 287, 200).setLineWidth(0.2f)); // right
+			pageUtil.printLine(new LineElement(10, 200, 287, 200).setLineWidth(0.2f)); // bottom
+			return pageUtil.getPage();
 		}
-		pageUtil.printText(new TextElement(10, 210, 277).setText(LINE_LAST).setReferenceY(ReferenceY.BOTTOM).setReferenceX(ReferenceX.RIGHT));
-
-		pageUtil.printLine(new LineElement(10, 10, 10, 200).setLineWidth(0.2f)); // left
-		pageUtil.printLine(new LineElement(10, 10, 287, 10).setLineWidth(0.2f)); // top
-		pageUtil.printLine(new LineElement(287, 10, 287, 200).setLineWidth(0.2f)); // right
-		pageUtil.printLine(new LineElement(10, 200, 287, 200).setLineWidth(0.2f)); // bottom
-
-		pageUtil.close();
-		return pageUtil.getPage();
 	}
 
 	private PDPage printPageMultiLine(PDDocument document) throws IOException {
 
-		PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, false));
+		try (PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, false))) {
+			pageUtil.printText(new TextElement(10, 0, 190).setText(LINE_FIRST).setReferenceX(ReferenceX.RIGHT));
+			pageUtil.printText(new TextElement(10, 10, 190).setText(LINE_CONTENT).setTextOption(TextOption.MULTI_LINE));
+			pageUtil.printText(new TextElement(10, 100, 190).setText(LINE_CONTENT).setTextOption(TextOption.MULTI_LINE).setMinHeight(5));
+			pageUtil.printText(new TextElement(10, 150, 190).setText(LINE_CONTENT).setTextOption(TextOption.MULTI_LINE).setMinHeight(15));
+			pageUtil.printText(new TextElement(10, 297, 190).setText(LINE_LAST).setReferenceY(ReferenceY.BOTTOM));
 
-		pageUtil.printText(new TextElement(10, 0, 190).setText(LINE_FIRST).setReferenceX(ReferenceX.RIGHT));
-		pageUtil.printText(new TextElement(10, 10, 190).setText(LINE_CONTENT).setTextOption(TextOption.MULTI_LINE));
-		pageUtil.printText(new TextElement(10, 100, 190).setText(LINE_CONTENT).setTextOption(TextOption.MULTI_LINE).setMinHeight(5));
-		pageUtil.printText(new TextElement(10, 150, 190).setText(LINE_CONTENT).setTextOption(TextOption.MULTI_LINE).setMinHeight(15));
-		pageUtil.printText(new TextElement(10, 297, 190).setText(LINE_LAST).setReferenceY(ReferenceY.BOTTOM));
-
-		pageUtil.printLine(new LineElement(10, 10, 10, 287).setLineWidth(0.2f)); // left
-		pageUtil.printLine(new LineElement(10, 10, 200, 10).setLineWidth(0.2f)); // top
-		pageUtil.printLine(new LineElement(200, 10, 200, 287).setLineWidth(0.2f)); // right
-		pageUtil.printLine(new LineElement(10, 287, 200, 287).setLineWidth(0.2f)); // bottom
-
-		pageUtil.close();
-		return pageUtil.getPage();
+			pageUtil.printLine(new LineElement(10, 10, 10, 287).setLineWidth(0.2f)); // left
+			pageUtil.printLine(new LineElement(10, 10, 200, 10).setLineWidth(0.2f)); // top
+			pageUtil.printLine(new LineElement(200, 10, 200, 287).setLineWidth(0.2f)); // right
+			pageUtil.printLine(new LineElement(10, 287, 200, 287).setLineWidth(0.2f)); // bottom
+			return pageUtil.getPage();
+		}
 	}
 
 	private PDPage printPageTextMinHeight(PDDocument document) throws IOException {
 
-		PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, false));
+		try (PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, false))) {
+			float y = 10.0f;
+			float minHeight = 5.0f;
+			for(int i = 0; i < 10; i++) {
+				y += pageUtil.printText(new TextElement(10, y, 190).setText(LINE_CONTENT).setMinHeight(minHeight + i * 1.0f));
+			}
 
-		float y = 10.0f;
-		float minHeight = 5.0f;
-		for(int i = 0; i < 10; i++) {
-			y += pageUtil.printText(new TextElement(10, y, 190).setText(LINE_CONTENT).setMinHeight(minHeight + i * 1.0f));
+			pageUtil.printLine(new LineElement(10, 10, 10, 287).setLineWidth(0.2f)); // left
+			pageUtil.printLine(new LineElement(10, 10, 200, 10).setLineWidth(0.2f)); // top
+			pageUtil.printLine(new LineElement(200, 10, 200, 287).setLineWidth(0.2f)); // right
+			pageUtil.printLine(new LineElement(10, 287, 200, 287).setLineWidth(0.2f)); // bottom
+			return pageUtil.getPage();
 		}
-
-		pageUtil.printLine(new LineElement(10, 10, 10, 287).setLineWidth(0.2f)); // left
-		pageUtil.printLine(new LineElement(10, 10, 200, 10).setLineWidth(0.2f)); // top
-		pageUtil.printLine(new LineElement(200, 10, 200, 287).setLineWidth(0.2f)); // right
-		pageUtil.printLine(new LineElement(10, 287, 200, 287).setLineWidth(0.2f)); // bottom
-
-		pageUtil.close();
-		return pageUtil.getPage();
 	}
 
 	private PDPage printPageRotate0(PDDocument document) throws IOException {
@@ -208,158 +196,149 @@ public class PageUtil_1_ITest {
 
 	private PDPage printPageLogoPortrait(PDDocument document) throws IOException {
 
-		PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, false));
+		try (PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, false))) {
+			pageUtil.printImage(new ImageElement(10, 10).setImage(getImage(document)).setWidth(63.5f).setHeight(8.05f));
+			pageUtil.printText(new TextElement(10, 20, 190).setText(TEXT));
 
-		pageUtil.printImage(new ImageElement(10, 10).setImage(getImage(document)).setWidth(63.5f).setHeight(8.05f));
-		pageUtil.printText(new TextElement(10, 20, 190).setText(TEXT));
+			pageUtil.printImage(new ImageElement(10, 148.5f).setImage(getImage(document)).setWidth(63.5f).setHeight(8.05f).setReferenceY(ReferenceY.CENTER));
+			pageUtil.printText(new TextElement(83.5f, 148.5f, 116.5f).setText(TEXT).setReferenceY(ReferenceY.CENTER));
 
-		pageUtil.printImage(new ImageElement(10, 148.5f).setImage(getImage(document)).setWidth(63.5f).setHeight(8.05f).setReferenceY(ReferenceY.CENTER));
-		pageUtil.printText(new TextElement(83.5f, 148.5f, 116.5f).setText(TEXT).setReferenceY(ReferenceY.CENTER));
-
-		pageUtil.printText(new TextElement(10, 277, 190).setText(TEXT).setReferenceY(ReferenceY.BOTTOM));
-		pageUtil.printImage(new ImageElement(10, 287).setImage(getImage(document)).setWidth(63.5f).setHeight(8.05f).setReferenceY(ReferenceY.BOTTOM));
-		pageUtil.printText(new TextElement(78, 287, 190).setText(FOOTER).setReferenceY(ReferenceY.BOTTOM));
-
-		pageUtil.close();
-		return pageUtil.getPage();
+			pageUtil.printText(new TextElement(10, 277, 190).setText(TEXT).setReferenceY(ReferenceY.BOTTOM));
+			pageUtil.printImage(new ImageElement(10, 287).setImage(getImage(document)).setWidth(63.5f).setHeight(8.05f).setReferenceY(ReferenceY.BOTTOM));
+			pageUtil.printText(new TextElement(78, 287, 190).setText(FOOTER).setReferenceY(ReferenceY.BOTTOM));
+			return pageUtil.getPage();
+		}
 	}
 
 	private PDPage printPageLogoLandscape(PDDocument document) throws IOException {
 
-		PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, true));
+		try (PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, true))) {
+			pageUtil.printImage(new ImageElement(10, 10).setImage(getImage(document)).setWidth(63.5f).setHeight(8.05f));
+			pageUtil.printText(new TextElement(10, 20, 277).setText(TEXT));
 
-		pageUtil.printImage(new ImageElement(10, 10).setImage(getImage(document)).setWidth(63.5f).setHeight(8.05f));
-		pageUtil.printText(new TextElement(10, 20, 277).setText(TEXT));
+			pageUtil.printImage(new ImageElement(10, 105).setImage(getImage(document)).setWidth(63.5f).setHeight(8.05f).setReferenceY(ReferenceY.CENTER));
+			pageUtil.printText(new TextElement(83.5f, 105, 203.5f).setText(TEXT).setReferenceY(ReferenceY.CENTER));
 
-		pageUtil.printImage(new ImageElement(10, 105).setImage(getImage(document)).setWidth(63.5f).setHeight(8.05f).setReferenceY(ReferenceY.CENTER));
-		pageUtil.printText(new TextElement(83.5f, 105, 203.5f).setText(TEXT).setReferenceY(ReferenceY.CENTER));
-
-		pageUtil.printText(new TextElement(10, 190, 277).setText(TEXT).setReferenceY(ReferenceY.BOTTOM));
-		pageUtil.printImage(new ImageElement(10, 200).setImage(getImage(document)).setWidth(63.5f).setHeight(8.05f).setReferenceY(ReferenceY.BOTTOM));
-		pageUtil.printText(new TextElement(78, 200, 277).setText(FOOTER).setReferenceY(ReferenceY.BOTTOM));
-
-		pageUtil.close();
-		return pageUtil.getPage();
+			pageUtil.printText(new TextElement(10, 190, 277).setText(TEXT).setReferenceY(ReferenceY.BOTTOM));
+			pageUtil.printImage(new ImageElement(10, 200).setImage(getImage(document)).setWidth(63.5f).setHeight(8.05f).setReferenceY(ReferenceY.BOTTOM));
+			pageUtil.printText(new TextElement(78, 200, 277).setText(FOOTER).setReferenceY(ReferenceY.BOTTOM));
+			return pageUtil.getPage();
+		}
 	}
 
 	private PDPage printPageTablePortrait(PDDocument document) throws IOException {
 
-		PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, false));
+		try (PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, false))) {
+			TableElement tableElement = new TableElement(10, 10, 5.5f);
+			tableElement.setTextOffsetX(1.0f);
+			tableElement.setTextOffsetY(1.0f);
+			tableElement.setLineWidth(0.2f);
+			PDTable pdTable = new PDTable();
+			tableElement.setPDTable(pdTable);
+			/*
+			 * Header
+			 */
+			pdTable.addColumn(new CellElement("", 50.0f, CellElement.BORDER_LEFT | CellElement.BORDER_TOP));
+			pdTable.addColumn(new CellElement("Test", 45.0f, CellElement.BORDER_LEFT | CellElement.BORDER_TOP));
+			pdTable.addColumn(new CellElement("STD", 25.0f, CellElement.BORDER_LEFT | CellElement.BORDER_TOP));
+			pdTable.addColumn(new CellElement("Content", 45.0f, CellElement.BORDER_LEFT | CellElement.BORDER_TOP));
+			pdTable.addColumn(new CellElement("Result", 25.0f, CellElement.BORDER_LEFT | CellElement.BORDER_RIGHT | CellElement.BORDER_TOP));
+			pdTable.nextHeaderRow();
+			pdTable.addColumn(new CellElement("Analyte", 50.0f, CellElement.BORDER_LEFT | CellElement.BORDER_BOTTOM));
+			pdTable.addColumn(new CellElement("Total", 22.5f, CellElement.BORDER_LEFT | CellElement.BORDER_BOTTOM));
+			pdTable.addColumn(new CellElement("Top", 22.5f, CellElement.BORDER_LEFT | CellElement.BORDER_BOTTOM));
+			pdTable.addColumn(new CellElement("AA", 25.0f, CellElement.BORDER_LEFT | CellElement.BORDER_BOTTOM));
+			pdTable.addColumn(new CellElement("-B", 22.5f, CellElement.BORDER_LEFT | CellElement.BORDER_BOTTOM));
+			pdTable.addColumn(new CellElement("+B", 22.5f, CellElement.BORDER_LEFT | CellElement.BORDER_BOTTOM));
+			pdTable.addColumn(new CellElement("[mg/L]", 25, CellElement.BORDER_LEFT | CellElement.BORDER_RIGHT | CellElement.BORDER_BOTTOM));
+			/*
+			 * Data
+			 */
+			for(int i = 0; i < 29; i++) {
+				List<String> row = new ArrayList<>();
+				row.add("A");
+				row.add(decimalFormat.format(Math.random()));
+				row.add(decimalFormat.format(Math.random()));
+				row.add(decimalFormat.format(Math.random()));
+				row.add(decimalFormat.format(Math.random()));
+				row.add(decimalFormat.format(Math.random()));
+				row.add(decimalFormat.format(Math.random()));
+				pdTable.addDataRow(row);
+			}
 
-		TableElement tableElement = new TableElement(10, 10, 5.5f);
-		tableElement.setTextOffsetX(1.0f);
-		tableElement.setTextOffsetY(1.0f);
-		tableElement.setLineWidth(0.2f);
-		PDTable pdTable = new PDTable();
-		tableElement.setPDTable(pdTable);
-		/*
-		 * Header
-		 */
-		pdTable.addColumn(new CellElement("", 50.0f, CellElement.BORDER_LEFT | CellElement.BORDER_TOP));
-		pdTable.addColumn(new CellElement("Test", 45.0f, CellElement.BORDER_LEFT | CellElement.BORDER_TOP));
-		pdTable.addColumn(new CellElement("STD", 25.0f, CellElement.BORDER_LEFT | CellElement.BORDER_TOP));
-		pdTable.addColumn(new CellElement("Content", 45.0f, CellElement.BORDER_LEFT | CellElement.BORDER_TOP));
-		pdTable.addColumn(new CellElement("Result", 25.0f, CellElement.BORDER_LEFT | CellElement.BORDER_RIGHT | CellElement.BORDER_TOP));
-		pdTable.nextHeaderRow();
-		pdTable.addColumn(new CellElement("Analyte", 50.0f, CellElement.BORDER_LEFT | CellElement.BORDER_BOTTOM));
-		pdTable.addColumn(new CellElement("Total", 22.5f, CellElement.BORDER_LEFT | CellElement.BORDER_BOTTOM));
-		pdTable.addColumn(new CellElement("Top", 22.5f, CellElement.BORDER_LEFT | CellElement.BORDER_BOTTOM));
-		pdTable.addColumn(new CellElement("AA", 25.0f, CellElement.BORDER_LEFT | CellElement.BORDER_BOTTOM));
-		pdTable.addColumn(new CellElement("-B", 22.5f, CellElement.BORDER_LEFT | CellElement.BORDER_BOTTOM));
-		pdTable.addColumn(new CellElement("+B", 22.5f, CellElement.BORDER_LEFT | CellElement.BORDER_BOTTOM));
-		pdTable.addColumn(new CellElement("[mg/L]", 25, CellElement.BORDER_LEFT | CellElement.BORDER_RIGHT | CellElement.BORDER_BOTTOM));
-		/*
-		 * Data
-		 */
-		for(int i = 0; i < 29; i++) {
-			List<String> row = new ArrayList<>();
-			row.add("A");
-			row.add(decimalFormat.format(Math.random()));
-			row.add(decimalFormat.format(Math.random()));
-			row.add(decimalFormat.format(Math.random()));
-			row.add(decimalFormat.format(Math.random()));
-			row.add(decimalFormat.format(Math.random()));
-			row.add(decimalFormat.format(Math.random()));
-			pdTable.addDataRow(row);
+			pageUtil.printTable(tableElement);
+			return pageUtil.getPage();
 		}
-
-		pageUtil.printTable(tableElement);
-		pageUtil.close();
-		return pageUtil.getPage();
 	}
 
 	private PDPage printPageTableLandscape(PDDocument document) throws IOException {
 
-		PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, true));
+		try (PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, true))) {
+			TableElement tableElement = new TableElement(10, 10, 5.5f);
+			tableElement.setTextOffsetX(1.0f);
+			tableElement.setTextOffsetY(1.0f);
+			tableElement.setLineWidth(0.2f);
+			PDTable pdTable = new PDTable();
+			tableElement.setPDTable(pdTable);
+			/*
+			 * Header
+			 */
+			pdTable.addColumn("A", 77);
+			pdTable.addColumn("B", 150);
+			pdTable.addColumn("C", 50);
+			/*
+			 * Data
+			 */
+			for(int i = 0; i < 30; i++) {
+				List<String> row = new ArrayList<>();
+				row.add(decimalFormat.format(Math.random()));
+				row.add(decimalFormat.format(Math.random()));
+				row.add(decimalFormat.format(Math.random()));
+				pdTable.addDataRow(row);
+			}
 
-		TableElement tableElement = new TableElement(10, 10, 5.5f);
-		tableElement.setTextOffsetX(1.0f);
-		tableElement.setTextOffsetY(1.0f);
-		tableElement.setLineWidth(0.2f);
-		PDTable pdTable = new PDTable();
-		tableElement.setPDTable(pdTable);
-		/*
-		 * Header
-		 */
-		pdTable.addColumn("A", 77);
-		pdTable.addColumn("B", 150);
-		pdTable.addColumn("C", 50);
-		/*
-		 * Data
-		 */
-		for(int i = 0; i < 30; i++) {
-			List<String> row = new ArrayList<>();
-			row.add(decimalFormat.format(Math.random()));
-			row.add(decimalFormat.format(Math.random()));
-			row.add(decimalFormat.format(Math.random()));
-			pdTable.addDataRow(row);
+			pageUtil.printTable(tableElement);
+			return pageUtil.getPage();
 		}
-
-		pageUtil.printTable(tableElement);
-		pageUtil.close();
-		return pageUtil.getPage();
 	}
 
 	private PDPage printPageTableExtendedText(PDDocument document) throws IOException {
 
-		PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, true));
+		try (PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.TOP_LEFT, Unit.MM, true))) {
+			TableElement tableElement = new TableElement(10, 10, 5.5f);
+			tableElement.setTextOffsetX(1.0f);
+			tableElement.setTextOffsetY(1.0f);
+			tableElement.setLineWidth(0.2f);
+			PDTable pdTable = new PDTable();
+			tableElement.setPDTable(pdTable);
+			/*
+			 * Header
+			 */
+			pdTable.addColumn(new CellElement("A - Lorem ipsum dolor sit amet,", 77, CellElement.BORDER_ALL).setTextOption(TextOption.NONE));
+			pdTable.addColumn(new CellElement("B - Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.", 150, CellElement.BORDER_ALL).setTextOption(TextOption.MULTI_LINE));
+			pdTable.addColumn(new CellElement("C - Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.", 50, CellElement.BORDER_ALL).setTextOption(TextOption.SHORTEN));
+			/*
+			 * Data
+			 */
+			for(int i = 0; i < 30; i++) {
+				List<String> row = new ArrayList<>();
+				row.add(decimalFormat.format(Math.random()));
+				row.add(decimalFormat.format(Math.random()));
+				row.add(decimalFormat.format(Math.random()));
+				pdTable.addDataRow(row);
+			}
 
-		TableElement tableElement = new TableElement(10, 10, 5.5f);
-		tableElement.setTextOffsetX(1.0f);
-		tableElement.setTextOffsetY(1.0f);
-		tableElement.setLineWidth(0.2f);
-		PDTable pdTable = new PDTable();
-		tableElement.setPDTable(pdTable);
-		/*
-		 * Header
-		 */
-		pdTable.addColumn(new CellElement("A - Lorem ipsum dolor sit amet,", 77, CellElement.BORDER_ALL).setTextOption(TextOption.NONE));
-		pdTable.addColumn(new CellElement("B - Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.", 150, CellElement.BORDER_ALL).setTextOption(TextOption.MULTI_LINE));
-		pdTable.addColumn(new CellElement("C - Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.", 50, CellElement.BORDER_ALL).setTextOption(TextOption.SHORTEN));
-		/*
-		 * Data
-		 */
-		for(int i = 0; i < 30; i++) {
-			List<String> row = new ArrayList<>();
-			row.add(decimalFormat.format(Math.random()));
-			row.add(decimalFormat.format(Math.random()));
-			row.add(decimalFormat.format(Math.random()));
-			pdTable.addDataRow(row);
+			pageUtil.printTable(tableElement);
+			return pageUtil.getPage();
 		}
-
-		pageUtil.printTable(tableElement);
-		pageUtil.close();
-		return pageUtil.getPage();
 	}
 
 	private PDPage printPageDefault(PDDocument document) throws IOException {
 
-		PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.BOTTOM_LEFT, Unit.PT, false));
-
-		pageUtil.printText(new TextElement(28.3465f, 28.3465f, 538.5835f).setText(LINE_CONTENT).setReferenceY(ReferenceY.BOTTOM).setTextOption(TextOption.SHORTEN));
-
-		pageUtil.close();
-		return pageUtil.getPage();
+		try (PageUtil pageUtil = new PageUtil(document, new PageSettings(PDRectangle.A4, PageBase.BOTTOM_LEFT, Unit.PT, false))) {
+			pageUtil.printText(new TextElement(28.3465f, 28.3465f, 538.5835f).setText(LINE_CONTENT).setReferenceY(ReferenceY.BOTTOM).setTextOption(TextOption.SHORTEN));
+			return pageUtil.getPage();
+		}
 	}
 
 	private PDImageXObject getImage(PDDocument document) throws IOException {

--- a/chemclipse/tests/org.eclipse.chemclipse.pdfbox.extensions.fragment.test/src/org/eclipse/chemclipse/pdfbox/extensions/core/PageUtil_1_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.pdfbox.extensions.fragment.test/src/org/eclipse/chemclipse/pdfbox/extensions/core/PageUtil_1_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -47,6 +47,8 @@ public class PageUtil_1_Test {
 	@AfterAll
 	public void tearDown() throws IOException {
 
+		pageUtilPT.close();
+		pageUtilMM.close();
 		document.close();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.pdfbox.extensions.fragment.test/src/org/eclipse/chemclipse/pdfbox/extensions/core/PageUtil_2_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.pdfbox.extensions.fragment.test/src/org/eclipse/chemclipse/pdfbox/extensions/core/PageUtil_2_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -47,6 +47,8 @@ public class PageUtil_2_Test {
 	@AfterAll
 	public void tearDown() throws IOException {
 
+		pageUtilPT.close();
+		pageUtilMM.close();
 		document.close();
 	}
 

--- a/chemclipse/tests/org.eclipse.chemclipse.pdfbox.extensions.fragment.test/src/org/eclipse/chemclipse/pdfbox/extensions/core/PageUtil_3_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.pdfbox.extensions.fragment.test/src/org/eclipse/chemclipse/pdfbox/extensions/core/PageUtil_3_Test.java
@@ -52,6 +52,8 @@ public class PageUtil_3_Test {
 	@AfterAll
 	public void tearDown() throws IOException {
 
+		pageUtilPT.close();
+		pageUtilMM.close();
 		document.close();
 	}
 


### PR DESCRIPTION
Object.finalize() is deprecated for removal (JEP 421) and becomes a no-op once finalization is disabled by default, so PageUtil cannot keep using it as a fallback for closing the page content stream.

PageUtil now implements Closeable and its callers use try-with-resources. That also closes the content stream when page rendering throws, which the finalizer only ever did at an unspecified later time, if at all. The tests hold PageUtil as a per-class fixture, so they close it in tearDown().

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])