### PR TITLE
Add BLAST filter by Entrez query

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/WebNucleotideBLAST.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/WebNucleotideBLAST.java
@@ -146,7 +146,7 @@ public class WebNucleotideBLAST extends AbstractNucleotideBLAST {
 	private static String retrieveXML(CloseableHttpClient client, String rid, WebIdentifierSettings settings) throws IOException, InterruptedException {
 
 		while(true) {
-			Thread.sleep(5000);
+			Thread.sleep(10000);
 			String pollResponse = "";
 			BasicHttpClientResponseHandler handler = new BasicHttpClientResponseHandler();
 			String pollRequest = settings.getEndpoint() + "?CMD=Get&FORMAT_OBJECT=SearchInfo&RID=" + rid;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/WebNucleotideBLAST.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/WebNucleotideBLAST.java
@@ -14,8 +14,9 @@ package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.io;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -23,11 +24,12 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
 import org.apache.hc.client5.http.impl.classic.BasicHttpClientResponseHandler;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.xml.v1.BlastOutput;
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings.Task;
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings.WebIdentifierSettings;
@@ -47,9 +49,9 @@ public class WebNucleotideBLAST extends AbstractNucleotideBLAST {
 
 	public static int run(IChromatogramWSD chromatogram, WebIdentifierSettings settings) throws IOException, InterruptedException {
 
-		String postData = buildPostData(settings, getFASTA(chromatogram)).toString();
+		List<NameValuePair> parameters = buildPostData(settings, getFASTA(chromatogram));
 		try (CloseableHttpClient client = HttpClients.createDefault()) {
-			String rid = submitSearch(client, settings, postData);
+			String rid = submitSearch(client, settings, parameters);
 			if(rid != null) {
 				String xml = retrieveXML(client, rid, settings);
 				try {
@@ -73,11 +75,11 @@ public class WebNucleotideBLAST extends AbstractNucleotideBLAST {
 	/**
 	 * @return the response ID
 	 */
-	private static String submitSearch(CloseableHttpClient client, WebIdentifierSettings settings, String postData) throws InterruptedException, IOException {
+	private static String submitSearch(CloseableHttpClient client, WebIdentifierSettings settings, List<NameValuePair> parameters) throws InterruptedException, IOException {
 
 		HttpPost request = new HttpPost(settings.getEndpoint());
 		request.setHeader("User-Agent", getUserAgent());
-		request.setEntity(new StringEntity(postData, ContentType.APPLICATION_FORM_URLENCODED));
+		request.setEntity(new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8));
 		BasicHttpClientResponseHandler handler = new BasicHttpClientResponseHandler();
 		return parseQueuedBlastInfo(client.execute(request, handler));
 	}
@@ -106,16 +108,17 @@ public class WebNucleotideBLAST extends AbstractNucleotideBLAST {
 		return null;
 	}
 
-	private static StringBuilder buildPostData(WebIdentifierSettings settings, String fasta) {
+	private static List<NameValuePair> buildPostData(WebIdentifierSettings settings, String fasta) {
 
-		StringBuilder stringBuilder = new StringBuilder("CMD=Put");
-		stringBuilder.append("&PROGRAM=");
-		stringBuilder.append(getProgram(settings));
-		stringBuilder.append("&DATABASE=");
-		stringBuilder.append(settings.getDatabase());
-		stringBuilder.append("&QUERY=");
-		stringBuilder.append(fasta);
-		return stringBuilder;
+		List<NameValuePair> parameters = new ArrayList<>();
+
+		parameters.add(new BasicNameValuePair("CMD", "Put"));
+		parameters.add(new BasicNameValuePair("PROGRAM", getProgram(settings)));
+		parameters.add(new BasicNameValuePair("DATABASE", settings.getDatabase()));
+		parameters.add(new BasicNameValuePair("QUERY", fasta));
+
+		return parameters;
+	}
 	}
 
 	private static String getProgram(WebIdentifierSettings settings) {
@@ -140,7 +143,7 @@ public class WebNucleotideBLAST extends AbstractNucleotideBLAST {
 
 		StringBuilder stringBuilder = new StringBuilder("> " + chromatogram.getSampleName() + "\n");
 		stringBuilder.append(chromatogram.getMiscInfo());
-		return URLEncoder.encode(stringBuilder.toString(), StandardCharsets.UTF_8);
+		return stringBuilder.toString();
 	}
 
 	private static String retrieveXML(CloseableHttpClient client, String rid, WebIdentifierSettings settings) throws IOException, InterruptedException {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/WebNucleotideBLAST.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/WebNucleotideBLAST.java
@@ -118,8 +118,38 @@ public class WebNucleotideBLAST extends AbstractNucleotideBLAST {
 		parameters.add(new BasicNameValuePair("DATABASE", settings.getDatabase()));
 		parameters.add(new BasicNameValuePair("QUERY", fasta));
 
+		String entryQuery = createEntrezQuery(settings);
+		if(!entryQuery.isBlank()) {
+			parameters.add(new BasicNameValuePair("ENTREZ_QUERY", entryQuery));
+		}
+
 		return parameters;
 	}
+
+	public static String createEntrezQuery(WebIdentifierSettings settings) {
+
+		if(!settings.isOnlyTypeMaterial() && !settings.isExcludeModels() && !settings.isExcludeUncultured()) {
+			return "";
+		}
+
+		String positive = settings.isOnlyTypeMaterial() ? "sequence_from_type[filter]" : "all [filter]";
+
+		List<String> negative = new ArrayList<>();
+		if(settings.isExcludeModels()) {
+			negative.add("XM_000001:XM_9999999[pacc]");
+			negative.add("XM_000000001:XM_999999999[pacc]");
+			negative.add("XR_000000001:XR_999999999[pacc]");
+		}
+		if(settings.isExcludeUncultured()) {
+			negative.add("(environmental samples[organism] OR metagenomes[orgn] OR txid32644[orgn])");
+			negative.add("env [DIV]");
+		}
+
+		StringBuilder builder = new StringBuilder(positive);
+		if(!negative.isEmpty()) {
+			builder.append(" NOT(").append(String.join(" OR ", negative)).append(')');
+		}
+		return builder.toString();
 	}
 
 	private static String getProgram(WebIdentifierSettings settings) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/WebNucleotideBLAST.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/WebNucleotideBLAST.java
@@ -113,7 +113,8 @@ public class WebNucleotideBLAST extends AbstractNucleotideBLAST {
 		List<NameValuePair> parameters = new ArrayList<>();
 
 		parameters.add(new BasicNameValuePair("CMD", "Put"));
-		parameters.add(new BasicNameValuePair("PROGRAM", getProgram(settings)));
+		parameters.add(new BasicNameValuePair("PROGRAM", "blastn"));
+		parameters.add(new BasicNameValuePair("BLAST_PROGRAMS", getProgram(settings)));
 		parameters.add(new BasicNameValuePair("DATABASE", settings.getDatabase()));
 		parameters.add(new BasicNameValuePair("QUERY", fasta));
 
@@ -123,10 +124,19 @@ public class WebNucleotideBLAST extends AbstractNucleotideBLAST {
 
 	private static String getProgram(WebIdentifierSettings settings) {
 
-		if(settings.getTask() == Task.MEGABLAST) {
-			return "blastn&MEGABLAST=on";
+		switch(settings.getTask()) {
+			case Task.BLASTN: {
+				return "blastn";
+			}
+			case Task.MEGABLAST: {
+				return "megaBlast";
+			}
+			case Task.DC_MEGABLAST: {
+				return "discoMegablast";
+			}
+			default:
+				return "blastn";
 		}
-		return settings.getTask().value();
 	}
 
 	private static String regexExtract(String input, String patternStr, int flags) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/WebIdentifierSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/WebIdentifierSettings.java
@@ -38,6 +38,18 @@ public class WebIdentifierSettings extends AbstractIdentifierSettingsWSD impleme
 	@JsonProperty(value = "Task", defaultValue = "megablast")
 	private Task task = Task.MEGABLAST;
 
+	@JsonProperty(value = "Exclude models (XM/XR)", defaultValue = "true")
+	@JsonPropertyDescription(value = "RefSeq predicted mRNA and ncRNA")
+	private boolean excludeModels = true;
+
+	@JsonProperty(value = "Exclude uncultured / environmental", defaultValue = "true")
+	@JsonPropertyDescription(value = "Organism nodes plus the ENV division")
+	private boolean excludeUncultured = true;
+
+	@JsonProperty(value = "Type strain, neotype, etc.", defaultValue = "false")
+	@JsonPropertyDescription(value = "Limit to sequences from type material")
+	private boolean onlyTypeMaterial = false;
+
 	public String getEndpoint() {
 
 		return endpoint;
@@ -66,6 +78,36 @@ public class WebIdentifierSettings extends AbstractIdentifierSettingsWSD impleme
 	public void setTask(Task task) {
 
 		this.task = task;
+	}
+
+	public boolean isExcludeModels() {
+
+		return excludeModels;
+	}
+
+	public void setExcludeModels(boolean excludeModels) {
+
+		this.excludeModels = excludeModels;
+	}
+
+	public boolean isExcludeUncultured() {
+
+		return excludeUncultured;
+	}
+
+	public void setExcludeUncultured(boolean excludeUncultured) {
+
+		this.excludeUncultured = excludeUncultured;
+	}
+
+	public boolean isOnlyTypeMaterial() {
+
+		return onlyTypeMaterial;
+	}
+
+	public void setOnlyTypeMaterial(boolean onlyTypeMaterial) {
+
+		this.onlyTypeMaterial = onlyTypeMaterial;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/WebIdentifierSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/WebIdentifierSettings.java
@@ -31,9 +31,9 @@ public class WebIdentifierSettings extends AbstractIdentifierSettingsWSD impleme
 	@JsonPropertyDescription("Select the web server to query against.")
 	private String endpoint = "https://blast.ncbi.nlm.nih.gov/blast/Blast.cgi";
 
-	@JsonProperty(value = "Database", defaultValue = "nt")
+	@JsonProperty(value = "Database", defaultValue = "core_nt")
 	@JsonPropertyDescription(value = "Select the database to search.")
-	private String database = "nt";
+	private String database = "core_nt";
 
 	@JsonProperty(value = "Task", defaultValue = "megablast")
 	private Task task = Task.MEGABLAST;

--- a/chemclipse/tests/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.fragment.test/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/EntrezQuery_Test.java
+++ b/chemclipse/tests/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.fragment.test/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/EntrezQuery_Test.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.io.WebNucleotideBLAST;
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings.WebIdentifierSettings;
+import org.junit.jupiter.api.Test;
+
+public class EntrezQuery_Test {
+
+	WebIdentifierSettings webIdentifierSettings = new WebIdentifierSettings();
+
+	@Test
+	public void testExcludeNone() {
+
+		webIdentifierSettings.setOnlyTypeMaterial(false);
+		webIdentifierSettings.setExcludeModels(false);
+		webIdentifierSettings.setExcludeUncultured(false);
+		String entrez = WebNucleotideBLAST.createEntrezQuery(webIdentifierSettings);
+		assertEquals("", entrez);
+	}
+
+	@Test
+	public void testExcludeAll() {
+
+		webIdentifierSettings.setOnlyTypeMaterial(true);
+		webIdentifierSettings.setExcludeModels(true);
+		webIdentifierSettings.setExcludeUncultured(true);
+		String entrez = WebNucleotideBLAST.createEntrezQuery(webIdentifierSettings);
+		assertEquals("sequence_from_type[filter] NOT(XM_000001:XM_9999999[pacc] OR XM_000000001:XM_999999999[pacc] OR XR_000000001:XR_999999999[pacc] OR (environmental samples[organism] OR metagenomes[orgn] OR txid32644[orgn]) OR env [DIV])", entrez);
+	}
+
+	@Test
+	public void testExcludeModelsUncultured() {
+
+		webIdentifierSettings.setExcludeModels(true);
+		webIdentifierSettings.setExcludeUncultured(true);
+		String entrez = WebNucleotideBLAST.createEntrezQuery(webIdentifierSettings);
+		assertEquals("all [filter] NOT(XM_000001:XM_9999999[pacc] OR XM_000000001:XM_999999999[pacc] OR XR_000000001:XR_999999999[pacc] OR (environmental samples[organism] OR metagenomes[orgn] OR txid32644[orgn]) OR env [DIV])", entrez);
+	}
+}


### PR DESCRIPTION
This adds the checkboxes from https://blast.ncbi.nlm.nih.gov/Blast.cgi which are extremely helpful to unclutter results.

Exclude
* [ ] Models (XM/XP) 
* [ ] Uncultured/environmental sample sequences

Limit to
* [ ] Sequences from type material
