### PR TITLE
Fix electropherograms sometimes glitching out when zoomed in

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -932,7 +932,7 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 			markedTraces.add(new TraceRasteredWSD(wavelength));
 			Nucleobase nucleobase = chromatogramDSD.getWavelengthMapping().get(wavelength);
 			String seriesId = SERIES_ID_CHROMATOGRAM + " " + nucleobase.letter();
-			ILineSeriesData lineSeriesData = chromatogramChartSupport.getLineSeriesData(chromatogramSelection, seriesId, DisplayType.XWC, Derivative.NONE, colorScheme.getColor(), markedTraces, false);
+			ILineSeriesData lineSeriesData = chromatogramChartSupport.getLineSeriesData(chromatogramDSD, seriesId, DisplayType.XWC, Derivative.NONE, colorScheme.getColor(), markedTraces);
 			lineSeriesData.getSettings().setEnableArea(enableChromatogramArea);
 			lineSeriesData.getSettings().setDescription(String.valueOf(nucleobase.label()));
 			lineSeriesDataList.add(lineSeriesData);


### PR DESCRIPTION
I am not entirely sure what causes it. It was easier to reproduce with `Restrict Select X`.

<img width="1320" height="353" alt="grafik" src="https://github.com/user-attachments/assets/e94b63b8-713b-408e-b749-0d5e4a87bbb5" />

After investigation I realized I might be able to rule out @eclipse-swtchart misbehaving. Its complicated compression techniques never really enable, as the number of data points, even at full zoom out, is too small for these data sets. So the easiest fix is also to just remove the chromatogram selection and render everything as a full-line series all the time as it slicing may be overkill as well.