### PR TITLE
Switch chart compression off for MALDI

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/preferences/PreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/preferences/PreferencePage.java
@@ -14,10 +14,8 @@ package org.eclipse.chemclipse.msd.swt.ui.preferences;
 
 import org.eclipse.chemclipse.msd.swt.ui.Activator;
 import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpacerFieldEditor;
-import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
-import org.eclipse.swtchart.extensions.charts.ChartOptions;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
@@ -34,7 +32,6 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	@Override
 	public void createFieldEditors() {
 
-		addField(new ComboFieldEditor(PreferenceSupplier.P_PROFILE_MASS_SPECTRUM_CHART_COMPRESSION_TYPE, "Chart compression:", ChartOptions.COMPRESSION_TYPES, getFieldEditorParent()));
 		addField(new DirectoryFieldEditor(PreferenceSupplier.P_PATH_MASS_SPECTRUM_LIBRARIES, "Path mass spectrum libraries.", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/preferences/PreferenceSupplier.java
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.msd.swt.ui.preferences;
 import org.eclipse.chemclipse.msd.swt.ui.Activator;
 import org.eclipse.chemclipse.support.preferences.AbstractPreferenceSupplier;
 import org.eclipse.chemclipse.support.preferences.IPreferenceSupplier;
-import org.eclipse.swtchart.extensions.linecharts.ICompressionSupport;
 
 public class PreferenceSupplier extends AbstractPreferenceSupplier {
 
@@ -24,9 +23,6 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	 */
 	public static final String P_PATH_MASS_SPECTRUM_LIBRARIES = "pathMassSpectrumLibraries";
 	public static final String DEF_PATH_MASS_SPECTRUM_LIBRARIES = "";
-
-	public static final String P_PROFILE_MASS_SPECTRUM_CHART_COMPRESSION_TYPE = "profileMassSpectrumChartCompressionType";
-	public static final String DEF_PROFILE_MASS_SPECTRUM_CHART_COMPRESSION_TYPE = ICompressionSupport.COMPRESSION_AUTO;
 
 	public static final String P_SHOW_MASS_SPECTRUM_SELECTION_COMBO = "showMassSpectrumSelectionCombo";
 	public static final boolean DEF_SHOW_MASS_SPECTRUM_SELECTION_COMBO = false;
@@ -49,7 +45,6 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public void initializeDefaults() {
 
 		putDefault(P_PATH_MASS_SPECTRUM_LIBRARIES, DEF_PATH_MASS_SPECTRUM_LIBRARIES);
-		putDefault(P_PROFILE_MASS_SPECTRUM_CHART_COMPRESSION_TYPE, DEF_PROFILE_MASS_SPECTRUM_CHART_COMPRESSION_TYPE);
 		putDefault(PreferenceSupplier.P_SHOW_MASS_SPECTRUM_SELECTION_COMBO, PreferenceSupplier.DEF_SHOW_MASS_SPECTRUM_SELECTION_COMBO);
 		putDefault(PreferenceSupplier.P_MASS_SPECTRUM_SHOW_METHODS_TOOLBAR, PreferenceSupplier.DEF_MASS_SPECTRUM_SHOW_METHODS_TOOLBAR);
 	}
@@ -57,11 +52,6 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static String getPathMassSpectrumLibraries() {
 
 		return INSTANCE().get(P_PATH_MASS_SPECTRUM_LIBRARIES, DEF_PATH_MASS_SPECTRUM_LIBRARIES);
-	}
-
-	public static String getProfileMassSpectrumChartCompression() {
-
-		return INSTANCE().get(P_PROFILE_MASS_SPECTRUM_CHART_COMPRESSION_TYPE, DEF_PROFILE_MASS_SPECTRUM_CHART_COMPRESSION_TYPE);
 	}
 
 	public static void setPathMassSpectrumLibraries(String pathMassSpectrumLibraries) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartCentroid.java
@@ -264,7 +264,7 @@ public class MassSpectrumChartCentroid extends BarChart implements IMassSpectrum
 			return false;
 		}
 
-		return supplier.getCategory() == ICategories.MASS_SPECTRUM_IDENTIFIER;
+		return supplier.getCategory().equals(ICategories.MASS_SPECTRUM_IDENTIFIER);
 	}
 
 	private void addCommand(IProcessSupplier<?> supplier, IChartMenuEntry cachedEntry) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
@@ -225,7 +225,7 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 			return false;
 		}
 
-		if(supplier.getCategory() != ICategories.MASS_SPECTRUM_FILTER) {
+		if(!supplier.getCategory().equals(ICategories.MASS_SPECTRUM_FILTER)) {
 			return false;
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
@@ -35,7 +35,6 @@ import org.eclipse.chemclipse.msd.converter.massspectrum.MassSpectrumConverterSu
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
-import org.eclipse.chemclipse.msd.swt.ui.preferences.PreferenceSupplier;
 import org.eclipse.chemclipse.processing.converter.ISupplier;
 import org.eclipse.chemclipse.processing.core.DefaultProcessingResult;
 import org.eclipse.chemclipse.processing.core.ICategories;
@@ -81,7 +80,6 @@ import org.eclipse.swtchart.extensions.core.ISeriesData;
 import org.eclipse.swtchart.extensions.core.RangeRestriction;
 import org.eclipse.swtchart.extensions.core.ScrollableChart;
 import org.eclipse.swtchart.extensions.core.SeriesData;
-import org.eclipse.swtchart.extensions.linecharts.ICompressionSupport;
 import org.eclipse.swtchart.extensions.linecharts.ILineSeriesData;
 import org.eclipse.swtchart.extensions.linecharts.ILineSeriesSettings;
 import org.eclipse.swtchart.extensions.linecharts.LineChart;
@@ -146,51 +144,11 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 				lineSeriesDataList.add(noiseLineSeriesData);
 				createAnnotations(standaloneMassSpectrum);
 			}
-			int compression = getCompressionLength(PreferenceSupplier.getProfileMassSpectrumChartCompression());
-			addSeriesData(lineSeriesDataList, compression);
+			addSeriesData(lineSeriesDataList);
 			updateAxis();
 			updateMenu();
 			UpdateNotifier.update(massSpectrum);
 		}
-	}
-
-	public int getCompressionLength(String compressionType) {
-
-		int numberIons = massSpectrum.getNumberOfIons();
-		int compressionToLength = 0;
-		switch(compressionType) {
-			case ICompressionSupport.COMPRESSION_AUTO:
-				if(numberIons >= 100000) {
-					compressionToLength = ICompressionSupport.EXTREME_COMPRESSION;
-				} else if(numberIons >= 10000) {
-					compressionToLength = ICompressionSupport.HIGH_COMPRESSION;
-				} else if(numberIons >= 5000) {
-					compressionToLength = ICompressionSupport.MEDIUM_COMPRESSION;
-				} else {
-					compressionToLength = ICompressionSupport.LOW_COMPRESSION;
-				}
-				break;
-			case ICompressionSupport.COMPRESSION_NONE:
-				compressionToLength = ICompressionSupport.NO_COMPRESSION;
-				break;
-			case ICompressionSupport.COMPRESSION_LOW:
-				compressionToLength = ICompressionSupport.LOW_COMPRESSION;
-				break;
-			case ICompressionSupport.COMPRESSION_MEDIUM:
-				compressionToLength = ICompressionSupport.MEDIUM_COMPRESSION;
-				break;
-			case ICompressionSupport.COMPRESSION_HIGH:
-				compressionToLength = ICompressionSupport.HIGH_COMPRESSION;
-				break;
-			case ICompressionSupport.COMPRESSION_EXTREME:
-				compressionToLength = ICompressionSupport.EXTREME_COMPRESSION;
-				break;
-			default:
-				compressionToLength = ICompressionSupport.MEDIUM_COMPRESSION;
-				break;
-		}
-
-		return compressionToLength;
 	}
 
 	private void updateAxis() {


### PR DESCRIPTION
I might revise on https://github.com/eclipse-chemclipse/chemclipse/pull/3047 I believe the chart compression causes artifacts on MALDI data because it omits points, and then peaks don't match data points anymore, which may be confusing. The charting already has buffered selection enabled by default https://github.com/eclipse-swtchart/swtchart/pull/412 which speeds up lasso rendering again.