### PR TITLE
Add a taxonomy report

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/META-INF/MANIFEST.MF
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.apache.httpcomponents.core5.httpcore5;bundle-version="5.3.4",
  org.glassfish.hk2.osgi-resource-locator;bundle-version="3.0.0",
  com.sun.xml.bind.jaxb-osgi;bundle-version="4.0.9",
- org.eclipse.chemclipse.dsd.model;bundle-version="[0.9.0,1.0.0)"
+ org.eclipse.chemclipse.dsd.model;bundle-version="0.9.0",
+ org.eclipse.chemclipse.chromatogram.xxd.report;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-25
 Bundle-Vendor: ChemClipse
 Bundle-ActivationPolicy: lazy

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/plugin.xml
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/plugin.xml
@@ -71,4 +71,16 @@
          </Metric>
       </Algorithm>
    </extension>
+   <extension
+         point="org.eclipse.chemclipse.chromatogram.xxd.report.chromatogramReportSupplier">
+      <ChromatogramReportSupplier
+            description="Reports taxonomy results as text."
+            fileExtension=".txt"
+            fileName="TaxonomyReport"
+            id="org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.report.taxonomy"
+            reportGenerator="org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.report.TaxonomyReportGenerator"
+            reportName="Taxonomy Report (*.txt)"
+            reportSettings="org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings.TaxonomyReportSettings">
+      </ChromatogramReportSupplier>
+   </extension>
 </plugin>

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/AbstractNucleotideBLAST.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/AbstractNucleotideBLAST.java
@@ -55,6 +55,7 @@ public abstract class AbstractNucleotideBLAST {
 			libraryInformation.setGenBankAccesion(description.getAccession());
 			libraryInformation.setReferenceIdentifier(description.getId());
 			libraryInformation.setTaxonomyIdentifierNCBI(description.getTaxid().intValue());
+			libraryInformation.getSynonyms().add(description.getSciname());
 			for(Hsp hsp : hit.getHsps().getHsp()) {
 				IdentificationTarget identificationTarget = new IdentificationTarget(libraryInformation, createComparisonResult(hsp, search));
 				identificationTarget.setIdentifier(report.getVersion());

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/LocalNucleotideBLAST.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/LocalNucleotideBLAST.java
@@ -87,6 +87,9 @@ public class LocalNucleotideBLAST extends AbstractNucleotideBLAST {
 					InputSource inputSource = new InputSource(new FileInputStream(xml));
 					BlastOutput2 blastOutput = XmlReaderVersion2.getBlastOutput(inputSource);
 					transferTargets(chromatogram, blastOutput);
+					if(chromatogram.getTargets().stream().noneMatch(t -> !t.getLibraryInformation().getSynonyms().isEmpty())) {
+						logger.warn("Taxonomy database is not installed.");
+					}
 					numberOfHits += XmlReaderVersion2.getNumberResults(blastOutput);
 				} catch(SAXException | IOException | JAXBException
 						| ParserConfigurationException e) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/report/AbstractReportGenerator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/report/AbstractReportGenerator.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+ package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.report;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.chemclipse.chromatogram.xxd.report.chromatogram.AbstractChromatogramReportGenerator;
+import org.eclipse.chemclipse.chromatogram.xxd.report.settings.IChromatogramReportSettings;
+import org.eclipse.chemclipse.model.core.IChromatogram;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+abstract class AbstractReportGenerator extends AbstractChromatogramReportGenerator {
+
+	public abstract IProcessingInfo<File> report(File file, boolean append, List<IChromatogram> chromatograms, IChromatogramReportSettings settings, IProgressMonitor monitor);
+
+	@Override
+	public IProcessingInfo<File> generate(File file, boolean append, IChromatogram chromatogram, IChromatogramReportSettings settings, IProgressMonitor monitor) {
+
+		List<IChromatogram> chromatograms = getChromatogramList(chromatogram);
+		return report(file, append, chromatograms, settings, monitor);
+	}
+
+	@Override
+	public IProcessingInfo<File> generate(File file, boolean append, List<IChromatogram> chromatograms, IChromatogramReportSettings settings, IProgressMonitor monitor) {
+
+		return report(file, append, chromatograms, settings, monitor);
+	}
+
+	protected List<IChromatogram> getChromatogramList(IChromatogram chromatogram) {
+
+		List<IChromatogram> chromatograms = new ArrayList<>();
+		chromatograms.add(chromatogram);
+		return chromatograms;
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/report/TaxonomyReportGenerator.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/report/TaxonomyReportGenerator.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.report;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings.TaxonomyReportSettings;
+import org.eclipse.chemclipse.chromatogram.xxd.report.settings.IChromatogramReportSettings;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.model.core.IChromatogram;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+public class TaxonomyReportGenerator extends AbstractReportGenerator {
+
+	private static final Logger logger = Logger.getLogger(TaxonomyReportGenerator.class);
+
+	@Override
+	public IProcessingInfo<File> report(File file, boolean append, List<IChromatogram> chromatograms, IChromatogramReportSettings settings, IProgressMonitor monitor) {
+
+		IProcessingInfo<File> processingInfo = super.validate(file);
+
+		if(!processingInfo.hasErrorMessages()) {
+			TaxonomyReportWriter taxonomyReportWriter = new TaxonomyReportWriter();
+			try {
+				taxonomyReportWriter.generate(file, append, chromatograms);
+				processingInfo.setProcessingResult(file);
+			} catch(IOException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage("Taxonomy Report", e.getMessage());
+			}
+		}
+
+		return processingInfo;
+	}
+
+	@Override
+	public IProcessingInfo<File> generate(File file, boolean append, IChromatogram chromatogram, IProgressMonitor monitor) {
+
+		List<IChromatogram> chromatograms = getChromatogramList(chromatogram);
+		TaxonomyReportSettings settings = new TaxonomyReportSettings();
+		return report(file, append, chromatograms, settings, monitor);
+	}
+
+	@Override
+	public IProcessingInfo<File> generate(File file, boolean append, List<IChromatogram> chromatograms, IProgressMonitor monitor) {
+
+		TaxonomyReportSettings settings = new TaxonomyReportSettings();
+		return report(file, append, chromatograms, settings, monitor);
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/report/TaxonomyReportWriter.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/report/TaxonomyReportWriter.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.report;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.DateFormat;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.model.BlastMetrics;
+import org.eclipse.chemclipse.model.core.IChromatogram;
+import org.eclipse.chemclipse.model.identifier.IComparisonResult;
+import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
+import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
+import org.eclipse.chemclipse.support.text.ValueFormat;
+
+public class TaxonomyReportWriter {
+
+	public void generate(File file, boolean append, List<IChromatogram> chromatograms) throws IOException {
+
+		try (PrintWriter printWriter = new PrintWriter(new FileWriter(file, append))) {
+			printWriter.println("Taxonomy Report");
+			printWriter.println();
+			for(IChromatogram chromatogram : chromatograms) {
+				printHeader(printWriter, chromatogram);
+				printWriter.println();
+				reportChromatogram(printWriter, chromatogram);
+			}
+		}
+	}
+
+	private void printHeader(PrintWriter printWriter, IChromatogram chromatogram) {
+
+		printKeyValue(printWriter, "Sample Name", chromatogram.getSampleName());
+		printKeyValue(printWriter, "Sample Group", chromatogram.getSampleGroup());
+		DateFormat dateFormat = ValueFormat.getDateFormatEnglish();
+		printKeyValue(printWriter, "Date", dateFormat.format(chromatogram.getDate()));
+	}
+
+	private void printKeyValue(PrintWriter printWriter, String key, String value) {
+
+		printWriter.print(key);
+		printWriter.print(": ");
+		printWriter.println(value);
+	}
+
+	private void reportChromatogram(PrintWriter printWriter, IChromatogram chromatogram) {
+
+		reportBestHit(printWriter, chromatogram);
+		printWriter.println();
+		reportGroupedHits(printWriter, chromatogram);
+	}
+
+	private void reportBestHit(PrintWriter printWriter, IChromatogram chromatogram) {
+
+		Optional<IIdentificationTarget> manuallyVerified = chromatogram.getTargets().stream().filter(t -> t.isVerified()).findAny();
+		if(manuallyVerified.isPresent()) {
+			reportBestHit(printWriter, manuallyVerified.get());
+		} else {
+			reportBestHit(printWriter, chromatogram.getTargets().stream().max(Comparator.comparingDouble(target -> target.getComparisonResult().getMetric(BlastMetrics.BIT_SCORE).getAsDouble())).orElse(null));
+		}
+	}
+
+	private void reportBestHit(PrintWriter printWriter, IIdentificationTarget bestIdentification) {
+
+		if(bestIdentification != null) {
+			ILibraryInformation libraryInformation = bestIdentification.getLibraryInformation();
+			if(libraryInformation.getSynonyms().iterator().hasNext()) {
+				printKeyValue(printWriter, "Best Hit", libraryInformation.getSynonyms().iterator().next());
+			} else {
+				printKeyValue(printWriter, "Best Hit", libraryInformation.getName());
+			}
+			IComparisonResult comparisonResult = bestIdentification.getComparisonResult();
+			printKeyValue(printWriter, "Bit Score", String.valueOf(comparisonResult.getMetric(BlastMetrics.BIT_SCORE).getAsDouble()));
+			printKeyValue(printWriter, "Bit Score", String.valueOf(comparisonResult.getMetric(BlastMetrics.SCORE).getAsDouble()));
+			printKeyValue(printWriter, "Coverage", String.valueOf(comparisonResult.getMetric(BlastMetrics.COVERAGE).getAsDouble()) + "%");
+			printKeyValue(printWriter, "E value", String.valueOf(comparisonResult.getMetric(BlastMetrics.EVALUE).getAsDouble()));
+			printKeyValue(printWriter, "Identity", String.valueOf(comparisonResult.getMetric(BlastMetrics.IDENTITY).getAsDouble()));
+			printKeyValue(printWriter, "Gaps", String.valueOf(comparisonResult.getMetric(BlastMetrics.GAPS).getAsDouble()));
+			printKeyValue(printWriter, "Accession", libraryInformation.getGenBankAccesion());
+			printKeyValue(printWriter, "Tax ID", String.valueOf(libraryInformation.getTaxonomyIdentifierNCBI()));
+		}
+	}
+
+	private void reportGroupedHits(PrintWriter printWriter, IChromatogram chromatogram) {
+
+		Map<Integer, List<IIdentificationTarget>> groupedResults = chromatogram.getTargets().stream().collect( //
+				Collectors.groupingBy(target -> target.getLibraryInformation().getTaxonomyIdentifierNCBI()));
+
+		List<List<IIdentificationTarget>> orderedResults = groupedResults.values().stream().sorted(//
+				Comparator.comparingDouble((List<IIdentificationTarget> targets) -> //
+				targets.stream().mapToDouble(target -> //
+				target.getComparisonResult().getMetric(BlastMetrics.BIT_SCORE).getAsDouble()).max().orElse(0.0)) //
+							.reversed()).toList();
+
+		for(List<IIdentificationTarget> targets : orderedResults) {
+			double highestBitScore = targets.stream().mapToDouble(target -> //
+			target.getComparisonResult().getMetric(BlastMetrics.BIT_SCORE).getAsDouble()).max().orElse(0.0);
+
+			String identifier = "";
+			ILibraryInformation libraryInformation = targets.getFirst().getLibraryInformation();
+			if(!libraryInformation.getSynonyms().isEmpty()) {
+				identifier = libraryInformation.getSynonyms().iterator().next();
+			} else {
+				identifier = String.valueOf(libraryInformation.getTaxonomyIdentifierNCBI()); // fallback if database is not installed
+			}
+			printWriter.println(targets.size() + " x " + identifier + ": " + highestBitScore);
+		}
+	}
+}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/TaxonomyReportSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/TaxonomyReportSettings.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn.settings;
+
+import org.eclipse.chemclipse.chromatogram.xxd.report.settings.DefaultChromatogramReportSettings;
+
+public class TaxonomyReportSettings extends DefaultChromatogramReportSettings {
+}


### PR DESCRIPTION
A simple text report that condenses the BLAST results again by species and best score.
```
Taxonomy Report

Sample Name: NM-1999-13-abcZ
Sample Group: 
Date: 2004/04/03

Best Hit: Neisseria meningitidis
Bit Score: 935.525
Bit Score: 506.0
Coverage: 77.82874617737004%
E value: 0.0
Identity: 99.80392156862744
Gaps: 1.0
Accession: CP185855
Tax ID: 487

192 x Neisseria meningitidis: 935.525
23 x Neisseria subflava: 747.167
319 x Neisseria gonorrhoeae: 701.001
```

Best hit is either the highest score or :ballot_box_with_check: manually verified target.

For this to work properly, it requires an installed `taxdb.tar.gz`. [[1](https://www.ncbi.nlm.nih.gov/sites/books/NBK62345/)]

Scientific names are stored as synonyms, as these sometimes get renamed.

<img width="634" height="181" alt="grafik" src="https://github.com/user-attachments/assets/882a08e5-98d8-477a-9e7b-0dab80217fa9" />
