### PR TITLE
Convenience functions for local BLAST databases

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/AbstractNucleotideBLAST.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/AbstractNucleotideBLAST.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.io;
 
+import java.io.File;
 import java.math.BigInteger;
 
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.BlastMetrics;
@@ -41,7 +42,13 @@ public abstract class AbstractNucleotideBLAST {
 			ILibraryInformation libraryInformation = new LibraryInformation();
 			HitDescr description = hit.getDescription().getHitDescr().getFirst();
 			libraryInformation.setName(description.getTitle());
-			libraryInformation.setDatabase(report.getSearchTarget().getTarget().getDb());
+			String db = report.getSearchTarget().getTarget().getDb();
+			File dbPath = new File(db);
+			if(dbPath.getParentFile().exists()) {
+				libraryInformation.setDatabase(dbPath.getName());
+			} else {
+				libraryInformation.setDatabase(db); // web
+			}
 			libraryInformation.setGenBankAccesion(description.getAccession());
 			libraryInformation.setReferenceIdentifier(description.getId());
 			libraryInformation.setTaxonomyIdentifierNCBI(description.getTaxid().intValue());

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/AbstractNucleotideBLAST.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/AbstractNucleotideBLAST.java
@@ -14,6 +14,7 @@ package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.io;
 
 import java.io.File;
 import java.math.BigInteger;
+import java.util.regex.Pattern;
 
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.BlastMetrics;
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.xml.v2.BlastOutput2;
@@ -30,6 +31,8 @@ import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
 
 public abstract class AbstractNucleotideBLAST {
 
+	private static final Pattern ENDS_WITH_DOT_NUMBER = Pattern.compile("\\.\\d+$");
+
 	public static void transferTargets(IChromatogramWSD chromatogram, BlastOutput2 blastOutput) {
 
 		if(blastOutput == null) {
@@ -45,7 +48,7 @@ public abstract class AbstractNucleotideBLAST {
 			String db = report.getSearchTarget().getTarget().getDb();
 			File dbPath = new File(db);
 			if(dbPath.getParentFile().exists()) {
-				libraryInformation.setDatabase(dbPath.getName());
+				libraryInformation.setDatabase(stripDotNumberSuffix(dbPath.getName()));
 			} else {
 				libraryInformation.setDatabase(db); // web
 			}
@@ -109,5 +112,14 @@ public abstract class AbstractNucleotideBLAST {
 		int covered = Math.abs(queryTo.intValue() - queryFrom.intValue()) + 1;
 
 		return 100.0d * covered / search.getQueryLen().intValue();
+	}
+
+	// treat multi-volume databases as one
+	private static String stripDotNumberSuffix(String value) {
+
+		if(ENDS_WITH_DOT_NUMBER.matcher(value).find()) {
+			return ENDS_WITH_DOT_NUMBER.matcher(value).replaceFirst("");
+		}
+		return value;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/LocalDatabaseComboSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/LocalDatabaseComboSupplier.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.preferences.PreferenceSupplier;
+import org.eclipse.chemclipse.support.settings.ComboSettingsProperty.ComboSupplier;
+
+public class LocalDatabaseComboSupplier implements ComboSupplier<String> {
+
+	@Override
+	public Collection<String> items() {
+
+		File databaseFolder = new File(PreferenceSupplier.getDatabaseFolder());
+		if(!databaseFolder.exists()) {
+			return null;
+		}
+
+		List<String> installedDatabases = new ArrayList<>();
+		File[] ndbFiles = databaseFolder.listFiles((_, name) -> name.endsWith(".ndb"));
+		if(ndbFiles != null) {
+			for(File file : ndbFiles) {
+				String filename = file.getName();
+				String nameWithoutExtension = filename.substring(0, filename.length() - 4);
+				installedDatabases.add(nameWithoutExtension);
+			}
+		}
+		return installedDatabases;
+	}
+
+	@Override
+	public String fromString(String string) {
+
+		return string;
+	}
+
+	@Override
+	public String asString(String item) {
+
+		return item;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/LocalIdentifierSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/LocalIdentifierSettings.java
@@ -19,6 +19,7 @@ import org.eclipse.chemclipse.chromatogram.wsd.identifier.chromatogram.IChromato
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.settings.AbstractIdentifierSettingsWSD;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.support.literature.LiteratureReference;
+import org.eclipse.chemclipse.support.settings.ComboSettingsProperty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -27,9 +28,10 @@ public class LocalIdentifierSettings extends AbstractIdentifierSettingsWSD imple
 
 	private static final Logger logger = Logger.getLogger(LocalIdentifierSettings.class);
 
-	@JsonProperty(value = "Database", defaultValue = "16S_ribosomal_RNA")
+	@JsonProperty(value = "Database")
 	@JsonPropertyDescription(value = "Select the database to query against.")
-	private String database = "16S_ribosomal_RNA";
+	@ComboSettingsProperty(LocalDatabaseComboSupplier.class)
+	private String database = "";
 
 	@JsonProperty(value = "Task", defaultValue = "megablast")
 	private Task task = Task.MEGABLAST;


### PR DESCRIPTION
Prefill the installed databases on query instead of requiring manual input, which is more convenient and less error-prone. Also, strip local machine paths from results to make this more portable.