### PR TITLE
Add an error message with a proposed solution when applying empty baselines

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/baselinesubtract/core/BaselineFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/baselinesubtract/core/BaselineFilter.java
@@ -20,7 +20,6 @@ import org.eclipse.chemclipse.model.core.IChromatogram;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
-import org.eclipse.chemclipse.processing.core.ProcessingInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 public class BaselineFilter extends AbstractChromatogramFilter {
@@ -28,6 +27,13 @@ public class BaselineFilter extends AbstractChromatogramFilter {
 	@Override
 	public IProcessingInfo<IChromatogramFilterResult> applyFilter(IChromatogramSelection chromatogramSelection, IChromatogramFilterSettings chromatogramFilterSettings, IProgressMonitor monitor) {
 
+		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
+		if(!processingInfo.hasErrorMessages()) {
+			if(!chromatogramSelection.getChromatogram().getBaselineModel().isBaselineSet()) {
+				processingInfo.addErrorMessage("Baseline Extractor", "No baseline to extract.", "Use baseline detector first.");
+				return processingInfo;
+			}
+		}
 		IChromatogram chromatogram = chromatogramSelection.getChromatogram();
 		int startScan = chromatogram.getScanNumber(chromatogramSelection.getStartRetentionTime());
 		int stopScan = chromatogram.getScanNumber(chromatogramSelection.getStopRetentionTime());
@@ -45,6 +51,6 @@ public class BaselineFilter extends AbstractChromatogramFilter {
 		chromatogram.getPeaks().clear();
 		baselineModel.removeBaseline();
 		chromatogramSelection.getChromatogram().setDirty(true);
-		return new ProcessingInfo<>();
+		return processingInfo;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/baselinesubtract/core/ChromatogramFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/baselinesubtract/core/ChromatogramFilter.java
@@ -29,6 +29,10 @@ public class ChromatogramFilter extends AbstractChromatogramFilter {
 
 		IProcessingInfo<IChromatogramFilterResult> processingInfo = validate(chromatogramSelection, chromatogramFilterSettings);
 		if(!processingInfo.hasErrorMessages()) {
+			if(!chromatogramSelection.getChromatogram().getBaselineModel().isBaselineSet()) {
+				processingInfo.addErrorMessage("Baseline Subtract", "No baseline to subtract.", "Use baseline detector first.");
+				return processingInfo;
+			}
 			BaselineSubtractProcessor.removeBaseline(chromatogramSelection);
 			chromatogramSelection.getChromatogram().setDirty(true);
 			processingInfo.setProcessingResult(new ChromatogramFilterResult(ResultStatus.OK, "The baseline was successfully removed."));


### PR DESCRIPTION
I like the separation between baseline detection and removal so you can inspect it first, plus modularity in the codebase. However, from a user perspective, this might be confusing because you can apply the baseline removal chromatogram filter without an estimated baseline, which will then look as if it is not working because it applies, but there is no effect other than peak removal. The right-click menu is pretty large, so you might not spot the section for baseline detection at first. This adds instructional errors that help with discoverability.