### PR TITLE
Add Lower Convex Hull and TopHat for chromatograms

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.convexhull/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.convexhull/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
  org.eclipse.chemclipse.chromatogram.filter;bundle-version="0.8.0",
  org.eclipse.chemclipse.logging;bundle-version="0.9.0",
- org.apache.commons.math3;bundle-version="3.6.1"
+ org.apache.commons.math3;bundle-version="3.6.1",
+ org.eclipse.chemclipse.chromatogram.xxd.baseline.detector;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-25
 Bundle-ActivationPolicy: lazy
 Import-Package: com.fasterxml.jackson.annotation,

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.convexhull/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.convexhull/plugin.xml
@@ -11,4 +11,14 @@
             id="org.eclipse.chemclipse.msd.filter.supplier.convexhull.massspectrum">
       </MassSpectrumFilterSupplier>
    </extension>
+   <extension
+         point="org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.baselineDetectorSupplier">
+      <BaselineDetectorSupplier
+            baselineDetector="org.eclipse.chemclipse.xxd.edit.supplier.convexhull.core.BaselineDetector"
+            description="This baseline detector uses a Lower Convex Hull."
+            detectorName="Lower Convex Hull"
+            detectorSettings="org.eclipse.chemclipse.xxd.edit.supplier.convexhull.settings.BaselineDetectorSettings"
+            id="org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.supplier.convexhull">
+      </BaselineDetectorSupplier>
+   </extension>
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.convexhull/src/org/eclipse/chemclipse/xxd/edit/supplier/convexhull/core/BaselineDetector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.convexhull/src/org/eclipse/chemclipse/xxd/edit/supplier/convexhull/core/BaselineDetector.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.edit.supplier.convexhull.core;
+
+import org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.core.AbstractBaselineDetector;
+import org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.settings.IBaselineDetectorSettings;
+import org.eclipse.chemclipse.model.core.IChromatogram;
+import org.eclipse.chemclipse.model.core.ISignal;
+import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
+import org.eclipse.chemclipse.model.signals.ITotalScanSignal;
+import org.eclipse.chemclipse.model.signals.ITotalScanSignalExtractor;
+import org.eclipse.chemclipse.model.signals.ITotalScanSignals;
+import org.eclipse.chemclipse.model.signals.TotalScanSignalExtractor;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.xxd.edit.supplier.convexhull.settings.BaselineDetectorSettings;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+public class BaselineDetector extends AbstractBaselineDetector {
+
+	@Override
+	public IProcessingInfo<?> setBaseline(IChromatogramSelection chromatogramSelection, IBaselineDetectorSettings baselineDetectorSettings, IProgressMonitor monitor) {
+
+		IProcessingInfo<?> processingInfo = super.validate(chromatogramSelection, baselineDetectorSettings, monitor);
+		if(!processingInfo.hasErrorMessages()) {
+			if(baselineDetectorSettings instanceof BaselineDetectorSettings settings) {
+				calculateBaseline(chromatogramSelection, settings, monitor);
+			}
+		}
+		return processingInfo;
+	}
+
+	private static void calculateBaseline(IChromatogramSelection chromatogramSelection, BaselineDetectorSettings detectorSettings, IProgressMonitor monitor) {
+
+		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+
+		double[] x = chromatogram.getScans().stream().mapToDouble(ISignal::getX).toArray();
+		double[] y = chromatogram.getScans().stream().mapToDouble(ISignal::getY).toArray();
+		double[] baseline = LowerConvexHull.baseline(x, y, detectorSettings.getTolerance());
+
+		ITotalScanSignalExtractor totalScanSignalExtractor = new TotalScanSignalExtractor(chromatogram);
+		int startScan = chromatogram.getScanNumber(chromatogramSelection.getStartRetentionTime());
+		int stopScan = chromatogram.getScanNumber(chromatogramSelection.getStopRetentionTime());
+		ITotalScanSignals totalScanSignals = totalScanSignalExtractor.getTotalScanSignals(startScan, stopScan);
+
+		int i = 0;
+		for(ITotalScanSignal totalScanSignal : totalScanSignals.getTotalScanSignals()) {
+			totalScanSignal.setTotalSignal((float)baseline[i]);
+			i++;
+		}
+
+		chromatogram.getBaselineModel().addBaseline(totalScanSignals);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.convexhull/src/org/eclipse/chemclipse/xxd/edit/supplier/convexhull/settings/BaselineDetectorSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.convexhull/src/org/eclipse/chemclipse/xxd/edit/supplier/convexhull/settings/BaselineDetectorSettings.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.edit.supplier.convexhull.settings;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.settings.AbstractBaselineDetectorSettings;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+public class BaselineDetectorSettings extends AbstractBaselineDetectorSettings {
+
+	private static final Logger logger = Logger.getLogger(BaselineDetectorSettings.class);
+
+	@JsonProperty(value = "Tolerance", defaultValue = "1e-10")
+	@JsonPropertyDescription(value = "below which points are considered identical")
+	private double tolerance = 1e-10; // AbstractConvexHullGenerator2D.DEFAULT_TOLERANCE
+
+	public double getTolerance() {
+
+		return tolerance;
+	}
+
+	public void setTolerance(double tolerance) {
+
+		this.tolerance = tolerance;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		List<LiteratureReference> literatureReferences = new ArrayList<>();
+		literatureReferences.add(createLiteratureReference("0020019079900723.ris", "10.1016/0020-0190(79)90072-3"));
+		return literatureReferences;
+	}
+
+	private static LiteratureReference createLiteratureReference(String file, String doi) {
+
+		String content;
+		try {
+			content = new String(MassSpectrumFilterSettings.class.getResourceAsStream(file).readAllBytes());
+		} catch(Exception e) {
+			content = doi;
+			logger.warn(e);
+		}
+		return new LiteratureReference(content);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.tophat/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.tophat/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
  org.eclipse.chemclipse.chromatogram.filter;bundle-version="0.8.0",
  org.eclipse.chemclipse.logging;bundle-version="0.9.0",
- org.apache.commons.math3;bundle-version="3.6.1"
+ org.apache.commons.math3;bundle-version="3.6.1",
+ org.eclipse.chemclipse.chromatogram.xxd.baseline.detector;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-25
 Bundle-ActivationPolicy: lazy
 Import-Package: com.fasterxml.jackson.annotation,

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.tophat/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.tophat/plugin.xml
@@ -11,4 +11,14 @@
             id="org.eclipse.chemclipse.msd.filter.supplier.tophat.massspectrum">
       </MassSpectrumFilterSupplier>
    </extension>
+   <extension
+         point="org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.baselineDetectorSupplier">
+      <BaselineDetectorSupplier
+            baselineDetector="org.eclipse.chemclipse.xxd.edit.supplier.tophat.core.BaselineDetector"
+            description="This baseline detector uses a TopHat algorithm."
+            detectorName="TopHat"
+            detectorSettings="org.eclipse.chemclipse.xxd.edit.supplier.tophat.settings.BaselineDetectorSettings"
+            id="org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.supplier.tophat">
+      </BaselineDetectorSupplier>
+   </extension>
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.tophat/src/org/eclipse/chemclipse/xxd/edit/supplier/tophat/core/BaselineDetector.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.tophat/src/org/eclipse/chemclipse/xxd/edit/supplier/tophat/core/BaselineDetector.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.edit.supplier.tophat.core;
+
+import org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.core.AbstractBaselineDetector;
+import org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.settings.IBaselineDetectorSettings;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.model.core.IChromatogram;
+import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
+import org.eclipse.chemclipse.model.signals.ITotalScanSignal;
+import org.eclipse.chemclipse.model.signals.ITotalScanSignalExtractor;
+import org.eclipse.chemclipse.model.signals.ITotalScanSignals;
+import org.eclipse.chemclipse.model.signals.TotalScanSignalExtractor;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.xxd.edit.supplier.tophat.settings.BaselineDetectorSettings;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+public class BaselineDetector extends AbstractBaselineDetector {
+
+	private static final Logger logger = Logger.getLogger(BaselineDetector.class);
+
+	@Override
+	public IProcessingInfo<?> setBaseline(IChromatogramSelection chromatogramSelection, IBaselineDetectorSettings baselineDetectorSettings, IProgressMonitor monitor) {
+
+		IProcessingInfo<?> processingInfo = super.validate(chromatogramSelection, baselineDetectorSettings, monitor);
+		if(!processingInfo.hasErrorMessages()) {
+			if(baselineDetectorSettings instanceof BaselineDetectorSettings settings) {
+				calculateBaseline(chromatogramSelection, settings, monitor);
+			}
+		}
+		return processingInfo;
+	}
+
+	private static void calculateBaseline(IChromatogramSelection chromatogramSelection, BaselineDetectorSettings detectorSettings, IProgressMonitor monitor) {
+
+		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
+		ITotalScanSignalExtractor totalScanSignalExtractor = new TotalScanSignalExtractor(chromatogram);
+
+		int startScan = chromatogram.getScanNumber(chromatogramSelection.getStartRetentionTime());
+		int stopScan = chromatogram.getScanNumber(chromatogramSelection.getStopRetentionTime());
+
+		ITotalScanSignals totalScanSignals = totalScanSignalExtractor.getTotalScanSignals(startScan, stopScan);
+		double[] abundances = totalScanSignals.getTotalScanSignals().stream().mapToDouble(ITotalScanSignal::getTotalSignal).toArray();
+
+		int halfWindowSize = detectorSettings.getHalfWindowSize();
+		if(halfWindowSize < 1) {
+			halfWindowSize = TopHat.optimizeHalfWindowSize(abundances);
+			logger.info("Estimated half window size: " + halfWindowSize);
+		}
+
+		double[] baseline = TopHat.baseline(abundances, halfWindowSize);
+
+		int i = 0;
+		for(ITotalScanSignal totalScanSignal : totalScanSignals.getTotalScanSignals()) {
+			totalScanSignal.setTotalSignal((float)baseline[i]);
+			i++;
+		}
+
+		chromatogram.getBaselineModel().addBaseline(totalScanSignals);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.tophat/src/org/eclipse/chemclipse/xxd/edit/supplier/tophat/settings/BaselineDetectorSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.tophat/src/org/eclipse/chemclipse/xxd/edit/supplier/tophat/settings/BaselineDetectorSettings.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.xxd.edit.supplier.tophat.settings;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.chemclipse.chromatogram.xxd.baseline.detector.settings.AbstractBaselineDetectorSettings;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.support.literature.LiteratureReference;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+public class BaselineDetectorSettings extends AbstractBaselineDetectorSettings {
+
+	private static final Logger logger = Logger.getLogger(BaselineDetectorSettings.class);
+
+	@JsonProperty(value = "Half Window Size", defaultValue = "")
+	@JsonPropertyDescription(value = "Leave empty to estimate best value.")
+	private int halfWindowSize = 0;
+
+	public int getHalfWindowSize() {
+
+		return halfWindowSize;
+	}
+
+	public void setHalfWindowSize(int halfWindowSize) {
+
+		this.halfWindowSize = halfWindowSize;
+	}
+
+	@Override
+	public List<LiteratureReference> getLiteratureReferences() {
+
+		List<LiteratureReference> literatureReferences = new ArrayList<>();
+		literatureReferences.add(createLiteratureReference("csp_64_.ris", "10.1366/000370210791414281"));
+		return literatureReferences;
+	}
+
+	private static LiteratureReference createLiteratureReference(String file, String doi) {
+
+		String content;
+		try {
+			content = new String(BaselineDetectorSettings.class.getResourceAsStream(file).readAllBytes());
+		} catch(Exception e) {
+			content = doi;
+			logger.warn(e);
+		}
+		return new LiteratureReference(content);
+	}
+}


### PR DESCRIPTION
I added TopHat and Lower Convex Hull because they are known to produce good results with MALDI-TOF MS.

* https://github.com/eclipse-chemclipse/chemclipse/pull/3077
* https://github.com/eclipse-chemclipse/chemclipse/pull/3065

Turns out they also do fairly well for TIC baseline estimation, so I added those as well.