### PR TITLE
Disable target markers by default

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/preferences/PreferenceSupplier.java
@@ -715,7 +715,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static final String P_SHOW_RETENTION_INDEX_MARKER = "showRetentionIndexMarker";
 	public static final boolean DEF_SHOW_RETENTION_INDEX_MARKER = true;
 	public static final String P_SHOW_TARGET_MARKER = "showTargetMarker";
-	public static final boolean DEF_SHOW_TARGET_MARKER = true;
+	public static final boolean DEF_SHOW_TARGET_MARKER = false;
 	/*
 	 * Calibration Chart
 	 */


### PR DESCRIPTION
as they tend to cause glitches that I haven't understood fully yet. Might be related to negative baselines where they suddenly all appear despite the targets being visible. This may be less of a problem for GC-MS but awkward for HPLC, where this happens more often. As discussed in https://github.com/eclipse-chemclipse/chemclipse/pull/3102.