### PR TITLE
Add a MALDI baseline concept

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/settings/ChromatogramFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/settings/ChromatogramFilterSettings.java
@@ -24,9 +24,11 @@ public class ChromatogramFilterSettings extends AbstractChromatogramFilterSettin
 	@JsonProperty(value = "Subtract Mass Spectrum", defaultValue = "")
 	@JsonPropertyDescription(value = "This is the mass spectrum used for subtraction.")
 	private IScanMSD subtractMassSpectrum = new ScanMSD();
+
 	@JsonProperty(value = "Use Nominal Mass", defaultValue = "true")
 	@JsonPropertyDescription(value = "Use the nominal mass schema.")
 	private boolean useNominalMasses = true;
+
 	@JsonProperty(value = "Normalize Data", defaultValue = "true")
 	@JsonPropertyDescription(value = "Normalize the intensities.")
 	private boolean useNormalize = true;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/settings/MassSpectrumFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/settings/MassSpectrumFilterSettings.java
@@ -28,9 +28,11 @@ public class MassSpectrumFilterSettings extends AbstractMassSpectrumFilterSettin
 	@JsonProperty(value = "Subtract Mass Spectrum", defaultValue = "")
 	@JsonPropertyDescription(value = "This is the mass spectrum used for subtraction.")
 	private IScanMSD subtractMassSpectrum = new ScanMSD();
+
 	@JsonProperty(value = "Use Nominal Mass", defaultValue = "true")
 	@JsonPropertyDescription(value = "Use the nominal mass schema.")
 	private boolean useNominalMasses = true;
+
 	@JsonProperty(value = "Normalize Data", defaultValue = "true")
 	@JsonPropertyDescription(value = "Normalize the intensities.")
 	private boolean useNormalize = true;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/settings/PeakFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter.supplier.subtract/src/org/eclipse/chemclipse/chromatogram/msd/filter/supplier/subtract/settings/PeakFilterSettings.java
@@ -24,9 +24,11 @@ public class PeakFilterSettings extends AbstractPeakFilterSettings {
 	@JsonProperty(value = "Subtract Mass Spectrum", defaultValue = "")
 	@JsonPropertyDescription(value = "This is the mass spectrum used for subtraction.")
 	private IScanMSD subtractMassSpectrum = new ScanMSD();
+
 	@JsonProperty(value = "Use Nominal Mass", defaultValue = "true")
 	@JsonPropertyDescription(value = "Use the nominal mass schema.")
 	private boolean useNominalMasses = true;
+
 	@JsonProperty(value = "Normalize Data", defaultValue = "true")
 	@JsonPropertyDescription(value = "Normalize the intensities.")
 	private boolean useNormalize = true;

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/massspectrum/MassSpectrumFilterProcessSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/core/massspectrum/MassSpectrumFilterProcessSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -67,6 +67,10 @@ public class MassSpectrumFilterProcessSupplier implements IProcessTypeSupplier {
 
 			super(supplier.getId(), supplier.getFilterName(), supplier.getDescription(), (Class<IMassSpectrumFilterSettings>)supplier.getSettingsClass(), parent, DataType.MSD);
 			getLiteratureReferences().addAll(supplier.getLiteratureReferences());
+			IMassSpectrumFilterSettings massSpectrumFilterSettings = createSettings();
+			if(massSpectrumFilterSettings != null) {
+				setCategory(massSpectrumFilterSettings.getCategory());
+			}
 		}
 
 		@Override
@@ -85,18 +89,27 @@ public class MassSpectrumFilterProcessSupplier implements IProcessTypeSupplier {
 				return false;
 			}
 			if(scan instanceof IRegularMassSpectrum regularMassSpectrum) {
+				IMassSpectrumFilterSettings massSpectrumFilterSettings = createSettings();
+				if(massSpectrumFilterSettings != null) {
+					return massSpectrumFilterSettings.appliesToMassSpectrumTypes().contains(regularMassSpectrum.getMassSpectrumType());
+				}
+			}
+			return true;
+		}
+
+		private IMassSpectrumFilterSettings createSettings() {
+
+			Class<IMassSpectrumFilterSettings> settingsClass = getSettingsClass();
+			if(settingsClass != null) {
 				try {
-					IMassSpectrumFilterSettings instance = getSettingsClass().getDeclaredConstructor().newInstance();
-					return instance.appliesToMassSpectrumTypes().contains(regularMassSpectrum.getMassSpectrumType());
+					return settingsClass.getDeclaredConstructor().newInstance();
 				} catch(InstantiationException | IllegalAccessException
 						| IllegalArgumentException | InvocationTargetException
 						| NoSuchMethodException | SecurityException e) {
 					logger.error(e);
 				}
-				return true;
-			} else {
-				return true;
 			}
+			return null;
 		}
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/settings/IMassSpectrumFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.msd.filter/src/org/eclipse/chemclipse/chromatogram/msd/filter/settings/IMassSpectrumFilterSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
  * 
  * Contributors:
  * Philip Wenig - initial API and implementation
+ * Matthias Mailänder - menu category
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.msd.filter.settings;
 
@@ -16,8 +17,19 @@ import java.util.List;
 
 import org.eclipse.chemclipse.model.settings.IProcessSettings;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
+import org.eclipse.chemclipse.processing.core.ICategories;
 
 public interface IMassSpectrumFilterSettings extends IProcessSettings {
 
 	List<MassSpectrumType> appliesToMassSpectrumTypes();
+
+	/**
+	 * The menu category the filter shall be listed in, see {@link ICategories}.
+	 *
+	 * @return String
+	 */
+	default String getCategory() {
+
+		return ICategories.MASS_SPECTRUM_FILTER;
+	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/src/org/eclipse/chemclipse/chromatogram/xxd/edit/supplier/snip/core/MassSpectrumFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/src/org/eclipse/chemclipse/chromatogram/xxd/edit/supplier/snip/core/MassSpectrumFilter.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip.core;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
@@ -20,9 +22,11 @@ import org.eclipse.chemclipse.chromatogram.msd.filter.core.massspectrum.Abstract
 import org.eclipse.chemclipse.chromatogram.msd.filter.result.IMassSpectrumFilterResult;
 import org.eclipse.chemclipse.chromatogram.msd.filter.result.MassSpectrumFilterResult;
 import org.eclipse.chemclipse.chromatogram.msd.filter.settings.IMassSpectrumFilterSettings;
-import org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip.calculator.FilterSupplier;
+import org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip.calculator.SnipCalculator;
 import org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip.settings.MassSpectrumFilterSettings;
+import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.MessageType;
 import org.eclipse.chemclipse.processing.core.ProcessingMessage;
@@ -35,26 +39,26 @@ public class MassSpectrumFilter extends AbstractMassSpectrumFilter {
 	@Override
 	public IProcessingInfo<IMassSpectrumFilterResult> applyFilter(List<IScanMSD> massSpectra, IMassSpectrumFilterSettings filterSettings, IProgressMonitor monitor) {
 
-		/*
-		 * Settings
-		 */
 		MassSpectrumFilterSettings massSpectrumFilterSettings;
 		if(filterSettings instanceof MassSpectrumFilterSettings settings) {
 			massSpectrumFilterSettings = settings;
 		} else {
 			massSpectrumFilterSettings = new MassSpectrumFilterSettings();
 		}
-		/*
-		 * Filter
-		 */
-		IProcessingInfo<IMassSpectrumFilterResult> processingInfo = validate(massSpectra, filterSettings);
-		if(!processingInfo.hasErrorMessages()) {
-			FilterSupplier filterSupplier = new FilterSupplier();
-			int iterations = massSpectrumFilterSettings.getIterations();
-			int transitions = massSpectrumFilterSettings.getTransitions();
-			double magnificationFactor = massSpectrumFilterSettings.getMagnificationFactor();
-			filterSupplier.applySnipFilter(massSpectra, iterations, transitions, magnificationFactor);
 
+		IProcessingInfo<IMassSpectrumFilterResult> processingInfo = validate(massSpectra, filterSettings);
+		if(processingInfo.hasErrorMessages()) {
+			return processingInfo;
+		}
+
+		int iterations = massSpectrumFilterSettings.getIterations();
+
+		for(IScanMSD scanMSD : massSpectra) {
+			double[] abundances = scanMSD.getIons().stream().mapToDouble(IIon::getAbundance).toArray();
+			double[] baseline = SnipCalculator.calculateBaselineIntensityValues(abundances, iterations, monitor);
+			if(scanMSD instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
+				standaloneMassSpectrum.setBaseline(new ArrayList<>(Arrays.stream(baseline).boxed().toList()));
+			}
 			processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, DESCRIPTION, "The mass spectrum has been optimized successfully."));
 			IMassSpectrumFilterResult massSpectrumFilterResult = new MassSpectrumFilterResult(ResultStatus.OK, "The SNIP filter has been applied successfully.");
 			processingInfo.setProcessingResult(massSpectrumFilterResult);

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/src/org/eclipse/chemclipse/chromatogram/xxd/edit/supplier/snip/settings/MassSpectrumFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/src/org/eclipse/chemclipse/chromatogram/xxd/edit/supplier/snip/settings/MassSpectrumFilterSettings.java
@@ -20,7 +20,6 @@ import org.eclipse.chemclipse.chromatogram.msd.filter.settings.AbstractMassSpect
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
 import org.eclipse.chemclipse.support.literature.LiteratureReference;
-import org.eclipse.chemclipse.support.settings.DoubleSettingsProperty;
 import org.eclipse.chemclipse.support.settings.IntSettingsProperty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -35,16 +34,6 @@ public class MassSpectrumFilterSettings extends AbstractMassSpectrumFilterSettin
 	@IntSettingsProperty(minValue = 5, maxValue = 2000)
 	private int iterations = 100;
 
-	@JsonProperty(value = "Magnification Factor", defaultValue = "1.0")
-	@JsonPropertyDescription(value = "The magnification factor run the filter.")
-	@DoubleSettingsProperty(minValue = 0.01d, maxValue = 5.0d)
-	private double magnificationFactor = 1.0d;
-
-	@JsonProperty(value = "Transitions", defaultValue = "1")
-	@JsonPropertyDescription(value = "The number of transitions run the filter.")
-	@IntSettingsProperty(minValue = 1, maxValue = 100)
-	private int transitions = 1;
-
 	public int getIterations() {
 
 		return iterations;
@@ -53,26 +42,6 @@ public class MassSpectrumFilterSettings extends AbstractMassSpectrumFilterSettin
 	public void setIterations(int iterations) {
 
 		this.iterations = iterations;
-	}
-
-	public double getMagnificationFactor() {
-
-		return magnificationFactor;
-	}
-
-	public void setMagnificationFactor(double magnificationFactor) {
-
-		this.magnificationFactor = magnificationFactor;
-	}
-
-	public int getTransitions() {
-
-		return transitions;
-	}
-
-	public void setTransitions(int transitions) {
-
-		this.transitions = transitions;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/src/org/eclipse/chemclipse/chromatogram/xxd/edit/supplier/snip/settings/MassSpectrumFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.edit.supplier.snip/src/org/eclipse/chemclipse/chromatogram/xxd/edit/supplier/snip/settings/MassSpectrumFilterSettings.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.eclipse.chemclipse.chromatogram.msd.filter.settings.AbstractMassSpectrumFilterSettings;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
+import org.eclipse.chemclipse.processing.core.ICategories;
 import org.eclipse.chemclipse.support.literature.LiteratureReference;
 import org.eclipse.chemclipse.support.settings.IntSettingsProperty;
 
@@ -42,6 +43,12 @@ public class MassSpectrumFilterSettings extends AbstractMassSpectrumFilterSettin
 	public void setIterations(int iterations) {
 
 		this.iterations = iterations;
+	}
+
+	@Override
+	public String getCategory() {
+
+		return ICategories.BASELINE_DETECTOR;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/META-INF/MANIFEST.MF
@@ -8,13 +8,14 @@ Bundle-Vendor: Chemclipse
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.msd.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.csd.model;bundle-version="0.8.0",
- org.eclipse.chemclipse.wsd.model;bundle-version="0.8.0", 
+ org.eclipse.chemclipse.wsd.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.logging;bundle-version="0.8.0",
  org.eclipse.chemclipse.processing;bundle-version="0.8.0",
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
  org.eclipse.chemclipse.chromatogram.filter;bundle-version="0.8.0",
- com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.6.2"
+ com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.6.2",
+ org.eclipse.chemclipse.chromatogram.msd.filter;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-25
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.core,

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/plugin.xml
@@ -18,4 +18,14 @@
             id="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselineextract">
       </ChromatogramFilterSupplier>
    </extension>
+   <extension
+         point="org.eclipse.chemclipse.chromatogram.msd.filter.massSpectrumFilterSupplier">
+      <MassSpectrumFilterSupplier
+            config="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.settings.MassSpectrumFilterSettings"
+            description="This is a baseline subtraction filter."
+            filter="org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.core.MassSpectrumFilter"
+            filterName="Baseline Subtract"
+            id="org.eclipse.chemclipse.msd.filter.supplier.baseline.subtract">
+      </MassSpectrumFilterSupplier>
+   </extension>
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/baselinesubtract/core/MassSpectrumFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/baselinesubtract/core/MassSpectrumFilter.java
@@ -10,10 +10,8 @@
  * Contributors:
  * Matthias Mailänder - initial API and implementation
  *******************************************************************************/
-package org.eclipse.chemclipse.xxd.edit.supplier.convexhull.core;
+package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.core;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
@@ -27,36 +25,37 @@ import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.MessageType;
 import org.eclipse.chemclipse.processing.core.ProcessingMessage;
-import org.eclipse.chemclipse.xxd.edit.supplier.convexhull.settings.MassSpectrumFilterSettings;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 public class MassSpectrumFilter extends AbstractMassSpectrumFilter {
 
-	private static final String DESCRIPTION = "Lower Convex Hull Filter Mass Spectra";
+	private static final String DESCRIPTION = "Baseline Subtract";
 
 	@Override
 	public IProcessingInfo<IMassSpectrumFilterResult> applyFilter(List<IScanMSD> massSpectra, IMassSpectrumFilterSettings filterSettings, IProgressMonitor monitor) {
 
-		MassSpectrumFilterSettings massSpectrumFilterSettings;
-		if(filterSettings instanceof MassSpectrumFilterSettings settings) {
-			massSpectrumFilterSettings = settings;
-		} else {
-			massSpectrumFilterSettings = new MassSpectrumFilterSettings();
-		}
 		IProcessingInfo<IMassSpectrumFilterResult> processingInfo = validate(massSpectra, filterSettings);
 		if(!processingInfo.hasErrorMessages()) {
 			for(IScanMSD scanMSD : massSpectra) {
-				double[] ions = scanMSD.getIons().stream().mapToDouble(IIon::getIon).toArray();
-				double[] abundances = scanMSD.getIons().stream().mapToDouble(IIon::getAbundance).toArray();
-				double[] baseline = LowerConvexHull.baseline(ions, abundances, massSpectrumFilterSettings.getTolerance());
-
 				if(scanMSD instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
-					standaloneMassSpectrum.setBaseline(new ArrayList<>(Arrays.stream(baseline).boxed().toList()));
-				}
 
-				processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, DESCRIPTION, "The mass spectrum has been optimized successfully."));
-				IMassSpectrumFilterResult massSpectrumFilterResult = new MassSpectrumFilterResult(ResultStatus.OK, "The Lower Convex Hull filter has been applied successfully.");
-				processingInfo.setProcessingResult(massSpectrumFilterResult);
+					if(standaloneMassSpectrum.getBaseline().isEmpty()) {
+						processingInfo.addMessage(new ProcessingMessage(MessageType.ERROR, DESCRIPTION, "No baseline to subtract.", "Estimate baseline first."));
+						return processingInfo;
+					}
+
+					int i = 0;
+					for(IIon ion : scanMSD.getIons()) {
+						ion.setAbundance(ion.getAbundance() - standaloneMassSpectrum.getBaseline().get(i).floatValue());
+						i++;
+					}
+
+					standaloneMassSpectrum.getBaseline().clear();
+
+					processingInfo.addMessage(new ProcessingMessage(MessageType.INFO, DESCRIPTION, "Baseline subtracted."));
+					IMassSpectrumFilterResult massSpectrumFilterResult = new MassSpectrumFilterResult(ResultStatus.OK, "Baseline subtracted.");
+					processingInfo.setProcessingResult(massSpectrumFilterResult);
+				}
 			}
 		}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/baselinesubtract/settings/MassSpectrumFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract/src/org/eclipse/chemclipse/chromatogram/xxd/filter/supplier/baselinesubtract/settings/MassSpectrumFilterSettings.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.xxd.filter.supplier.baselinesubtract.settings;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.chemclipse.chromatogram.msd.filter.settings.AbstractMassSpectrumFilterSettings;
+import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
+
+public class MassSpectrumFilterSettings extends AbstractMassSpectrumFilterSettings {
+
+	@Override
+	public List<MassSpectrumType> appliesToMassSpectrumTypes() {
+
+		return Arrays.asList(MassSpectrumType.PROFILE);
+	}
+
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractStandaloneMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/AbstractStandaloneMassSpectrum.java
@@ -40,6 +40,7 @@ public abstract class AbstractStandaloneMassSpectrum extends AbstractRegularMass
 
 	private List<IMassSpectrumPeak> peaks = new ArrayList<>();
 	private List<Double> noise = new ArrayList<>();
+	private List<Double> baseline = new ArrayList<>();
 
 	private final IEditHistory editHistory = new EditHistory();
 
@@ -165,5 +166,17 @@ public abstract class AbstractStandaloneMassSpectrum extends AbstractRegularMass
 	public List<Double> getNoise() {
 
 		return noise;
+	}
+
+	@Override
+	public List<Double> getBaseline() {
+
+		return baseline;
+	}
+
+	@Override
+	public void setBaseline(List<Double> baseline) {
+
+		this.baseline = baseline;
 	}
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IStandaloneMassSpectrum.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.msd.model/src/org/eclipse/chemclipse/msd/model/core/IStandaloneMassSpectrum.java
@@ -86,4 +86,8 @@ public interface IStandaloneMassSpectrum extends IRegularMassSpectrum, ISupplier
 	List<IMassSpectrumPeak> getPeaks();
 
 	List<Double> getNoise();
+
+	List<Double> getBaseline();
+
+	void setBaseline(List<Double> baseline);
 }

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/ExtendedMassSpectrumUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/ExtendedMassSpectrumUI.java
@@ -195,8 +195,9 @@ public class ExtendedMassSpectrumUI extends Composite implements IExtendedPartUI
 		GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
 		gridData.horizontalAlignment = GridData.END;
 		composite.setLayoutData(gridData);
-		composite.setLayout(new GridLayout(5, false));
+		composite.setLayout(new GridLayout(6, false));
 
+		createButtonDeleteBaseline(composite);
 		buttonToolbarSelection.set(createButtonToggleSelection(composite));
 		buttonToolbarMethod.set(createButtonToggleMethod(composite));
 		createButtonToggleChartGrid(composite);
@@ -259,6 +260,27 @@ public class ExtendedMassSpectrumUI extends Composite implements IExtendedPartUI
 		composite.setLayout(new FillLayout());
 		Label label = new Label(composite, SWT.NONE);
 		label.setText("The mass spectrum couldn't be loaded.");
+	}
+
+	private void createButtonDeleteBaseline(Composite composite) {
+
+		Button button = new Button(composite, SWT.PUSH);
+		button.setImage(ApplicationImageFactory.getInstance().getImage(IApplicationImage.IMAGE_BASELINE_DELETE, IApplicationImageProvider.SIZE_16x16));
+		button.setToolTipText("Delete baseline");
+		button.setEnabled(getMassSpectrumType() == MassSpectrumType.PROFILE);
+		button.addSelectionListener(new SelectionAdapter() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+
+				if(massSpectrum instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
+					standaloneMassSpectrum.getBaseline().clear();
+					update(standaloneMassSpectrum);
+					massSpectrumChart.update();
+					MassSpectrumUpdateNotifierUI.update(getDisplay(), standaloneMassSpectrum);
+				}
+			}
+		});
 	}
 
 	private Button createButtonToggleSelection(Composite parent) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
@@ -233,7 +233,8 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 			return false;
 		}
 
-		if(!supplier.getCategory().equals(ICategories.MASS_SPECTRUM_FILTER)) {
+		String category = supplier.getCategory();
+		if(!category.equals(ICategories.MASS_SPECTRUM_FILTER) && !category.equals(ICategories.BASELINE_DETECTOR)) {
 			return false;
 		}
 
@@ -248,6 +249,9 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 
 		Command command = commandService.getCommand(supplier.getId());
 		Category category = commandService.getCategory(supplier.getCategory());
+		if(!category.isDefined()) {
+			category.define(supplier.getCategory(), "");
+		}
 		command.define(supplier.getName(), supplier.getDescription(), category);
 		command.setHandler(new DynamicHandler(cachedEntry, this));
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.msd.ui/src/org/eclipse/chemclipse/ux/extension/msd/ui/swt/MassSpectrumChartProfile.java
@@ -148,6 +148,8 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 				lineSeriesDataList.add(peakLineSeriesData);
 				LineSeriesData noiseLineSeriesData = getNoise(standaloneMassSpectrum);
 				lineSeriesDataList.add(noiseLineSeriesData);
+				LineSeriesData baselineLineSeriesData = getBaseline(standaloneMassSpectrum);
+				lineSeriesDataList.add(baselineLineSeriesData);
 				createAnnotations(standaloneMassSpectrum);
 			}
 
@@ -377,7 +379,7 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 		return noiseSeries;
 	}
 
-	public static ISeriesData createNoiseSeries(String id, IStandaloneMassSpectrum massSpectrum) {
+	private static ISeriesData createNoiseSeries(String id, IStandaloneMassSpectrum massSpectrum) {
 
 		List<Double> noiseList = massSpectrum.getNoise();
 		int size = Math.min(noiseList.size(), massSpectrum.getNumberOfIons());
@@ -387,6 +389,35 @@ public class MassSpectrumChartProfile extends LineChart implements IMassSpectrum
 		for(int i = 0; i < size; i++) {
 			xSeries[index] = massSpectrum.getIons().get(index).getIon();
 			ySeries[index] = noiseList.get(index);
+			index++;
+		}
+		return new SeriesData(xSeries, ySeries, id);
+	}
+
+	private LineSeriesData getBaseline(IStandaloneMassSpectrum massSpectrum) {
+
+		ISeriesData noiseSeriesData = createBaselineSeries("Baseline", massSpectrum);
+		LineSeriesData noiseSeries = new LineSeriesData(noiseSeriesData);
+		ILineSeriesSettings lineSeriesSettings = noiseSeries.getLineSeriesSettings();
+		lineSeriesSettings.setEnableArea(false);
+		lineSeriesSettings.setLineWidth(2);
+		lineSeriesSettings.setLineStyle(LineStyle.SOLID);
+		lineSeriesSettings.setSymbolType(PlotSymbolType.NONE);
+		lineSeriesSettings.setLineColor(getDisplay().getSystemColor(SWT.COLOR_BLACK));
+		lineSeriesSettings.setSymbolColor(getDisplay().getSystemColor(SWT.COLOR_BLACK));
+		return noiseSeries;
+	}
+
+	private static ISeriesData createBaselineSeries(String id, IStandaloneMassSpectrum massSpectrum) {
+
+		List<Double> baselineList = massSpectrum.getBaseline();
+		int size = Math.min(baselineList.size(), massSpectrum.getNumberOfIons());
+		double[] xSeries = new double[size];
+		double[] ySeries = new double[size];
+		int index = 0;
+		for(int i = 0; i < size; i++) {
+			xSeries[index] = massSpectrum.getIons().get(index).getIon();
+			ySeries[index] = baselineList.get(index);
 			index++;
 		}
 		return new SeriesData(xSeries, ySeries, id);

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.convexhull/src/org/eclipse/chemclipse/xxd/edit/supplier/convexhull/settings/MassSpectrumFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.convexhull/src/org/eclipse/chemclipse/xxd/edit/supplier/convexhull/settings/MassSpectrumFilterSettings.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.eclipse.chemclipse.chromatogram.msd.filter.settings.AbstractMassSpectrumFilterSettings;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
+import org.eclipse.chemclipse.processing.core.ICategories;
 import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -46,6 +47,12 @@ public class MassSpectrumFilterSettings extends AbstractMassSpectrumFilterSettin
 	public List<MassSpectrumType> appliesToMassSpectrumTypes() {
 
 		return Arrays.asList(MassSpectrumType.PROFILE);
+	}
+
+	@Override
+	public String getCategory() {
+
+		return ICategories.BASELINE_DETECTOR;
 	}
 
 	@Override

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.tophat/src/org/eclipse/chemclipse/xxd/edit/supplier/tophat/core/MassSpectrumFilter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.tophat/src/org/eclipse/chemclipse/xxd/edit/supplier/tophat/core/MassSpectrumFilter.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.chemclipse.xxd.edit.supplier.tophat.core;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.filter.result.ResultStatus;
@@ -22,6 +24,7 @@ import org.eclipse.chemclipse.chromatogram.msd.filter.settings.IMassSpectrumFilt
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.msd.model.core.IStandaloneMassSpectrum;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.MessageType;
 import org.eclipse.chemclipse.processing.core.ProcessingMessage;
@@ -44,8 +47,8 @@ public class MassSpectrumFilter extends AbstractMassSpectrumFilter {
 		}
 		IProcessingInfo<IMassSpectrumFilterResult> processingInfo = validate(massSpectra, filterSettings);
 		if(!processingInfo.hasErrorMessages()) {
-			for(IScanMSD massSpectrum : massSpectra) {
-				double[] abundances = massSpectrum.getIons().stream().mapToDouble(IIon::getAbundance).toArray();
+			for(IScanMSD scanMSD : massSpectra) {
+				double[] abundances = scanMSD.getIons().stream().mapToDouble(IIon::getAbundance).toArray();
 
 				int halfWindowSize = massSpectrumFilterSettings.getHalfWindowSize();
 				if(halfWindowSize < 1) {
@@ -55,11 +58,8 @@ public class MassSpectrumFilter extends AbstractMassSpectrumFilter {
 
 				double[] baseline = TopHat.baseline(abundances, halfWindowSize);
 
-				// subtract
-				int i = 0;
-				for(IIon ion : massSpectrum.getIons()) {
-					ion.setAbundance(ion.getAbundance() - (float)baseline[i]);
-					i++;
+				if(scanMSD instanceof IStandaloneMassSpectrum standaloneMassSpectrum) {
+					standaloneMassSpectrum.setBaseline(new ArrayList<>(Arrays.stream(baseline).boxed().toList()));
 				}
 			}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.tophat/src/org/eclipse/chemclipse/xxd/edit/supplier/tophat/settings/MassSpectrumFilterSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.edit.supplier.tophat/src/org/eclipse/chemclipse/xxd/edit/supplier/tophat/settings/MassSpectrumFilterSettings.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.eclipse.chemclipse.chromatogram.msd.filter.settings.AbstractMassSpectrumFilterSettings;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.msd.model.core.MassSpectrumType;
+import org.eclipse.chemclipse.processing.core.ICategories;
 import org.eclipse.chemclipse.support.literature.LiteratureReference;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -46,6 +47,12 @@ public class MassSpectrumFilterSettings extends AbstractMassSpectrumFilterSettin
 	public List<MassSpectrumType> appliesToMassSpectrumTypes() {
 
 		return Arrays.asList(MassSpectrumType.PROFILE);
+	}
+
+	@Override
+	public String getCategory() {
+
+		return ICategories.BASELINE_DETECTOR;
 	}
 
 	@Override


### PR DESCRIPTION
It is the same menu layout we already have for chromatograms. First detect the baseline in `Baseline Detector` and then use `Mass Spectrum Filter` → `Baseline Subtract` to actually remove it, which enables you to preview it.

<img width="1110" height="333" alt="grafik" src="https://github.com/user-attachments/assets/24f36757-2f81-4c49-92be-0d4f0d2cbad6" />
