### PR TITLE
Don't draw area for performance reasons in MALDI-TOF profile spectra

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
@@ -136,7 +136,13 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 			List<ILineSeriesData> lineSeriesDataList = new ArrayList<>();
 			ISeriesData seriesData = getMassSpectrum(massSpectrum);
 			ILineSeriesData lineSeriesData = new LineSeriesData(seriesData);
+
+			ILineSeriesSettings settings = lineSeriesData.getSettings();
+			settings.setEnableArea(false);
+			settings.setAreaStrict(false);
+
 			lineSeriesDataList.add(lineSeriesData);
+
 			if(massSpectrum instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
 				LineSeriesData peakLineSeriesData = getPeaks(standaloneMassSpectrum);
 				lineSeriesDataList.add(peakLineSeriesData);
@@ -144,6 +150,7 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 				lineSeriesDataList.add(noiseLineSeriesData);
 				createAnnotations(standaloneMassSpectrum);
 			}
+
 			addSeriesData(lineSeriesDataList);
 			updateAxis();
 			updateMenu();


### PR DESCRIPTION
Another follow-up to https://github.com/eclipse-chemclipse/chemclipse/pull/3079. It seems @eclipse-swtchart area drawing is too expensive on spectra with a lot of data points. This allows for more fluid zooming and rendering. It can make a return once the bottleneck is resolved upstream. 
<img width="1108" height="333" alt="grafik" src="https://github.com/user-attachments/assets/ae8b8810-0a36-4ac4-bb2d-4aef12721bea" />
