### PR TITLE
Add nucleotide statistics

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.dsd.model/src/org/eclipse/chemclipse/dsd/model/core/AbstractChromatogramDSD.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.dsd.model/src/org/eclipse/chemclipse/dsd/model/core/AbstractChromatogramDSD.java
@@ -34,6 +34,7 @@ public abstract class AbstractChromatogramDSD extends AbstractChromatogramWSD im
 	@Override
 	public String getMiscInfo() {
 
+		nucleotideSequence.fromScans(getScans());
 		return nucleotideSequence.toString();
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.dsd.model/src/org/eclipse/chemclipse/dsd/model/core/NucleotideSequence.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.dsd.model/src/org/eclipse/chemclipse/dsd/model/core/NucleotideSequence.java
@@ -23,7 +23,12 @@ import org.eclipse.chemclipse.support.comparator.SortOrder;
 
 public class NucleotideSequence {
 
-	private List<Nucleobase> nucleotideSequence = new ArrayList<>();
+	private List<Nucleobase> nucleobases = new ArrayList<>();
+
+	public List<Nucleobase> getNucleobases() {
+
+		return nucleobases;
+	}
 
 	public void fromScans(List<IScan> scans) {
 
@@ -34,7 +39,7 @@ public class NucleotideSequence {
 			}
 			Nucleobase nucleobase = getNucleobase(bestTarget);
 			if(nucleobase != null) {
-				nucleotideSequence.add(nucleobase);
+				nucleobases.add(nucleobase);
 			}
 		}
 	}
@@ -42,9 +47,9 @@ public class NucleotideSequence {
 	@Override
 	public String toString() {
 
-		StringBuilder result = new StringBuilder(nucleotideSequence.size());
+		StringBuilder result = new StringBuilder(nucleobases.size());
 
-		for(Nucleobase nucleotide : nucleotideSequence) {
+		for(Nucleobase nucleotide : nucleobases) {
 			result.append(nucleotide.letter());
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramStatisticsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramStatisticsUI.java
@@ -14,7 +14,6 @@ package org.eclipse.chemclipse.ux.extension.xxd.ui.swt;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -42,7 +41,6 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
-import org.eclipse.swtchart.extensions.preferences.PreferencePage;
 
 public class ExtendedChromatogramStatisticsUI extends Composite implements IExtendedPartUI {
 
@@ -88,10 +86,9 @@ public class ExtendedChromatogramStatisticsUI extends Composite implements IExte
 		GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
 		gridData.horizontalAlignment = SWT.END;
 		composite.setLayoutData(gridData);
-		composite.setLayout(new GridLayout(2, false));
+		composite.setLayout(new GridLayout(1, false));
 
 		buttonToolbarInfo = createButtonToggleToolbar(composite, toolbarInfo, IMAGE_INFO, TOOLTIP_INFO);
-		createSettingsButton(composite);
 
 		return composite;
 	}
@@ -111,18 +108,6 @@ public class ExtendedChromatogramStatisticsUI extends Composite implements IExte
 		table.setLayoutData(new GridData(GridData.FILL_BOTH));
 
 		tableControl.set(keyValueListUI);
-	}
-
-	private void createSettingsButton(Composite parent) {
-
-		createSettingsButton(parent, Arrays.asList(PreferencePage.class), _ -> {
-			applySettings();
-		});
-	}
-
-	private void applySettings() {
-
-		updateInput();
 	}
 
 	private void updateInput() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramStatisticsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramStatisticsUI.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.eclipse.chemclipse.dsd.model.core.IChromatogramDSD;
+import org.eclipse.chemclipse.dsd.model.core.Nucleobase;
 import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.model.core.IPeak;
@@ -118,18 +120,29 @@ public class ExtendedChromatogramStatisticsUI extends Composite implements IExte
 			/*
 			 * Map
 			 */
-			addTimeData(chromatogramSelection, dataMap);
-			addSignalData(chromatogramSelection, dataMap);
-			addScanData(chromatogramSelection, dataMap);
-			addPeakData(chromatogramSelection, dataMap);
-			addIonTransitionData(chromatogramSelection, dataMap);
-
 			IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+			if(chromatogram instanceof IChromatogramDSD chromatogramDSD) {
+				addNucleobaseStats(chromatogramDSD, dataMap);
+			} else {
+				addTimeData(chromatogramSelection, dataMap);
+				addSignalData(chromatogramSelection, dataMap);
+				addScanData(chromatogramSelection, dataMap);
+				addPeakData(chromatogramSelection, dataMap);
+				addIonTransitionData(chromatogramSelection, dataMap);
+			}
+
 			info = ChromatogramDataSupport.getChromatogramLabel(chromatogram);
 		}
 
 		toolbarInfo.get().setText(info);
 		tableControl.get().setInput(dataMap);
+	}
+
+	private void addNucleobaseStats(IChromatogramDSD chromatogramDSD, Map<String, String> dataMap) {
+
+		List<Nucleobase> nucleobases = chromatogramDSD.getNucleotideSequence().getNucleobases();
+		long numberUnknowns = nucleobases.stream().filter(n -> n == Nucleobase.UNKNOWN).count();
+		dataMap.put("Unknown Bases [%]", decimalFormat.format(numberUnknowns / (double)nucleobases.size() * 100));
 	}
 
 	private void addTimeData(IChromatogramSelection chromatogramSelection, Map<String, String> dataMap) {


### PR DESCRIPTION
Gene analyzer electropherograms have no concept of retention time or peaks so most of the statistics shown don't make much sense. The quality is determined by the amount of non-determined bases: N for Unknown:
<img width="1316" height="345" alt="grafik" src="https://github.com/user-attachments/assets/ea662d5f-b408-4684-b50d-a409556d7afb" />
so display that instead:
<img width="377" height="98" alt="grafik" src="https://github.com/user-attachments/assets/e93c3015-e6b8-4073-953d-e69d9f3037e4" />
