### PR TITLE
Dispose the marker transform on chart dispose instead of in finalize()

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangeMarker.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/ranges/TimeRangeMarker.java
@@ -47,6 +47,7 @@ public class TimeRangeMarker extends AbstractBaseChartPaintListener {
 
 		super(baseChart);
 		transform.rotate(-90);
+		baseChart.addDisposeListener(_ -> transform.dispose());
 	}
 
 	public Set<TimeRange> getTimeRanges() {
@@ -92,12 +93,6 @@ public class TimeRangeMarker extends AbstractBaseChartPaintListener {
 
 			gc.setAlpha(255);
 		}
-	}
-
-	@Override
-	protected void finalize() throws Throwable {
-
-		transform.dispose();
 	}
 
 	private void plotMarker(GC gc, TimeRange timeRange) {


### PR DESCRIPTION
Object.finalize() is deprecated for removal (JEP 421) and becomes a no-op once finalization is disabled by default, so it cannot be relied on to free the rotated Transform. Register a dispose listener on the base chart instead, which frees the resource at a defined time - when the chart the marker paints on goes away.

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])