### PR TITLE
Add XmlParserFactory and use it for the various file formats

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/XmlReaderVersion1.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/XmlReaderVersion1.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
@@ -14,13 +14,13 @@ package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.io;
 
 import java.io.IOException;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.xml.v1.BlastOutput;
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.xml.v1.ObjectFactory;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
@@ -34,11 +34,9 @@ public class XmlReaderVersion1 {
 
 	public static BlastOutput getBlastOutput(InputSource inputSource) throws SAXException, IOException, JAXBException, ParserConfigurationException {
 
-		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+		DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
+		documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
 		documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-		documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
 
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document document = documentBuilder.parse(inputSource);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/XmlReaderVersion2.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/XmlReaderVersion2.java
@@ -21,6 +21,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.xml.v2.BlastOutput2;
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.xml.v2.ObjectFactory;
 import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.xml.v2.Results;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
@@ -34,7 +35,7 @@ public class XmlReaderVersion2 {
 
 	public static BlastOutput2 getBlastOutput(InputSource inputSource) throws SAXException, IOException, JAXBException, ParserConfigurationException {
 
-		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+		DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document document = documentBuilder.parse(inputSource);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/internal/io/AbstractMassSpectrumReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mmass/src/org/eclipse/chemclipse/msd/converter/supplier/mmass/internal/io/AbstractMassSpectrumReader.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -44,6 +43,7 @@ import org.eclipse.chemclipse.msd.converter.supplier.mmass.converter.model.IVend
 import org.eclipse.chemclipse.msd.converter.supplier.mmass.converter.model.VendorIon;
 import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
@@ -59,11 +59,7 @@ public abstract class AbstractMassSpectrumReader extends AbstractMassSpectraRead
 
 	public NodeList getTopNode(File file) throws SAXException, IOException, ParserConfigurationException {
 
-		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-		documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-		documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document document = documentBuilder.parse(file);
 		// document.getDocumentElement().normalize();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion104.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion104.java
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.io;
 import java.io.File;
 import java.io.IOException;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -48,6 +47,7 @@ import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransition;
 import org.eclipse.chemclipse.support.history.EditInformation;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -198,11 +198,7 @@ public class ChromatogramReaderVersion104 extends AbstractChromatogramReader {
 
 	private MzData readMzData(File file) throws SAXException, IOException, ParserConfigurationException, JAXBException {
 
-		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-		documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-		documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document document = documentBuilder.parse(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion105.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/ChromatogramReaderVersion105.java
@@ -15,7 +15,6 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzdata.internal.io;
 import java.io.File;
 import java.io.IOException;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -49,6 +48,7 @@ import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransition;
 import org.eclipse.chemclipse.support.history.EditInformation;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -125,11 +125,7 @@ public class ChromatogramReaderVersion105 extends AbstractChromatogramReader {
 
 	private MzData readMzData(File file) throws SAXException, IOException, ParserConfigurationException, JAXBException {
 
-		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-		documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-		documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document document = documentBuilder.parse(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/MassSpectrumReaderVersion105.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzdata/src/org/eclipse/chemclipse/msd/converter/supplier/mzdata/internal/io/MassSpectrumReaderVersion105.java
@@ -16,7 +16,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Date;
 
-import javax.xml.XMLConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -45,6 +44,7 @@ import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
 import org.eclipse.chemclipse.support.history.EditInformation;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -67,11 +67,7 @@ public class MassSpectrumReaderVersion105 extends AbstractMassSpectraReader {
 		massSpectra.setName(file.getName());
 
 		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion20.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion20.java
@@ -16,7 +16,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -47,6 +46,7 @@ import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransition;
 import org.eclipse.chemclipse.support.history.EditInformation;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -68,11 +68,7 @@ public class ChromatogramReaderVersion20 extends AbstractChromatogramReader {
 		IVendorChromatogram chromatogram = null;
 		MsRun msRun = null;
 		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion21.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion21.java
@@ -16,7 +16,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -47,6 +46,7 @@ import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransition;
 import org.eclipse.chemclipse.support.history.EditInformation;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -68,11 +68,7 @@ public class ChromatogramReaderVersion21 extends AbstractChromatogramReader {
 		IVendorChromatogram chromatogram = null;
 		MsRun msRun = null;
 		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion22.java
@@ -16,7 +16,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -47,6 +46,7 @@ import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransition;
 import org.eclipse.chemclipse.support.history.EditInformation;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -68,11 +68,7 @@ public class ChromatogramReaderVersion22 extends AbstractChromatogramReader {
 		IVendorChromatogram chromatogram = null;
 		MsRun msRun = null;
 		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion30.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion30.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.zip.DataFormatException;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -48,6 +47,7 @@ import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransition;
 import org.eclipse.chemclipse.support.history.EditInformation;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -69,11 +69,7 @@ public class ChromatogramReaderVersion30 extends AbstractChromatogramReader {
 		IVendorChromatogram chromatogram = null;
 
 		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion31.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion31.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.zip.DataFormatException;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -48,6 +47,7 @@ import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransition;
 import org.eclipse.chemclipse.support.history.EditInformation;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -69,11 +69,7 @@ public class ChromatogramReaderVersion31 extends AbstractChromatogramReader {
 		IVendorChromatogram chromatogram = null;
 
 		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion32.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/ChromatogramReaderVersion32.java
@@ -18,7 +18,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.zip.DataFormatException;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -50,6 +49,7 @@ import org.eclipse.chemclipse.msd.model.core.IIonTransition;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.IonTransition;
 import org.eclipse.chemclipse.support.history.EditInformation;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -71,11 +71,7 @@ public class ChromatogramReaderVersion32 extends AbstractChromatogramReader {
 		IVendorChromatogram chromatogram = null;
 
 		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 			documentBuilderFactory.setNamespaceAware(true);
 
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion20.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion20.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 
-import javax.xml.XMLConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -43,6 +42,7 @@ import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
 import org.eclipse.chemclipse.support.history.EditInformation;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -64,11 +64,7 @@ public class MassSpectrumReaderVersion20 extends AbstractMassSpectraReader {
 		IStandaloneMassSpectrum massSpectrum = null;
 
 		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion21.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion21.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 
-import javax.xml.XMLConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -43,6 +42,7 @@ import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
 import org.eclipse.chemclipse.support.history.EditInformation;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -64,11 +64,7 @@ public class MassSpectrumReaderVersion21 extends AbstractMassSpectraReader {
 		IStandaloneMassSpectrum massSpectrum = null;
 
 		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion22.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion22.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 
-import javax.xml.XMLConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -43,6 +42,7 @@ import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
 import org.eclipse.chemclipse.support.history.EditInformation;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -64,11 +64,7 @@ public class MassSpectrumReaderVersion22 extends AbstractMassSpectraReader {
 		IStandaloneMassSpectrum massSpectrum = null;
 
 		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 			documentBuilderFactory.setNamespaceAware(true);
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion30.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion30.java
@@ -19,7 +19,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.zip.DataFormatException;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -44,6 +43,7 @@ import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
 import org.eclipse.chemclipse.support.history.EditInformation;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -64,11 +64,7 @@ public class MassSpectrumReaderVersion30 extends AbstractMassSpectraReader {
 
 		MsRun msRun = null;
 		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion31.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion31.java
@@ -19,7 +19,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.zip.DataFormatException;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -44,6 +43,7 @@ import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
 import org.eclipse.chemclipse.support.history.EditInformation;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -64,11 +64,7 @@ public class MassSpectrumReaderVersion31 extends AbstractMassSpectraReader {
 
 		MsRun msRun = null;
 		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion32.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.converter.supplier.mzxml/src/org/eclipse/chemclipse/msd/converter/supplier/mzxml/internal/io/MassSpectrumReaderVersion32.java
@@ -19,7 +19,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.zip.DataFormatException;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -44,6 +43,7 @@ import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.msd.model.core.Polarity;
 import org.eclipse.chemclipse.msd.model.implementation.StandaloneMassSpectrum;
 import org.eclipse.chemclipse.support.history.EditInformation;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -64,11 +64,7 @@ public class MassSpectrumReaderVersion32 extends AbstractMassSpectraReader {
 
 		MsRun msRun = null;
 		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter.supplier.nmrml/src/org/eclipse/chemclipse/nmr/converter/supplier/nmrml/io/ScanReaderVersion100.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.nmr.converter.supplier.nmrml/src/org/eclipse/chemclipse/nmr/converter/supplier/nmrml/io/ScanReaderVersion100.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -47,6 +46,7 @@ import org.eclipse.chemclipse.nmr.converter.supplier.nmrml.model.VendorFIDMeasur
 import org.eclipse.chemclipse.nmr.converter.supplier.nmrml.model.VendorFIDSignal;
 import org.eclipse.chemclipse.nmr.processing.supplier.base.settings.ExponentialApodizationSettings;
 import org.eclipse.chemclipse.nmr.processing.supplier.base.settings.PhaseCorrectionSettings;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -63,11 +63,7 @@ public class ScanReaderVersion100 {
 
 		List<IComplexSignalMeasurement<?>> measurements = new ArrayList<>();
 		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdml/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/io/PCRReaderVersion11.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdml/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/io/PCRReaderVersion11.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.InvalidParameterException;
 
-import javax.xml.XMLConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -44,6 +43,7 @@ import org.eclipse.chemclipse.pcr.model.core.IPlate;
 import org.eclipse.chemclipse.pcr.model.core.IWell;
 import org.eclipse.chemclipse.pcr.model.core.Position;
 import org.eclipse.chemclipse.pcr.model.core.Well;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -68,11 +68,7 @@ public class PCRReaderVersion11 implements IPCRReader {
 
 	private static Rdml getRDML(InputStream inputStream) throws SAXException, IOException, JAXBException, ParserConfigurationException {
 
-		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-		documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-		documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document document = documentBuilder.parse(inputStream);

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdml/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/io/PCRReaderVersion12.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdml/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/io/PCRReaderVersion12.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.InvalidParameterException;
 
-import javax.xml.XMLConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -44,6 +43,7 @@ import org.eclipse.chemclipse.pcr.model.core.IPlate;
 import org.eclipse.chemclipse.pcr.model.core.IWell;
 import org.eclipse.chemclipse.pcr.model.core.Position;
 import org.eclipse.chemclipse.pcr.model.core.Well;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -68,11 +68,7 @@ public class PCRReaderVersion12 implements IPCRReader {
 
 	private static Rdml getRDML(InputStream inputStream) throws SAXException, IOException, JAXBException, ParserConfigurationException {
 
-		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-		documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-		documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document document = documentBuilder.parse(inputStream);

--- a/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdml/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/io/PCRReaderVersion13.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.pcr.converter.supplier.rdml/src/org/eclipse/chemclipse/pcr/converter/supplier/rdml/io/PCRReaderVersion13.java
@@ -18,7 +18,6 @@ import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.XMLConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -47,6 +46,7 @@ import org.eclipse.chemclipse.pcr.model.core.IPlate;
 import org.eclipse.chemclipse.pcr.model.core.IWell;
 import org.eclipse.chemclipse.pcr.model.core.Position;
 import org.eclipse.chemclipse.pcr.model.core.Well;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -71,11 +71,7 @@ public class PCRReaderVersion13 implements IPCRReader {
 
 	private static Rdml getRDML(InputStream inputStream) throws SAXException, IOException, JAXBException, ParserConfigurationException {
 
-		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-		documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-		documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document document = documentBuilder.parse(inputStream);

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/META-INF/MANIFEST.MF
@@ -26,7 +26,8 @@ Export-Package: org.eclipse.chemclipse.support.comparator,
  org.eclipse.chemclipse.support.traces,
  org.eclipse.chemclipse.support.updates,
  org.eclipse.chemclipse.support.util,
- org.eclipse.chemclipse.support.validators
+ org.eclipse.chemclipse.support.validators,
+ org.eclipse.chemclipse.support.xml
 Require-Bundle: org.eclipse.osgi;bundle-version="3.13.0",
  org.eclipse.e4.core.services;bundle-version="2.3.400",
  org.eclipse.e4.core.contexts;bundle-version="1.11.0",

--- a/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/xml/XmlParserFactory.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.support/src/org/eclipse/chemclipse/support/xml/XmlParserFactory.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Aleksandar Kurtakov - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.support.xml;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLInputFactory;
+
+/**
+ * Creates XML parser factories that are hardened against external entity
+ * resolution but still able to read the large data files this application deals
+ * with.
+ */
+public class XmlParserFactory {
+
+	private static final String FEATURE_DISALLOW_DOCTYPE = "http://apache.org/xml/features/disallow-doctype-decl";
+	private static final String FEATURE_LOAD_EXTERNAL_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+	/*
+	 * JDK 24 lowered both limits to 100.000. Raising only the general
+	 * entity limit moves the failure to the total entity limit.
+	 */
+	private static final String LIMIT_GENERAL_ENTITY_SIZE = "jdk.xml.maxGeneralEntitySizeLimit";
+	private static final String LIMIT_TOTAL_ENTITY_SIZE = "jdk.xml.totalEntitySizeLimit";
+	private static final String NO_LIMIT = "0";
+
+	private XmlParserFactory() {
+
+	}
+
+	public static DocumentBuilderFactory createDocumentBuilderFactory() throws ParserConfigurationException {
+
+		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+		documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		documentBuilderFactory.setFeature(FEATURE_DISALLOW_DOCTYPE, true);
+		documentBuilderFactory.setFeature(FEATURE_LOAD_EXTERNAL_DTD, false);
+		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		documentBuilderFactory.setAttribute(LIMIT_GENERAL_ENTITY_SIZE, NO_LIMIT);
+		documentBuilderFactory.setAttribute(LIMIT_TOTAL_ENTITY_SIZE, NO_LIMIT);
+		return documentBuilderFactory;
+	}
+
+	public static XMLInputFactory createInputFactory() {
+
+		XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+		xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+		xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
+		xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		xmlInputFactory.setProperty(LIMIT_GENERAL_ENTITY_SIZE, NO_LIMIT);
+		xmlInputFactory.setProperty(LIMIT_TOTAL_ENTITY_SIZE, NO_LIMIT);
+		return xmlInputFactory;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.spectroml/src/org/eclipse/chemclipse/wsd/converter/supplier/spectroml/io/ScanReader.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.wsd.converter.supplier.spectroml/src/org/eclipse/chemclipse/wsd/converter/supplier/spectroml/io/ScanReader.java
@@ -22,13 +22,13 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.chemclipse.wsd.converter.supplier.spectroml.model.IVendorSpectrumWSD;
 import org.eclipse.chemclipse.wsd.converter.supplier.spectroml.model.VendorSpectrumWSD;
 import org.eclipse.chemclipse.wsd.converter.supplier.spectroml.model.v1.DataCore;
@@ -116,11 +116,7 @@ public class ScanReader {
 
 	private static SpectroML getSpectroML(File file) throws SAXException, IOException, JAXBException, ParserConfigurationException {
 
-		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-		documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-		documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 		documentBuilderFactory.setNamespaceAware(true);
 
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.cml/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.cml/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Export-Package: org.eclipse.chemclipse.xxd.converter.supplier.cml.converter,
 Import-Package: jakarta.xml.bind;version="4.0.0",
  jakarta.xml.bind.annotation;version="4.0.0"
 Require-Bundle: org.eclipse.core.runtime,
- org.eclipse.chemclipse.converter
+ org.eclipse.chemclipse.converter,
+ org.eclipse.chemclipse.support
 Bundle-RequiredExecutionEnvironment: JavaSE-25
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: ChemClipse

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.cml/src/org/eclipse/chemclipse/xxd/converter/supplier/cml/io/RootElement.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.cml/src/org/eclipse/chemclipse/xxd/converter/supplier/cml/io/RootElement.java
@@ -15,11 +15,11 @@ package org.eclipse.chemclipse.xxd.converter.supplier.cml.io;
 import java.io.File;
 import java.io.IOException;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.chemclipse.xxd.converter.supplier.cml.model.v3.Cml;
 import org.eclipse.chemclipse.xxd.converter.supplier.cml.model.v3.Spectrum;
 import org.w3c.dom.Document;
@@ -35,11 +35,7 @@ public class RootElement {
 	// both <cml><spectrum> and <spectrum> alone are valid
 	public static Spectrum getSpectrum(File file) throws SAXException, IOException, JAXBException, ParserConfigurationException {
 
-		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-		documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-		documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document document = documentBuilder.parse(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramFileContentMatcher.java
@@ -16,12 +16,12 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter;
 import java.io.File;
 import java.io.FileInputStream;
 
-import javax.xml.XMLConstants;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 
 public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher {
 
@@ -32,10 +32,7 @@ public class ChromatogramFileContentMatcher extends AbstractFileContentMatcher {
 
 		boolean isValidFormat = false;
 		try {
-			XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
-			xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-			xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-			xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+			XMLInputFactory xmlInputFactory = XmlParserFactory.createInputFactory();
 			XMLStreamReader xmlStreamReader = xmlInputFactory.createXMLStreamReader(new FileInputStream(file));
 
 			boolean hasChromatogramList = false;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramFileContentMatcherIndexed.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/ChromatogramFileContentMatcherIndexed.java
@@ -31,6 +31,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 
 public class ChromatogramFileContentMatcherIndexed extends AbstractFileContentMatcher {
 
@@ -73,9 +74,7 @@ public class ChromatogramFileContentMatcherIndexed extends AbstractFileContentMa
 
 	private static boolean scanForChromatogramOffset(InputStream input) throws XMLStreamException {
 
-		XMLInputFactory factory = XMLInputFactory.newInstance();
-		factory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
-		factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
+		XMLInputFactory factory = XmlParserFactory.createInputFactory();
 		factory.setProperty(XMLInputFactory.IS_COALESCING, Boolean.TRUE);
 		XMLStreamReader reader = factory.createXMLStreamReader(input, StandardCharsets.UTF_8.name());
 		try {

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumFileContentMatcher.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/msd/converter/supplier/mzml/converter/MassSpectrumFileContentMatcher.java
@@ -16,12 +16,12 @@ package org.eclipse.chemclipse.msd.converter.supplier.mzml.converter;
 import java.io.File;
 import java.io.FileInputStream;
 
-import javax.xml.XMLConstants;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 
 public class MassSpectrumFileContentMatcher extends AbstractFileContentMatcher {
 
@@ -32,10 +32,7 @@ public class MassSpectrumFileContentMatcher extends AbstractFileContentMatcher {
 
 		boolean isValidFormat = false;
 		try {
-			XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
-			xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-			xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-			xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+			XMLInputFactory xmlInputFactory = XmlParserFactory.createInputFactory();
 			XMLStreamReader xmlStreamReader = xmlInputFactory.createXMLStreamReader(new FileInputStream(file));
 
 			boolean hasChromatogramList = false;

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlHelper.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlHelper.java
@@ -27,12 +27,13 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.XMLConstants;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.util.StreamReaderDelegate;
+
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
@@ -134,12 +135,8 @@ public class XmlHelper {
 
 	private static XMLInputFactory createInputFactory() {
 
-		XMLInputFactory xmlInputFactory = XMLInputFactory.newFactory();
-		xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-		xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+		XMLInputFactory xmlInputFactory = XmlParserFactory.createInputFactory();
 		xmlInputFactory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
-		xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-		xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
 		return xmlInputFactory;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlReader10.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlReader10.java
@@ -15,11 +15,11 @@ package org.eclipse.chemclipse.xxd.converter.supplier.mzml.io;
 import java.io.File;
 import java.io.IOException;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v10.CVParamType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v10.MzMLType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v10.ObjectFactory;
@@ -41,11 +41,7 @@ public class XmlReader10 {
 
 	public static MzMLType getMzML(File file) throws SAXException, IOException, JAXBException, ParserConfigurationException {
 
-		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-		documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-		documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document document = documentBuilder.parse(file);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlReader110.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.converter.supplier.mzml/src/org/eclipse/chemclipse/xxd/converter/supplier/mzml/io/XmlReader110.java
@@ -15,12 +15,12 @@ package org.eclipse.chemclipse.xxd.converter.supplier.mzml.io;
 import java.io.File;
 import java.io.IOException;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.chemclipse.model.core.IChromatogramOverview;
+import org.eclipse.chemclipse.support.xml.XmlParserFactory;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.CVParamType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.MzMLType;
 import org.eclipse.chemclipse.xxd.converter.supplier.mzml.model.v110.ObjectFactory;
@@ -42,11 +42,7 @@ public class XmlReader110 {
 
 	public static MzMLType getMzML(File file) throws SAXException, IOException, JAXBException, ParserConfigurationException {
 
-		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-		documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-		documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-		documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		DocumentBuilderFactory documentBuilderFactory = XmlParserFactory.createDocumentBuilderFactory();
 		documentBuilderFactory.setNamespaceAware(true);
 
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();


### PR DESCRIPTION
JDK 24 capped maxGeneralEntitySizeLimit and totalEntitySizeLimit at 100.000, which large mzML files exceed via escaped characters.