### PR TITLE
Fix set verified target checkbox not being editable

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/internal/provider/TargetsLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/internal/provider/TargetsLabelProvider.java
@@ -37,25 +37,6 @@ import org.eclipse.swt.graphics.Image;
 
 public class TargetsLabelProvider extends AbstractChemClipseLabelProvider {
 
-	public static final String VERIFIED = "Verified";
-	public static final String NAME = "Name";
-	public static final String MATCH_FACTOR = "Match Factor";
-	public static final String REVERSE_MATCH_FACTOR = "Reverse Match Factor";
-	public static final String MATCH_FACTOR_DIRECT = "Match Factor Direct";
-	public static final String REVERSE_MATCH_FACTOR_DIRECT = "Reverse Match Factor Direct";
-	public static final String PROBABILITY = "Probability";
-	public static final String ADVICE = "Advice";
-	public static final String IDENTIFIER = "Identifier";
-	public static final String MISCELLANEOUS = "Miscellaneous";
-	public static final String DATABASE = "Database";
-	public static final String DATABASE_INDEX = "Database Index";
-	public static final String RATING = "Rating";
-	public static final String COMMENTS = "Comments";
-	public static final String CONTRIBUTOR = "Contributor";
-	public static final String REFERENCE_ID = "Reference ID";
-	public static final String NCBI_TAXONOMY = "NCBI Taxonomy ID";
-	public static final String GENBANK_ACCESSION = "GenBank Accession";
-
 	private static final Stream<TargetColumn> TARGET_COLUMNS = Stream.of(TargetsColumns.BIOLOGICAL_IDENTIFIERS);
 	public static final Collection<TargetColumn> TRAILING_COLUMNS = TARGET_COLUMNS.toList();
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/TargetsEditingSupport.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/TargetsEditingSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Lablicate GmbH.
+ * Copyright (c) 2016, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,7 @@ package org.eclipse.chemclipse.ux.extension.xxd.ui.internal.provider;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.support.events.IChemClipseEvents;
 import org.eclipse.chemclipse.swt.ui.notifier.UpdateNotifierUI;
+import org.eclipse.chemclipse.ux.extension.ui.provider.TargetColumn;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.swt.TargetsListUI;
 import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.CheckboxCellEditor;
@@ -25,13 +26,13 @@ public class TargetsEditingSupport extends EditingSupport {
 
 	private CellEditor cellEditor;
 	private TargetsListUI tableViewer;
-	private String column;
+	private TargetColumn column;
 
-	public TargetsEditingSupport(TargetsListUI tableViewer, String column) {
+	public TargetsEditingSupport(TargetsListUI tableViewer, TargetColumn column) {
 
 		super(tableViewer);
 		this.column = column;
-		if(column.equals(TargetsLabelProvider.VERIFIED)) {
+		if(column == TargetColumn.VERIFIED) {
 			this.cellEditor = new CheckboxCellEditor(tableViewer.getTable());
 		} else {
 			this.cellEditor = new TextCellEditor(tableViewer.getTable());
@@ -48,7 +49,7 @@ public class TargetsEditingSupport extends EditingSupport {
 	@Override
 	protected boolean canEdit(Object element) {
 
-		if(column == TargetsLabelProvider.VERIFIED) {
+		if(column == TargetColumn.VERIFIED) {
 			return true;
 		} else {
 			return tableViewer.isEditEnabled();
@@ -59,36 +60,19 @@ public class TargetsEditingSupport extends EditingSupport {
 	protected Object getValue(Object element) {
 
 		if(element instanceof IIdentificationTarget identificationTarget) {
-			if(column.equals(TargetsLabelProvider.VERIFIED)) {
-				return identificationTarget.isVerified();
-			}
-			if(column.equals(TargetsLabelProvider.NAME)) {
-				return identificationTarget.getLibraryInformation().getName();
-			}
-			if(column.equals(TargetsLabelProvider.CAS)) {
-				return identificationTarget.getLibraryInformation().getCasNumber();
-			}
-			if(column.equals(TargetsLabelProvider.COMMENTS)) {
-				return identificationTarget.getLibraryInformation().getComments();
-			}
-			if(column.equals(TargetsLabelProvider.FORMULA)) {
-				return identificationTarget.getLibraryInformation().getFormula();
-			}
-			if(column.equals(TargetsLabelProvider.SMILES)) {
-				return identificationTarget.getLibraryInformation().getSmiles();
-			}
-			if(column.equals(TargetsLabelProvider.INCHI)) {
-				return identificationTarget.getLibraryInformation().getInChI();
-			}
-			if(column.equals(TargetsLabelProvider.INCHI_KEY)) {
-				return identificationTarget.getLibraryInformation().getInChIKey();
-			}
-			if(column.equals(TargetsLabelProvider.CONTRIBUTOR)) {
-				return identificationTarget.getLibraryInformation().getContributor();
-			}
-			if(column.equals(TargetsLabelProvider.REFERENCE_ID)) {
-				return identificationTarget.getLibraryInformation().getReferenceIdentifier();
-			}
+			return switch(column) {
+				case VERIFIED -> identificationTarget.isVerified();
+				case NAME -> identificationTarget.getLibraryInformation().getName();
+				case CAS -> identificationTarget.getLibraryInformation().getCasNumber();
+				case COMMENTS -> identificationTarget.getLibraryInformation().getComments();
+				case FORMULA -> identificationTarget.getLibraryInformation().getFormula();
+				case SMILES -> identificationTarget.getLibraryInformation().getSmiles();
+				case INCHI -> identificationTarget.getLibraryInformation().getInChI();
+				case INCHI_KEY -> identificationTarget.getLibraryInformation().getInChIKey();
+				case CONTRIBUTOR -> identificationTarget.getLibraryInformation().getContributor();
+				case REFERENCE_ID -> identificationTarget.getLibraryInformation().getReferenceIdentifier();
+				default -> false;
+			};
 		}
 
 		return false;
@@ -98,35 +82,20 @@ public class TargetsEditingSupport extends EditingSupport {
 	protected void setValue(Object element, Object value) {
 
 		if(element instanceof IIdentificationTarget identificationTarget) {
-			if(column.equals(TargetsLabelProvider.VERIFIED)) {
-				identificationTarget.setVerified((boolean)value);
-			}
-			if(column.equals(TargetsLabelProvider.NAME)) {
-				identificationTarget.getLibraryInformation().setName((String)value);
-			}
-			if(column.equals(TargetsLabelProvider.CAS)) {
-				identificationTarget.getLibraryInformation().setCasNumber((String)value);
-			}
-			if(column.equals(TargetsLabelProvider.COMMENTS)) {
-				identificationTarget.getLibraryInformation().setComments((String)value);
-			}
-			if(column.equals(TargetsLabelProvider.FORMULA)) {
-				identificationTarget.getLibraryInformation().setFormula((String)value);
-			}
-			if(column.equals(TargetsLabelProvider.SMILES)) {
-				identificationTarget.getLibraryInformation().setSmiles((String)value);
-			}
-			if(column.equals(TargetsLabelProvider.INCHI)) {
-				identificationTarget.getLibraryInformation().setInChI((String)value);
-			}
-			if(column.equals(TargetsLabelProvider.INCHI_KEY)) {
-				identificationTarget.getLibraryInformation().setInChIKey((String)value);
-			}
-			if(column.equals(TargetsLabelProvider.CONTRIBUTOR)) {
-				identificationTarget.getLibraryInformation().setContributor((String)value);
-			}
-			if(column.equals(TargetsLabelProvider.REFERENCE_ID)) {
-				identificationTarget.getLibraryInformation().setReferenceIdentifier((String)value);
+			switch(column) {
+				case VERIFIED -> identificationTarget.setVerified((boolean)value);
+				case NAME -> identificationTarget.getLibraryInformation().setName((String)value);
+				case CAS -> identificationTarget.getLibraryInformation().setCasNumber((String)value);
+				case COMMENTS -> identificationTarget.getLibraryInformation().setComments((String)value);
+				case FORMULA -> identificationTarget.getLibraryInformation().setFormula((String)value);
+				case SMILES -> identificationTarget.getLibraryInformation().setSmiles((String)value);
+				case INCHI -> identificationTarget.getLibraryInformation().setInChI((String)value);
+				case INCHI_KEY -> identificationTarget.getLibraryInformation().setInChIKey((String)value);
+				case CONTRIBUTOR -> identificationTarget.getLibraryInformation().setContributor((String)value);
+				case REFERENCE_ID -> identificationTarget.getLibraryInformation().setReferenceIdentifier((String)value);
+				default -> {
+					// The column is not editable.
+				}
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/TargetsLabelProvider.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/internal/provider/TargetsLabelProvider.java
@@ -36,41 +36,11 @@ import org.eclipse.chemclipse.ux.extension.ui.provider.IdentificationTargetSuppo
 import org.eclipse.chemclipse.ux.extension.ui.provider.TargetColumn;
 import org.eclipse.chemclipse.ux.extension.ui.provider.TargetsColumns;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
-import org.eclipse.chemclipse.ux.extension.xxd.ui.l10n.ExtensionMessages;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.preferences.PreferenceSupplier;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.swt.graphics.Image;
 
 public class TargetsLabelProvider extends AbstractChemClipseLabelProvider {
-
-	public static final String VERIFIED = ExtensionMessages.verified;
-	public static final String NAME = ExtensionMessages.name;
-	public static final String MATCH_FACTOR = ExtensionMessages.matchFactor;
-	public static final String REVERSE_MATCH_FACTOR = ExtensionMessages.reverseMatchFactor;
-	public static final String MATCH_FACTOR_DIRECT = ExtensionMessages.matchFactorDirect;
-	public static final String REVERSE_MATCH_FACTOR_DIRECT = ExtensionMessages.reverseMatchFactorDirect;
-	public static final String PROBABILITY = ExtensionMessages.probability;
-	public static final String MOL_WEIGHT = ExtensionMessages.molWeight;
-	public static final String EXACT_MASS = ExtensionMessages.excactMass;
-	public static final String ADVICE = ExtensionMessages.advice;
-	public static final String IDENTIFIER = ExtensionMessages.identifier;
-	public static final String MISCELLANEOUS = ExtensionMessages.miscellaneous;
-	public static final String DATABASE = ExtensionMessages.database;
-	public static final String DATABASE_INDEX = ExtensionMessages.databaseIndex;
-	public static final String RATING = ExtensionMessages.rating;
-	public static final String CAS = "CAS";
-	public static final String COMMENTS = ExtensionMessages.comments;
-	public static final String FORMULA = ExtensionMessages.formula;
-	public static final String SMILES = "SMILES";
-	public static final String INCHI = "InChI";
-	public static final String INCHI_KEY = "InChI Key";
-	public static final String CONTRIBUTOR = ExtensionMessages.contributor;
-	public static final String RETENTION_TIME = ExtensionMessages.retentionTime;
-	public static final String RETENTION_INDEX = ExtensionMessages.retentionIndex;
-	public static final String REFERENCE_ID = ExtensionMessages.referenceID;
-	public static final String INLIB_FACTOR = ExtensionMessages.inLibFactor;
-	public static final String NCBI_TAXONOMY = "NCBI Taxonomy ID";
-	public static final String GENBANK_ACCESSION = "GenBank Accession";
 
 	private static final IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/TargetsListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/TargetsListUI.java
@@ -15,7 +15,9 @@
 package org.eclipse.chemclipse.ux.extension.xxd.ui.swt;
 
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
@@ -24,6 +26,7 @@ import org.eclipse.chemclipse.support.ui.swt.ExtendedTableViewer;
 import org.eclipse.chemclipse.support.ui.swt.IRecordTableComparator;
 import org.eclipse.chemclipse.support.updates.IUpdateListener;
 import org.eclipse.chemclipse.swt.ui.support.Colors;
+import org.eclipse.chemclipse.ux.extension.ui.provider.TargetColumn;
 import org.eclipse.chemclipse.ux.extension.ui.provider.TargetListFilter;
 import org.eclipse.chemclipse.ux.extension.ui.provider.TargetsColumns;
 import org.eclipse.chemclipse.ux.extension.xxd.ui.Activator;
@@ -47,6 +50,18 @@ public class TargetsListUI extends ExtendedTableViewer {
 
 	private static final String[] TITLES = TargetsLabelProvider.TITLES;
 	private static final int[] BOUNDS = TargetsLabelProvider.BOUNDS;
+	private static final Set<TargetColumn> EDITABLE_COLUMNS = EnumSet.of( //
+			TargetColumn.VERIFIED, //
+			TargetColumn.NAME, //
+			TargetColumn.CAS, //
+			TargetColumn.COMMENTS, //
+			TargetColumn.FORMULA, //
+			TargetColumn.SMILES, //
+			TargetColumn.INCHI, //
+			TargetColumn.INCHI_KEY, //
+			TargetColumn.CONTRIBUTOR, //
+			TargetColumn.REFERENCE_ID //
+	);
 
 	private final TargetsLabelProvider labelProvider = new TargetsLabelProvider();
 	private final TargetsComparator targetsComparator = new TargetsComparator();
@@ -55,7 +70,7 @@ public class TargetsListUI extends ExtendedTableViewer {
 	private Integer retentionTime = null;
 	private Float retentionIndex = null;
 
-	private TargetsColumns targetsColumns = null;
+	private TargetsColumns targetsColumns = TargetsColumns.create(null, TargetsLabelProvider.TRAILING_COLUMNS);
 	private boolean dynamicColumns = false;
 	private boolean editingSupport = false;
 
@@ -172,30 +187,23 @@ public class TargetsListUI extends ExtendedTableViewer {
 		editingSupport = true;
 		List<TableViewerColumn> tableViewerColumns = getTableViewerColumns();
 		for(int i = 0; i < tableViewerColumns.size(); i++) {
-			TableViewerColumn tableViewerColumn = tableViewerColumns.get(i);
-			String label = tableViewerColumn.getColumn().getText();
-			if(label.equals(TargetsLabelProvider.VERIFIED)) {
-				tableViewerColumn.setEditingSupport(new TargetsEditingSupport(this, label));
-			} else if(label.equals(TargetsLabelProvider.NAME)) {
-				tableViewerColumn.setEditingSupport(new TargetsEditingSupport(this, label));
-			} else if(label.equals(TargetsLabelProvider.CAS)) {
-				tableViewerColumn.setEditingSupport(new TargetsEditingSupport(this, label));
-			} else if(label.equals(TargetsLabelProvider.COMMENTS)) {
-				tableViewerColumn.setEditingSupport(new TargetsEditingSupport(this, label));
-			} else if(label.equals(TargetsLabelProvider.FORMULA)) {
-				tableViewerColumn.setEditingSupport(new TargetsEditingSupport(this, label));
-			} else if(label.equals(TargetsLabelProvider.SMILES)) {
-				tableViewerColumn.setEditingSupport(new TargetsEditingSupport(this, label));
-			} else if(label.equals(TargetsLabelProvider.INCHI)) {
-				tableViewerColumn.setEditingSupport(new TargetsEditingSupport(this, label));
-			} else if(label.equals(TargetsLabelProvider.INCHI_KEY)) {
-				tableViewerColumn.setEditingSupport(new TargetsEditingSupport(this, label));
-			} else if(label.equals(TargetsLabelProvider.CONTRIBUTOR)) {
-				tableViewerColumn.setEditingSupport(new TargetsEditingSupport(this, label));
-			} else if(label.equals(TargetsLabelProvider.REFERENCE_ID)) {
-				tableViewerColumn.setEditingSupport(new TargetsEditingSupport(this, label));
+			TargetColumn targetColumn = targetsColumns.getColumn(i);
+			if(targetColumn != null && EDITABLE_COLUMNS.contains(targetColumn)) {
+				tableViewerColumns.get(i).setEditingSupport(new TargetsEditingSupport(this, targetColumn));
 			}
 		}
+	}
+
+	private TableViewerColumn getTableViewerColumn(TargetColumn targetColumn) {
+
+		List<TableViewerColumn> tableViewerColumns = getTableViewerColumns();
+		for(int i = 0; i < tableViewerColumns.size(); i++) {
+			if(targetsColumns.getColumn(i) == targetColumn) {
+				return tableViewerColumns.get(i);
+			}
+		}
+
+		return null;
 	}
 
 	private void setCellColorProvider() {
@@ -206,7 +214,7 @@ public class TargetsListUI extends ExtendedTableViewer {
 
 	private void setColorProviderRetentionTime() {
 
-		TableViewerColumn tableViewerColumn = getTableViewerColumn(TargetsLabelProvider.RETENTION_TIME);
+		TableViewerColumn tableViewerColumn = getTableViewerColumn(TargetColumn.RETENTION_TIME);
 		if(tableViewerColumn != null) {
 			tableViewerColumn.setLabelProvider(new StyledCellLabelProvider() {
 
@@ -260,7 +268,7 @@ public class TargetsListUI extends ExtendedTableViewer {
 
 	private void setColorProviderRetentionIndex() {
 
-		TableViewerColumn tableViewerColumn = getTableViewerColumn(TargetsLabelProvider.RETENTION_INDEX);
+		TableViewerColumn tableViewerColumn = getTableViewerColumn(TargetColumn.RETENTION_INDEX);
 		if(tableViewerColumn != null) {
 			tableViewerColumn.setLabelProvider(new StyledCellLabelProvider() {
 


### PR DESCRIPTION
Identifying columns by their label no longer worked reliably since https://github.com/eclipse-chemclipse/chemclipse/pull/3067/ most prominently, the :ballot_box_with_check: set verified was not editable anymore. This makes the column matching more robust and removes redundant code.