### PR TITLE
Remove --add-modules=ALL-SYSTEM from product file

### DIFF
--- a/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
+++ b/chemclipse/products/org.eclipse.chemclipse.rcp.compilation.community.product/chemclipse.compilation.community.product
@@ -25,7 +25,6 @@
 -XX:+UseG1GC
 -XX:+UseStringDeduplication
 --enable-native-access=ALL-UNNAMED
---add-modules=ALL-SYSTEM
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread
       </vmArgsMac>


### PR DESCRIPTION
Chemclipse doesn't need it.