### PR TITLE
Fix chromatogram colors not matching nucleobases

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.dsd.model/src/org/eclipse/chemclipse/dsd/model/core/AbstractChromatogramDSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.dsd.model/src/org/eclipse/chemclipse/dsd/model/core/AbstractChromatogramDSD.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.dsd.model.core;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.chemclipse.wsd.model.core.AbstractChromatogramWSD;
@@ -22,7 +22,7 @@ public abstract class AbstractChromatogramDSD extends AbstractChromatogramWSD im
 	private static final long serialVersionUID = 121187623672499533L;
 
 	private String nucleotideSequence = "";
-	private Map<Float, Nucleobase> nucleobasePerWavelength = new HashMap<>();
+	private Map<Float, Nucleobase> nucleobasePerWavelength = new LinkedHashMap<>();
 
 	@Override
 	public String getNucleotideSequence() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/src/org/eclipse/chemclipse/swt/ui/support/Colors.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/src/org/eclipse/chemclipse/swt/ui/support/Colors.java
@@ -174,16 +174,6 @@ public class Colors {
 			new Color(170, 0, 212) //
 	);
 	/*
-	 * DNA Sequencing
-	 */
-	public static final String COLOR_SCHEME_SEQUENCING = "Sequencing";
-	private static final List<Color> colorsSequencing = List.of( //
-			new Color(0, 175, 0), // Adenine
-			new Color(0, 0, 255), // Cytosine
-			new Color(0, 0, 0), // Guanine
-			new Color(255, 0, 0) // Thymine
-	);
-	/*
 	 *
 	 */
 	public static final String COLOR_SCHEME_UNLIMITED = "Unlimited";
@@ -219,11 +209,8 @@ public class Colors {
 		elements[6][0] = COLOR_SCHEME_GRAYSCALE;
 		elements[6][1] = COLOR_SCHEME_GRAYSCALE;
 
-		elements[7][0] = COLOR_SCHEME_SEQUENCING;
-		elements[7][1] = COLOR_SCHEME_SEQUENCING;
-
-		elements[8][0] = COLOR_SCHEME_UNLIMITED;
-		elements[8][1] = COLOR_SCHEME_UNLIMITED;
+		elements[7][0] = COLOR_SCHEME_UNLIMITED;
+		elements[7][1] = COLOR_SCHEME_UNLIMITED;
 
 		return elements;
 	}
@@ -253,9 +240,6 @@ public class Colors {
 				break;
 			case COLOR_SCHEME_ANALYSIS:
 				colorScheme = new ColorScheme(colorsGradientAnalysis);
-				break;
-			case COLOR_SCHEME_SEQUENCING:
-				colorScheme = new ColorScheme(colorsSequencing);
 				break;
 			case COLOR_SCHEME_NOISE:
 				colorScheme = new ColorScheme(colorsGradientNoise);

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -92,6 +92,7 @@ import org.eclipse.chemclipse.swt.ui.marker.RetentionIndexMarker;
 import org.eclipse.chemclipse.swt.ui.marker.TargetMarker;
 import org.eclipse.chemclipse.swt.ui.notifier.UpdateNotifierUI;
 import org.eclipse.chemclipse.swt.ui.preferences.PreferencePageSystem;
+import org.eclipse.chemclipse.swt.ui.support.ColorScheme;
 import org.eclipse.chemclipse.swt.ui.support.Colors;
 import org.eclipse.chemclipse.swt.ui.support.IColorScheme;
 import org.eclipse.chemclipse.ux.extension.ui.editors.ProcessorSupplierMenuEntry;
@@ -918,8 +919,9 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 	 */
 	private void addSequencingData(List<ILineSeriesData> lineSeriesDataList, IChromatogramDSD chromatogramDSD, boolean enableChromatogramArea) {
 
-		IColorScheme colorScheme = Colors.getColorScheme(Colors.COLOR_SCHEME_SEQUENCING);
-		for(Float wavelength : chromatogramDSD.getWavelengths()) {
+		IColorScheme colorScheme = generateColorScheme(chromatogramDSD);
+
+		for(Float wavelength : chromatogramDSD.getWavelengthMapping().keySet()) {
 			IMarkedTraces<ITrace> markedTraces = new MarkedTraces(MarkedTraceModus.INCLUDE);
 			markedTraces.add(new TraceRasteredWSD(wavelength));
 			Nucleobase nucleobase = chromatogramDSD.getWavelengthMapping().get(wavelength);
@@ -930,6 +932,26 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 			lineSeriesDataList.add(lineSeriesData);
 			colorScheme.incrementColor();
 		}
+	}
+
+	private IColorScheme generateColorScheme(IChromatogramDSD chromatogramDSD) {
+
+		List<Color> colorsNucleobases = new ArrayList<>();
+		for(Nucleobase nucleobase : chromatogramDSD.getWavelengthMapping().values()) {
+			if(nucleobase == Nucleobase.ADENINE) {
+				colorsNucleobases.add(new Color(0, 175, 0));
+			}
+			if(nucleobase == Nucleobase.CYTOSINE) {
+				colorsNucleobases.add(new Color(0, 0, 255));
+			}
+			if(nucleobase == Nucleobase.GUANINE) {
+				colorsNucleobases.add(new Color(0, 0, 0));
+			}
+			if(nucleobase == Nucleobase.THYMINE) {
+				colorsNucleobases.add(new Color(255, 0, 0));
+			}
+		}
+		return new ColorScheme(colorsNucleobases);
 	}
 
 	private void addPeakData(List<ILineSeriesData> lineSeriesDataList, ITargetDisplaySettings settings) {


### PR DESCRIPTION
because this is depending on the file format. It can be any order (mostly GATC) for Applied BioSystems or the hardcoded ACGT for Standard Chromatograms array order or anything depending on the parser. This orders and maps nucleobases to colors, as people are used to a very specific scheme. It also does not make sense to expose this gene analzyer color schema to regular chromatograms.