### PR TITLE
Add ambigious base codes and support for RNA

### DIFF
--- a/chemclipse/plugins/org.eclipse.chemclipse.dsd.model/src/org/eclipse/chemclipse/dsd/model/core/Nucleobase.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.dsd.model/src/org/eclipse/chemclipse/dsd/model/core/Nucleobase.java
@@ -23,6 +23,17 @@ public enum Nucleobase implements ILabel {
 	CYTOSINE('C', "Cytosine"), //
 	GUANINE('G', "Guanine"), //
 	THYMINE('T', "Thymine"), //
+	URACIL('U', "Uracil"), //
+	PURINES('R', "purines"), //
+	PYRIMIDINES('Y', "pyrimidines"), //
+	KETONES('K', "ketones"), //
+	AMINO('M', "with amino group"), //
+	STRONG('S', "strong interaction"), //
+	WEAK('W', "weak interaction"), //
+	NOT_A('B', "not A"), //
+	NOT_C('D', "not C"), //
+	NOT_G('H', "not G"), //
+	NOT_T_U('V', "neither T nor U"), //
 	UNKNOWN('N', "Unknown"); //
 
 	private final char letter;
@@ -57,6 +68,17 @@ public enum Nucleobase implements ILabel {
 			case 'C' -> CYTOSINE;
 			case 'G' -> GUANINE;
 			case 'T' -> THYMINE;
+			case 'U' -> URACIL;
+			case 'R' -> PURINES;
+			case 'Y' -> PYRIMIDINES;
+			case 'K' -> KETONES;
+			case 'M' -> AMINO;
+			case 'S' -> STRONG;
+			case 'W' -> WEAK;
+			case 'B' -> NOT_A;
+			case 'D' -> NOT_C;
+			case 'H' -> NOT_G;
+			case 'V' -> NOT_T_U;
 			default -> UNKNOWN;
 		};
 	}

--- a/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramStatisticsUI.java
+++ b/chemclipse/plugins/org.eclipse.chemclipse.ux.extension.xxd.ui/src/org/eclipse/chemclipse/ux/extension/xxd/ui/swt/ExtendedChromatogramStatisticsUI.java
@@ -143,6 +143,15 @@ public class ExtendedChromatogramStatisticsUI extends Composite implements IExte
 		List<Nucleobase> nucleobases = chromatogramDSD.getNucleotideSequence().getNucleobases();
 		long numberUnknowns = nucleobases.stream().filter(n -> n == Nucleobase.UNKNOWN).count();
 		dataMap.put("Unknown Bases [%]", decimalFormat.format(numberUnknowns / (double)nucleobases.size() * 100));
+
+		long numberUnclear = nucleobases.stream() //
+										.filter(n -> n != Nucleobase.GUANINE //
+												&& n != Nucleobase.ADENINE //
+												&& n != Nucleobase.THYMINE //
+												&& n != Nucleobase.CYTOSINE //
+												&& n != Nucleobase.URACIL) //
+										.count();
+		dataMap.put("Ambiguous Bases [%]", decimalFormat.format(numberUnclear / (double)nucleobases.size() * 100));
 	}
 
 	private void addTimeData(IChromatogramSelection chromatogramSelection, Map<String, String> dataMap) {


### PR DESCRIPTION
I treated everything not clearly defined as unknown, which is an information loss. This adds all of https://en.wikipedia.org/wiki/FASTA_format#Sequence_representation and also adds a statistic about ambiguous bases.