### PR TITLE
Fix mzData from CompassXport not being detected

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/converter/ChromatogramFileContentMatcher.java
@@ -46,7 +46,7 @@ public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher {
 					if("mzData".equals(localName)) {
 						hasRootElement = true;
 					} else if("cvParam".equals(localName) && //
-							xmlStreamReader.getAttributeValue(null, "name").startsWith("time")) {
+							xmlStreamReader.getAttributeValue(null, "name").toLowerCase().startsWith("time")) {
 						hasRetentionTime = true;
 					}
 				}


### PR DESCRIPTION
Avoid case sensitivity as otherwise `TimeInMinutes` gets not matched.