### PR TITLE
Cleanup "QC: use RI"

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/OSGI-INF/l10n/bundle.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2023 Lablicate GmbH.
+# Copyright (c) 2023, 2026 Lablicate GmbH.
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -20,5 +20,4 @@ TargetName=Target Name
 Minima=Minima
 MinimaDescription=Detect maxima or minima.
 TargetNameDescription=The target name marks the selected maximum/minimum.
-UseRetentionIndex=QC: Use Retention Index
-UseRetentionIndexDescription=Set this system value to use retention indices for quality control purposes.
+UseRetentionIndex=Sort targets by RI delta

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/OSGI-INF/l10n/bundle_de.properties
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2023 Lablicate GmbH.
+# Copyright (c) 2023, 2026 Lablicate GmbH.
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -20,5 +20,4 @@ TargetName=Treffername
 Minima=Minima
 MinimaDescription=Detektiert Maxima oder Minima.
 TargetNameDescription=Der Treffername markiert das ausgewählte Maximum/Minimum.
-UseRetentionIndex=QS: Verwende Retentionsindex
-UseRetentionIndexDescription=Aktiviert den Retentionindex zur Qualitätssicherung auf Systemebene.
+UseRetentionIndex=Sortiere Treffer nach RI-Abweichung

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/system/SettingsRetentionIndexQC.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.filter/src/org/eclipse/chemclipse/chromatogram/filter/system/SettingsRetentionIndexQC.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,8 +19,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class SettingsRetentionIndexQC implements ISystemProcessSettings {
 
-	@JsonProperty(value = "QC: Use Retention Index", defaultValue = "false")
-	@LabelProperty(value = "%UseRetentionIndex", tooltip = "%UseRetentionIndexDescription")
+	@JsonProperty(value = "Sort targets by RI delta", defaultValue = "false")
+	@LabelProperty(value = "%UseRetentionIndex")
 	private boolean useRetentionIndexQC = false;
 
 	public boolean isUseRetentionIndexQC() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt.ui/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/ui/preferences/PreferencePage.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt.ui/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/ui/preferences/PreferencePage.java
@@ -48,7 +48,6 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 		addField(new LabelFieldEditor("Area% Report", getFieldEditorParent()));
 		addField(new IntegerFieldEditor(PreferenceSupplier.P_DELTA_RETENTION_TIME_LEFT, "Delta Retention Time Left [ms]", getFieldEditorParent()));
 		addField(new IntegerFieldEditor(PreferenceSupplier.P_DELTA_RETENTION_TIME_LEFT, "Delta Retention Time Right [ms]", getFieldEditorParent()));
-		addField(new BooleanFieldEditor(PreferenceSupplier.P_USE_RETENTION_INDEX_QC, "Use Retention Index QC", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_ADD_PEAK_AREA, "Add Peak Area", getFieldEditorParent()));
 	}
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/preferences/PreferenceSupplier.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/preferences/PreferenceSupplier.java
@@ -32,8 +32,6 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static final int DEF_DELTA_RETENTION_TIME_RIGHT = 0;
 	public static final String P_USE_BEST_MATCH = "useBestMatch";
 	public static final boolean DEF_USE_BEST_MATCH = true;
-	public static final String P_USE_RETENTION_INDEX_QC = "useRetentionIndexQC";
-	public static final boolean DEF_USE_RETENTION_INDEX_QC = false;
 	public static final String P_ADD_PEAK_AREA = "addPeakArea";
 	public static final boolean DEF_ADD_PEAK_AREA = false;
 
@@ -55,7 +53,6 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 		putDefault(P_DELTA_RETENTION_TIME_LEFT, Integer.toString(DEF_DELTA_RETENTION_TIME_LEFT));
 		putDefault(P_DELTA_RETENTION_TIME_RIGHT, Integer.toString(DEF_DELTA_RETENTION_TIME_RIGHT));
 		putDefault(P_USE_BEST_MATCH, Boolean.toString(DEF_USE_BEST_MATCH));
-		putDefault(P_USE_RETENTION_INDEX_QC, Boolean.toString(DEF_USE_RETENTION_INDEX_QC));
 		putDefault(P_ADD_PEAK_AREA, Boolean.toString(DEF_ADD_PEAK_AREA));
 	}
 
@@ -70,7 +67,6 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 		settings.setDeltaRetentionTimeLeft(getDeltaRetentionTimeLeft());
 		settings.setDeltaRetentionTimeRight(getDeltaRetentionTimeRight());
 		settings.setUseBestMatch(isUseBestMatch());
-		settings.setUseRetentionIndexQC(isUseRetentionIndexQC());
 		settings.setAddPeakArea(isAddPeakArea());
 		return settings;
 	}
@@ -103,11 +99,6 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier {
 	public static boolean isUseBestMatch() {
 
 		return INSTANCE().getBoolean(P_USE_BEST_MATCH, DEF_USE_BEST_MATCH);
-	}
-
-	public static boolean isUseRetentionIndexQC() {
-
-		return INSTANCE().getBoolean(P_USE_RETENTION_INDEX_QC, DEF_USE_RETENTION_INDEX_QC);
 	}
 
 	public static boolean isAddPeakArea() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/settings/ReportSettings2.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.chromatogram.xxd.report.supplier.txt/src/org/eclipse/chemclipse/chromatogram/xxd/report/supplier/txt/settings/ReportSettings2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 Lablicate GmbH.
+ * Copyright (c) 2012, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,14 +24,14 @@ public class ReportSettings2 extends DefaultChromatogramReportSettings {
 	@JsonProperty(value = "Delta Retention Time Left [ms]", defaultValue = "0")
 	@JsonPropertyDescription(value = "This is the left delta retention time in milliseconds.")
 	private int deltaRetentionTimeLeft = 0;
+
 	@JsonProperty(value = "Delta Retention Time Right [ms]", defaultValue = "0")
 	@JsonPropertyDescription(value = "This is the right delta retention time in milliseconds.")
 	private int deltaRetentionTimeRight = 0;
+
 	@JsonProperty(value = "Use Best Match", defaultValue = "" + PreferenceSupplier.DEF_USE_BEST_MATCH)
 	private boolean useBestMatch;
-	@JsonProperty(value = "Use Retention Index QC", defaultValue = "" + PreferenceSupplier.DEF_USE_RETENTION_INDEX_QC)
-	@JsonPropertyDescription(value = "When trying to get the best target, additionally use the min retention index delta.")
-	private boolean useRetentionIndexQC;
+
 	@JsonProperty(value = "Add Peak Area", defaultValue = "" + PreferenceSupplier.DEF_ADD_PEAK_AREA)
 	private boolean addPeakArea;
 
@@ -63,16 +63,6 @@ public class ReportSettings2 extends DefaultChromatogramReportSettings {
 	public void setUseBestMatch(boolean useBestMatch) {
 
 		this.useBestMatch = useBestMatch;
-	}
-
-	public boolean isUseRetentionIndexQC() {
-
-		return useRetentionIndexQC;
-	}
-
-	public void setUseRetentionIndexQC(boolean useRetentionIndexQC) {
-
-		this.useRetentionIndexQC = useRetentionIndexQC;
 	}
 
 	public boolean isAddPeakArea() {

--- a/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/src/org/eclipse/chemclipse/swt/ui/preferences/PreferencePageSystem.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/src/org/eclipse/chemclipse/swt/ui/preferences/PreferencePageSystem.java
@@ -54,7 +54,7 @@ public class PreferencePageSystem extends FieldEditorPreferencePage implements I
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SEARCH_CASE_SENSITIVE, "Search: Case sensitive", getFieldEditorParent()));
 
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		addField(new BooleanFieldEditor(PreferenceSupplier.P_USE_RETENTION_INDEX_QC, "QC: Use Retention Index", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_USE_RETENTION_INDEX_QC, "Sort targets by retention index delta", getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_BEST_TARGET_LIBRARY_FIELD, "Best Target", LibraryField.getOptions(), getFieldEditorParent()));
 		addField(new ComboFieldEditor(PreferenceSupplier.P_ION_ROUND_METHOD, "Ion Round Method", IonRoundMethod.getOptions(), getFieldEditorParent()));
 

--- a/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/src/org/eclipse/chemclipse/swt/ui/preferences/PreferencePageSystem.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.swt.ui/src/org/eclipse/chemclipse/swt/ui/preferences/PreferencePageSystem.java
@@ -46,9 +46,6 @@ public class PreferencePageSystem extends FieldEditorPreferencePage implements I
 	@Override
 	protected void createFieldEditors() {
 
-		/*
-		 * Use this for the new UI and data analysis perspective instead of SWTPreferencePage.
-		 */
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_ALTERNATE_WINDOW_MOVE_DIRECTION, "Alternate window move direction.", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_CONDENSE_CYCLE_NUMBER_SCANS, "Condense Scans with Cycle Number", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_RETENTION_INDEX_WITHOUT_DECIMALS, "Show retention index without decimals", getFieldEditorParent()));


### PR DESCRIPTION
This replaces `QC: Use Retention Index` because "quality control" can mean anything and is a specific term in labs used for all kinds of measures to improve measurement correctness. It is actually a UI specific setting, but it can't be easily moved because everything is located in model code. It was also duplicated in a report setting that was not tied to anything. 