### PR TITLE
Hide MALDI baseline operations for chromatograms

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -53,6 +53,7 @@ import org.eclipse.chemclipse.model.core.MarkedTraceModus;
 import org.eclipse.chemclipse.model.core.MarkedTraces;
 import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.model.supplier.IChromatogramSelectionProcessSupplier;
+import org.eclipse.chemclipse.model.supplier.IScanProcessSupplier;
 import org.eclipse.chemclipse.model.support.IAnalysisSegment;
 import org.eclipse.chemclipse.model.support.RetentionIndexMath;
 import org.eclipse.chemclipse.model.targets.ITargetDisplaySettings;
@@ -788,6 +789,11 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 		}
 
 		if(supplier.getTypeSupplier() instanceof EditorProcessTypeSupplier) {
+			return false;
+		}
+
+		// MALDI
+		if(supplier instanceof IScanProcessSupplier) {
 			return false;
 		}
 


### PR DESCRIPTION
In https://github.com/eclipse-chemclipse/chemclipse/pull/3108 I reused the same baseline detector category from the chromatogram realm for MALDI which then caused clashes since the filters share the same name.