### PR TITLE
Fix running RCPTT tests

### DIFF
--- a/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
+++ b/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
@@ -24,8 +24,8 @@
 -Dosgi.user.area=@user.home/.chemclipse/0.8.x
 -XX:+UseG1GC
 -XX:+UseStringDeduplication
---add-modules=ALL-SYSTEM
 --enable-native-access=ALL-UNNAMED
+--add-modules=ALL-SYSTEM
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread
       </vmArgsMac>


### PR DESCRIPTION
Workaround for
https://github.com/eclipse-rcptt/org.eclipse.rcptt/issues/336 due to which any argument with ALL-UNNAMED will make RCPTT fail if there was --add-opens before it.