### PR TITLE
Use EHelpService instead of PlatformUI for context help

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/IExtendedPartUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.ui/src/org/eclipse/chemclipse/ux/extension/ui/swt/IExtendedPartUI.java
@@ -26,7 +26,10 @@ import org.eclipse.chemclipse.rcp.ui.icons.core.ApplicationImageFactory;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImage;
 import org.eclipse.chemclipse.rcp.ui.icons.core.IApplicationImageProvider;
 import org.eclipse.chemclipse.support.ui.swt.ExtendedTableViewer;
+import org.eclipse.chemclipse.ux.extension.ui.Activator;
 import org.eclipse.chemclipse.ux.extension.ui.support.PartSupport;
+import org.eclipse.e4.ui.model.application.MApplication;
+import org.eclipse.e4.ui.services.help.EHelpService;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.IPreferencePage;
 import org.eclipse.jface.preference.PreferenceDialog;
@@ -40,7 +43,6 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swtchart.extensions.core.IChartSettings;
 import org.eclipse.swtchart.extensions.core.ScrollableChart;
-import org.eclipse.ui.PlatformUI;
 
 public interface IExtendedPartUI {
 
@@ -140,15 +142,28 @@ public interface IExtendedPartUI {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 
-				if(context != null && !context.isBlank()) {
-					PlatformUI.getWorkbench().getHelpSystem().displayHelp(context);
-				} else {
-					PlatformUI.getWorkbench().getHelpSystem().displayHelp();
+				EHelpService helpService = getHelpService();
+				if(helpService != null && context != null && !context.isBlank()) {
+					helpService.displayHelp(context);
 				}
 			}
 		});
 
 		return button;
+	}
+
+	default EHelpService getHelpService() {
+
+		MApplication application = Activator.getDefault().getApplication();
+		return application != null ? application.getContext().get(EHelpService.class) : null;
+	}
+
+	default void setHelp(Object element, String context) {
+
+		EHelpService helpService = getHelpService();
+		if(helpService != null && context != null && !context.isBlank()) {
+			helpService.setHelp(element, context);
+		}
 	}
 
 	default Button createButtonToggleEditTable(Composite parent, AtomicReference<? extends ExtendedTableViewer> viewer, String image) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramOverlayUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramOverlayUI.java
@@ -112,7 +112,6 @@ import org.eclipse.swtchart.extensions.linecharts.ILineSeriesData;
 import org.eclipse.swtchart.extensions.linecharts.ILineSeriesSettings;
 import org.eclipse.swtchart.extensions.linecharts.LineSeriesData;
 import org.eclipse.swtchart.extensions.preferences.PreferencePage;
-import org.eclipse.ui.PlatformUI;
 
 public class ExtendedChromatogramOverlayUI extends Composite implements IExtendedPartUI {
 
@@ -212,7 +211,7 @@ public class ExtendedChromatogramOverlayUI extends Composite implements IExtende
 		 * This is needed to layout both combo boxes accordingly.
 		 */
 		this.layout(true);
-		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, HelpContext.CHROMATOGRAM_OVERLAY);
+		setHelp(this, HelpContext.CHROMATOGRAM_OVERLAY);
 	}
 
 	private Composite createToolbarMain(Composite parent) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakDetectorUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakDetectorUI.java
@@ -86,7 +86,6 @@ import org.eclipse.swtchart.extensions.events.AbstractHandledEventProcessor;
 import org.eclipse.swtchart.extensions.linecharts.ICompressionSupport;
 import org.eclipse.swtchart.extensions.linecharts.ILineSeriesData;
 import org.eclipse.swtchart.extensions.linecharts.ILineSeriesSettings;
-import org.eclipse.ui.PlatformUI;
 
 import jakarta.inject.Inject;
 
@@ -390,7 +389,7 @@ public class ExtendedPeakDetectorUI extends Composite implements IExtendedPartUI
 	private void initialize() {
 
 		enableToolbar(toolbarInfo, buttonToolbarInfo, IMAGE_INFO, TOOLTIP_INFO, true);
-		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, HelpContext.PEAK_DETECTOR);
+		setHelp(this, HelpContext.PEAK_DETECTOR);
 	}
 
 	private void createToolbarMain(Composite parent) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedPeakScanListUI.java
@@ -253,7 +253,7 @@ public class ExtendedPeakScanListUI extends Composite implements IExtendedPartUI
 		buttonMerge.get().setEnabled(false);
 		buttonDelete.get().setEnabled(false);
 		scanIdentifierControl.get().setEnabled(false);
-		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, HelpContext.PEAK_SCAN_LIST);
+		setHelp(this, HelpContext.PEAK_SCAN_LIST);
 	}
 
 	private void createToolbarMain(Composite parent) {

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedTargetsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedTargetsUI.java
@@ -223,7 +223,7 @@ public class ExtendedTargetsUI extends Composite implements IExtendedPartUI {
 		enableToolbar(toolbarSearch, buttonToolbarSearch.get(), IMAGE_SEARCH, TOOLTIP_SEARCH, false);
 		enableToolbar(toolbarEdit, buttonToolbarEdit.get(), IMAGE_EDIT, TOOLTIP_EDIT, false);
 
-		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, HelpContext.TARGETS);
+		setHelp(this, HelpContext.TARGETS);
 		enableEdit(Arrays.asList(targetListOther, targetListChromatogram), buttonTableEditControl.get(), IMAGE_EDIT_ENTRY, false);
 		applySettings();
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/editors/ExtendedChromatogramUI.java
@@ -1239,7 +1239,7 @@ public class ExtendedChromatogramUI extends Composite implements IToolbarConfig,
 
 	private void initialize() {
 
-		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, HelpContext.CHROMATOGRAM_EDITOR);
+		setHelp(this, HelpContext.CHROMATOGRAM_EDITOR);
 
 		enableToolbar(toolbarInfoControl, buttonToolbarInfo.get(), IMAGE_INFO, TOOLTIP_INFO, false);
 		enableToolbar(toolbarReferencesControl, buttonToolbarReferences.get(), IMAGE_REFERENCES, TOOLTIP_REFERENCES, preferenceStore.getBoolean(PreferenceSupplier.P_CHROMATOGRAM_SHOW_REFERENCES_COMBO));

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedLoadingsPlot.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedLoadingsPlot.java
@@ -51,7 +51,6 @@ import org.eclipse.swtchart.extensions.core.IChartSettings;
 import org.eclipse.swtchart.extensions.core.IMouseSupport;
 import org.eclipse.swtchart.extensions.core.UserSelection;
 import org.eclipse.swtchart.extensions.events.IHandledEventProcessor;
-import org.eclipse.ui.PlatformUI;
 
 public class ExtendedLoadingsPlot extends Composite implements IExtendedPartUI {
 
@@ -130,7 +129,7 @@ public class ExtendedLoadingsPlot extends Composite implements IExtendedPartUI {
 
 		createToolbarMain(this);
 		createPlot(this);
-		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, HelpContext.LOADINGS_PLOT);
+		setHelp(this, HelpContext.LOADINGS_PLOT);
 		control = this;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedSPlot.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedSPlot.java
@@ -51,7 +51,6 @@ import org.eclipse.swtchart.extensions.core.IChartSettings;
 import org.eclipse.swtchart.extensions.core.IMouseSupport;
 import org.eclipse.swtchart.extensions.core.UserSelection;
 import org.eclipse.swtchart.extensions.events.IHandledEventProcessor;
-import org.eclipse.ui.PlatformUI;
 
 public class ExtendedSPlot extends Composite implements IExtendedPartUI {
 
@@ -126,7 +125,7 @@ public class ExtendedSPlot extends Composite implements IExtendedPartUI {
 
 		createToolbarMain(this);
 		createPlot(this);
-		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, HelpContext.S_PLOT);
+		setHelp(this, HelpContext.S_PLOT);
 		control = this;
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedScorePlot2D.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.xxd.process.supplier.pca.ui/src/org/eclipse/chemclipse/xxd/process/supplier/pca/ui/swt/ExtendedScorePlot2D.java
@@ -57,7 +57,6 @@ import org.eclipse.swtchart.extensions.core.IChartSettings;
 import org.eclipse.swtchart.extensions.core.IMouseSupport;
 import org.eclipse.swtchart.extensions.core.UserSelection;
 import org.eclipse.swtchart.extensions.events.IHandledEventProcessor;
-import org.eclipse.ui.PlatformUI;
 
 public class ExtendedScorePlot2D extends Composite implements IExtendedPartUI {
 
@@ -132,7 +131,7 @@ public class ExtendedScorePlot2D extends Composite implements IExtendedPartUI {
 
 		createToolbarMain(this);
 		createScorePlot(this);
-		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, HelpContext.SCORE_PLOT);
+		setHelp(this, HelpContext.SCORE_PLOT);
 		control = this;
 	}
 


### PR DESCRIPTION
The lookup lives in IExtendedPartUI so that all implementors share it, as the Extended*UI composites are not created through dependency injection.

A blank context no longer opens the general help, as EHelpService has no parameterless displayHelp(), but all callers pass a real context.

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])