### PR TITLE
Fix missing labels for electropherograms

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -1093,13 +1093,9 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 					targetReferenceSettings.setBaseChart(baseChart);
 					targetReferenceSettings.setLabel(LABEL_SCAN_TARGETS);
 					targetReferenceSettings.setDescription("Identified Scans");
-					if(baseChart.getSeriesIds().contains(SERIES_ID_CHROMATOGRAM)) {
-						targetReferenceSettings.setReferenceSeriesId(SERIES_ID_CHROMATOGRAM);
-					} else {
-						Optional<String> chromatogramSeriesId = baseChart.getSeriesIds().stream().filter(s -> s.startsWith(SERIES_ID_CHROMATOGRAM)).findFirst();
-						if(chromatogramSeriesId.isPresent()) {
-							targetReferenceSettings.setReferenceSeriesId(chromatogramSeriesId.get());
-						}
+					Optional<String> chromatogramSeriesId = lineSeriesDataList.stream().map(l -> l.getSeriesData().getId()).filter(s -> s.startsWith(SERIES_ID_CHROMATOGRAM)).findFirst();
+					if(chromatogramSeriesId.isPresent()) {
+						targetReferenceSettings.setReferenceSeriesId(chromatogramSeriesId.get());
 					}
 					TargetReferenceLabelMarker scanLabelMarker = new TargetReferenceLabelMarker(targetReferenceSettings);
 					plotArea.addCustomPaintListener(scanLabelMarker);


### PR DESCRIPTION
It comes with 4 chromatograms rather than one and they need to have different IDs
<img width="367" height="255" alt="grafik" src="https://github.com/user-attachments/assets/6ace6f41-4316-46c9-985c-674bb539d505" />
This is a follow-up to https://github.com/eclipse-chemclipse/chemclipse/pull/3090.
