### PR TITLE
Filter uncultured/environmental by default in local BLAST

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/AbstractNucleotideBLAST.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/AbstractNucleotideBLAST.java
@@ -54,7 +54,9 @@ public abstract class AbstractNucleotideBLAST {
 			}
 			libraryInformation.setGenBankAccesion(description.getAccession());
 			libraryInformation.setReferenceIdentifier(description.getId());
-			libraryInformation.setTaxonomyIdentifierNCBI(description.getTaxid().intValue());
+			if(description.getTaxid() != null) {
+				libraryInformation.setTaxonomyIdentifierNCBI(description.getTaxid().intValue());
+			}
 			libraryInformation.getSynonyms().add(description.getSciname());
 			for(Hsp hsp : hit.getHsps().getHsp()) {
 				IdentificationTarget identificationTarget = new IdentificationTarget(libraryInformation, createComparisonResult(hsp, search));

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/LocalNucleotideBLAST.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/io/LocalNucleotideBLAST.java
@@ -87,6 +87,10 @@ public class LocalNucleotideBLAST extends AbstractNucleotideBLAST {
 					InputSource inputSource = new InputSource(new FileInputStream(xml));
 					BlastOutput2 blastOutput = XmlReaderVersion2.getBlastOutput(inputSource);
 					transferTargets(chromatogram, blastOutput);
+					if(settings.isExcludeUncultured()) {
+						chromatogram.getTargets().removeIf(t -> t.getLibraryInformation().getTaxonomyIdentifierNCBI() == 48479); // environmental
+						chromatogram.getTargets().removeIf(t -> t.getLibraryInformation().getTaxonomyIdentifierNCBI() == 77133); // uncultured
+					}
 					if(chromatogram.getTargets().stream().noneMatch(t -> !t.getLibraryInformation().getSynonyms().isEmpty())) {
 						logger.warn("Taxonomy database is not installed.");
 					}

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/LocalIdentifierSettings.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.wsd.identifier.supplier.blastn/src/org/eclipse/chemclipse/chromatogram/wsd/identifier/supplier/blastn/settings/LocalIdentifierSettings.java
@@ -36,6 +36,10 @@ public class LocalIdentifierSettings extends AbstractIdentifierSettingsWSD imple
 	@JsonProperty(value = "Task", defaultValue = "MEGABLAST")
 	private Task task = Task.MEGABLAST;
 
+	@JsonProperty(value = "Exclude uncultured / environmental", defaultValue = "true")
+	@JsonPropertyDescription(value = "Uncultured bacteria and environmental samples")
+	private boolean excludeUncultured = true;
+
 	public String getDatabase() {
 
 		return database;
@@ -54,6 +58,16 @@ public class LocalIdentifierSettings extends AbstractIdentifierSettingsWSD imple
 	public void setTask(Task task) {
 
 		this.task = task;
+	}
+
+	public boolean isExcludeUncultured() {
+
+		return excludeUncultured;
+	}
+
+	public void setExcludeUncultured(boolean excludeUncultured) {
+
+		this.excludeUncultured = excludeUncultured;
 	}
 
 	@Override


### PR DESCRIPTION
These are useless for identification because there is no taxon associated with it:
* https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=48479
* https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=77133