### PR TITLE
Add delete peak button to the mass spectrum list

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/xpass/core/HighPassMassSpectrumPeaksFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/xpass/core/HighPassMassSpectrumPeaksFilter.java
@@ -25,6 +25,7 @@ import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass.operations.
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass.settings.HighPassMassSpectrumPeaksFilterSettings;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IMassSpectrumPeak;
+import org.eclipse.chemclipse.model.notifier.UpdateNotifier;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -57,6 +58,7 @@ public class HighPassMassSpectrumPeaksFilter extends AbstractMassSpectrumFilter 
 					processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, DESCRIPTION, "The mass spectrum has filtered successfully."));
 					IMassSpectrumFilterResult massSpectrumFilterResult = new MassSpectrumFilterResult(ResultStatus.OK, "The mass spectrum has filtered successfully.");
 					processingInfo.setProcessingResult(massSpectrumFilterResult);
+					UpdateNotifier.update(standaloneMassSpectrum);
 				}
 			}
 		} else {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/xpass/core/HighPassMassSpectrumPeaksFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/xpass/core/HighPassMassSpectrumPeaksFilter.java
@@ -21,13 +21,13 @@ import org.eclipse.chemclipse.chromatogram.msd.filter.core.massspectrum.Abstract
 import org.eclipse.chemclipse.chromatogram.msd.filter.result.IMassSpectrumFilterResult;
 import org.eclipse.chemclipse.chromatogram.msd.filter.result.MassSpectrumFilterResult;
 import org.eclipse.chemclipse.chromatogram.msd.filter.settings.IMassSpectrumFilterSettings;
-import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass.operations.DeleteMassSpectrumPeaksOperation;
 import org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass.settings.HighPassMassSpectrumPeaksFilterSettings;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IMassSpectrumPeak;
-import org.eclipse.chemclipse.model.notifier.UpdateNotifier;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.notifier.MassSpectrumUpdateNotifier;
+import org.eclipse.chemclipse.msd.model.operations.DeleteMassSpectrumPeaksOperation;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.MessageType;
 import org.eclipse.chemclipse.processing.core.ProcessingMessage;
@@ -58,7 +58,7 @@ public class HighPassMassSpectrumPeaksFilter extends AbstractMassSpectrumFilter 
 					processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, DESCRIPTION, "The mass spectrum has filtered successfully."));
 					IMassSpectrumFilterResult massSpectrumFilterResult = new MassSpectrumFilterResult(ResultStatus.OK, "The mass spectrum has filtered successfully.");
 					processingInfo.setProcessingResult(massSpectrumFilterResult);
-					UpdateNotifier.update(standaloneMassSpectrum);
+					MassSpectrumUpdateNotifier.update(standaloneMassSpectrum);
 				}
 			}
 		} else {

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Model Plug-in
 Bundle-SymbolicName: org.eclipse.chemclipse.msd.model
 Bundle-Version: 0.9.0.qualifier
+Bundle-Activator: org.eclipse.chemclipse.msd.model.Activator
 Bundle-Vendor: ChemClipse
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.numeric;bundle-version="0.8.0",
@@ -24,7 +25,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.apache.poi.ooxml;bundle-version="5.5.1",
  org.apache.poi.ooxml.schemas;bundle-version="5.5.1",
  org.apache.commons.commons-compress;bundle-version="1.28.0",
- org.apache.xmlbeans;bundle-version="5.3.0"
+ org.apache.xmlbeans;bundle-version="5.3.0",
+ org.eclipse.core.commands;bundle-version="3.12.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-25
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.msd.model.core,
@@ -36,6 +38,7 @@ Export-Package: org.eclipse.chemclipse.msd.model.core,
  org.eclipse.chemclipse.msd.model.matrix,
  org.eclipse.chemclipse.msd.model.noise,
  org.eclipse.chemclipse.msd.model.notifier,
+ org.eclipse.chemclipse.msd.model.operations,
  org.eclipse.chemclipse.msd.model.preferences,
  org.eclipse.chemclipse.msd.model.serializer,
  org.eclipse.chemclipse.msd.model.service,

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/Activator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/Activator.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Philip Wenig - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.model;
+
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.e4.core.contexts.EclipseContextFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.core.services.events.IEventBroker;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+public class Activator implements BundleActivator {
+
+	private static final Logger logger = Logger.getLogger(Activator.class);
+
+	private static Activator plugin;
+	private IEclipseContext eclipseContext = null;
+	private Bundle bundle;
+
+	public Activator() {
+
+	}
+
+	@Override
+	public void start(BundleContext context) throws Exception {
+
+		plugin = this;
+		this.bundle = context.getBundle();
+	}
+
+	@Override
+	public void stop(BundleContext context) throws Exception {
+
+		plugin = null;
+	}
+
+	public final Bundle getBundle() {
+
+		return bundle;
+	}
+
+	public static Activator getDefault() {
+
+		return plugin;
+	}
+
+	public IEventBroker getEventBroker() {
+
+		IEclipseContext eclipseContext = getEclipseContext();
+		return eclipseContext.get(IEventBroker.class);
+	}
+
+	public IEclipseContext getEclipseContext() {
+
+		if(eclipseContext == null) {
+			eclipseContext = EclipseContextFactory.getServiceContext(bundle.getBundleContext());
+			eclipseContext.set(Logger.class, logger);
+		}
+
+		return eclipseContext;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/notifier/MassSpectrumUpdateNotifier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/notifier/MassSpectrumUpdateNotifier.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Philip Wenig - initial API and implementation
+ * Matthias Mailänder - update upon events
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.model.notifier;
+
+import org.eclipse.chemclipse.msd.model.Activator;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.support.events.IChemClipseEvents;
+import org.eclipse.e4.core.services.events.IEventBroker;
+
+public class MassSpectrumUpdateNotifier {
+
+	public static void update(IScanMSD scan) {
+
+		IEventBroker eventBroker = Activator.getDefault().getEventBroker();
+		if(eventBroker != null) {
+			eventBroker.send(IChemClipseEvents.TOPIC_MASS_SPECTRUM_UPDATE_SELECTION, scan);
+		}
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/operations/DeleteMassSpectrumPeaksOperation.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/operations/DeleteMassSpectrumPeaksOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,13 +10,14 @@
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
-package org.eclipse.chemclipse.chromatogram.msd.filter.supplier.xpass.operations;
+package org.eclipse.chemclipse.msd.model.operations;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.chemclipse.model.core.IMassSpectrumPeak;
-import org.eclipse.chemclipse.model.notifier.UpdateNotifier;
 import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.notifier.MassSpectrumUpdateNotifier;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.operations.AbstractOperation;
 import org.eclipse.core.runtime.IAdaptable;
@@ -33,7 +34,7 @@ public class DeleteMassSpectrumPeaksOperation extends AbstractOperation {
 
 		super("Delete Peaks");
 		this.massSpectrum = massSpectrum;
-		this.peaksToDelete = peaksToDelete;
+		this.peaksToDelete = new ArrayList<>(peaksToDelete);
 	}
 
 	@Override
@@ -71,7 +72,7 @@ public class DeleteMassSpectrumPeaksOperation extends AbstractOperation {
 	private void updateMassSpectrum() {
 
 		massSpectrum.setDirty(true);
-		UpdateNotifier.update(massSpectrum);
+		MassSpectrumUpdateNotifier.update(massSpectrum);
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.peakpicker.localmax/src/org/eclipse/chemclipse/msd/peakpicker/localmax/LocalMaximaPeakPickerFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.peakpicker.localmax/src/org/eclipse/chemclipse/msd/peakpicker/localmax/LocalMaximaPeakPickerFilter.java
@@ -19,6 +19,7 @@ import org.eclipse.chemclipse.chromatogram.msd.filter.result.IMassSpectrumFilter
 import org.eclipse.chemclipse.chromatogram.msd.filter.settings.IMassSpectrumFilterSettings;
 import org.eclipse.chemclipse.model.core.IMassSpectrumPeak;
 import org.eclipse.chemclipse.model.core.MassSpectrumPeak;
+import org.eclipse.chemclipse.model.notifier.UpdateNotifier;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
@@ -52,6 +53,7 @@ public class LocalMaximaPeakPickerFilter extends AbstractMassSpectrumFilter {
 					int pickedPeaks = pickPeaks(standaloneMassSpectrum, localMaximaSettings, monitor);
 					String message = "The local maxima peak picker has detected " + pickedPeaks + " peaks.";
 					processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, DESCRIPTION, message));
+					UpdateNotifier.update(standaloneMassSpectrum);
 				}
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.peakpicker.localmax/src/org/eclipse/chemclipse/msd/peakpicker/localmax/LocalMaximaPeakPickerFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.peakpicker.localmax/src/org/eclipse/chemclipse/msd/peakpicker/localmax/LocalMaximaPeakPickerFilter.java
@@ -19,10 +19,10 @@ import org.eclipse.chemclipse.chromatogram.msd.filter.result.IMassSpectrumFilter
 import org.eclipse.chemclipse.chromatogram.msd.filter.settings.IMassSpectrumFilterSettings;
 import org.eclipse.chemclipse.model.core.IMassSpectrumPeak;
 import org.eclipse.chemclipse.model.core.MassSpectrumPeak;
-import org.eclipse.chemclipse.model.notifier.UpdateNotifier;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.notifier.MassSpectrumUpdateNotifier;
 import org.eclipse.chemclipse.msd.peakpicker.localmax.settings.LocalMaximaPeakPickerFilterSettings;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.MessageType;
@@ -53,7 +53,7 @@ public class LocalMaximaPeakPickerFilter extends AbstractMassSpectrumFilter {
 					int pickedPeaks = pickPeaks(standaloneMassSpectrum, localMaximaSettings, monitor);
 					String message = "The local maxima peak picker has detected " + pickedPeaks + " peaks.";
 					processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, DESCRIPTION, message));
-					UpdateNotifier.update(standaloneMassSpectrum);
+					MassSpectrumUpdateNotifier.update(standaloneMassSpectrum);
 				}
 			}
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.support.ui;bundle-version="0.8.0",
  org.eclipse.e4.core.services;bundle-version="2.0.0",
  org.eclipse.chemclipse.processing.ui;bundle-version="0.9.0",
- org.eclipse.swtchart.extensions;bundle-version="1.2.0"
+ org.eclipse.swtchart.extensions;bundle-version="1.2.0",
+ org.eclipse.chemclipse.rcp.app;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-25
 Export-Package: org.eclipse.chemclipse.msd.swt.ui.components.identification,
  org.eclipse.chemclipse.msd.swt.ui.components.massspectrum,

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/ExtendedMassSpectrumPeakListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/ExtendedMassSpectrumPeakListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,14 +12,36 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.msd.swt.ui.components.massspectrum;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.model.core.IMassSpectrumPeak;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.model.operations.DeleteMassSpectrumPeaksOperation;
+import org.eclipse.chemclipse.rcp.app.undo.UndoContextFactory;
+import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
+import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
+import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.commands.operations.OperationHistoryFactory;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Table;
 
 public class ExtendedMassSpectrumPeakListUI extends Composite {
 
+	private static final Logger logger = Logger.getLogger(ExtendedMassSpectrumPeakListUI.class);
+
 	private MassSpectrumPeakListUI massSpectrumPeaksListUI;
+
+	private IRegularMassSpectrum regularMassSpectrum;
 
 	public ExtendedMassSpectrumPeakListUI(Composite parent, int style) {
 
@@ -29,12 +51,91 @@ public class ExtendedMassSpectrumPeakListUI extends Composite {
 
 	public void update(IRegularMassSpectrum regularMassSpectrum) {
 
+		this.regularMassSpectrum = regularMassSpectrum;
 		massSpectrumPeaksListUI.update(regularMassSpectrum);
 	}
 
 	private void createControl() {
 
-		setLayout(new FillLayout());
-		massSpectrumPeaksListUI = new MassSpectrumPeakListUI(this, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION | SWT.VIRTUAL);
+		setLayout(new GridLayout(1, true));
+		createToolbarMain(this);
+		massSpectrumPeaksListUI = createPeakTable(this);
+	}
+
+	private MassSpectrumPeakListUI createPeakTable(Composite parent) {
+
+		MassSpectrumPeakListUI massSpectrumPeakListUI = new MassSpectrumPeakListUI(parent, SWT.BORDER | SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION);
+		Table table = massSpectrumPeakListUI.getTable();
+		table.setLayoutData(new GridData(GridData.FILL_BOTH));
+		return massSpectrumPeakListUI;
+	}
+
+	private Composite createToolbarMain(Composite parent) {
+
+		Composite composite = new Composite(parent, SWT.NONE);
+		GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
+		gridData.horizontalAlignment = SWT.END;
+		composite.setLayoutData(gridData);
+		composite.setLayout(new GridLayout(2, false));
+
+		createButtonDelete(composite);
+		createButtonDeleteAll(composite);
+
+		return composite;
+	}
+
+	private Button createButtonDelete(Composite parent) {
+
+		Button button = new Button(parent, SWT.PUSH);
+		button.setToolTipText("Delete the selected peaks.");
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_DELETE, IApplicationImageProvider.SIZE_16x16));
+		button.addSelectionListener(new SelectionAdapter() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+
+				if(regularMassSpectrum instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
+					List<IMassSpectrumPeak> peaksToDelete = new ArrayList<>();
+					for(Object object : massSpectrumPeaksListUI.getStructuredSelection().toList()) {
+						if(object instanceof IMassSpectrumPeak peak) {
+							peaksToDelete.add(peak);
+						}
+					}
+					deletePeaks(peaksToDelete, standaloneMassSpectrum);
+				}
+			}
+		});
+
+		return button;
+	}
+
+	private Button createButtonDeleteAll(Composite parent) {
+
+		Button button = new Button(parent, SWT.PUSH);
+		button.setToolTipText("Delete all peaks.");
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_DELETE_ALL, IApplicationImageProvider.SIZE_16x16));
+		button.addSelectionListener(new SelectionAdapter() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+
+				if(regularMassSpectrum instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
+					deletePeaks(new ArrayList<>(standaloneMassSpectrum.getPeaks()), standaloneMassSpectrum);
+				}
+			}
+		});
+
+		return button;
+	}
+
+	private void deletePeaks(List<IMassSpectrumPeak> peaksToDelete, IStandaloneMassSpectrum standaloneMassSpectrum) {
+
+		DeleteMassSpectrumPeaksOperation deletePeaks = new DeleteMassSpectrumPeaksOperation(standaloneMassSpectrum, peaksToDelete);
+		deletePeaks.addContext(UndoContextFactory.getUndoContext());
+		try {
+			OperationHistoryFactory.getOperationHistory().execute(deletePeaks, null, null);
+		} catch(ExecutionException e) {
+			logger.warn(e);
+		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/MassSpectrumPeakListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/MassSpectrumPeakListUI.java
@@ -24,7 +24,7 @@ import org.eclipse.swt.widgets.Composite;
 public class MassSpectrumPeakListUI extends ExtendedTableViewer {
 
 	private String[] titles = {"m/z", "abundance", "s/n"};
-	private int[] bounds = {160, 200, 10};
+	private int[] bounds = {150, 100, 10};
 
 	public MassSpectrumPeakListUI(Composite parent) {
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/MassSpectrumPeakListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/components/massspectrum/MassSpectrumPeakListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Lablicate GmbH.
+ * Copyright (c) 2015, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -42,14 +42,13 @@ public class MassSpectrumPeakListUI extends ExtendedTableViewer {
 
 		if(regularMassSpectrum != null) {
 			setContentProviders();
-			if(regularMassSpectrum instanceof IStandaloneMassSpectrum standaloneMassSpectrum && !standaloneMassSpectrum.getPeaks().isEmpty()) {
+			if(regularMassSpectrum instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
 				super.setInput(standaloneMassSpectrum.getPeaks());
 				setItemCount(standaloneMassSpectrum.getPeaks().size());
 			} else if(regularMassSpectrum.getMassSpectrumType() == MassSpectrumType.CENTROID) {
 				super.setInput(regularMassSpectrum.getIons());
 				setItemCount(regularMassSpectrum.getIons().size());
 			}
-
 		} else {
 			super.setInput(null);
 		}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/support/MassSpectrumUpdateNotifierUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.swt.ui/src/org/eclipse/chemclipse/msd/swt/ui/support/MassSpectrumUpdateNotifierUI.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.msd.swt.ui.support;
+
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.msd.model.notifier.MassSpectrumUpdateNotifier;
+import org.eclipse.swt.widgets.Display;
+
+public class MassSpectrumUpdateNotifierUI {
+
+	public static void update(Display display, IScanMSD scan) {
+
+		if(display != null) {
+			display.asyncExec(() -> MassSpectrumUpdateNotifier.update(scan));
+		}
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/events/IChemClipseEvents.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/events/IChemClipseEvents.java
@@ -59,6 +59,7 @@ public interface IChemClipseEvents {
 	String TOPIC_PEAK_XXD_UPDATE_SELECTION = "peak/xxd/update/selection";
 	String TOPIC_SCAN_VSD_UPDATE_SELECTION = "scan/vsd/update/selection";
 	String TOPIC_SCAN_NMR_UPDATE_SELECTION = "scan/nmr/update/selection";
+
 	String TOPIC_MASS_SPECTRUM_UPDATE_SELECTION = "spectrum/ms/update/selection";
 
 	String TOPIC_LITERATURE_UPDATE = "literature/update";

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/MassSpectrumEditor.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/editors/MassSpectrumEditor.java
@@ -104,6 +104,7 @@ public class MassSpectrumEditor implements IMassSpectrumEditor {
 		createPages(parent);
 		registeredEventHandler = new ArrayList<>();
 		registerEvents();
+		announceSelection();
 	}
 
 	private void createPages(Composite parent) {
@@ -115,11 +116,16 @@ public class MassSpectrumEditor implements IMassSpectrumEditor {
 	@Focus
 	public void setFocus() {
 
-		/*
-		 * Fire an update if a loaded mass spectrum has been selected.
-		 */
-		if(massSpectrum != null) {
-			UpdateNotifier.update(massSpectrum);
+		extendedMassSpectrumUI.setFocus();
+		announceSelection();
+	}
+
+	private void announceSelection() {
+
+		IScanMSD displayedMassSpectrum = extendedMassSpectrumUI.getMassSpectrum();
+		if(displayedMassSpectrum != null && displayedMassSpectrum != massSpectrum) {
+			massSpectrum = displayedMassSpectrum;
+			UpdateNotifier.update(displayedMassSpectrum);
 		}
 	}
 
@@ -197,6 +203,9 @@ public class MassSpectrumEditor implements IMassSpectrumEditor {
 				 * false.
 				 */
 				processingInfo.getProcessingResult();
+				if(massSpectrum != null) {
+					massSpectrum.setDirty(false);
+				}
 				dirtyable.setDirty(false);
 			} else {
 				throw new NoMassSpectrumConverterAvailableException();
@@ -330,7 +339,7 @@ public class MassSpectrumEditor implements IMassSpectrumEditor {
 
 	private void update(String topic) {
 
-		if(extendedMassSpectrumUI.isVisible()) {
+		if(extendedMassSpectrumUI.isVisible() || IChemClipseEvents.TOPIC_MASS_SPECTRUM_UPDATE_SELECTION.equals(topic)) {
 			updateObjects(objects, topic);
 		}
 	}
@@ -348,10 +357,9 @@ public class MassSpectrumEditor implements IMassSpectrumEditor {
 				if(objects.size() == 1) {
 					Object object = objects.get(0);
 					if(object instanceof IScanMSD scanMSD) {
-						if(object != massSpectrum) {
+						massSpectrum = scanMSD;
+						if(scanMSD != extendedMassSpectrumUI.getMassSpectrum()) {
 							extendedMassSpectrumUI.update(scanMSD);
-						} else {
-							dirtyable.setDirty(massSpectrum.isDirty());
 						}
 					}
 				}
@@ -360,7 +368,12 @@ public class MassSpectrumEditor implements IMassSpectrumEditor {
 			case IChemClipseEvents.TOPIC_MASS_SPECTRUM_UPDATE_SELECTION: {
 				if(objects.size() == 1) {
 					Object object = objects.get(0);
-					if(object instanceof IMassSpectra updatedMassSpectra) {
+					if(object instanceof IScanMSD scanMSD) {
+						if(scanMSD == extendedMassSpectrumUI.getMassSpectrum()) {
+							extendedMassSpectrumUI.refresh();
+							dirtyable.setDirty(scanMSD.isDirty());
+						}
+					} else if(object instanceof IMassSpectra updatedMassSpectra) {
 						if(object != massSpectra) {
 							extendedMassSpectrumUI.update(updatedMassSpectra);
 						} else {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/parts/MassSpectrumPeakListPart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/parts/MassSpectrumPeakListPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -28,6 +28,7 @@ import jakarta.inject.Inject;
 public class MassSpectrumPeakListPart extends AbstractPart<ExtendedMassSpectrumPeakListUI> {
 
 	private static final String TOPIC = IChemClipseEvents.TOPIC_SCAN_XXD_UPDATE_SELECTION;
+	private static final String TOPIC_MASS_SPECTRUM = IChemClipseEvents.TOPIC_MASS_SPECTRUM_UPDATE_SELECTION;
 
 	@Inject
 	public MassSpectrumPeakListPart(Composite parent) {
@@ -55,8 +56,14 @@ public class MassSpectrumPeakListPart extends AbstractPart<ExtendedMassSpectrumP
 	}
 
 	@Override
+	protected void subscribeAdditionalTopics() {
+
+		subscribeAdditionalTopic(TOPIC_MASS_SPECTRUM, IChemClipseEvents.EVENT_BROKER_DATA);
+	}
+
+	@Override
 	protected boolean isUpdateTopic(String topic) {
 
-		return TOPIC.equals(topic);
+		return TOPIC.equals(topic) || TOPIC_MASS_SPECTRUM.equals(topic);
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/ExtendedMassSpectrumUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/ExtendedMassSpectrumUI.java
@@ -26,6 +26,7 @@ import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.swt.ui.preferences.PreferenceSupplier;
+import org.eclipse.chemclipse.msd.swt.ui.support.MassSpectrumUpdateNotifierUI;
 import org.eclipse.chemclipse.processing.core.IMessageProvider;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.ProcessingInfo;
@@ -37,7 +38,6 @@ import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
-import org.eclipse.chemclipse.swt.ui.notifier.UpdateNotifierUI;
 import org.eclipse.chemclipse.ux.extension.msd.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.ui.methods.MethodSupportUI;
 import org.eclipse.chemclipse.ux.extension.ui.support.AuditTrailSupport;
@@ -107,6 +107,18 @@ public class ExtendedMassSpectrumUI extends Composite implements IExtendedPartUI
 
 		this.massSpectrum = massSpectrum;
 		massSpectrumChart.update(massSpectrum);
+	}
+
+	public IScanMSD getMassSpectrum() {
+
+		return massSpectrum;
+	}
+
+	public void refresh() {
+
+		if(massSpectrumChart != null) {
+			massSpectrumChart.update();
+		}
 	}
 
 	private void createControl() {
@@ -214,7 +226,6 @@ public class ExtendedMassSpectrumUI extends Composite implements IExtendedPartUI
 			IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
 			AbstractProcessEntryContainer.applyProcessEntries(processMethod, new ProcessExecutionContext(monitor, processingInfo, processTypeSupport), IScanProcessSupplier.createConsumer(scanMSD));
 			scanMSD.setDirty(true);
-			UpdateNotifier.update(scanMSD);
 			if(scanMSD instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
 				AuditTrailSupport.updateAuditTrail(standaloneMassSpectrum, processingInfo, processMethod, processTypeSupport);
 			}
@@ -222,7 +233,7 @@ public class ExtendedMassSpectrumUI extends Composite implements IExtendedPartUI
 			DisplayUtils.getDisplay().syncExec(() -> {
 				update(scanMSD);
 				massSpectrumChart.update();
-				UpdateNotifierUI.update(getDisplay(), scanMSD);
+				MassSpectrumUpdateNotifierUI.update(getDisplay(), scanMSD);
 				updateResult(processingInfo);
 			});
 		}));

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
@@ -27,7 +27,6 @@ import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IMassSpectrumPeak;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
-import org.eclipse.chemclipse.model.notifier.UpdateNotifier;
 import org.eclipse.chemclipse.model.supplier.IScanProcessSupplier;
 import org.eclipse.chemclipse.model.supplier.ScanProcessSupplier;
 import org.eclipse.chemclipse.msd.converter.massspectrum.MassSpectrumConverter;
@@ -35,6 +34,7 @@ import org.eclipse.chemclipse.msd.converter.massspectrum.MassSpectrumConverterSu
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
+import org.eclipse.chemclipse.msd.swt.ui.support.MassSpectrumUpdateNotifierUI;
 import org.eclipse.chemclipse.processing.converter.ISupplier;
 import org.eclipse.chemclipse.processing.core.DefaultProcessingResult;
 import org.eclipse.chemclipse.processing.core.ICategories;
@@ -154,7 +154,6 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 			addSeriesData(lineSeriesDataList);
 			updateAxis();
 			updateMenu();
-			UpdateNotifier.update(massSpectrum);
 		}
 	}
 
@@ -283,6 +282,9 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 			monitor.run(true, true, runnable);
 			massSpectrum.setDirty(true);
 			update();
+			if(!isDisposed()) {
+				MassSpectrumUpdateNotifierUI.update(getDisplay(), massSpectrum);
+			}
 		} catch(InterruptedException e) {
 			logger.error(e);
 			Thread.currentThread().interrupt();

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/EditHistoryPart.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/parts/EditHistoryPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -87,6 +87,7 @@ public class EditHistoryPart extends AbstractPart<ExtendedEditHistoryUI> {
 
 	private boolean isMassSpectrumTopic(String topic) {
 
-		return IChemClipseEvents.TOPIC_SCAN_XXD_UPDATE_SELECTION.equals(topic);
+		return IChemClipseEvents.TOPIC_SCAN_XXD_UPDATE_SELECTION.equals(topic) //
+				|| IChemClipseEvents.TOPIC_MASS_SPECTRUM_UPDATE_SELECTION.equals(topic);
 	}
 }


### PR DESCRIPTION
There is now a quick way to manually thin out the peaks or delete them all and retry peak peaking with different signal to noise settings. I found it difficult to get the events wired up correctly without causing loops or dead ends. This probably needs more work in the future.